### PR TITLE
Prevent OneSignal specific logic if SDK is not initialized

### DIFF
--- a/iOS_SDK/OneSignal/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignal/UNUserNotificationCenter+OneSignal.m
@@ -92,7 +92,7 @@ static NSArray* delegateUNSubclasses = nil;
                   withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
     // If OneSignal has not been initialized there is no reason to proceed with all the code below this if statement
     // since delaying method swizzling past + [UIApplication load] is dangerous this check is in place.
-    // For more details see: https://github.com/OneSignal/OneSignal-iOS-SDK/pull/155
+    // For more details see: https://github.com/OneSignal/OneSignal-iOS-SDK/pull/156
     if (![OneSignal app_id]) {
         [swizzleUNUserNotif callLegacyAppDeletegateSelector:notification
                                                 isTextReply:false

--- a/iOS_SDK/OneSignal/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignal/UNUserNotificationCenter+OneSignal.m
@@ -90,6 +90,19 @@ static NSArray* delegateUNSubclasses = nil;
 - (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
                 willPresentNotification:(UNNotification *)notification
                   withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
+    // If OneSignal has not been initialized there is no reason to proceed with all the code below this if statement
+    // since delaying method swizzling past + [UIApplication load] is dangerous this check is in place.
+    // For more details see: https://github.com/OneSignal/OneSignal-iOS-SDK/pull/155
+    if (![OneSignal app_id]) {
+        [swizzleUNUserNotif callLegacyAppDeletegateSelector:notification
+                                                isTextReply:false
+                                           actionIdentifier:nil
+                                                   userText:nil
+                                    fromPresentNotification:true
+                                      withCompletionHandler:^() {}];
+        completionHandler(0);
+        return;
+    }
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler: Fired!"];
     
     // Set the completionHandler options based on the ONESIGNAL_ALERT_OPTION value.


### PR DESCRIPTION
* Related issue: https://github.com/OneSignal/OneSignal-iOS-SDK/issues/144
* Num of :+1: needed: 1
* Code Reviewers: @jkasten2, @JKalash 
* Copy: @500px/ios

### Summary

We're in the process of moving away from Parse to OneSignal. However, as we started deploying push notifications with OneSignal SDK we've started seeing crashes which are described in https://github.com/OneSignal/OneSignal-iOS-SDK/issues/144.

The way our app behaves is as follows:
We have a rollout flag `one_signal`, if on app start it is set to true then we call OneSignal SDK's
```Obj-C
+ (id)initWithLaunchOptions:(NSDictionary*)launchOptions
                      appId:(NSString*)appId
 handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback
   handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback
                   settings:(NSDictionary*)settings
```
if the flag value is false, we fallback to registering with Parse. However, because 
```Obj-C
+ [UIApplication (OneSignal) load]
```
does method swizzling on `UIApplication` load all of the app delegate messages are handled by OneSignal SDK and some of them call system delegate methods that we implement as they being called by the OS.

So if we enable `one_signal` flag and then disable it, the device is registered with two systems. The way our backend is written it will send push request to both Parse and OneSignal which in practice will generate duplicate notifications. The crash happens, when we try to handle OneSignal notification while not registered with OneSignal, meaning without ever calling
```Obj-C
+ (id)initWithLaunchOptions:(NSDictionary*)launchOptions
                      appId:(NSString*)appId
 handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback
   handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback
                   settings:(NSDictionary*)settings
```
thus `httpClient` is `nil` which doesn't create the `NSURLRequest` and we pass `nil` to `NSURLConnection`.

The temporary patch not to do OneSignal fancy stuff, unless SDK has been properly initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/156)
<!-- Reviewable:end -->
