### PR TITLE
Fixed AppDelegate compatibility, isAppInFocus, and stability fix

### DIFF
--- a/iOS_SDK/OneSignal/OneSignal.h
+++ b/iOS_SDK/OneSignal/OneSignal.h
@@ -148,6 +148,9 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
  Set to false when app is in focus and in-app alerts are disabled, or the remote notification is silent. */
 @property(readonly, getter=wasShown)BOOL shown;
 
+/* Set to true if the app was in focus when the notification  */
+@property(readonly, getter=wasAppInFocus)BOOL isAppInFocus;
+
 /* Set to true when the received notification is silent
  Silent means there is no alert, sound, or badge payload in the aps dictionary
  requires remote-notification within UIBackgroundModes array of the Info.plist */

--- a/iOS_SDK/OneSignal/OneSignal.m
+++ b/iOS_SDK/OneSignal/OneSignal.m
@@ -1206,14 +1206,13 @@ static NSArray* delegateSubclasses = nil;
 // User Tap on Notification while app was in background - OR - Notification received (silent or not, foreground or background) on iOS 7+
 - (void) oneSignalRemoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {
     
-    if([OneSignal app_id]) {
-        
-        //Call notificationAction if app is active -> not a silent notification but rather user tap on notification
-        //Unless iOS 10+ then call remoteSilentNotification instead.
-        if([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
+    if ([OneSignal app_id]) {
+        // Call notificationAction if app is active -> not a silent notification but rather user tap on notification
+        // Unless iOS 10+ then call remoteSilentNotification instead.
+        if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
             [OneSignal notificationOpened:userInfo isActive:YES];
-        else [OneSignal remoteSilentNotification:application UserInfo:userInfo];
-        
+        else
+            [OneSignal remoteSilentNotification:application UserInfo:userInfo];
     }
     
     if ([self respondsToSelector:@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:)]) {
@@ -1221,7 +1220,7 @@ static NSArray* delegateSubclasses = nil;
         return;
     }
     
-    //Make sure not a cold start from tap on notification (OS doesn't call didReceiveRemoteNotification)
+    // Make sure not a cold start from tap on notification (OS doesn't call didReceiveRemoteNotification)
     if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)] && ![[OneSignal valueForKey:@"coldStartFromTapOnNotification"] boolValue])
         [self oneSignalReceivedRemoteNotification:application userInfo:userInfo];
     

--- a/iOS_SDK/OneSignal/OneSignalHelper.m
+++ b/iOS_SDK/OneSignal/OneSignalHelper.m
@@ -144,7 +144,7 @@
 @end
 
 @implementation OSNotification
-@synthesize payload = _payload, shown = _shown, silentNotification = _silentNotification, displayType = _displayType;
+@synthesize payload = _payload, shown = _shown, isAppInFocus = _isAppInFocus, silentNotification = _silentNotification, displayType = _displayType;
 
 #if XC8_AVAILABLE
 @synthesize mutableContent = _mutableContent;
@@ -165,11 +165,12 @@
         
         _shown = true;
         
-        BOOL isActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+        _isAppInFocus = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
         
         //If remote silent -> shown = false
         //If app is active and in-app alerts are not enabled -> shown = false
-        if(_silentNotification || (isActive && [[NSUserDefaults standardUserDefaults] boolForKey:@"ONESIGNAL_ALERT_OPTION"] == OSNotificationDisplayTypeNone))
+        if (_silentNotification ||
+            (_isAppInFocus && [[NSUserDefaults standardUserDefaults] boolForKey:@"ONESIGNAL_ALERT_OPTION"] == OSNotificationDisplayTypeNone))
             _shown = false;
         
     }
@@ -216,10 +217,11 @@
     if(self.displayType)
         [obj setObject:@(self.displayType) forKeyedSubscript: @"displayType"];
     
-    if(self.shown)
-        [obj setObject:@(self.shown) forKeyedSubscript: @"shown"];
     
-    if(self.silentNotification)
+    [obj setObject:@(self.shown) forKeyedSubscript: @"shown"];
+    [obj setObject:@(self.isAppInFocus) forKeyedSubscript: @"isAppInFocus"];
+    
+    if (self.silentNotification)
         [obj setObject:@(self.silentNotification) forKeyedSubscript: @"silentNotification"];
     
     
@@ -494,7 +496,7 @@ static OneSignal* singleInstance = nil;
     if(!NSClassFromString(@"UNNotificationAction") || !NSClassFromString(@"UNNotificationRequest")) return NULL;
     
     NSMutableArray * actionArray = [[NSMutableArray alloc] init];
-    for( NSDictionary* button in data[@"o"]) {
+    for(NSDictionary* button in data[@"o"]) {
         NSString* title = button[@"n"] != NULL ? button[@"n"] : @"";
         NSString* buttonID = button[@"i"] != NULL ? button[@"i"] : title;
         id action = [NSClassFromString(@"UNNotificationAction") actionWithIdentifier:buttonID title:title options:UNNotificationActionOptionForeground];
@@ -667,7 +669,6 @@ static OneSignal* singleInstance = nil;
 }
 
 + (void)enqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
-    
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message: [NSString stringWithFormat:@"request.body: %@", [[NSString alloc]initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]]];
     
     if (isSynchronous) {


### PR DESCRIPTION
* Fix for application:didReceiveRemoteNotification:fetchCompletionHandler: no longer firing on the AppDelegate.
  - Now calls this from UNUserNotificationCenterDelegate's userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler
* Added isAppInFocus property to OSNotification to match Android's properties.
* Fixed crash when opening a notification from a cold start if OneSignal.initWithLaunchOptions was called with a delay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/121)
<!-- Reviewable:end -->
