### PR TITLE
Add support for notification actions with text input [Status: Needs Rebase]

### DIFF
--- a/iOS_SDK/OneSignal/OneSignal.h
+++ b/iOS_SDK/OneSignal/OneSignal.h
@@ -169,6 +169,8 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 @property(readonly)OSNotificationAction *action;
 
+@property(readonly)NSString* userText;
+
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
 - (NSString*)stringify;
 

--- a/iOS_SDK/OneSignal/OneSignal.m
+++ b/iOS_SDK/OneSignal/OneSignal.m
@@ -945,18 +945,21 @@ static BOOL waitingForOneSReg = false;
         
         //app was in background / not running and opened due to a tap on a notification or an action check what type
         NSString* actionSelected = NULL;
+		NSString* userText = NULL;
         OSNotificationActionType type = OSNotificationActionTypeOpened;
         if (messageDict[@"custom"][@"a"][@"actionSelected"]) {
             actionSelected = messageDict[@"custom"][@"a"][@"actionSelected"];
+			userText = messageDict[@"custom"][@"a"][@"actionUserText"];
             type = OSNotificationActionTypeActionTaken;
         }
         if (messageDict[@"actionSelected"]) {
             actionSelected = messageDict[@"actionSelected"];
+			userText = messageDict[@"actionUserText"];
             type = OSNotificationActionTypeActionTaken;
         }
         
         // Call Action Block
-        [OneSignalHelper handleNotificationAction:type actionID:actionSelected displayType:OSNotificationDisplayTypeNotification];
+		[OneSignalHelper handleNotificationAction:type actionID:actionSelected userText:userText displayType:OSNotificationDisplayTypeNotification];
         [OneSignal handleNotificationOpened:messageDict isActive:isActive actionType:type displayType:OSNotificationDisplayTypeNotification];
     }
 }
@@ -989,15 +992,21 @@ static BOOL waitingForOneSReg = false;
     [self clearBadgeCount:true];
     
     NSString* actionID = NULL;
+	NSString* userText = NULL;
     if (actionType == OSNotificationActionTypeActionTaken) {
         actionID = messageDict[@"custom"][@"a"][@"actionSelected"];
-        if(!actionID)
+		if(!actionID) {
             actionID = messageDict[@"actionSelected"];
+			userText = messageDict[@"actionUserText"];
+		}
+		else {
+			userText = messageDict[@"custom"][@"a"][@"actionUserText"];
+		}
     }
     
     //Call Action Block
     [OneSignalHelper lastMessageReceived:messageDict];
-    [OneSignalHelper handleNotificationAction:actionType actionID:actionID displayType:displayType];
+	[OneSignalHelper handleNotificationAction:actionType actionID:actionID userText:userText displayType:displayType];
 }
 
 + (void)launchWebURL:(NSString*)openUrl {
@@ -1152,11 +1161,11 @@ static BOOL waitingForOneSReg = false;
 }
 
 // iOS 8-9 - Entry point when OneSignal action button notifiation is displayed or opened.
-+ (void)processLocalActionBasedNotification:(UILocalNotification*) notification identifier:(NSString*)identifier {
++ (void)processLocalActionBasedNotification:(UILocalNotification*) notification identifier:(NSString*)identifier userText:(NSString *)userText {
     if (notification.userInfo) {
         
-        NSMutableDictionary* userInfo = [OneSignalHelper formatApsPayloadIntoStandard:notification.userInfo identifier:identifier];
-        
+		NSMutableDictionary* userInfo = [OneSignalHelper formatApsPayloadIntoStandard:notification.userInfo identifier:identifier userText:userText];
+		
         if (!userInfo)
             return;
         

--- a/iOS_SDK/OneSignal/OneSignalHelper.h
+++ b/iOS_SDK/OneSignal/OneSignalHelper.h
@@ -40,11 +40,11 @@
 // - Notification Opened
 + (NSDictionary*)getPushTitleBody:(NSDictionary*)messageDict;
 + (NSArray*)getActionButtons:(NSDictionary*)messageDict;
-+ (NSMutableDictionary*) formatApsPayloadIntoStandard:(NSDictionary*)remoteUserInfo identifier:(NSString*)identifier;
++ (NSMutableDictionary*) formatApsPayloadIntoStandard:(NSDictionary*)remoteUserInfo identifier:(NSString*)identifier userText:(NSString *)userText;
 + (void)lastMessageReceived:(NSDictionary*)message;
 + (void)notificationBlocks:(OSHandleNotificationReceivedBlock)receivedBlock :(OSHandleNotificationActionBlock)actionBlock;
 + (void)handleNotificationReceived:(OSNotificationDisplayType)displayType;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType;
++ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID userText:(NSString*)userText displayType:(OSNotificationDisplayType)displayType;
 
 // - iOS 10
 + (BOOL)isiOS10Plus;

--- a/iOS_SDK/OneSignal/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignal/UNUserNotificationCenter+OneSignal.m
@@ -172,8 +172,12 @@ static NSArray* delegateUNSubclasses = nil;
     
     
     NSMutableDictionary *userInfo;
-    userInfo = [OneSignalHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo identifier:[response valueForKey:@"actionIdentifier"]];
-    
+	BOOL isTextReply = [response isKindOfClass:NSClassFromString(@"UNTextInputNotificationResponse")];
+	NSString* userText = isTextReply ? [response valueForKey:@"userText"] : nil;
+	userInfo = [OneSignalHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo
+												  identifier:[response valueForKey:@"actionIdentifier"]
+													userText:userText];
+	
     [OneSignal notificationOpened:userInfo isActive:isActive];
 }
 


### PR DESCRIPTION
Adds support for notification actions with text input
(UNTextInputNotificationAction).
Also fixes notifications actions handling on iOS 9.x if application
delegate class has implementation for
application:handleActionWithIdentifier:forLocalNotification:withResponse
Info:completionHandler:

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/154)
<!-- Reviewable:end -->

