### PR TITLE
Fixes for local notification AppDelegate selectors not firing

### DIFF
--- a/iOS_SDK/OneSignal/OneSignal.h
+++ b/iOS_SDK/OneSignal/OneSignal.h
@@ -52,12 +52,6 @@
 #define XC8_AVAILABLE 1
 #import <UserNotifications/UserNotifications.h>
 
-@protocol OSUserNotificationCenterDelegate <NSObject>
-@optional
-- (void)userNotificationCenter:(id)center willPresentNotification:(id)notification withCompletionHandler:(void (^)(NSUInteger options))completionHandler __deprecated_msg("Can use your own delegate as normal.");
-- (void)userNotificationCenter:(id)center didReceiveNotificationResponse:(id)response withCompletionHandler:(void (^)())completionHandler __deprecated_msg("Can use your own delegate as normal.");
-@end
-
 #endif
 
 /* The action type associated to an OSNotificationAction object */
@@ -80,9 +74,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 
 
-/* iOS 10+
+/*
  Used as value type for `kOSSettingsKeyInFocusDisplayOption`
- for setting the display option of a notification received while the app was in focus
+   for setting the display option of a notification received while the app was in focus.
  */
 typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
@@ -239,7 +233,7 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationReceived:(OSHandleNotificationReceivedBlock)erceivedCallback handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
 
 + (NSString*)app_id;
-    
+
 // Only use if you passed FALSE to autoRegister
 + (void)registerForPushNotifications;
 
@@ -279,11 +273,5 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 // - Sends the MD5 and SHA1 of the provided email
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
 + (void)syncHashedEmail:(NSString*)email;
-
-// - iOS 10 features currently only available on XCode 8 & iOS 10.0+
-#if XC8_AVAILABLE
-+ (void)setNotificationCenterDelegate:(id<OSUserNotificationCenterDelegate>)delegate __deprecated_msg("Can use your own delegate as normal.");
-+ (id<OSUserNotificationCenterDelegate>)notificationCenterDelegate __deprecated_msg("Can use your own delegate as normal.");
-#endif
 
 @end

--- a/iOS_SDK/OneSignal/OneSignal.m
+++ b/iOS_SDK/OneSignal/OneSignal.m
@@ -860,7 +860,7 @@ static BOOL waitingForOneSReg = false;
         
         // App is active and a notification was received without inApp display. Display type is none or notification
         // Call Received Block
-        [OneSignalHelper handleNotificationReceived:[[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_ALERT_OPTION"] intValue]];
+        [OneSignalHelper handleNotificationReceived:iaaoption];
         
         // Notify backend that user opened the notifiation
         NSString* messageId = [customDict objectForKey:@"i"];
@@ -1091,23 +1091,6 @@ static BOOL waitingForOneSReg = false;
     }
     
 }
-
-#if XC8_AVAILABLE
-static id<OSUserNotificationCenterDelegate> notificationCenterDelegate;
-
-+ (void) setNotificationCenterDelegate:(id<OSUserNotificationCenterDelegate>)delegate {
-    if (!NSClassFromString(@"UNNotification")) {
-        onesignal_Log(ONE_S_LL_ERROR, @"Cannot assign delegate. Please make sure you are running on iOS 10+.");
-        return;
-    }
-    notificationCenterDelegate = delegate;
-}
-
-+ (id<OSUserNotificationCenterDelegate>)notificationCenterDelegate {
-    return notificationCenterDelegate;
-}
-
-#endif
 
 + (void)syncHashedEmail:(NSString *)email {
     


### PR DESCRIPTION
* Fixed local notification selectors not firing when app is in focus
   - userNotificationCenter:willPresentNotification:withCompletionHandler was not calling legacy selectors as it should.
* Fixed issue where local notifications created with presentLocalNotificationNow would not fire their AppDelegate selector.
* Removed deprecated OSUserNotificationCenterDelegate class
   - Due to very low usage and complexly to maintain, it’s being removed before a major release version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/145)
<!-- Reviewable:end -->
