### PR TITLE
Added more error notification_type statuses

### DIFF
--- a/iOS_SDK/OneSignal/OneSignalHelper.h
+++ b/iOS_SDK/OneSignal/OneSignalHelper.h
@@ -50,7 +50,6 @@
 + (BOOL)isiOS10Plus;
 #if XC8_AVAILABLE
 + (void)registerAsUNNotificationCenterDelegate;
-+ (void) requestAuthorization;
 + (void)clearCachedMedia;
 + (id)prepareUNNotificationRequest:(NSDictionary *)data :(NSDictionary *)userInfo;
 + (void)addnotificationRequest:(NSDictionary *)data userInfo:(NSDictionary *)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;

--- a/iOS_SDK/OneSignal/OneSignalHelper.m
+++ b/iOS_SDK/OneSignal/OneSignalHelper.m
@@ -586,10 +586,6 @@ static OneSignal* singleInstance = nil;
 
 #if XC8_AVAILABLE
 
-+ (void)requestAuthorization {
-    [[NSClassFromString(@"UNUserNotificationCenter") currentNotificationCenter] requestAuthorizationWithOptions:7 completionHandler:^(BOOL granted, NSError * _Nullable error) {}];
-}
-
 + (void)registerAsUNNotificationCenterDelegate {
     Class UNNofiCenterClass = NSClassFromString(@"UNUserNotificationCenter");
     UNUserNotificationCenter *curNotifCenter = [UNNofiCenterClass currentNotificationCenter];
@@ -767,7 +763,8 @@ static OneSignal* singleInstance = nil;
 }
 
 + (void)enqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message: [NSString stringWithFormat:@"request.body: %@", [[NSString alloc]initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]]];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"network request to: %@", request.URL]];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"request.body: %@", [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]]];
     
     if (isSynchronous) {
         NSURLResponse* response = nil;
@@ -800,6 +797,7 @@ static OneSignal* singleInstance = nil;
     
     if (data != nil && [data length] > 0) {
         innerJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&jsonError];
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"network response: %@", innerJson]];
         if (jsonError) {
             if (failureBlock != nil)
                 failureBlock([NSError errorWithDomain:@"OneSignal Error" code:statusCode userInfo:@{@"returned" : jsonError}]);

--- a/iOS_SDK/OneSignal/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignal/UIApplicationDelegate+OneSignal.m
@@ -85,8 +85,8 @@ static NSArray* delegateSubclasses = nil;
     delegateClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
     delegateSubclasses = ClassGetSubclasses(delegateClass);
     
-    // Need to keep this one for iOS 10 for content-available notifiations.
-    //   iOS 10 doesn't fire a selector on UNUserNotificationCenter as
+    // Need to keep this one for iOS 10 for content-available notifiations when the app is not in focus
+    //   iOS 10 doesn't fire a selector on UNUserNotificationCenter in this cases most likely becuase
     //   UNNotificationServiceExtension (mutable-content) and UNNotificationContentExtension (with category) replaced it.
     injectToProperClass(@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:),
                         @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:), delegateSubclasses, newClass, delegateClass);

--- a/iOS_SDK/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalTracker.m
@@ -35,7 +35,7 @@
 @interface OneSignal ()
 
 + (void)registerUser;
-+ (void) sendNotificationTypesUpdate:(BOOL)isNewType;
++ (void) sendNotificationTypesUpdate;
 + (BOOL) clearBadgeCount:(BOOL)fromNotifOpened;
 + (NSString*)mUserId;
 
@@ -73,7 +73,7 @@ BOOL lastOnFocusWasToBackground = YES;
     
     if (!toBackground) {
         lastOpenedTime = now;
-        [OneSignal sendNotificationTypesUpdate:false];
+        [OneSignal sendNotificationTypesUpdate];
         wasBadgeSet = [OneSignal clearBadgeCount:false];
         
         //Make sure webview dismissed if came back from deep link


### PR DESCRIPTION
* This will provide more error status other than just “No Push Token” on the OneSignal Dashboard.
* Rework some internal logic for notification_type handling.
* Added additional logging to network calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/150)
<!-- Reviewable:end -->
