### PR TITLE
Fixed issue where both received and open events would fire

### DIFF
--- a/iOS_SDK/OneSignal/OneSignalHelper.h
+++ b/iOS_SDK/OneSignal/OneSignalHelper.h
@@ -57,10 +57,10 @@
 #endif
 
 // - Notifications
-+ (BOOL) isCapableOfGettingNotificationTypes;
++ (BOOL)isCapableOfGettingNotificationTypes;
 + (UILocalNotification*)prepareUILocalNotification:(NSDictionary*)data :(NSDictionary*)userInfo;
 + (BOOL)verifyURL:(NSString *)urlString;
-+ (BOOL) isRemoteSilentNotification:(NSDictionary*)msg;
++ (BOOL)isRemoteSilentNotification:(NSDictionary*)msg;
 
 // - Networking
 + (NSNumber*)getNetType;

--- a/iOS_SDK/OneSignal/OneSignalHelper.m
+++ b/iOS_SDK/OneSignal/OneSignalHelper.m
@@ -456,7 +456,7 @@ OSHandleNotificationActionBlock handleNotificationAction;
     OSNotificationPayload *payload = [[OSNotificationPayload alloc] initWithRawMessage:lastMessageReceived];
     OSNotification *notification = [[OSNotification alloc] initWithPayload:payload displayType:displayType];
     
-    //Prevent duplicate calls to same action
+    // Prevent duplicate calls to same receive event
     static NSString* lastMessageID = @"";
     if ([payload.notificationID isEqualToString:lastMessageID])
         return;
@@ -474,7 +474,7 @@ OSHandleNotificationActionBlock handleNotificationAction;
     OSNotification *notification = [[OSNotification alloc] initWithPayload:payload displayType:displayType];
     OSNotificationOpenedResult * result = [[OSNotificationOpenedResult alloc] initWithNotification:notification action:action];
     
-    //Prevent duplicate calls to same action
+    // Prevent duplicate calls to same action
     static NSString* lastMessageID = @"";
     if ([payload.notificationID isEqualToString:lastMessageID])
         return;


### PR DESCRIPTION
* Fixed issue where received event would fire when an action button or attachment notification was received in the background.
   - The received in the foreground unless the developer specifically sets cogent-available.
* Fixed case where application:didReceiveRemoteNotification:fetchCompletionHandler could double fire when content-available was set.
* Added addtional duplicate checks to prevent any possible double firing of events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/146)
<!-- Reviewable:end -->
