### PR TITLE
Fixed no-push token + other issues when library is loaded twice

### DIFF
--- a/OneSignalExample/push-notifications/AppDelegate.m
+++ b/OneSignalExample/push-notifications/AppDelegate.m
@@ -60,7 +60,7 @@
                                                   cancelButtonTitle:@"Close"
                                                   otherButtonTitles:nil, nil];
         [alertView show];
-
+        
     } settings:@{kOSSettingsKeyInFocusDisplayOption : @(OSNotificationDisplayTypeNotification), kOSSettingsKeyAutoPrompt : @NO}];
     
     [OneSignal IdsAvailable:^(NSString *userId, NSString *pushToken) {
@@ -71,21 +71,21 @@
     }];
     
     /*
-    // iOS 10 ONLY - Add category for the OSContentExtension
-    // Make sure to add UserNotifications framework in the Linked Frameworks & Libraries.
+     // iOS 10 ONLY - Add category for the OSContentExtension
+     // Make sure to add UserNotifications framework in the Linked Frameworks & Libraries.
      
-    [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> * _Nonnull categories) {
-        
-        UNNotificationAction* myAction = [UNNotificationAction actionWithIdentifier:@"action0" title:@"Hit Me!" options:UNNotificationActionOptionForeground];
-        UNNotificationCategory* myCategory = [UNNotificationCategory categoryWithIdentifier:@"myOSContentCategory" actions:@[myAction] intentIdentifiers:@[] options:UNNotificationCategoryOptionCustomDismissAction];
-        NSSet* mySet = [[NSSet alloc] initWithArray:@[myCategory]];
-        
-        //Add existing cateogories
-        mySet = [mySet setByAddingObjectsFromSet:categories];
-        
-        [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:mySet];
-    }];
-    */
+     [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> * _Nonnull categories) {
+     
+     UNNotificationAction* myAction = [UNNotificationAction actionWithIdentifier:@"action0" title:@"Hit Me!" options:UNNotificationActionOptionForeground];
+     UNNotificationCategory* myCategory = [UNNotificationCategory categoryWithIdentifier:@"myOSContentCategory" actions:@[myAction] intentIdentifiers:@[] options:UNNotificationCategoryOptionCustomDismissAction];
+     NSSet* mySet = [[NSSet alloc] initWithArray:@[myCategory]];
+     
+     //Add existing cateogories
+     mySet = [mySet setByAddingObjectsFromSet:categories];
+     
+     [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:mySet];
+     }];
+     */
     
     return YES;
 }

--- a/iOS_SDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignal.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3EBD83FE1D49364E008F135D /* OneSignalHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EBD83FD1D49364E008F135D /* OneSignalHelper.m */; };
 		3EBD84041D49416A008F135D /* NSString+Hash.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EBD84031D49416A008F135D /* NSString+Hash.m */; };
 		3ECE8FDD1D39829300742055 /* OneSignalAlertViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECE8FDC1D39829300742055 /* OneSignalAlertViewDelegate.m */; };
+		9139AF5B1DDECB6300642ED5 /* UIApplicationDelegate+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9139AF5A1DDECB6300642ED5 /* UIApplicationDelegate+OneSignal.m */; };
 		918416271DC2E32500D458A5 /* OneSignalSelectorHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 918416261DC2E32500D458A5 /* OneSignalSelectorHelpers.m */; };
 		918416281DC2E80A00D458A5 /* OneSignalSelectorHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 918416261DC2E32500D458A5 /* OneSignalSelectorHelpers.m */; };
 		91D684CC1DC2D60E00D09C41 /* UNUserNotificationCenter+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 91D684CB1DC2D60E00D09C41 /* UNUserNotificationCenter+OneSignal.m */; };
@@ -89,6 +90,8 @@
 		3EBD84031D49416A008F135D /* NSString+Hash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+Hash.m"; path = "OneSignal/NSString+Hash.m"; sourceTree = "<group>"; };
 		3ECE8FDB1D39829300742055 /* OneSignalAlertViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OneSignalAlertViewDelegate.h; path = OneSignal/OneSignalAlertViewDelegate.h; sourceTree = "<group>"; };
 		3ECE8FDC1D39829300742055 /* OneSignalAlertViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OneSignalAlertViewDelegate.m; path = OneSignal/OneSignalAlertViewDelegate.m; sourceTree = "<group>"; };
+		9139AF591DDECB4200642ED5 /* UIApplicationDelegate+OneSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "UIApplicationDelegate+OneSignal.h"; path = "OneSignal/UIApplicationDelegate+OneSignal.h"; sourceTree = "<group>"; };
+		9139AF5A1DDECB6300642ED5 /* UIApplicationDelegate+OneSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIApplicationDelegate+OneSignal.m"; path = "OneSignal/UIApplicationDelegate+OneSignal.m"; sourceTree = "<group>"; };
 		918416251DC2E30500D458A5 /* OneSignalSelectorHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OneSignalSelectorHelpers.h; path = OneSignal/OneSignalSelectorHelpers.h; sourceTree = "<group>"; };
 		918416261DC2E32500D458A5 /* OneSignalSelectorHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OneSignalSelectorHelpers.m; path = OneSignal/OneSignalSelectorHelpers.m; sourceTree = "<group>"; };
 		91D684C91DC2D5F200D09C41 /* UNUserNotificationCenter+OneSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UNUserNotificationCenter+OneSignal.h"; path = "OneSignal/UNUserNotificationCenter+OneSignal.h"; sourceTree = "<group>"; };
@@ -259,6 +262,8 @@
 				3EBD84031D49416A008F135D /* NSString+Hash.m */,
 				91D684C91DC2D5F200D09C41 /* UNUserNotificationCenter+OneSignal.h */,
 				91D684CB1DC2D60E00D09C41 /* UNUserNotificationCenter+OneSignal.m */,
+				9139AF591DDECB4200642ED5 /* UIApplicationDelegate+OneSignal.h */,
+				9139AF5A1DDECB6300642ED5 /* UIApplicationDelegate+OneSignal.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -394,6 +399,7 @@
 			files = (
 				3ECE8FDD1D39829300742055 /* OneSignalAlertViewDelegate.m in Sources */,
 				371FDED919F1A486001479B7 /* OneSignalTrackIAP.m in Sources */,
+				9139AF5B1DDECB6300642ED5 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				3EBD83FE1D49364E008F135D /* OneSignalHelper.m in Sources */,
 				3E84C6231D4AE53500ED8557 /* NSObject+Extras.m in Sources */,
 				3724485819F6D1DE00573B5A /* OneSignalJailbreakDetection.m in Sources */,

--- a/iOS_SDK/OneSignal/UIApplicationDelegate+OneSignal.h
+++ b/iOS_SDK/OneSignal/UIApplicationDelegate+OneSignal.h
@@ -25,13 +25,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef OneSignalSelectorHelpers_h
-#define OneSignalSelectorHelpers_h
-
-BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector);
-Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind);
-NSArray* ClassGetSubclasses(Class parentClass);
-void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass);
-BOOL injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);
-
-#endif /* OneSignalSelectorHelpers_h */
+#ifndef UIApplicationDelegate_OneSignal_h
+#define UIApplicationDelegate_OneSignal_h
+@interface OneSignalAppDelegate : NSObject
+@end
+#endif /* UIApplicationDelegate_OneSignal_h */

--- a/iOS_SDK/OneSignal/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignal/UIApplicationDelegate+OneSignal.m
@@ -1,0 +1,252 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2016 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "UIApplicationDelegate+OneSignal.h"
+#import "OneSignal.h"
+#import "OneSignalTracker.h"
+#import "OneSignalLocation.h"
+#import "OneSignalSelectorHelpers.h"
+
+@interface OneSignal (UN_extra)
++ (void) didRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken;
++ (void) handleDidFailRegisterForRemoteNotification:(NSError*)error;
++ (void) updateNotificationTypes:(int)notificationTypes;
++ (NSString*) app_id;
++ (void) notificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive;
++ (void) remoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo;
++ (void) processLocalActionBasedNotification:(UILocalNotification*) notification identifier:(NSString*)identifier;
++ (void) onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString*) message;
+@end
+
+
+
+// This class hooks into the UIApplicationDelegate selectors to receive iOS 9 and older events.
+//   - UNUserNotificationCenter is used for iOS 10
+//   - Orignal implementations are called so other plugins and the developers AppDelegate is still called.
+
+@implementation OneSignalAppDelegate
+
++ (void) oneSignalLoadedTagSelector {}
+
+static Class delegateClass = nil;
+
+// Store an array of all UIAppDelegate subclasses to iterate over in cases where UIAppDelegate swizzled methods are not overriden in main AppDelegate
+// But rather in one of the subclasses
+static NSArray* delegateSubclasses = nil;
+
++(Class)delegateClass {
+    return delegateClass;
+}
+
+
+
+
+- (void) setOneSignalDelegate:(id<UIApplicationDelegate>)delegate {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"ONESIGNAL setOneSignalDelegate CALLED: %@", delegate]];
+    
+    if (delegateClass) {
+        [self setOneSignalDelegate:delegate];
+        return;
+    }
+    
+    Class newClass = [OneSignalAppDelegate class];
+    
+    delegateClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
+    delegateSubclasses = ClassGetSubclasses(delegateClass);
+    
+    injectToProperClass(@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:),
+                        @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:),
+                        @selector(application:handleActionWithIdentifier:forLocalNotification:completionHandler:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalDidFailRegisterForRemoteNotification:error:),
+                        @selector(application:didFailToRegisterForRemoteNotificationsWithError:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalDidRegisterUserNotifications:settings:),
+                        @selector(application:didRegisterUserNotificationSettings:), delegateSubclasses, newClass, delegateClass);
+    
+    if (NSClassFromString(@"CoronaAppDelegate")) {
+        [self setOneSignalDelegate:delegate];
+        return;
+    }
+    
+    injectToProperClass(@selector(oneSignalReceivedRemoteNotification:userInfo:), @selector(application:didReceiveRemoteNotification:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalDidRegisterForRemoteNotifications:deviceToken:), @selector(application:didRegisterForRemoteNotificationsWithDeviceToken:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalLocalNotificationOpened:notification:), @selector(application:didReceiveLocalNotification:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalApplicationWillResignActive:), @selector(applicationWillResignActive:), delegateSubclasses, newClass, delegateClass);
+    
+    //Required for background location
+    injectToProperClass(@selector(oneSignalApplicationDidEnterBackground:), @selector(applicationDidEnterBackground:), delegateSubclasses, newClass, delegateClass);
+    
+    injectToProperClass(@selector(oneSignalApplicationDidBecomeActive:), @selector(applicationDidBecomeActive:), delegateSubclasses, newClass, delegateClass);
+    
+    //Used to track how long the app has been closed
+    injectToProperClass(@selector(oneSignalApplicationWillTerminate:), @selector(applicationWillTerminate:), delegateSubclasses, newClass, delegateClass);
+    
+    [self setOneSignalDelegate:delegate];
+}
+
+
+
+
+
+- (void)oneSignalDidRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalDidRegisterForRemoteNotifications:deviceToken:"];
+    
+    if ([OneSignal app_id])
+        [OneSignal didRegisterForRemoteNotifications:app deviceToken:inDeviceToken];
+    
+    if ([self respondsToSelector:@selector(oneSignalDidRegisterForRemoteNotifications:deviceToken:)])
+        [self oneSignalDidRegisterForRemoteNotifications:app deviceToken:inDeviceToken];
+}
+
+- (void)oneSignalDidFailRegisterForRemoteNotification:(UIApplication*)app error:(NSError*)err {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalDidFailRegisterForRemoteNotification:error:"];
+    
+    [OneSignal handleDidFailRegisterForRemoteNotification:err];
+    
+    if ([self respondsToSelector:@selector(oneSignalDidFailRegisterForRemoteNotification:error:)])
+        [self oneSignalDidFailRegisterForRemoteNotification:app error:err];
+}
+
+- (void)oneSignalDidRegisterUserNotifications:(UIApplication*)application settings:(UIUserNotificationSettings*)notificationSettings {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalDidRegisterUserNotifications:settings:"];
+    
+    if ([OneSignal app_id])
+        [OneSignal updateNotificationTypes:notificationSettings.types];
+    
+    if ([self respondsToSelector:@selector(oneSignalDidRegisterUserNotifications:settings:)])
+        [self oneSignalDidRegisterUserNotifications:application settings:notificationSettings];
+}
+
+
+// Notification opened! iOS 6 ONLY!
+- (void)oneSignalReceivedRemoteNotification:(UIApplication*)application userInfo:(NSDictionary*)userInfo {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalReceivedRemoteNotification:userInfo:"];
+    
+    if ([OneSignal app_id])
+        [OneSignal notificationOpened:userInfo isActive:[application applicationState] == UIApplicationStateActive];
+    
+    if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)])
+        [self oneSignalReceivedRemoteNotification:application userInfo:userInfo];
+}
+
+// User Tap on Notification while app was in background - OR - Notification received (silent or not, foreground or background) on iOS 7+
+- (void) oneSignalRemoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:"];
+    
+    if ([OneSignal app_id]) {
+        // Call notificationAction if app is active -> not a silent notification but rather user tap on notification
+        // Unless iOS 10+ then call remoteSilentNotification instead.
+        if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
+            [OneSignal notificationOpened:userInfo isActive:YES];
+        else
+            [OneSignal remoteSilentNotification:application UserInfo:userInfo];
+    }
+    
+    if ([self respondsToSelector:@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:)]) {
+        [self oneSignalRemoteSilentNotification:application UserInfo:userInfo fetchCompletionHandler:completionHandler];
+        return;
+    }
+    
+    // Make sure not a cold start from tap on notification (OS doesn't call didReceiveRemoteNotification)
+    if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)] && ![[OneSignal valueForKey:@"coldStartFromTapOnNotification"] boolValue])
+        [self oneSignalReceivedRemoteNotification:application userInfo:userInfo];
+    
+    completionHandler(UIBackgroundFetchResultNewData);
+}
+
+- (void) oneSignalLocalNotificationOpened:(UIApplication*)application handleActionWithIdentifier:(NSString*)identifier forLocalNotification:(UILocalNotification*)notification completionHandler:(void(^)()) completionHandler {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:"];
+    
+    if ([OneSignal app_id])
+        [OneSignal processLocalActionBasedNotification:notification identifier:identifier];
+    
+    if ([self respondsToSelector:@selector(oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:)])
+        [self oneSignalLocalNotificationOpened:application handleActionWithIdentifier:identifier forLocalNotification:notification completionHandler:completionHandler];
+    
+    completionHandler();
+}
+
+- (void)oneSignalLocalNotificationOpened:(UIApplication*)application notification:(UILocalNotification*)notification {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalLocalNotificationOpened:notification:"];
+    
+    if ([OneSignal app_id])
+        [OneSignal processLocalActionBasedNotification:notification identifier:@"__DEFAULT__"];
+    
+    if([self respondsToSelector:@selector(oneSignalLocalNotificationOpened:notification:)])
+        [self oneSignalLocalNotificationOpened:application notification:notification];
+}
+
+- (void)oneSignalApplicationWillResignActive:(UIApplication*)application {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalApplicationWillResignActive"];
+    
+    if ([OneSignal app_id])
+        [OneSignalTracker onFocus:YES];
+    
+    if ([self respondsToSelector:@selector(oneSignalApplicationWillResignActive:)])
+        [self oneSignalApplicationWillResignActive:application];
+}
+
+- (void) oneSignalApplicationDidEnterBackground:(UIApplication*)application {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalApplicationDidEnterBackground"];
+    
+    if ([OneSignal app_id])
+        [OneSignalLocation onfocus:NO];
+    
+    if ([self respondsToSelector:@selector(oneSignalApplicationDidEnterBackground:)])
+        [self oneSignalApplicationDidEnterBackground:application];
+}
+
+- (void)oneSignalApplicationDidBecomeActive:(UIApplication*)application {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalApplicationDidBecomeActive"];
+    
+    if ([OneSignal app_id]) {
+        [OneSignalTracker onFocus:NO];
+        [OneSignalLocation onfocus:YES];
+    }
+    
+    if ([self respondsToSelector:@selector(oneSignalApplicationDidBecomeActive:)])
+        [self oneSignalApplicationDidBecomeActive:application];
+}
+
+-(void)oneSignalApplicationWillTerminate:(UIApplication *)application {
+    
+    if ([OneSignal app_id])
+        [OneSignalTracker onFocus:YES];
+    
+    if ([self respondsToSelector:@selector(oneSignalApplicationWillTerminate:)])
+        [self oneSignalApplicationWillTerminate:application];
+}
+
+@end


### PR DESCRIPTION
* Moved implementations of selectors outside of the UIApplication category.
* Issues can happen if both a static and dynamic copy of OneSignal is loaded.
   - iOS seems to create a 2nd "static instance" of all classes.
   - Runtime reference to the classes seems to use which ever one was loaded
      first. However with a category this instead seems to then override all
      implements with an independent static instance.
* Fixed re-displaying notification when buttons or attachments or used on iOS 10
   - Dismiss event was triggering SDK to re-display the last notification.
* Finished moving most swizzling logic into its own classes. 
   - OneSignal.m - UIApplication - This swizzled class must stay in OneSignal.m
   - UIApplicationDelegate+OneSignal.m - new this commit
   - UNUserNotificationCenter+OneSignal.m - was in last SDK version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/138)
<!-- Reviewable:end -->
