### PR TITLE
Fixed the oneSignalDidFailRegisterForRemoteNotification method for iOS 7

### DIFF
--- a/iOS_SDK/OneSignal/OneSignal.m
+++ b/iOS_SDK/OneSignal/OneSignal.m
@@ -1355,7 +1355,7 @@ static NSArray* delegateSubclasses = nil;
 
 - (void)oneSignalDidFailRegisterForRemoteNotification:(UIApplication*)app error:(NSError*)err {
     
-    if(err.code == 3000 && [(NSString*)[err.userInfo objectForKey:NSLocalizedDescriptionKey] containsString:@"no valid 'aps-environment'"]) {
+    if(err.code == 3000 && [((NSString*)[err.userInfo objectForKey:NSLocalizedDescriptionKey]) rangeOfString:@"no valid 'aps-environment'"].location != NSNotFound) {
         //User did not enable push notification capability
         [OneSignal setErrorNotificationType];
         [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"'Push Notification' capability not turned on. Make sure it is enabled by going to your Project Target -> Capability."];


### PR DESCRIPTION
The "oneSignalDidFailRegisterForRemoteNotification" method was making use of the method "containsString:" which was introduced in iOS 8, causing a crash in iOS 7. This pull request fixes it, by replacing it by "rangeOfString:"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/113)
<!-- Reviewable:end -->
