### PR TITLE
Added public permission and subscripiton statuses

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				CODE_SIGN_ENTITLEMENTS = OneSignalDevApp/OneSignalDevApp.entitlements;
 				DEVELOPMENT_TEAM = 99SW8E36CT;
 				INFOPLIST_FILE = OneSignalDevApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -433,7 +433,7 @@
 				CODE_SIGN_ENTITLEMENTS = OneSignalDevApp/OneSignalDevApp.entitlements;
 				DEVELOPMENT_TEAM = 99SW8E36CT;
 				INFOPLIST_FILE = OneSignalDevApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -29,8 +29,9 @@
 // This project exisits to make testing OneSignal SDK changes.
 
 #import <UIKit/UIKit.h>
+#import <OneSignal/OneSignal.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -30,12 +30,6 @@
 
 #import "AppDelegate.h"
 
-#import <OneSignal/OneSignal.h>
-
-@interface AppDelegate ()
-
-@end
-
 @implementation AppDelegate
 
 
@@ -50,7 +44,20 @@
     
     [OneSignal sendTag:@"someKey1122" value:@"03222017"];
     
+    [OneSignal addPermissionObserver:self];
+    [OneSignal addSubscriptionObserver:self];
+    
     return YES;
+}
+
+- (void) onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
+    NSLog(@"onOSSubscriptionChanged.to.subscribed: %d", stateChanges.to.subscribed);
+    NSLog(@"onOSSubscriptionChanged.to.userId: %@", stateChanges.to.userId);
+    NSLog(@"onOSSubscriptionChanged.to.pushToken: %@", stateChanges.to.pushToken);
+}
+
+- (void) onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
+    NSLog(@"onOSPermissionChanged: %@", stateChanges);
 }
 
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -51,13 +51,12 @@
 }
 
 - (void) onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
-    NSLog(@"onOSSubscriptionChanged.to.subscribed: %d", stateChanges.to.subscribed);
-    NSLog(@"onOSSubscriptionChanged.to.userId: %@", stateChanges.to.userId);
-    NSLog(@"onOSSubscriptionChanged.to.pushToken: %@", stateChanges.to.pushToken);
+    NSLog(@"onOSSubscriptionChanged: %@", stateChanges);
 }
 
 - (void) onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
     NSLog(@"onOSPermissionChanged: %@", stateChanges);
+    NSLog(@"HERE");
 }
 
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -48,6 +48,8 @@
             handleNotificationAction:^(OSNotificationOpenedResult *result) {}
                             settings:@{kOSSettingsKeyAutoPrompt: @false}];
     
+    [OneSignal sendTag:@"someKey1122" value:@"03222017"];
+    
     return YES;
 }
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -44,11 +44,15 @@
 }
 
 - (IBAction)sendTagButton:(id)sender {
+    [self promptForNotificationsWithNativeiOS10Code];
+    
     //[OneSignal registerForPushNotifications];
     
-    [OneSignal promptForPushNotificationWithUserResponse:^(BOOL accepted) {
+    /*[OneSignal promptForPushNotificationWithUserResponse:^(BOOL accepted) {
         NSLog(@"NEW SDK 2.5.0 METHDO: promptForPushNotificationWithUserResponse: %d", accepted);
-    }];
+    }];*/
+    
+    
     
     [OneSignal sendTag:@"key1"
                  value:@"value1"
@@ -65,6 +69,16 @@
         NSLog(@"IdsAvailable Fired");
     }];
     
+}
+
+- (void)promptForNotificationsWithNativeiOS10Code {
+    id responseBlock = ^(BOOL granted, NSError* error) {
+        NSLog(@"promptForNotificationsWithNativeiOS10Code: %d", granted);
+    };
+    
+    UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert + UNAuthorizationOptionSound + UNAuthorizationOptionBadge)
+                          completionHandler:responseBlock];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -44,7 +44,11 @@
 }
 
 - (IBAction)sendTagButton:(id)sender {
-    [OneSignal registerForPushNotifications];
+    //[OneSignal registerForPushNotifications];
+    
+    [OneSignal promptForPushNotificationWithUserResponse:^(BOOL accepted) {
+        NSLog(@"NEW SDK 2.5.0 METHDO: promptForPushNotificationWithUserResponse: %d", accepted);
+    }];
     
     [OneSignal sendTag:@"key1"
                  value:@"value1"

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -206,7 +206,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 // TODO: Change public interface from to onOSPermissionChanged:
 @protocol OSPermissionObserver <NSObject>
-- (void)onChanged:(OSPermissionStateChanges*)stateChanges;
+- (void)onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges;
 @end
 
 
@@ -231,7 +231,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 // TODO: Change public interface from to onOSSubscriptionChanged:
 @protocol OSSubscriptionObserver <NSObject>
-- (void)onChanged:(OSSubscriptionStateChanges*)stateChanges;
+- (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges;
 @end
 
 

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -55,7 +55,7 @@
 typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeOpened,
     OSNotificationActionTypeActionTaken
-} ;
+};
 
 /* The way a notification was displayed to the user */
 typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
@@ -67,7 +67,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
     
     /*iOS native notification display*/
     OSNotificationDisplayTypeNotification
-} ;
+};
 
 
 
@@ -181,11 +181,6 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @interface OSPermissionState : NSObject
 
 @property (readonly, nonatomic) BOOL hasPrompted;
-
-// TODO: Combine has anwseredPrompt and accepted into enum
-//    Need to keep internal bools for backing however.
-//    Check with Swift. See what can be done without needing rawValue. Considering this to be a deal breaker due to crashings without it.
-//       This might be ok with a non-Int type Enum?
 @property (readonly, nonatomic) BOOL anwseredPrompt;
 @property (readonly, nonatomic) BOOL accepted;
 

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -211,7 +211,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 
 // Subscription Classes
-@interface OSSubscriptionState : NSObject
+@protocol OSSubscriptionState<NSObject>
 
 @property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
 @property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
@@ -222,8 +222,8 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 @interface OSSubscriptionStateChanges : NSObject
 
-@property OSSubscriptionState* to;
-@property OSSubscriptionState* from;
+@property NSObject<OSSubscriptionState>* to;
+@property NSObject<OSSubscriptionState>* from;
 @property BOOL becameSubscribed;
 @property BOOL becameUnsubscribed;
 
@@ -241,7 +241,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @interface OSPermissionSubscriptionState : NSObject
 
 @property OSPermissionState* permissionStatus;
-@property OSSubscriptionState* subscriptionStatus;
+@property NSObject<OSSubscriptionState>* subscriptionStatus;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -180,14 +180,14 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 // Permission Classes
 @interface OSPermissionState : NSObject
 
-@property (nonatomic, readonly) BOOL hasPrompted;
+@property (readonly, nonatomic) BOOL hasPrompted;
 
 // TODO: Combine has anwseredPrompt and accepted into enum
 //    Need to keep internal bools for backing however.
 //    Check with Swift. See what can be done without needing rawValue. Considering this to be a deal breaker due to crashings without it.
 //       This might be ok with a non-Int type Enum?
-@property (nonatomic, readonly) BOOL anwseredPrompt;
-@property (nonatomic, readonly) BOOL accepted;
+@property (readonly, nonatomic) BOOL anwseredPrompt;
+@property (readonly, nonatomic) BOOL accepted;
 
 @end
 
@@ -208,10 +208,10 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 // Subscription Classes
 @interface OSSubscriptionState : NSObject
 
-@property (nonatomic, readonly) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (nonatomic, readonly) BOOL userSubscriptionSetting; // returns setSubscription state.
-@property (nonatomic, readonly) NSString* userId;    // AKA OneSignal PlayerId
-@property (nonatomic, readonly) NSString* pushToken; // AKA Apple Device Token
+@property (readonly, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (readonly, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (readonly, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
+@property (readonly, nonatomic) NSString* pushToken; // AKA Apple Device Token
 
 @end
 
@@ -227,7 +227,6 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @protocol OSSubscriptionObserver <NSObject>
 - (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges;
 @end
-
 
 
 
@@ -318,8 +317,8 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)deleteTags:(NSArray*)keys;
 + (void)deleteTagsWithJsonString:(NSString*)jsonString;
 
-// - Sends the MD5 and SHA1 of the provided email
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
+// Sends as MD5 and SHA1 of the provided email
 + (void)syncHashedEmail:(NSString*)email;
 
 // - Subscription and Permissions

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -166,7 +166,6 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @interface OSNotificationOpenedResult : NSObject
 
 @property(readonly)OSNotification* notification;
-
 @property(readonly)OSNotificationAction *action;
 
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
@@ -175,32 +174,77 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @end;
 
 
-@interface OSSubscriptionState : NSObject
 
-@property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
-@property NSString* userId;    // AKA OneSignal PlayerId
-@property NSString* pushToken; // AKA Apple Device Token
 
-@end
+// TODO: Test that state proprites are read-only at the app level.
+// TODO: Check tenses (past vs present)
 
-@interface OSPermissionStatus : NSObject
+
+// Permission Classes
+@interface OSPermissionState : NSObject
 
 @property (nonatomic) BOOL hasPrompted;
+
+// TODO: Combine has anwseredPrompt and accepted into enum
+//    Need to keep internal bools for backing however.
 @property (nonatomic) BOOL anwseredPrompt;
-@property BOOL accepted;
+@property (nonatomic) BOOL accepted;
+
+// TDOO: Make this internal only
 @property int notificationTypes;
 
 @end
 
-@interface OSPermisionSubscriptionState : NSObject
+@interface OSPermissionStateChanges : NSObject
 
-@property OSPermissionStatus* permissionStatus;
+@property OSPermissionState* to;
+@property OSPermissionState* from;
+@property (nonatomic) BOOL justEnabled;
+@property (nonatomic) BOOL justDisabled;
+
+@end
+
+// TODO: Change public interface from to onOSPermissionChanged:
+@protocol OSPermissionObserver <NSObject>
+- (void)onChanged:(OSPermissionStateChanges*)stateChanges;
+@end
+
+
+// Subscription Classes
+@interface OSSubscriptionState : NSObject
+
+@property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (nonatomic) NSString* userId;    // AKA OneSignal PlayerId
+@property (nonatomic) NSString* pushToken; // AKA Apple Device Token
+
+@end
+
+@interface OSSubscriptionStateChanges : NSObject
+
+@property OSSubscriptionState* to;
+@property OSSubscriptionState* from;
+@property BOOL becameSubscribed;
+@property BOOL becameUnsubscribed;
+
+@end
+
+// TODO: Change public interface from to onOSSubscriptionChanged:
+@protocol OSSubscriptionObserver <NSObject>
+- (void)onChanged:(OSSubscriptionStateChanges*)stateChanges;
+@end
+
+
+
+
+// Permission+Subscription Classes
+@interface OSPermissionSubscriptionState : NSObject
+
+@property OSPermissionState* permissionStatus;
 @property OSSubscriptionState* subscriptionStatus;
 
 @end
 
-// TODO: Add classes that inherit the above added changed* flag properites
 
 
 
@@ -284,11 +328,17 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
 + (void)syncHashedEmail:(NSString*)email;
 
-// - Get user ID & Push Token
+// - Subscription and Permissions
 + (void)IdsAvailable:(OSIdsAvailableBlock)idsAvailableBlock;
-+ (OSPermisionSubscriptionState*)getPermisionSubscriptionState;
++ (OSPermissionSubscriptionState*)getPermisionSubscriptionState;
 
-// - Subscription
+// + (void)addSubscriptionChanged:(void(^)(OSSubscriptionStateChanges* subscriptionStatus))completionHandler;
++ (void)addSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
++ (void)removeSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
+
++ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
++ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer;
+
 + (void)setSubscription:(BOOL)enable;
 
 

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -174,62 +174,56 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @end;
 
 
-
-
-// TODO: Test that state proprites are read-only at the app level.
 // TODO: Check tenses (past vs present)
 
 
 // Permission Classes
 @interface OSPermissionState : NSObject
 
-@property (nonatomic) BOOL hasPrompted;
+@property (nonatomic, readonly) BOOL hasPrompted;
 
 // TODO: Combine has anwseredPrompt and accepted into enum
 //    Need to keep internal bools for backing however.
-@property (nonatomic) BOOL anwseredPrompt;
-@property (nonatomic) BOOL accepted;
-
-// TDOO: Make this internal only
-@property int notificationTypes;
+//    Check with Swift. See what can be done without needing rawValue. Considering this to be a deal breaker due to crashings without it.
+//       This might be ok with a non-Int type Enum?
+@property (nonatomic, readonly) BOOL anwseredPrompt;
+@property (nonatomic, readonly) BOOL accepted;
 
 @end
 
 @interface OSPermissionStateChanges : NSObject
 
-@property OSPermissionState* to;
-@property OSPermissionState* from;
-@property (nonatomic) BOOL justEnabled;
-@property (nonatomic) BOOL justDisabled;
+@property (readonly) OSPermissionState* to;
+@property (readonly) OSPermissionState* from;
+@property (readonly, nonatomic) BOOL justEnabled;
+@property (readonly, nonatomic) BOOL justDisabled;
 
 @end
 
-// TODO: Change public interface from to onOSPermissionChanged:
 @protocol OSPermissionObserver <NSObject>
 - (void)onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges;
 @end
 
 
 // Subscription Classes
-@protocol OSSubscriptionState<NSObject>
+@interface OSSubscriptionState : NSObject
 
-@property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
-@property (nonatomic) NSString* userId;    // AKA OneSignal PlayerId
-@property (nonatomic) NSString* pushToken; // AKA Apple Device Token
+@property (nonatomic, readonly) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (nonatomic, readonly) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (nonatomic, readonly) NSString* userId;    // AKA OneSignal PlayerId
+@property (nonatomic, readonly) NSString* pushToken; // AKA Apple Device Token
 
 @end
 
 @interface OSSubscriptionStateChanges : NSObject
 
-@property NSObject<OSSubscriptionState>* to;
-@property NSObject<OSSubscriptionState>* from;
-@property BOOL becameSubscribed;
-@property BOOL becameUnsubscribed;
+@property (readonly) OSSubscriptionState* to;
+@property (readonly) OSSubscriptionState* from;
+@property (readonly) BOOL becameSubscribed;
+@property (readonly) BOOL becameUnsubscribed;
 
 @end
 
-// TODO: Change public interface from to onOSSubscriptionChanged:
 @protocol OSSubscriptionObserver <NSObject>
 - (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges;
 @end
@@ -240,8 +234,8 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 // Permission+Subscription Classes
 @interface OSPermissionSubscriptionState : NSObject
 
-@property OSPermissionState* permissionStatus;
-@property NSObject<OSSubscriptionState>* subscriptionStatus;
+@property (readonly) OSPermissionState* permissionStatus;
+@property (readonly) OSSubscriptionState* subscriptionStatus;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -77,6 +77,10 @@
 		9124124B1E7337A800E41FD7 /* OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411F01E73342200E41FD7 /* OneSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		91719A9C1E80839500DBE43C /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911E2CC71E399834003112A4 /* UserNotifications.framework */; };
 		918CB0301E73388E0067130F /* OneSignal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 912411F01E73342200E41FD7 /* OneSignal.h */; };
+		91B6EA411E85D38F00B5CF01 /* OSObservable.m in Sources */ = {isa = PBXBuildFile; fileRef = 91B6EA401E85D38F00B5CF01 /* OSObservable.m */; };
+		91B6EA421E85D38F00B5CF01 /* OSObservable.m in Sources */ = {isa = PBXBuildFile; fileRef = 91B6EA401E85D38F00B5CF01 /* OSObservable.m */; };
+		91B6EA431E85D38F00B5CF01 /* OSObservable.m in Sources */ = {isa = PBXBuildFile; fileRef = 91B6EA401E85D38F00B5CF01 /* OSObservable.m */; };
+		91B6EA451E86555200B5CF01 /* OSObservable.h in Headers */ = {isa = PBXBuildFile; fileRef = 91B6EA441E85D3D600B5CF01 /* OSObservable.h */; };
 		91C7725C1E7CA7A800D612D0 /* OneSignalNotificationSettingsIOS7.h in Headers */ = {isa = PBXBuildFile; fileRef = 91C7725B1E7CA7A800D612D0 /* OneSignalNotificationSettingsIOS7.h */; };
 		91C7725E1E7CCE1000D612D0 /* OneSignalInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 91C7725D1E7CCE1000D612D0 /* OneSignalInternal.h */; };
 		91F58D7A1E7C7D3F0017D24D /* OneSignalNotificationSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 91F58D791E7C7D3F0017D24D /* OneSignalNotificationSettings.h */; };
@@ -158,6 +162,8 @@
 		912412091E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplicationDelegate+OneSignal.m"; sourceTree = "<group>"; };
 		9124120A1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UNUserNotificationCenter+OneSignal.h"; sourceTree = "<group>"; };
 		9124120B1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UNUserNotificationCenter+OneSignal.m"; sourceTree = "<group>"; };
+		91B6EA401E85D38F00B5CF01 /* OSObservable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSObservable.m; sourceTree = "<group>"; };
+		91B6EA441E85D3D600B5CF01 /* OSObservable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSObservable.h; sourceTree = "<group>"; };
 		91C7725B1E7CA7A800D612D0 /* OneSignalNotificationSettingsIOS7.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalNotificationSettingsIOS7.h; sourceTree = "<group>"; };
 		91C7725D1E7CCE1000D612D0 /* OneSignalInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalInternal.h; sourceTree = "<group>"; };
 		91F58D791E7C7D3F0017D24D /* OneSignalNotificationSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalNotificationSettings.h; sourceTree = "<group>"; };
@@ -279,6 +285,8 @@
 				912412031E73342200E41FD7 /* OneSignalTracker.m */,
 				912412041E73342200E41FD7 /* OneSignalTrackIAP.h */,
 				912412051E73342200E41FD7 /* OneSignalTrackIAP.m */,
+				91B6EA441E85D3D600B5CF01 /* OSObservable.h */,
+				91B6EA401E85D38F00B5CF01 /* OSObservable.m */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -337,6 +345,7 @@
 				91F58D7A1E7C7D3F0017D24D /* OneSignalNotificationSettings.h in Headers */,
 				91F58D811E7C80C30017D24D /* OneSignalNotificationSettingsIOS8.h in Headers */,
 				912412411E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.h in Headers */,
+				91B6EA451E86555200B5CF01 /* OSObservable.h in Headers */,
 				912412351E73342200E41FD7 /* OneSignalTrackIAP.h in Headers */,
 				912412111E73342200E41FD7 /* OneSignalAlertViewDelegate.h in Headers */,
 				1AF75EB11E8569F60097B315 /* NSString+OneSignal.h in Headers */,
@@ -503,6 +512,7 @@
 				912412261E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				912412321E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				9124121A1E73342200E41FD7 /* OneSignalHTTPClient.m in Sources */,
+				91B6EA411E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				91F58D891E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */,
 				912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				1AF75EAE1E8567FD0097B315 /* NSString+OneSignal.m in Sources */,
@@ -528,6 +538,7 @@
 				912412271E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				912412331E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				9124121B1E73342200E41FD7 /* OneSignalHTTPClient.m in Sources */,
+				91B6EA421E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				91F58D8A1E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */,
 				912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
@@ -551,6 +562,7 @@
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,
 				9124122C1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				911E2CBD1E398AB3003112A4 /* UnitTests.m in Sources */,
+				91B6EA431E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				9124121C1E73342200E41FD7 /* OneSignalHTTPClient.m in Sources */,
 				912412401E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				1AF75EAF1E8569710097B315 /* NSString+OneSignal.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -75,6 +75,14 @@
 		912412481E73369700E41FD7 /* OneSignalHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411F51E73342200E41FD7 /* OneSignalHelper.m */; };
 		912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411F51E73342200E41FD7 /* OneSignalHelper.m */; };
 		9124124B1E7337A800E41FD7 /* OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411F01E73342200E41FD7 /* OneSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9129C6B71E89E59B009CB6A0 /* OSPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 9129C6B51E89E59B009CB6A0 /* OSPermission.h */; };
+		9129C6B81E89E59B009CB6A0 /* OSPermission.m in Sources */ = {isa = PBXBuildFile; fileRef = 9129C6B61E89E59B009CB6A0 /* OSPermission.m */; };
+		9129C6B91E89E59B009CB6A0 /* OSPermission.m in Sources */ = {isa = PBXBuildFile; fileRef = 9129C6B61E89E59B009CB6A0 /* OSPermission.m */; };
+		9129C6BA1E89E59B009CB6A0 /* OSPermission.m in Sources */ = {isa = PBXBuildFile; fileRef = 9129C6B61E89E59B009CB6A0 /* OSPermission.m */; };
+		9129C6BD1E89E7AB009CB6A0 /* OSSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = 9129C6BB1E89E7AB009CB6A0 /* OSSubscription.h */; };
+		9129C6BE1E89E7AB009CB6A0 /* OSSubscription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9129C6BC1E89E7AB009CB6A0 /* OSSubscription.m */; };
+		9129C6BF1E89E7AB009CB6A0 /* OSSubscription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9129C6BC1E89E7AB009CB6A0 /* OSSubscription.m */; };
+		9129C6C01E89E7AB009CB6A0 /* OSSubscription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9129C6BC1E89E7AB009CB6A0 /* OSSubscription.m */; };
 		91719A9C1E80839500DBE43C /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911E2CC71E399834003112A4 /* UserNotifications.framework */; };
 		918CB0301E73388E0067130F /* OneSignal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 912411F01E73342200E41FD7 /* OneSignal.h */; };
 		91B6EA411E85D38F00B5CF01 /* OSObservable.m in Sources */ = {isa = PBXBuildFile; fileRef = 91B6EA401E85D38F00B5CF01 /* OSObservable.m */; };
@@ -162,6 +170,10 @@
 		912412091E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplicationDelegate+OneSignal.m"; sourceTree = "<group>"; };
 		9124120A1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UNUserNotificationCenter+OneSignal.h"; sourceTree = "<group>"; };
 		9124120B1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UNUserNotificationCenter+OneSignal.m"; sourceTree = "<group>"; };
+		9129C6B51E89E59B009CB6A0 /* OSPermission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSPermission.h; sourceTree = "<group>"; };
+		9129C6B61E89E59B009CB6A0 /* OSPermission.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSPermission.m; sourceTree = "<group>"; };
+		9129C6BB1E89E7AB009CB6A0 /* OSSubscription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSSubscription.h; sourceTree = "<group>"; };
+		9129C6BC1E89E7AB009CB6A0 /* OSSubscription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSSubscription.m; sourceTree = "<group>"; };
 		91B6EA401E85D38F00B5CF01 /* OSObservable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSObservable.m; sourceTree = "<group>"; };
 		91B6EA441E85D3D600B5CF01 /* OSObservable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSObservable.h; sourceTree = "<group>"; };
 		91C7725B1E7CA7A800D612D0 /* OneSignalNotificationSettingsIOS7.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalNotificationSettingsIOS7.h; sourceTree = "<group>"; };
@@ -263,6 +275,7 @@
 		912411EE1E73342200E41FD7 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				9129C6B41E89E541009CB6A0 /* State */,
 				91F58D7B1E7C7EE30017D24D /* NotificationSettings */,
 				912412461E73349500E41FD7 /* Categories */,
 				912412451E73346700E41FD7 /* UI */,
@@ -285,8 +298,6 @@
 				912412031E73342200E41FD7 /* OneSignalTracker.m */,
 				912412041E73342200E41FD7 /* OneSignalTrackIAP.h */,
 				912412051E73342200E41FD7 /* OneSignalTrackIAP.m */,
-				91B6EA441E85D3D600B5CF01 /* OSObservable.h */,
-				91B6EA401E85D38F00B5CF01 /* OSObservable.m */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -315,6 +326,19 @@
 				9124120B1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m */,
 			);
 			name = Categories;
+			sourceTree = "<group>";
+		};
+		9129C6B41E89E541009CB6A0 /* State */ = {
+			isa = PBXGroup;
+			children = (
+				91B6EA441E85D3D600B5CF01 /* OSObservable.h */,
+				91B6EA401E85D38F00B5CF01 /* OSObservable.m */,
+				9129C6B51E89E59B009CB6A0 /* OSPermission.h */,
+				9129C6B61E89E59B009CB6A0 /* OSPermission.m */,
+				9129C6BB1E89E7AB009CB6A0 /* OSSubscription.h */,
+				9129C6BC1E89E7AB009CB6A0 /* OSSubscription.m */,
+			);
+			name = State;
 			sourceTree = "<group>";
 		};
 		91F58D7B1E7C7EE30017D24D /* NotificationSettings */ = {
@@ -354,11 +378,13 @@
 				9124122D1E73342200E41FD7 /* OneSignalSelectorHelpers.h in Headers */,
 				9124123D1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.h in Headers */,
 				9124121D1E73342200E41FD7 /* OneSignalJailbreakDetection.h in Headers */,
+				9129C6B71E89E59B009CB6A0 /* OSPermission.h in Headers */,
 				912412191E73342200E41FD7 /* OneSignalHTTPClient.h in Headers */,
 				912412151E73342200E41FD7 /* OneSignalHelper.h in Headers */,
 				91F58D7F1E7C7F5F0017D24D /* OneSignalNotificationSettingsIOS10.h in Headers */,
 				912412391E73342200E41FD7 /* OneSignalWebView.h in Headers */,
 				91C7725E1E7CCE1000D612D0 /* OneSignalInternal.h in Headers */,
+				9129C6BD1E89E7AB009CB6A0 /* OSSubscription.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -505,6 +531,7 @@
 				9124122E1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122A1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				91F58D7D1E7C7F330017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
+				9129C6B81E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				912412121E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
 				912412421E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				9124123A1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
@@ -516,6 +543,7 @@
 				91F58D891E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */,
 				912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				1AF75EAE1E8567FD0097B315 /* NSString+OneSignal.m in Sources */,
+				9129C6BE1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412361E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -531,6 +559,7 @@
 				9124122F1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122B1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				91F58D841E7C88220017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
+				9129C6B91E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				912412131E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
 				912412431E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				9124123B1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
@@ -542,6 +571,7 @@
 				91F58D8A1E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */,
 				912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
+				9129C6BF1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -567,9 +597,11 @@
 				912412401E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				1AF75EAF1E8569710097B315 /* NSString+OneSignal.m in Sources */,
 				912412281E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
+				9129C6C01E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412141E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
 				912412441E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				9124123C1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
+				9129C6BA1E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				91F58D871E7C88250017D24D /* OneSignalNotificationSettingsIOS8.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,33 +25,18 @@
  * THE SOFTWARE.
  */
 
+#ifndef OSObservable_h
+#define OSObservable_h
 
-// Internal selectors to the OneSignal SDK to be shared by other Classes.
 
-#ifndef OneSignalInternal_h
-#define OneSignalInternal_h
-
-#import "OneSignal.h"
-#import "OSObservable.h"
-#import "OneSignalNotificationSettings.h"
-
-typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
-
-@interface OneSignal (OneSignalInternal)
-+ (NSString*)getDeviceToken;
-+ (void)updateNotificationTypes:(int)notificationTypes;
-+ (BOOL)registerForAPNsToken;
-+ (void)setWaitingForApnsResponse:(BOOL)value;
-
-@property (class) NSObject<OneSignalNotificationSettings>* osNotificationSettings;
-
-@property (class) OSPermissionState* lastPermissionState;
-@property (class) OSPermissionState* currentPermissionState;
-
-// Used to manage observers added by the app developer.
-@property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;
-
+@protocol OSObserver
+- (void)onChanged:(id)state;
 @end
 
+@interface OSObservable<__covariant ObserverType, __covariant ObjectType> : NSObject
+- (void)addObserver:(ObserverType)observer;
+- (void)removeObserver:(ObserverType)observer;
+- (BOOL)notifyChange:(ObjectType)state;
+@end
 
-#endif /* OneSignalInternal_h */
+#endif /* OSObservable_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.h
@@ -34,6 +34,7 @@
 @end
 
 @interface OSObservable<__covariant ObserverType, __covariant ObjectType> : NSObject
+- (instancetype)initWithChangeSelector:(SEL)selector;
 - (void)addObserver:(ObserverType)observer;
 - (void)removeObserver:(ObserverType)observer;
 - (BOOL)notifyChange:(ObjectType)state;

--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,33 +25,36 @@
  * THE SOFTWARE.
  */
 
-
-// Internal selectors to the OneSignal SDK to be shared by other Classes.
-
-#ifndef OneSignalInternal_h
-#define OneSignalInternal_h
-
-#import "OneSignal.h"
+#import <Foundation/Foundation.h>
 #import "OSObservable.h"
-#import "OneSignalNotificationSettings.h"
 
-typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
+@implementation OSObservable {
+NSHashTable* observers;
+}
 
-@interface OneSignal (OneSignalInternal)
-+ (NSString*)getDeviceToken;
-+ (void)updateNotificationTypes:(int)notificationTypes;
-+ (BOOL)registerForAPNsToken;
-+ (void)setWaitingForApnsResponse:(BOOL)value;
+- (instancetype)init {
+    if (self = [super init])
+        observers = [[NSHashTable alloc] init];
+    return self;
+}
 
-@property (class) NSObject<OneSignalNotificationSettings>* osNotificationSettings;
+// TODO: Add setting to fire last onChanged on add
+- (void)addObserver:(id)observer {
+    [observers addObject:observer];
+}
 
-@property (class) OSPermissionState* lastPermissionState;
-@property (class) OSPermissionState* currentPermissionState;
+- (void)removeObserver:(id)observer {
+    [observers removeObject:observer];
+}
 
-// Used to manage observers added by the app developer.
-@property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;
+- (BOOL)notifyChange:(id)state {
+    BOOL fired = false;
+     for (id observer in observers) {
+         fired = true;
+         [observer onChanged:state];
+     }
+    
+    return fired;
+}
 
 @end
-
-
-#endif /* OneSignalInternal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.m
@@ -28,6 +28,8 @@
 #import <Foundation/Foundation.h>
 #import "OSObservable.h"
 
+#import "OneSignalHelper.h"
+
 @implementation OSObservable {
 NSHashTable* observers;
 SEL changeSelector;
@@ -62,8 +64,14 @@ SEL changeSelector;
     BOOL fired = false;
      for (id observer in observers) {
          fired = true;
-         if (changeSelector)
-             [observer performSelector:changeSelector withObject:state];
+         if (changeSelector) {
+             // Any Obserable setup to fire a custom selector with changeSelector
+             //  is external to our SDK. Run on the main thread in case the
+             //  app developer needs to update UI elements.
+             [OneSignalHelper dispatch_async_on_main_queue: ^{
+                 [observer performSelector:changeSelector withObject:state];
+             }];
+         }
          else
              [observer onChanged:state];
      }

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.h
@@ -43,10 +43,10 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 // Redefine OSPermissionState
 @interface OSPermissionState () {
 @protected BOOL _hasPrompted;
-@protected BOOL _anwseredPrompt;
+@protected BOOL _answeredPrompt;
 }
 @property (readwrite, nonatomic) BOOL hasPrompted;
-@property (readwrite, nonatomic) BOOL anwseredPrompt;
+@property (readwrite, nonatomic) BOOL answeredPrompt;
 @property (readwrite, nonatomic) BOOL accepted;
 @property int notificationTypes;
 
@@ -66,8 +66,6 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 
 @property (readwrite) OSPermissionState* to;
 @property (readwrite) OSPermissionState* from;
-@property (readwrite, nonatomic) BOOL justEnabled;
-@property (readwrite, nonatomic) BOOL justDisabled;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.h
@@ -1,0 +1,90 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "OneSignal.h"
+
+#import "OSObservable.h"
+
+// Redefines are done so we can make properites writeable and backed internal variables accesiable to the SDK.
+// Basicly the C# equivlent of a public gettter with an internal settter.
+
+
+@protocol OSPermissionStateObserver<NSObject>
+- (void)onChanged:(OSPermissionState*)state;
+@end
+
+typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> ObserablePermissionStateType;
+
+
+// Redefine OSPermissionState
+@interface OSPermissionState ()
+
+@property (readwrite, nonatomic) BOOL hasPrompted;
+@property (readwrite, nonatomic) BOOL anwseredPrompt;
+@property (readwrite, nonatomic) BOOL accepted;
+@property int notificationTypes;
+
+@property (nonatomic) ObserablePermissionStateType* observable;
+
+- (void) persistAsFrom;
+
+- (instancetype)initAsTo;
+- (instancetype)initAsFrom;
+
+@end
+
+// Redefine OSPermissionStateChanges
+@interface OSPermissionStateChanges ()
+
+@property (readwrite) OSPermissionState* to;
+@property (readwrite) OSPermissionState* from;
+@property (readwrite, nonatomic) BOOL justEnabled;
+@property (readwrite, nonatomic) BOOL justDisabled;
+
+@end
+
+typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
+
+
+@interface OSPermissionChangedInternalObserver : NSObject<OSPermissionStateObserver>
+@end
+
+@interface OSPermissionStateObserverWrapper : NSObject<OSObserver>
+- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
+@end
+
+@interface OneSignal (PermissionAdditions)
+
+@property (class) OSPermissionState* lastPermissionState;
+@property (class) OSPermissionState* currentPermissionState;
+
+// Used to manage observers added by the app developer.
+@property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.h
@@ -28,12 +28,10 @@
 #import <Foundation/Foundation.h>
 
 #import "OneSignal.h"
-
 #import "OSObservable.h"
 
 // Redefines are done so we can make properites writeable and backed internal variables accesiable to the SDK.
-// Basicly the C# equivlent of a public gettter with an internal settter.
-
+// Basicly the C# equivlent of a public gettter with an internal/protected settter.
 
 @protocol OSPermissionStateObserver<NSObject>
 - (void)onChanged:(OSPermissionState*)state;
@@ -43,8 +41,10 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 
 
 // Redefine OSPermissionState
-@interface OSPermissionState ()
-
+@interface OSPermissionState () {
+@protected BOOL _hasPrompted;
+@protected BOOL _anwseredPrompt;
+}
 @property (readwrite, nonatomic) BOOL hasPrompted;
 @property (readwrite, nonatomic) BOOL anwseredPrompt;
 @property (readwrite, nonatomic) BOOL accepted;
@@ -73,10 +73,6 @@ typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*>
 
 
 @interface OSPermissionChangedInternalObserver : NSObject<OSPermissionStateObserver>
-@end
-
-@interface OSPermissionStateObserverWrapper : NSObject<OSObserver>
-- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
 @end
 
 @interface OneSignal (PermissionAdditions)

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.h
@@ -57,6 +57,8 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 - (instancetype)initAsTo;
 - (instancetype)initAsFrom;
 
+- (BOOL)compare:(OSPermissionState*)from;
+
 @end
 
 // Redefine OSPermissionStateChanges
@@ -73,6 +75,7 @@ typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*>
 
 
 @interface OSPermissionChangedInternalObserver : NSObject<OSPermissionStateObserver>
++ (void)fireChangesObserver:(OSPermissionState*)state;
 @end
 
 @interface OneSignal (PermissionAdditions)

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -33,7 +33,7 @@
 
 - (ObserablePermissionStateType*)observable {
     if (!_observable)
-        _observable = [[OSObservable alloc] init];
+        _observable = [OSObservable new];
     return _observable;
 }
 
@@ -65,7 +65,7 @@
 
 
 - (instancetype)copyWithZone:(NSZone*)zone {
-    OSPermissionState* copy = [[[self class] alloc] init];
+    OSPermissionState* copy = [[self class] new];
     
     if (copy) {
         copy->_hasPrompted = _hasPrompted;
@@ -76,12 +76,25 @@
     return copy;
 }
 
+- (void)setHasPrompted:(BOOL)inHasPrompted {
+    BOOL last = self.hasPrompted;
+    _hasPrompted = inHasPrompted;
+    if (last != self.hasPrompted)
+        [self.observable notifyChange:self];
+}
 
 - (BOOL)hasPrompted {
     // If we know they anwsered turned notificaitons on then were prompted at some point.
     if (self.anwseredPrompt) // self. triggers getter
         return true;
     return _hasPrompted;
+}
+
+- (void)setAnwseredPrompt:(BOOL)inAnwseredPrompt {
+    BOOL last = self.anwseredPrompt;
+    _anwseredPrompt = inAnwseredPrompt;
+    if (last != self.anwseredPrompt)
+        [self.observable notifyChange:self];
 }
 
 - (BOOL)anwseredPrompt {
@@ -98,10 +111,19 @@
         [self.observable notifyChange:self];
 }
 
+- (NSString*)description {
+    static NSString* format = @"<OSPermissionState: hasPrompted: %d, anwseredPrompt: %d, accepted: %d>";
+    return [NSString stringWithFormat:format, self.hasPrompted, self.anwseredPrompt, self.accepted];
+}
+
 @end
 
 
 @implementation OSPermissionStateChanges
+- (NSString*)description {
+    static NSString* format = @"<OSSubscriptionStateChanges:\nfrom: %@,\nto:   %@\n>";
+    return [NSString stringWithFormat:format, _from, _to];
+}
 @end
 
 
@@ -114,26 +136,9 @@
     
     [OneSignal.permissionStateChangesObserver notifyChange:stateChanges];
     
-    
     OneSignal.lastPermissionState = [state copy];
     
     [OneSignal.lastPermissionState persistAsFrom];
-}
-
-@end
-
-
-@implementation OSPermissionStateObserverWrapper {
-    NSObject<OSPermissionObserver>* _observer;
-}
-
-- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    _observer = observer;
-    return self;
-}
-
-- (void)onChanged:(id)state {
-    [_observer onOSPermissionChanged:state];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -1,0 +1,139 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OSPermission.h"
+
+#import "OneSignalInternal.h"
+
+@implementation OSPermissionState
+
+- (ObserablePermissionStateType*)observable {
+    if (!_observable)
+        _observable = [[OSObservable alloc] init];
+    return _observable;
+}
+
+- (instancetype)initAsTo {
+    [OneSignal.osNotificationSettings getNotificationPermissionState];
+    
+    return self;
+}
+
+- (instancetype)initAsFrom {
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    
+    _hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
+    _anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
+    _accepted  = [userDefaults boolForKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
+    
+    return self;
+}
+
+- (void)persistAsFrom {
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    
+    [userDefaults setBool:_hasPrompted forKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
+    [userDefaults setBool:_anwseredPrompt forKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
+    [userDefaults setBool:_accepted forKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
+    
+    [userDefaults synchronize];
+}
+
+
+- (instancetype)copyWithZone:(NSZone*)zone {
+    OSPermissionState* copy = [[[self class] alloc] init];
+    
+    if (copy) {
+        copy->_hasPrompted = _hasPrompted;
+        copy->_anwseredPrompt = _anwseredPrompt;
+        copy->_accepted = _accepted;
+    }
+    
+    return copy;
+}
+
+
+- (BOOL)hasPrompted {
+    // If we know they anwsered turned notificaitons on then were prompted at some point.
+    if (self.anwseredPrompt) // self. triggers getter
+        return true;
+    return _hasPrompted;
+}
+
+- (BOOL)anwseredPrompt {
+    // If we got an accepted permission then they anwsered the prompt.
+    if (_accepted)
+        return true;
+    return _anwseredPrompt;
+}
+
+- (void)setAccepted:(BOOL)accepted {
+    BOOL changed = _accepted != accepted;
+    _accepted = accepted;
+    if (changed)
+        [self.observable notifyChange:self];
+}
+
+@end
+
+
+@implementation OSPermissionStateChanges
+@end
+
+
+@implementation OSPermissionChangedInternalObserver
+
+- (void)onChanged:(OSPermissionState*)state {
+    OSPermissionStateChanges* stateChanges = [OSPermissionStateChanges alloc];
+    stateChanges.from = OneSignal.lastPermissionState;
+    stateChanges.to = state;
+    
+    [OneSignal.permissionStateChangesObserver notifyChange:stateChanges];
+    
+    
+    OneSignal.lastPermissionState = [state copy];
+    
+    [OneSignal.lastPermissionState persistAsFrom];
+}
+
+@end
+
+
+@implementation OSPermissionStateObserverWrapper {
+    NSObject<OSPermissionObserver>* _observer;
+}
+
+- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
+    _observer = observer;
+    return self;
+}
+
+- (void)onChanged:(id)state {
+    [_observer onOSPermissionChanged:state];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -47,7 +47,7 @@
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     
     _hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
-    _anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
+    _answeredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
     _accepted  = [userDefaults boolForKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
     
     return self;
@@ -57,7 +57,7 @@
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     
     [userDefaults setBool:_hasPrompted forKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
-    [userDefaults setBool:_anwseredPrompt forKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
+    [userDefaults setBool:_answeredPrompt forKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
     [userDefaults setBool:_accepted forKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
     
     [userDefaults synchronize];
@@ -69,7 +69,7 @@
     
     if (copy) {
         copy->_hasPrompted = _hasPrompted;
-        copy->_anwseredPrompt = _anwseredPrompt;
+        copy->_answeredPrompt = _answeredPrompt;
         copy->_accepted = _accepted;
     }
     
@@ -90,24 +90,24 @@
 }
 
 - (BOOL)hasPrompted {
-    // If we know they anwsered turned notificaitons on then were prompted at some point.
-    if (self.anwseredPrompt) // self. triggers getter
+    // If we know they answered turned notificaitons on then were prompted at some point.
+    if (self.answeredPrompt) // self. triggers getter
         return true;
     return _hasPrompted;
 }
 
-- (void)setAnwseredPrompt:(BOOL)inAnwseredPrompt {
-    BOOL last = self.anwseredPrompt;
-    _anwseredPrompt = inAnwseredPrompt;
-    if (last != self.anwseredPrompt)
+- (void)setAnsweredPrompt:(BOOL)inansweredPrompt {
+    BOOL last = self.answeredPrompt;
+    _answeredPrompt = inansweredPrompt;
+    if (last != self.answeredPrompt)
         [self.observable notifyChange:self];
 }
 
-- (BOOL)anwseredPrompt {
-    // If we got an accepted permission then they anwsered the prompt.
+- (BOOL)answeredPrompt {
+    // If we got an accepted permission then they answered the prompt.
     if (_accepted)
         return true;
-    return _anwseredPrompt;
+    return _answeredPrompt;
 }
 
 - (void)setAccepted:(BOOL)accepted {
@@ -117,15 +117,36 @@
         [self.observable notifyChange:self];
 }
 
+- (OSNotificationPermission)status {
+    if (_accepted)
+        return OSNotificationPermissionAuthorized;
+    
+    if (self.answeredPrompt)
+        return OSNotificationPermissionDenied;
+    return OSNotificationPermissionNotDetermined;
+}
+
+- (NSString*)statusAsString {
+    switch(self.status) {
+        case OSNotificationPermissionNotDetermined:
+            return @"NotDetermined";
+        case OSNotificationPermissionAuthorized:
+            return @"Authorized";
+        case OSNotificationPermissionDenied:
+            return @"Denied";
+    }
+    return @"NotDetermined";
+}
+
 - (BOOL)compare:(OSPermissionState*)from {
     return self.accepted != from.accepted ||
-           self.anwseredPrompt != from.anwseredPrompt ||
+           self.answeredPrompt != from.answeredPrompt ||
            self.hasPrompted != from.hasPrompted;
 }
 
 - (NSString*)description {
-    static NSString* format = @"<OSPermissionState: hasPrompted: %d, anwseredPrompt: %d, accepted: %d>";
-    return [NSString stringWithFormat:format, self.hasPrompted, self.anwseredPrompt, self.accepted];
+    static NSString* format = @"<OSPermissionState: hasPrompted: %d, status: %@>";
+    return [NSString stringWithFormat:format, self.hasPrompted, self.statusAsString];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -77,6 +77,12 @@
 }
 
 - (void)setHasPrompted:(BOOL)inHasPrompted {
+    if (_hasPrompted != inHasPrompted) {
+        NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults setBool:true forKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
+        [userDefaults synchronize];
+    }
+    
     BOOL last = self.hasPrompted;
     _hasPrompted = inHasPrompted;
     if (last != self.hasPrompted)

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -46,10 +46,10 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 @interface OSSubscriptionState () {
 @protected BOOL _userSubscriptionSetting;
 @protected NSString* _userId;
-@protected NSString* _pushToken;
+@package NSString* _pushToken;
 }
 
-@property (readwrite, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+// @property (readonly, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
 @property (readwrite, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
 @property (readwrite, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
 @property (readwrite, nonatomic) NSString* pushToken; // AKA Apple Device Token

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -46,7 +46,7 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 @interface OSSubscriptionState () {
 @protected BOOL _userSubscriptionSetting;
 @protected NSString* _userId;
-@package NSString* _pushToken;
+@protected NSString* _pushToken;
 }
 
 // @property (readonly, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
@@ -61,6 +61,16 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 @end
 
 
+// Redefine OSSubscriptionState
+@interface OSSubscriptionState () <OSPermissionStateObserver>
+
+@property (nonatomic) BOOL accpeted;
+
+- (void)setAccepted:(BOOL)inAccpeted;
+- (void)persistAsFrom;
+- (BOOL)compare:(OSSubscriptionState*)from;
+@end
+
 // Redefine OSSubscriptionStateChanges
 @interface OSSubscriptionStateChanges ()
 
@@ -71,24 +81,11 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 
 @end
 
-@interface OSSubscriptionState () <OSPermissionStateObserver>
-
-@property (nonatomic) BOOL accpeted;
-
-- (void)setAccepted:(BOOL)inAccpeted;
-- (void)persistAsFrom;
-- (BOOL)compareWithFrom:(OSSubscriptionState*)from;
-@end
 
 typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChanges*> ObserableSubscriptionStateChangesType;
 
 
 @interface OSSubscriptionChangedInternalObserver : NSObject<OSSubscriptionStateObserver>
-@end
-
-// Maps generic onChanged observer to specific onOSSubscriptionChanged selector.
-@interface OSSubscriptionStateObserverWrapper : NSObject<OSObserver>
-- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
 @end
 
 @interface OneSignal (SubscriptionAdditions)

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -76,8 +76,6 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 
 @property (readwrite) OSSubscriptionState* to;
 @property (readwrite) OSSubscriptionState* from;
-@property (readwrite) BOOL becameSubscribed;
-@property (readwrite) BOOL becameUnsubscribed;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -86,6 +86,7 @@ typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChang
 
 
 @interface OSSubscriptionChangedInternalObserver : NSObject<OSSubscriptionStateObserver>
++ (void)fireChangesObserver:(OSSubscriptionState*)state;
 @end
 
 @interface OneSignal (SubscriptionAdditions)

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -1,0 +1,102 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#import <Foundation/Foundation.h>
+
+#import "OneSignal.h"
+
+#import "OSObservable.h"
+
+#import "OSPermission.h"
+
+// Redefines are done so we can make properites writeable and backed internal variables accesiable to the SDK.
+// Basicly the C# equivlent of a public gettter with an internal settter.
+
+
+@protocol OSSubscriptionStateObserver
+-(void)onChanged:(OSSubscriptionState*)state;
+@end
+
+typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState*> ObserableSubscriptionStateType;
+
+// Redefine OSSubscriptionState
+@interface OSSubscriptionState () {
+@protected BOOL _userSubscriptionSetting;
+@protected NSString* _userId;
+@protected NSString* _pushToken;
+}
+
+@property (readwrite, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (readwrite, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (readwrite, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
+@property (readwrite, nonatomic) NSString* pushToken; // AKA Apple Device Token
+@property (nonatomic) ObserableSubscriptionStateType* observable;
+
+- (instancetype)initAsToWithPermision:(BOOL)permission;
+- (instancetype)initAsFrom;
+
+@end
+
+
+// Redefine OSSubscriptionStateChanges
+@interface OSSubscriptionStateChanges ()
+
+@property (readwrite) OSSubscriptionState* to;
+@property (readwrite) OSSubscriptionState* from;
+@property (readwrite) BOOL becameSubscribed;
+@property (readwrite) BOOL becameUnsubscribed;
+
+@end
+
+@interface OSSubscriptionState () <OSPermissionStateObserver>
+
+@property (nonatomic) BOOL accpeted;
+
+- (void)setAccepted:(BOOL)inAccpeted;
+- (void)persistAsFrom;
+- (BOOL)compareWithFrom:(OSSubscriptionState*)from;
+@end
+
+typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChanges*> ObserableSubscriptionStateChangesType;
+
+
+@interface OSSubscriptionChangedInternalObserver : NSObject<OSSubscriptionStateObserver>
+@end
+
+// Maps generic onChanged observer to specific onOSSubscriptionChanged selector.
+@interface OSSubscriptionStateObserverWrapper : NSObject<OSObserver>
+- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
+@end
+
+@interface OneSignal (SubscriptionAdditions)
+
+@property (class) OSSubscriptionState* lastSubscriptionState;
+@property (class) OSSubscriptionState* currentSubscriptionState;
+
+// Used to manage observers added by the app developer.
+@property (class) ObserableSubscriptionStateChangesType* subscriptionStateChangesObserver;
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -1,0 +1,164 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OSSubscription.h"
+
+
+@implementation OSSubscriptionState
+
+- (ObserableSubscriptionStateType*)observable {
+    if (!_observable)
+        _observable = [OSObservable new];
+    return _observable;
+}
+
+- (instancetype)initAsToWithPermision:(BOOL)permission {
+    _accpeted = permission;
+    
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    _userId = [userDefaults stringForKey:@"GT_PLAYER_ID"];
+    _pushToken = [userDefaults stringForKey:@"GT_DEVICE_TOKEN"];
+    _userSubscriptionSetting = [userDefaults objectForKey:@"ONESIGNAL_SUBSCRIPTION"] == nil;
+    
+    return self;
+}
+
+- (BOOL)compareWithFrom:(OSSubscriptionState*)from {
+    return self.userId != from.userId ||
+    self.pushToken != from.pushToken ||
+    self.userSubscriptionSetting != from.userSubscriptionSetting ||
+    self.accpeted != from.accpeted;
+}
+
+- (instancetype)initAsFrom {
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    
+    _userId = [userDefaults stringForKey:@"GT_PLAYER_ID_LAST"];
+    _pushToken = [userDefaults stringForKey:@"GT_DEVICE_TOKEN_LAST"];
+    _userSubscriptionSetting = [userDefaults boolForKey:@"ONESIGNAL_SUBSCRIPTION_LAST"];
+    _accpeted = [userDefaults boolForKey:@"ONESIGNAL_PERMISSION_ACCEPTED_LAST"];
+    
+    return self;
+}
+
+- (void)persistAsFrom {
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    
+    [userDefaults setObject:_userId forKey:@"GT_PLAYER_ID_LAST"];
+    [userDefaults setObject:_pushToken forKey:@"GT_DEVICE_TOKEN_LAST"];
+    [userDefaults setBool:_userSubscriptionSetting forKey:@"ONESIGNAL_SUBSCRIPTION_LAST"];
+    [userDefaults setBool:_accpeted forKey:@"ONESIGNAL_PERMISSION_ACCEPTED_LAST"];
+    
+    [userDefaults synchronize];
+}
+
+- (instancetype)copyWithZone:(NSZone*)zone {
+    OSSubscriptionState* copy = [[[self class] alloc] init];
+    
+    if (copy) {
+        copy->_userId = [_userId copy];
+        copy->_pushToken = [_pushToken copy];
+        copy->_userSubscriptionSetting = _userSubscriptionSetting;
+        copy->_accpeted = _accpeted;
+    }
+    
+    return copy;
+}
+
+
+- (void)onChanged:(OSPermissionState*)state {
+    [self setAccepted:state.accepted];
+}
+
+- (void)setUserId:(NSString*)userId {
+    BOOL changed = ![[NSString stringWithString:userId] isEqualToString:_userId];
+    _userId = userId;
+    if (self.observable && changed)
+        [self.observable notifyChange:self];
+}
+
+- (void)setPushToken:(NSString*)pushToken {
+    BOOL changed = ![[NSString stringWithString:pushToken] isEqualToString:_pushToken];
+    _pushToken = pushToken;
+    if (self.observable && changed)
+        [self.observable notifyChange:self];
+}
+
+- (void)setUserSubscriptionSetting:(BOOL)userSubscriptionSetting {
+    BOOL changed = userSubscriptionSetting != _userSubscriptionSetting;
+    _userSubscriptionSetting = userSubscriptionSetting;
+    if (self.observable && changed)
+        [self.observable notifyChange:self];
+}
+
+- (void)setAccepted:(BOOL)inAccpeted {
+    BOOL lastSubscribed = self.subscribed;
+    _accpeted = inAccpeted;
+    if (lastSubscribed != self.subscribed)
+        [self.observable notifyChange:self];
+}
+
+- (BOOL)subscribed {
+    return _userId && _pushToken && _userSubscriptionSetting && _accpeted;
+}
+
+@end
+
+
+@implementation OSSubscriptionChangedInternalObserver
+
+- (void)onChanged:(OSSubscriptionState*)state {
+    OSSubscriptionStateChanges* stateChanges = [OSSubscriptionStateChanges alloc];
+    stateChanges.from = OneSignal.lastSubscriptionState;
+    stateChanges.to = state;
+    
+    [OneSignal.subscriptionStateChangesObserver notifyChange:stateChanges];
+    
+    OneSignal.lastSubscriptionState = [state copy];
+    [OneSignal.lastSubscriptionState persistAsFrom];
+}
+
+@end
+
+@implementation OSSubscriptionStateObserverWrapper {
+    NSObject<OSSubscriptionObserver>* _observer;
+}
+
+- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
+    _observer = observer;
+    return self;
+}
+
+- (void)onChanged:(id)state {
+    [_observer onOSSubscriptionChanged:state];
+}
+
+@end
+
+
+@implementation OSSubscriptionStateChanges
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -47,11 +47,11 @@
     return self;
 }
 
-- (BOOL)compareWithFrom:(OSSubscriptionState*)from {
+- (BOOL)compare:(OSSubscriptionState*)from {
     return self.userId != from.userId ||
-    self.pushToken != from.pushToken ||
-    self.userSubscriptionSetting != from.userSubscriptionSetting ||
-    self.accpeted != from.accpeted;
+           self.pushToken != from.pushToken ||
+           self.userSubscriptionSetting != from.userSubscriptionSetting ||
+           self.accpeted != from.accpeted;
 }
 
 - (instancetype)initAsFrom {
@@ -126,6 +126,11 @@
     return _userId && _pushToken && _userSubscriptionSetting && _accpeted;
 }
 
+- (NSString*)description {
+    static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, userSubscriptionSetting: %d, subscribed: %d>";
+    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.userSubscriptionSetting, self.subscribed];
+}
+
 @end
 
 
@@ -144,31 +149,10 @@
 
 @end
 
-@implementation OSSubscriptionStateObserverWrapper {
-    NSObject<OSSubscriptionObserver>* _observer;
-}
-
-- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
-    _observer = observer;
-    return self;
-}
-
-- (void)onChanged:(OSSubscriptionStateChanges*)state {
-    // Don't fire for pushToken that is autotmaticly retreived.
-    if (state.to.pushToken && !state.from.pushToken && !state.to.userId)
-        return;
-    
-    if (!state.to.userId)
-        state.to->_pushToken = nil;
-    
-    if (!state.from.userId)
-        state.from->_pushToken = nil;
-    
-    [_observer onOSSubscriptionChanged:state];
-}
-
-@end
-
-
 @implementation OSSubscriptionStateChanges
+
+- (NSString*)description {
+    static NSString* format = @"<OSSubscriptionStateChanges:\nfrom: %@,\nto:   %@\n>";
+    return [NSString stringWithFormat:format, _from, _to];
+}
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -134,7 +134,7 @@
 - (void)onChanged:(OSSubscriptionState*)state {
     OSSubscriptionStateChanges* stateChanges = [OSSubscriptionStateChanges alloc];
     stateChanges.from = OneSignal.lastSubscriptionState;
-    stateChanges.to = state;
+    stateChanges.to = [state copy];
     
     [OneSignal.subscriptionStateChangesObserver notifyChange:stateChanges];
     
@@ -153,7 +153,17 @@
     return self;
 }
 
-- (void)onChanged:(id)state {
+- (void)onChanged:(OSSubscriptionStateChanges*)state {
+    // Don't fire for pushToken that is autotmaticly retreived.
+    if (state.to.pushToken && !state.from.pushToken && !state.to.userId)
+        return;
+    
+    if (!state.to.userId)
+        state.to->_pushToken = nil;
+    
+    if (!state.from.userId)
+        state.from->_pushToken = nil;
+    
     [_observer onOSSubscriptionChanged:state];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -173,15 +173,24 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @end;
 
 
-// TODO: Check tenses (past vs present)
+typedef NS_ENUM(NSInteger, OSNotificationPermission) {
+    // The user has not yet made a choice regarding whether your app can show notifications.
+    OSNotificationPermissionNotDetermined = 0,
+    
+    // The application is not authorized to post user notifications.
+    OSNotificationPermissionDenied,
+    
+    // The application is authorized to post user notifications.
+    OSNotificationPermissionAuthorized
+};
+
 
 
 // Permission Classes
 @interface OSPermissionState : NSObject
 
 @property (readonly, nonatomic) BOOL hasPrompted;
-@property (readonly, nonatomic) BOOL anwseredPrompt;
-@property (readonly, nonatomic) BOOL accepted;
+@property (readonly, nonatomic) OSNotificationPermission status;
 
 @end
 
@@ -189,8 +198,6 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 @property (readonly) OSPermissionState* to;
 @property (readonly) OSPermissionState* from;
-@property (readonly, nonatomic) BOOL justEnabled;
-@property (readonly, nonatomic) BOOL justDisabled;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -48,7 +48,6 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
 #define XC8_AVAILABLE 1
 #import <UserNotifications/UserNotifications.h>
-
 #endif
 
 /* The action type associated to an OSNotificationAction object */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -206,7 +206,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 // TODO: Change public interface from to onOSPermissionChanged:
 @protocol OSPermissionObserver <NSObject>
-- (void)onChanged:(OSPermissionStateChanges*)stateChanges;
+- (void)onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges;
 @end
 
 
@@ -231,7 +231,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 // TODO: Change public interface from to onOSSubscriptionChanged:
 @protocol OSSubscriptionObserver <NSObject>
-- (void)onChanged:(OSSubscriptionStateChanges*)stateChanges;
+- (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges;
 @end
 
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -55,7 +55,7 @@
 typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeOpened,
     OSNotificationActionTypeActionTaken
-} ;
+};
 
 /* The way a notification was displayed to the user */
 typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
@@ -67,7 +67,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
     
     /*iOS native notification display*/
     OSNotificationDisplayTypeNotification
-} ;
+};
 
 
 
@@ -181,11 +181,6 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @interface OSPermissionState : NSObject
 
 @property (readonly, nonatomic) BOOL hasPrompted;
-
-// TODO: Combine has anwseredPrompt and accepted into enum
-//    Need to keep internal bools for backing however.
-//    Check with Swift. See what can be done without needing rawValue. Considering this to be a deal breaker due to crashings without it.
-//       This might be ok with a non-Int type Enum?
 @property (readonly, nonatomic) BOOL anwseredPrompt;
 @property (readonly, nonatomic) BOOL accepted;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -211,7 +211,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 
 // Subscription Classes
-@interface OSSubscriptionState : NSObject
+@protocol OSSubscriptionState<NSObject>
 
 @property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
 @property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
@@ -222,8 +222,8 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 @interface OSSubscriptionStateChanges : NSObject
 
-@property OSSubscriptionState* to;
-@property OSSubscriptionState* from;
+@property NSObject<OSSubscriptionState>* to;
+@property NSObject<OSSubscriptionState>* from;
 @property BOOL becameSubscribed;
 @property BOOL becameUnsubscribed;
 
@@ -241,7 +241,7 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @interface OSPermissionSubscriptionState : NSObject
 
 @property OSPermissionState* permissionStatus;
-@property OSSubscriptionState* subscriptionStatus;
+@property NSObject<OSSubscriptionState>* subscriptionStatus;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -88,6 +88,9 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 @end
 
+
+// #### Notification Payload Received Object
+
 @interface OSNotificationPayload : NSObject
 
 /* Unique Message Identifier */
@@ -171,6 +174,38 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 
 @end;
 
+
+@interface OSSubscriptionState : NSObject
+
+@property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property NSString* userId;    // AKA OneSignal PlayerId
+@property NSString* pushToken; // AKA Apple Device Token
+
+@end
+
+@interface OSPermissionStatus : NSObject
+
+@property (nonatomic) BOOL hasPrompted;
+@property (nonatomic) BOOL anwseredPrompt;
+@property BOOL accepted;
+@property int notificationTypes;
+
+@end
+
+@interface OSPermisionSubscriptionState : NSObject
+
+@property OSPermissionStatus* permissionStatus;
+@property OSSubscriptionState* subscriptionStatus;
+
+@end
+
+// TODO: Add classes that inherit the above added changed* flag properites
+
+
+
+
+
 typedef void (^OSResultSuccessBlock)(NSDictionary* result);
 typedef void (^OSFailureBlock)(NSError* error);
 
@@ -194,18 +229,13 @@ extern NSString * const kOSSettingsKeyInAppAlerts;
 /*Enable In-App display of Launch URLs*/
 extern NSString * const kOSSettingsKeyInAppLaunchURL;
 
-/* iOS10+ - 
+/* iOS10 +
  Set notification's in-focus display option.
  Value must be an OSNotificationDisplayType enum
 */
 extern NSString * const kOSSettingsKeyInFocusDisplayOption;
 
-/**
-    OneSignal provides a high level interface to interact with OneSignal's push service.
-    OneSignal is a singleton for applications which use a globally available client to share configuration settings.
-    You should avoid creating instances of this class at all costs. Instead, access its instance methods.
-    Include `#import <OneSignal/OneSignal.h>` in your application files to access OneSignal's methods.
- **/
+
 @interface OneSignal : NSObject
 
 extern NSString* const ONESIGNAL_VERSION;
@@ -214,9 +244,6 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
     ONE_S_LL_NONE, ONE_S_LL_FATAL, ONE_S_LL_ERROR, ONE_S_LL_WARN, ONE_S_LL_INFO, ONE_S_LL_DEBUG, ONE_S_LL_VERBOSE
 };
 
-///--------------------
-/// @name Initialize`
-///--------------------
 
 /**
  Initialize OneSignal. Sends push token to OneSignal so you can later send notifications.
@@ -233,8 +260,9 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (NSString*)sdk_version_raw;
 + (NSString*)sdk_semantic_version;
 
-// Only use if you passed FALSE to autoRegister
+// Only use if you set kOSSettingsKeyAutoPrompt to false
 + (void)registerForPushNotifications;
++ (void)promptForPushNotificationWithUserResponse:(void(^)(BOOL accepted))completionHandler;
 
 // - Logging
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
@@ -254,11 +282,18 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)deleteTags:(NSArray*)keys;
 + (void)deleteTagsWithJsonString:(NSString*)jsonString;
 
+// - Sends the MD5 and SHA1 of the provided email
+// Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
++ (void)syncHashedEmail:(NSString*)email;
+
 // - Get user ID & Push Token
 + (void)IdsAvailable:(OSIdsAvailableBlock)idsAvailableBlock;
++ (OSPermisionSubscriptionState*)getPermisionSubscriptionState;
 
-// - Alerting
+// - Subscription
 + (void)setSubscription:(BOOL)enable;
+
+
 
 // - Posting Notification
 + (void)postNotification:(NSDictionary*)jsonData;
@@ -270,20 +305,15 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)promptLocation;
 + (void)setLocationShared:(BOOL)enable;
 
-// - Sends the MD5 and SHA1 of the provided email
-// Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
-+ (void)syncHashedEmail:(NSString*)email;
 
 // Only used for wrapping SDKs, such as Unity, Cordova, Xamarin, etc.
 + (void)setMSDKType:(NSString*)type;
 
 
-#ifdef XC8_AVAILABLE
 // iOS 10 only
 // Process from Notification Service Extension.
 // Used for iOS Media Attachemtns and Action Buttons.
-+ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest *)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent;
-+ (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest *)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent;
-#endif
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent;
++ (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -180,14 +180,14 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 // Permission Classes
 @interface OSPermissionState : NSObject
 
-@property (nonatomic, readonly) BOOL hasPrompted;
+@property (readonly, nonatomic) BOOL hasPrompted;
 
 // TODO: Combine has anwseredPrompt and accepted into enum
 //    Need to keep internal bools for backing however.
 //    Check with Swift. See what can be done without needing rawValue. Considering this to be a deal breaker due to crashings without it.
 //       This might be ok with a non-Int type Enum?
-@property (nonatomic, readonly) BOOL anwseredPrompt;
-@property (nonatomic, readonly) BOOL accepted;
+@property (readonly, nonatomic) BOOL anwseredPrompt;
+@property (readonly, nonatomic) BOOL accepted;
 
 @end
 
@@ -208,10 +208,10 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 // Subscription Classes
 @interface OSSubscriptionState : NSObject
 
-@property (nonatomic, readonly) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (nonatomic, readonly) BOOL userSubscriptionSetting; // returns setSubscription state.
-@property (nonatomic, readonly) NSString* userId;    // AKA OneSignal PlayerId
-@property (nonatomic, readonly) NSString* pushToken; // AKA Apple Device Token
+@property (readonly, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (readonly, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (readonly, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
+@property (readonly, nonatomic) NSString* pushToken; // AKA Apple Device Token
 
 @end
 
@@ -227,7 +227,6 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @protocol OSSubscriptionObserver <NSObject>
 - (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges;
 @end
-
 
 
 
@@ -320,8 +319,8 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)deleteTags:(NSArray*)keys;
 + (void)deleteTagsWithJsonString:(NSString*)jsonString;
 
-// - Sends the MD5 and SHA1 of the provided email
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
+// Sends as MD5 and SHA1 of the provided email
 + (void)syncHashedEmail:(NSString*)email;
 
 // - Subscription and Permissions

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -174,62 +174,56 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 @end;
 
 
-
-
-// TODO: Test that state proprites are read-only at the app level.
 // TODO: Check tenses (past vs present)
 
 
 // Permission Classes
 @interface OSPermissionState : NSObject
 
-@property (nonatomic) BOOL hasPrompted;
+@property (nonatomic, readonly) BOOL hasPrompted;
 
 // TODO: Combine has anwseredPrompt and accepted into enum
 //    Need to keep internal bools for backing however.
-@property (nonatomic) BOOL anwseredPrompt;
-@property (nonatomic) BOOL accepted;
-
-// TDOO: Make this internal only
-@property int notificationTypes;
+//    Check with Swift. See what can be done without needing rawValue. Considering this to be a deal breaker due to crashings without it.
+//       This might be ok with a non-Int type Enum?
+@property (nonatomic, readonly) BOOL anwseredPrompt;
+@property (nonatomic, readonly) BOOL accepted;
 
 @end
 
 @interface OSPermissionStateChanges : NSObject
 
-@property OSPermissionState* to;
-@property OSPermissionState* from;
-@property (nonatomic) BOOL justEnabled;
-@property (nonatomic) BOOL justDisabled;
+@property (readonly) OSPermissionState* to;
+@property (readonly) OSPermissionState* from;
+@property (readonly, nonatomic) BOOL justEnabled;
+@property (readonly, nonatomic) BOOL justDisabled;
 
 @end
 
-// TODO: Change public interface from to onOSPermissionChanged:
 @protocol OSPermissionObserver <NSObject>
 - (void)onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges;
 @end
 
 
 // Subscription Classes
-@protocol OSSubscriptionState<NSObject>
+@interface OSSubscriptionState : NSObject
 
-@property (nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
-@property (nonatomic) NSString* userId;    // AKA OneSignal PlayerId
-@property (nonatomic) NSString* pushToken; // AKA Apple Device Token
+@property (nonatomic, readonly) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (nonatomic, readonly) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (nonatomic, readonly) NSString* userId;    // AKA OneSignal PlayerId
+@property (nonatomic, readonly) NSString* pushToken; // AKA Apple Device Token
 
 @end
 
 @interface OSSubscriptionStateChanges : NSObject
 
-@property NSObject<OSSubscriptionState>* to;
-@property NSObject<OSSubscriptionState>* from;
-@property BOOL becameSubscribed;
-@property BOOL becameUnsubscribed;
+@property (readonly) OSSubscriptionState* to;
+@property (readonly) OSSubscriptionState* from;
+@property (readonly) BOOL becameSubscribed;
+@property (readonly) BOOL becameUnsubscribed;
 
 @end
 
-// TODO: Change public interface from to onOSSubscriptionChanged:
 @protocol OSSubscriptionObserver <NSObject>
 - (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges;
 @end
@@ -240,8 +234,8 @@ typedef OSNotificationDisplayType OSInFocusDisplayOption;
 // Permission+Subscription Classes
 @interface OSPermissionSubscriptionState : NSObject
 
-@property OSPermissionState* permissionStatus;
-@property NSObject<OSSubscriptionState>* subscriptionStatus;
+@property (readonly) OSPermissionState* permissionStatus;
+@property (readonly) OSSubscriptionState* subscriptionStatus;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -211,20 +211,18 @@ static OSSubscriptionState* _lastSubscriptionState;
 static ObserablePermissionStateChangesType* _permissionStateChangesObserver;
 + (ObserablePermissionStateChangesType*)permissionStateChangesObserver {
     if (!_permissionStateChangesObserver)
-        _permissionStateChangesObserver = [[OSObservable alloc] init];
+        _permissionStateChangesObserver = [[OSObservable alloc] initWithChangeSelector:@selector(onOSPermissionChanged:)];
     return _permissionStateChangesObserver;
 }
-
-
 
 static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
 + (ObserableSubscriptionStateChangesType*)subscriptionStateChangesObserver {
     if (!_subscriptionStateChangesObserver)
-        _subscriptionStateChangesObserver = [[OSObservable alloc] init];
+        _subscriptionStateChangesObserver = [[OSObservable alloc] initWithChangeSelector:@selector(onOSSubscriptionChanged:)];
     return _subscriptionStateChangesObserver;
 }
 
-+ (void) setMSubscriptionStatus:(NSNumber*)status {
++ (void)setMSubscriptionStatus:(NSNumber*)status {
     mSubscriptionStatus = [status intValue];
 }
     
@@ -252,12 +250,8 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
     return self.currentSubscriptionState.userId;
 }
 
-+ (void) setMSDKType:(NSString*)type {
++ (void)setMSDKType:(NSString*)type {
     mSDKType = type;
-}
-
-+ (NSString*)getDeviceToken {
-    return self.currentSubscriptionState.pushToken;
 }
 
 + (void) setWaitingForApnsResponse:(BOOL)value {
@@ -278,7 +272,7 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
     _subscriptionStateChangesObserver = nil;
 }
 
-//Set to false as soon as it's read.
+// Set to false as soon as it's read.
 + (BOOL)coldStartFromTapOnNotification {
     BOOL val = coldStartFromTapOnNotification;
     coldStartFromTapOnNotification = NO;
@@ -532,8 +526,11 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // onOSPermissionChanged should only fire if something changed.
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    id wrapperObserver = [[OSPermissionStateObserverWrapper alloc] initWithOSPermissionObserver:observer];
-    [self.permissionStateChangesObserver addObserver:wrapperObserver];
+   // id wrapperObserver = [[OSPermissionStateObserverWrapper alloc] initWithOSPermissionObserver:observer];
+   // [self.permissionStateChangesObserver addObserver:wrapperObserver];
+    
+    [self.permissionStateChangesObserver addObserver:observer];
+    
     // TODO: Read previous values stored here. Compare and fire event right away if different.
 }
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer {
@@ -543,8 +540,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // onOSSubscriptionChanged should only fire if something changed.
 + (void)addSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
-    id wrapperObserver = [[OSSubscriptionStateObserverWrapper alloc] initWithOSSubscriptionObserver:observer];
-    [self.subscriptionStateChangesObserver addObserver:wrapperObserver];
+    [self.subscriptionStateChangesObserver addObserver:observer];
+    
     // TODO: Read previous values stored here. Compare and fire event right away if different.
 }
 + (void)removeSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -223,6 +223,26 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, NSObject<OSSubscrip
 
 @end
 
+// Maps generic onChanged observer to specific onOSSubscriptionChanged selector.
+@interface OSSubscriptionStateObserverWrapper : NSObject<OSObserver>
+- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
+@end
+
+@implementation OSSubscriptionStateObserverWrapper {
+    NSObject<OSSubscriptionObserver>* _observer;
+}
+
+- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
+    _observer = observer;
+    return self;
+}
+
+- (void)onChanged:(id)state {
+    [_observer onOSSubscriptionChanged:state];
+}
+
+@end
+
 
 
 // Permission Start
@@ -311,6 +331,26 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
     [OneSignal.permissionStateChangesObserver notifyChange:stateChanges];
     
     [stateChanges.from persist];
+}
+
+@end
+
+// Maps generic onChanged observer to specific onOSPermissionChanged selector.
+@interface OSPermissionStateObserverWrapper : NSObject<OSObserver>
+- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
+@end
+
+@implementation OSPermissionStateObserverWrapper {
+    NSObject<OSPermissionObserver>* _observer;
+}
+
+- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
+    _observer = observer;
+    return self;
+}
+
+- (void)onChanged:(id)state {
+    [_observer onOSPermissionChanged:state];
 }
 
 @end
@@ -805,7 +845,10 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // onOSPermissionChanged should only fire if something changed.
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    [self.permissionStateChangesObserver addObserver:observer];
+    
+    id wrapperObserver = [[OSPermissionStateObserverWrapper alloc] initWithOSPermissionObserver:observer];
+    
+    [self.permissionStateChangesObserver addObserver:wrapperObserver];
     // TODO: Read previous values stored here. Compare and fire event right away if different.
 }
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer {
@@ -816,7 +859,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // onOSSubscriptionChanged should only fire if something changed.
 + (void)addSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
-    [self.subscriptionStateChangesObserver addObserver:observer];
+    id wrapperObserver = [[OSSubscriptionStateObserverWrapper alloc] initWithOSSubscriptionObserver:observer];
+    [self.subscriptionStateChangesObserver addObserver:wrapperObserver];
     // TODO: Read previous values stored here. Compare and fire event right away if different.
 }
 + (void)removeSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -275,6 +275,7 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
     _currentSubscriptionState = nil;
     
     _permissionStateChangesObserver = nil;
+    _subscriptionStateChangesObserver = nil;
 }
 
 //Set to false as soon as it's read.

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -523,12 +523,10 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // onOSPermissionChanged should only fire if something changed.
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-   // id wrapperObserver = [[OSPermissionStateObserverWrapper alloc] initWithOSPermissionObserver:observer];
-   // [self.permissionStateChangesObserver addObserver:wrapperObserver];
-    
     [self.permissionStateChangesObserver addObserver:observer];
     
-    // TODO: Read previous values stored here. Compare and fire event right away if different.
+    if ([self.currentPermissionState compare:self.lastPermissionState])
+        [OSPermissionChangedInternalObserver fireChangesObserver:self.currentPermissionState];
 }
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer {
     [self.permissionStateChangesObserver removeObserver:observer];
@@ -539,7 +537,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 + (void)addSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
     [self.subscriptionStateChangesObserver addObserver:observer];
     
-    // TODO: Read previous values stored here. Compare and fire event right away if different.
+    if ([self.currentSubscriptionState compare:self.lastSubscriptionState])
+        [OSSubscriptionChangedInternalObserver fireChangesObserver:self.currentSubscriptionState];
 }
 + (void)removeSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
     [self.subscriptionStateChangesObserver removeObserver:observer];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -100,342 +100,8 @@ NSString* const kOSSettingsKeyInFocusDisplayOption = @"kOSSettingsKeyInFocusDisp
 NSString* const kOSSettingsKeyInOmitNoAppIdLogging = @"kOSSettingsKeyInOmitNoAppIdLogging";
 
 
-
-
-// OSSubscription.subscribed has a depency on OSPermission.
-//   They need to both need a has-a then?
-
-
-
-
-@interface OSSubscriptionStateChanges (Internal)
-- (void)onChanged;
-@end
-
-@protocol OSSubscriptionStateObserver
--(void)onChanged:(OSSubscriptionState*)state;
-@end
-
-typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState*> ObserableSubscriptionStateType;
-
-@implementation OSSubscriptionState {
-    ObserableSubscriptionStateType* _observable;
-}
-
-- (ObserableSubscriptionStateType*)observable {
-    if (!_observable)
-        _observable = [[OSObservable alloc] init];
-    return _observable;
-}
-
-- (instancetype)initAsToWithPermision:(BOOL)permission {
-    _accpeted = permission;
-    
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    _userId = [userDefaults stringForKey:@"GT_PLAYER_ID"];
-    _pushToken = [userDefaults stringForKey:@"GT_DEVICE_TOKEN"];
-    _userSubscriptionSetting = [userDefaults objectForKey:@"ONESIGNAL_SUBSCRIPTION"] == nil;
-    
-    return self;
-}
-
-- (BOOL)compareWithFrom:(OSSubscriptionState*)from {
-    return self.userId != from.userId ||
-    self.pushToken != from.pushToken ||
-    self.userSubscriptionSetting != from.userSubscriptionSetting ||
-    self.accpeted != from.accpeted;
-}
-
-- (instancetype)initAsFrom {
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    
-    _userId = [userDefaults stringForKey:@"GT_PLAYER_ID_LAST"];
-    _pushToken = [userDefaults stringForKey:@"GT_DEVICE_TOKEN_LAST"];
-    _userSubscriptionSetting = [userDefaults boolForKey:@"ONESIGNAL_SUBSCRIPTION_LAST"];
-    _accpeted = [userDefaults boolForKey:@"ONESIGNAL_PERMISSION_ACCEPTED_LAST"];
-    
-    return self;
-}
-
-- (void)persistAsFrom {
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    
-    [userDefaults setObject:_userId forKey:@"GT_PLAYER_ID_LAST"];
-    [userDefaults setObject:_pushToken forKey:@"GT_DEVICE_TOKEN_LAST"];
-    [userDefaults setBool:_userSubscriptionSetting forKey:@"ONESIGNAL_SUBSCRIPTION_LAST"];
-    [userDefaults setBool:_accpeted forKey:@"ONESIGNAL_PERMISSION_ACCEPTED_LAST"];
-    
-    [userDefaults synchronize];
-}
-
-- (instancetype)copyWithZone:(NSZone*)zone {
-    OSSubscriptionState* copy = [[[self class] alloc] init];
-    
-    if (copy) {
-        copy->_userId = [_userId copy];
-        copy->_pushToken = [_pushToken copy];
-        copy->_userSubscriptionSetting = _userSubscriptionSetting;
-        copy->_accpeted = _accpeted;
-    }
-    
-    return copy;
-}
-
-
-- (void)onChanged:(OSPermissionState*)state {
-    [self setAccepted:state.accepted];
-}
-
-- (void)setUserId:(NSString*)userId {
-    BOOL changed = ![[NSString stringWithString:userId] isEqualToString:_userId];
-    _userId = userId;
-    if (self.observable && changed)
-        [self.observable notifyChange:self];
-}
-
-- (void)setPushToken:(NSString*)pushToken {
-    BOOL changed = ![[NSString stringWithString:pushToken] isEqualToString:_pushToken];
-    _pushToken = pushToken;
-    if (self.observable && changed)
-        [self.observable notifyChange:self];
-}
-
-- (void)setUserSubscriptionSetting:(BOOL)userSubscriptionSetting {
-    BOOL changed = userSubscriptionSetting != _userSubscriptionSetting;
-    _userSubscriptionSetting = userSubscriptionSetting;
-    if (self.observable && changed)
-        [self.observable notifyChange:self];
-}
-
-- (void)setAccepted:(BOOL)inAccpeted {
-    BOOL lastSubscribed = self.subscribed;
-    _accpeted = inAccpeted;
-    if (lastSubscribed != self.subscribed)
-        [self.observable notifyChange:self];
-}
-
-- (BOOL)subscribed {
-    return _userId && _pushToken && _userSubscriptionSetting && _accpeted;
-}
-
-@end
-
-
-@interface OSSubscriptionChangedInternalObserver : NSObject<OSSubscriptionStateObserver>
-@end
-
-@implementation OSSubscriptionChangedInternalObserver
-
-- (void)onChanged:(OSSubscriptionState*)state {
-    OSSubscriptionStateChanges* stateChanges = [OSSubscriptionStateChanges alloc];
-    stateChanges.from = OneSignal.lastSubscriptionState;
-    stateChanges.to = state;
-    
-    [OneSignal.subscriptionStateChangesObserver notifyChange:stateChanges];
-    
-    OneSignal.lastSubscriptionState = [state copy];
-    [OneSignal.lastSubscriptionState persistAsFrom];
-}
-
-@end
-
-// Maps generic onChanged observer to specific onOSSubscriptionChanged selector.
-@interface OSSubscriptionStateObserverWrapper : NSObject<OSObserver>
-- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
-@end
-
-@implementation OSSubscriptionStateObserverWrapper {
-    NSObject<OSSubscriptionObserver>* _observer;
-}
-
-- (instancetype)initWithOSSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
-    _observer = observer;
-    return self;
-}
-
-- (void)onChanged:(id)state {
-    [_observer onOSSubscriptionChanged:state];
-}
-
-@end
-
-
-
-// Permission Start
-
-typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> ObserablePermissionStateType;
-
-@implementation OSPermissionState {
-    ObserablePermissionStateType* _observable;
-}
-
-- (ObserablePermissionStateType*)observable {
-    if (!_observable)
-        _observable = [[OSObservable alloc] init];
-    return _observable;
-}
-
-- (instancetype)initAsTo {
-    [OneSignal.osNotificationSettings getNotificationPermissionState];
-    
-    return self;
-}
-
-- (instancetype)initAsFrom {
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    
-    _hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
-    _anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
-    _accepted  = [userDefaults boolForKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
-    
-    return self;
-}
-
-- (void)persistAsFrom {
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    
-    [userDefaults setBool:_hasPrompted forKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
-    [userDefaults setBool:_anwseredPrompt forKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
-    [userDefaults setBool:_accepted forKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
-    
-    [userDefaults synchronize];
-}
-
-
-- (instancetype)copyWithZone:(NSZone*)zone {
-    OSPermissionState* copy = [[[self class] alloc] init];
-    
-    if (copy) {
-        copy->_hasPrompted = _hasPrompted;
-        copy->_anwseredPrompt = _anwseredPrompt;
-        copy->_accepted = _accepted;
-    }
-    
-    return copy;
-}
-
-
-- (BOOL)hasPrompted {
-    // If we know they anwsered turned notificaitons on then were prompted at some point.
-    if (self.anwseredPrompt) // self. triggers getter
-        return true;
-    return _hasPrompted;
-}
-
-- (BOOL)anwseredPrompt {
-    // If we got an accepted permission then they anwsered the prompt.
-    if (_accepted)
-        return true;
-    return _anwseredPrompt;
-}
-
-- (void)setAccepted:(BOOL)accepted {
-    BOOL changed = _accepted != accepted;
-    _accepted = accepted;
-    if (changed)
-        [self.observable notifyChange:self];
-}
-
-@end
-
-
-@implementation OSPermissionStateChanges
-
-- (instancetype)init {
-    return self;
-}
-
-@end
-
-
-@interface OSPermissionChangedInternalObserver : NSObject<OSPermissionStateObserver>
-@end
-
-@implementation OSPermissionChangedInternalObserver
-
-- (void)onChanged:(OSPermissionState*)state {
-    OSPermissionStateChanges* stateChanges = [OSPermissionStateChanges alloc];
-    stateChanges.from = OneSignal.lastPermissionState;
-    stateChanges.to = state;
-    
-    [OneSignal.permissionStateChangesObserver notifyChange:stateChanges];
-    
-    
-    OneSignal.lastPermissionState = [state copy];
-    
-    [OneSignal.lastPermissionState persistAsFrom];
-}
-
-@end
-
-// Maps generic onChanged observer to specific onOSPermissionChanged selector.
-@interface OSPermissionStateObserverWrapper : NSObject<OSObserver>
-- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
-@end
-
-@implementation OSPermissionStateObserverWrapper {
-    NSObject<OSPermissionObserver>* _observer;
-}
-
-- (instancetype)initWithOSPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    _observer = observer;
-    return self;
-}
-
-- (void)onChanged:(id)state {
-    [_observer onOSPermissionChanged:state];
-}
-
-@end
-
-
-// Permission End
-
-
-
-
-@implementation OSSubscriptionStateChanges {
-    @public void (^changedHandler)(OSSubscriptionStateChanges* subscriptionStatus);
-}
-
--(instancetype)initWithToState:(OSSubscriptionState*)state withPermission:(BOOL)accpeted {
-    if (self = [super init]) {
-        _to = state;
-    }
-    
-    return self;
-}
-
-- (void)changedEvent {
-    changedHandler(self);
-    [self saveLasts];
-}
-
-- (BOOL)hasChanged {
-   // _from = [[OSSubscriptionState alloc] initAsFrom];
-    return ![_to isEqual:_from];
-}
-
-- (void)saveLasts {
-    if (![_to isEqual:_from]) {
-        _from = [_to copy];
-        
-        NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-        
-        [userDefaults setObject:_from.userId forKey:@"GT_PLAYER_ID_LAST"];
-        [userDefaults setObject:_from.pushToken forKey:@"GT_DEVICE_TOKEN_LAST"];
-        [userDefaults setBool:_from.userSubscriptionSetting forKey:@"ONESIGNAL_SUBSCRIPTION_LAST"];
-        
-        [userDefaults synchronize];
-    }
-}
-
-@end
-
-
 @implementation OSPermissionSubscriptionState
 @end
-
 
 @interface OSPendingCallbacks : NSObject
  @property OSResultSuccessBlock successBlock;
@@ -476,10 +142,6 @@ static int mSubscriptionStatus = -1;
 OSIdsAvailableBlock idsAvailableBlockWhenReady;
 BOOL disableBadgeClearing = NO;
 BOOL mShareLocation = YES;
-
-void (^subscriptionChangedCallback)(OSSubscriptionStateChanges* subscriptionStatus);
-
-OSSubscriptionStateChanges* currentOSSubscriptionStateChanges;
 
 // iOS version implemation
 static NSObject<OneSignalNotificationSettings>* _osNotificationSettings;
@@ -602,7 +264,7 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
     waitingForApnsResponse = value;
 }
 
-+(void)clearStatics {
++ (void)clearStatics {
     _osNotificationSettings = nil;
     waitingForApnsResponse = false;
     
@@ -839,9 +501,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     return true;
 }
 
-
-
-
 + (void)promptForPushNotificationWithUserResponse:(void(^)(BOOL accepted))completionHandler {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"registerForPushNotifications Called:waitingForApnsResponse: %d", waitingForApnsResponse]];
     
@@ -872,16 +531,13 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // onOSPermissionChanged should only fire if something changed.
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    
     id wrapperObserver = [[OSPermissionStateObserverWrapper alloc] initWithOSPermissionObserver:observer];
-    
     [self.permissionStateChangesObserver addObserver:wrapperObserver];
     // TODO: Read previous values stored here. Compare and fire event right away if different.
 }
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer {
     [self.permissionStateChangesObserver removeObserver:observer];
 }
-
 
 
 // onOSSubscriptionChanged should only fire if something changed.

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -74,7 +74,7 @@
 #define ERROR_PUSH_UNKOWN_APNS_ERROR       -16
 #define ERROR_PUSH_OTHER_3000_ERROR        -17
 #define ERROR_PUSH_NEVER_PROMPTED          -18
-#define ERROR_PUSH_PROMPT_NEVER_ANWSERED   -19
+#define ERROR_PUSH_PROMPT_NEVER_ANSWERED   -19
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
@@ -383,7 +383,7 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
             [self registerUser];
         else {
             [self.osNotificationSettings getNotificationPermissionState:^(OSPermissionState *state) {
-                if (state.anwseredPrompt)
+                if (state.answeredPrompt)
                     [self registerUser];
                 else
                     [self performSelector:@selector(registerUser) withObject:nil afterDelay:30.0f];
@@ -874,7 +874,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
         // iOS 8+ - We get a token right away but give the user 30 sec to respond notification permission prompt.
         // The goal is to only have 1 server call.
         [self.osNotificationSettings getNotificationPermissionState:^(OSPermissionState *status) {
-            if (status.anwseredPrompt)
+            if (status.answeredPrompt)
                 [OneSignal registerUser];
             else {
                 [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(registerUser) object:nil];
@@ -1361,8 +1361,8 @@ static NSString *_lastnonActiveMessageId;
     
     if (!permissionStatus.hasPrompted)
         return ERROR_PUSH_NEVER_PROMPTED;
-    if (!permissionStatus.anwseredPrompt)
-        return ERROR_PUSH_PROMPT_NEVER_ANWSERED;
+    if (!permissionStatus.answeredPrompt)
+        return ERROR_PUSH_PROMPT_NEVER_ANSWERED;
     
     if (!self.currentSubscriptionState.userSubscriptionSetting)
         return -2;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -605,6 +605,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(sendTagsToServer) object:nil];
     
     // Can't send tags yet as their isn't a player_id.
+    //   tagsToSend will be sent with the POST create player call later in this case.
     if (self.currentSubscriptionState.userId)
         [self performSelector:@selector(sendTagsToServer) withObject:nil afterDelay:5];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -97,6 +97,15 @@ NSString* const kOSSettingsKeyInFocusDisplayOption = @"kOSSettingsKeyInFocusDisp
 NSString* const kOSSettingsKeyInOmitNoAppIdLogging = @"kOSSettingsKeyInOmitNoAppIdLogging";
 
 
+
+@implementation OSSubscriptionState
+
+- (BOOL)subscribed {
+    return _userId && _pushToken && _userSubscriptionSetting;
+}
+
+@end
+
 @implementation OSPermissionStatus
 // Override Getters
 // Returns logical turths so the comsumer of the object don't have to check more than one property
@@ -116,6 +125,11 @@ NSString* const kOSSettingsKeyInOmitNoAppIdLogging = @"kOSSettingsKeyInOmitNoApp
 }
 
 @end
+
+@implementation OSPermisionSubscriptionState
+@end
+
+
 
 @interface OSPendingCallbacks : NSObject
  @property OSResultSuccessBlock successBlock;
@@ -465,6 +479,22 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 //    Will trigger didRegisterForRemoteNotificationsWithDeviceToken on the AppDelegate when APNs responses.
 + (void)registerForPushNotifications {
     [self promptForPushNotificationWithUserResponse:nil];
+}
+
+
++ (OSPermisionSubscriptionState*)getPermisionSubscriptionState {
+    OSPermisionSubscriptionState* status = [OSPermisionSubscriptionState alloc];
+    
+    status.permissionStatus = [osNotificationSettings getNotificationPermissionStatus];
+    
+    status.subscriptionStatus = [OSSubscriptionState alloc];
+    status.subscriptionStatus.userId = mUserId;
+    status.subscriptionStatus.pushToken = mDeviceToken;
+    status.subscriptionStatus.userSubscriptionSetting = mSubscriptionSet;
+    
+    // TODO: Consider adding subscribing state for OneSignal and Apns
+    
+    return status;
 }
 
 // Block not assigned if userID nil and there is a device token

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -105,6 +105,7 @@
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:url];
     
     DirectDownloadDelegate* delegate = [[DirectDownloadDelegate alloc] initWithFilePath:localPath];
+    // TODO: Try cleaning up warning with connectionWithRequest
     [[NSURLConnection alloc] initWithRequest:request delegate:delegate];
     
     while ([delegate isDone] == NO) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -36,6 +36,7 @@
 #import "OneSignalNotificationSettings.h"
 
 typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
+typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChanges*> ObserableSubscriptionStateChangesType;
 
 @interface OneSignal (OneSignalInternal)
 + (NSString*)getDeviceToken;
@@ -48,10 +49,12 @@ typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*>
 @property (class) OSPermissionState* lastPermissionState;
 @property (class) OSPermissionState* currentPermissionState;
 
+@property (class) NSObject<OSSubscriptionState>* lastSubscriptionState;
 @property (class) NSObject<OSSubscriptionState>* currentSubscriptionState;
 
 // Used to manage observers added by the app developer.
 @property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;
+@property (class) ObserableSubscriptionStateChangesType* subscriptionStateChangesObserver;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -101,14 +101,13 @@
 - (void)onChanged:(OSPermissionState*)state;
 @end
 
-@interface OSSubscriptionStateInternal : OSSubscriptionState<OSPermissionStateObserver>
+@interface OSSubscriptionState () <OSPermissionStateObserver>
 
 @property (nonatomic) BOOL accpeted;
 
-
 - (void)setAccepted:(BOOL)inAccpeted;
 - (void)persistAsFrom;
-- (BOOL)compareWithFrom:(OSSubscriptionStateInternal*)from;
+- (BOOL)compareWithFrom:(OSSubscriptionState*)from;
 @end
 
 typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
@@ -125,8 +124,8 @@ typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChang
 @property (class) OSPermissionState* lastPermissionState;
 @property (class) OSPermissionState* currentPermissionState;
 
-@property (class) OSSubscriptionStateInternal* lastSubscriptionState;
-@property (class) OSSubscriptionStateInternal* currentSubscriptionState;
+@property (class) OSSubscriptionState* lastSubscriptionState;
+@property (class) OSSubscriptionState* currentSubscriptionState;
 
 // Used to manage observers added by the app developer.
 @property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -48,6 +48,8 @@ typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*>
 @property (class) OSPermissionState* lastPermissionState;
 @property (class) OSPermissionState* currentPermissionState;
 
+@property (class) NSObject<OSSubscriptionState>* currentSubscriptionState;
+
 // Used to manage observers added by the app developer.
 @property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -33,7 +33,7 @@
 
 #import "OneSignal.h"
 
-@interface OneSignal (UN_extra)
+@interface OneSignal (OneSignalInternal)
 + (NSString*)getDeviceToken;
 + (void)updateNotificationTypes:(int)notificationTypes;
 + (BOOL)registerForAPNsToken;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -49,7 +49,6 @@
 
 
 @interface OneSignal (OneSignalInternal)
-+ (NSString*)getDeviceToken;
 + (void)updateNotificationTypes:(int)notificationTypes;
 + (BOOL)registerForAPNsToken;
 + (void)setWaitingForApnsResponse:(BOOL)value;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -39,7 +39,7 @@
 #import "OSSubscription.h"
 
 
-// Redefine OSPermissionSubscriptionState
+// Permission + Subscription - Redefine OSPermissionSubscriptionState
 @interface OSPermissionSubscriptionState ()
 
 @property (readwrite) OSPermissionState* permissionStatus;
@@ -54,6 +54,8 @@
 + (void)setWaitingForApnsResponse:(BOOL)value;
 
 @property (class) NSObject<OneSignalNotificationSettings>* osNotificationSettings;
+
+@property (class) OSPermissionState* currentPermissionState;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -35,6 +35,82 @@
 #import "OSObservable.h"
 #import "OneSignalNotificationSettings.h"
 
+
+
+// Redefines are done so we can make properites writeable and backed internal variables accesiable to the SDK.
+// Basicly the C# equivlent of a public gettter with an internal settter.
+
+
+// Redefine OSPermissionState
+@interface OSPermissionState ()
+
+@property (readwrite, nonatomic) BOOL hasPrompted;
+@property (readwrite, nonatomic) BOOL anwseredPrompt;
+@property (readwrite, nonatomic) BOOL accepted;
+@property int notificationTypes;
+
+- (void) persistAsFrom;
+
+@end
+
+// Redefine OSSubscriptionState
+@interface OSSubscriptionState () {
+@protected BOOL _userSubscriptionSetting;
+@protected NSString* _userId;
+@protected NSString* _pushToken;
+}
+
+@property (readwrite, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (readwrite, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (readwrite, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
+@property (readwrite, nonatomic) NSString* pushToken; // AKA Apple Device Token
+
+@end
+
+// Redefine OSSubscriptionState
+@interface OSPermissionStateChanges ()
+
+@property (readwrite) OSPermissionState* to;
+@property (readwrite) OSPermissionState* from;
+@property (readwrite, nonatomic) BOOL justEnabled;
+@property (readwrite, nonatomic) BOOL justDisabled;
+
+@end
+
+
+// Redefine OSPermissionSubscriptionState
+@interface OSPermissionSubscriptionState ()
+
+@property (readwrite) OSPermissionState* permissionStatus;
+@property (readwrite) OSSubscriptionState* subscriptionStatus;
+
+@end
+
+// Redefine OSSubscriptionStateChanges
+@interface OSSubscriptionStateChanges ()
+
+@property (readwrite) OSSubscriptionState* to;
+@property (readwrite) OSSubscriptionState* from;
+@property (readwrite) BOOL becameSubscribed;
+@property (readwrite) BOOL becameUnsubscribed;
+
+@end
+
+
+@protocol OSPermissionStateObserver<NSObject>
+- (void)onChanged:(OSPermissionState*)state;
+@end
+
+@interface OSSubscriptionStateInternal : OSSubscriptionState<OSPermissionStateObserver>
+
+@property (nonatomic) BOOL accpeted;
+
+
+- (void)setAccepted:(BOOL)inAccpeted;
+- (void)persistAsFrom;
+- (BOOL)compareWithFrom:(OSSubscriptionStateInternal*)from;
+@end
+
 typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
 typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChanges*> ObserableSubscriptionStateChangesType;
 
@@ -49,8 +125,8 @@ typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChang
 @property (class) OSPermissionState* lastPermissionState;
 @property (class) OSPermissionState* currentPermissionState;
 
-@property (class) NSObject<OSSubscriptionState>* lastSubscriptionState;
-@property (class) NSObject<OSSubscriptionState>* currentSubscriptionState;
+@property (class) OSSubscriptionStateInternal* lastSubscriptionState;
+@property (class) OSSubscriptionStateInternal* currentSubscriptionState;
 
 // Used to manage observers added by the app developer.
 @property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -35,47 +35,8 @@
 #import "OSObservable.h"
 #import "OneSignalNotificationSettings.h"
 
-
-
-// Redefines are done so we can make properites writeable and backed internal variables accesiable to the SDK.
-// Basicly the C# equivlent of a public gettter with an internal settter.
-
-
-// Redefine OSPermissionState
-@interface OSPermissionState ()
-
-@property (readwrite, nonatomic) BOOL hasPrompted;
-@property (readwrite, nonatomic) BOOL anwseredPrompt;
-@property (readwrite, nonatomic) BOOL accepted;
-@property int notificationTypes;
-
-- (void) persistAsFrom;
-
-@end
-
-// Redefine OSSubscriptionState
-@interface OSSubscriptionState () {
-@protected BOOL _userSubscriptionSetting;
-@protected NSString* _userId;
-@protected NSString* _pushToken;
-}
-
-@property (readwrite, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (readwrite, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
-@property (readwrite, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
-@property (readwrite, nonatomic) NSString* pushToken; // AKA Apple Device Token
-
-@end
-
-// Redefine OSSubscriptionState
-@interface OSPermissionStateChanges ()
-
-@property (readwrite) OSPermissionState* to;
-@property (readwrite) OSPermissionState* from;
-@property (readwrite, nonatomic) BOOL justEnabled;
-@property (readwrite, nonatomic) BOOL justDisabled;
-
-@end
+#import "OSPermission.h"
+#import "OSSubscription.h"
 
 
 // Redefine OSPermissionSubscriptionState
@@ -86,32 +47,6 @@
 
 @end
 
-// Redefine OSSubscriptionStateChanges
-@interface OSSubscriptionStateChanges ()
-
-@property (readwrite) OSSubscriptionState* to;
-@property (readwrite) OSSubscriptionState* from;
-@property (readwrite) BOOL becameSubscribed;
-@property (readwrite) BOOL becameUnsubscribed;
-
-@end
-
-
-@protocol OSPermissionStateObserver<NSObject>
-- (void)onChanged:(OSPermissionState*)state;
-@end
-
-@interface OSSubscriptionState () <OSPermissionStateObserver>
-
-@property (nonatomic) BOOL accpeted;
-
-- (void)setAccepted:(BOOL)inAccpeted;
-- (void)persistAsFrom;
-- (BOOL)compareWithFrom:(OSSubscriptionState*)from;
-@end
-
-typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObserablePermissionStateChangesType;
-typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChanges*> ObserableSubscriptionStateChangesType;
 
 @interface OneSignal (OneSignalInternal)
 + (NSString*)getDeviceToken;
@@ -120,16 +55,6 @@ typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChang
 + (void)setWaitingForApnsResponse:(BOOL)value;
 
 @property (class) NSObject<OneSignalNotificationSettings>* osNotificationSettings;
-
-@property (class) OSPermissionState* lastPermissionState;
-@property (class) OSPermissionState* currentPermissionState;
-
-@property (class) OSSubscriptionState* lastSubscriptionState;
-@property (class) OSSubscriptionState* currentSubscriptionState;
-
-// Used to manage observers added by the app developer.
-@property (class) ObserablePermissionStateChangesType* permissionStateChangesObserver;
-@property (class) ObserableSubscriptionStateChangesType* subscriptionStateChangesObserver;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettings.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettings.h
@@ -28,25 +28,22 @@
 #ifndef OneSignalNotificationSettings_h
 #define OneSignalNotificationSettings_h
 
+#import "OneSignal.h"
+
 #import <Foundation/Foundation.h>
-
-@interface OSPermissionStatus : NSObject
-
-@property (nonatomic) BOOL hasPrompted;
-@property (nonatomic) BOOL anwseredPrompt;
-@property BOOL accepted;
-@property int notificationTypes;
-
-@end
-
-
 
 @protocol OneSignalNotificationSettings <NSObject>
 
 - (int) getNotificationTypes;
 - (OSPermissionStatus*)getNotificationPermissionStatus;
 - (void)getNotificationPermissionStatus:(void (^)(OSPermissionStatus *subcscriptionStatus))completionHandler;
-- (void)promptForNotifications;
+- (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler;
+
+// Only used for iOS 8 & 9
+- (void)onNotificationPromptResponse:(int)notificationTypes;
+
+// Only used for iOS 7
+- (void)onAPNsResponse:(BOOL)success;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettings.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettings.h
@@ -35,8 +35,8 @@
 @protocol OneSignalNotificationSettings <NSObject>
 
 - (int) getNotificationTypes;
-- (OSPermissionStatus*)getNotificationPermissionStatus;
-- (void)getNotificationPermissionStatus:(void (^)(OSPermissionStatus *subcscriptionStatus))completionHandler;
+- (OSPermissionState*)getNotificationPermissionState;
+- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionState))completionHandler;
 - (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler;
 
 // Only used for iOS 8 & 9

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.h
@@ -31,6 +31,7 @@
 #import "OneSignalNotificationSettings.h"
 
 @interface OneSignalNotificationSettingsIOS10 : NSObject <OneSignalNotificationSettings>
++(dispatch_queue_t)getQueue;
 @end
 
 #endif /* OneSignalNotificationSettingsIOS10_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -102,6 +102,7 @@ static dispatch_queue_t serialQueue;
 }
 
 // Prompt then run updateNotificationTypes on the main thread with the response.
+// FUTURE: Add a 2nd seloctor with 'withOptions' for UNAuthorizationOptions*'s
 - (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler {
     
     id responseBlock = ^(BOOL granted, NSError* error) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -63,12 +63,12 @@ static dispatch_queue_t serialQueue;
     // NOTE2: Apple runs the callback on a background serial queue
     dispatch_async(serialQueue, ^{
         [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings* settings) {
+            NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
             OSPermissionState* status = OneSignal.currentPermissionState;
             
-            NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-            status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
-            status.anwseredPrompt = settings.authorizationStatus != UNAuthorizationStatusNotDetermined;
             status.accepted = settings.authorizationStatus == UNAuthorizationStatusAuthorized;
+            status.anwseredPrompt = settings.authorizationStatus != UNAuthorizationStatusNotDetermined;
+            status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
             status.notificationTypes = (settings.badgeSetting == UNNotificationSettingEnabled ? 1 : 0)
                                      + (settings.soundSetting == UNNotificationSettingEnabled ? 2 : 0)
                                      + (settings.alertSetting == UNNotificationSettingEnabled ? 4 : 0)
@@ -108,8 +108,8 @@ static dispatch_queue_t serialQueue;
     id responseBlock = ^(BOOL granted, NSError* error) {
         // Run callback on main / UI thread
         [OneSignalHelper dispatch_async_on_main_queue: ^{
-            OneSignal.currentPermissionState.anwseredPrompt = true;
             OneSignal.currentPermissionState.accepted = granted;
+            OneSignal.currentPermissionState.anwseredPrompt = true;
             [OneSignal updateNotificationTypes: granted ? 15 : 0];
             if (completionHandler)
                 completionHandler(granted);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -63,12 +63,10 @@ static dispatch_queue_t serialQueue;
     // NOTE2: Apple runs the callback on a background serial queue
     dispatch_async(serialQueue, ^{
         [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings* settings) {
-            NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
             OSPermissionState* status = OneSignal.currentPermissionState;
             
             status.accepted = settings.authorizationStatus == UNAuthorizationStatusAuthorized;
             status.anwseredPrompt = settings.authorizationStatus != UNAuthorizationStatusNotDetermined;
-            status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
             status.notificationTypes = (settings.badgeSetting == UNNotificationSettingEnabled ? 1 : 0)
                                      + (settings.soundSetting == UNNotificationSettingEnabled ? 2 : 0)
                                      + (settings.alertSetting == UNNotificationSettingEnabled ? 4 : 0)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -85,15 +85,18 @@ OSPermissionStatus *cachedStatus;
 }
 
 // Prompt then run updateNotificationTypes on the main thread with the response.
-- (void)promptForNotifications {
+- (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler {
     
     id responseBlock = ^(BOOL granted, NSError* error) {
+        // Run callback on main / UI thread
         [OneSignalHelper dispatch_async_on_main_queue: ^{
             if (cachedStatus) {
                 cachedStatus.anwseredPrompt = true;
                 cachedStatus.accepted = granted;
             }
             [OneSignal updateNotificationTypes: granted ? 15 : 0];
+            if (completionHandler)
+                completionHandler(granted);
         }];
     };
     
@@ -103,5 +106,11 @@ OSPermissionStatus *cachedStatus;
     
     [OneSignal registerForAPNsToken];
 }
+
+// Ignore these 2 events, promptForNotifications: already takes care of this.
+// Only iOS 8 & 9
+- (void)onNotificationPromptResponse:(int)notificationTypes { }
+// Only iOS 7
+- (void)onAPNsResponse:(BOOL)success {}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -66,7 +66,7 @@ static dispatch_queue_t serialQueue;
             OSPermissionState* status = OneSignal.currentPermissionState;
             
             status.accepted = settings.authorizationStatus == UNAuthorizationStatusAuthorized;
-            status.anwseredPrompt = settings.authorizationStatus != UNAuthorizationStatusNotDetermined;
+            status.answeredPrompt = settings.authorizationStatus != UNAuthorizationStatusNotDetermined;
             status.notificationTypes = (settings.badgeSetting == UNNotificationSettingEnabled ? 1 : 0)
                                      + (settings.soundSetting == UNNotificationSettingEnabled ? 2 : 0)
                                      + (settings.alertSetting == UNNotificationSettingEnabled ? 4 : 0)
@@ -107,7 +107,7 @@ static dispatch_queue_t serialQueue;
         // Run callback on main / UI thread
         [OneSignalHelper dispatch_async_on_main_queue: ^{
             OneSignal.currentPermissionState.accepted = granted;
-            OneSignal.currentPermissionState.anwseredPrompt = true;
+            OneSignal.currentPermissionState.answeredPrompt = true;
             [OneSignal updateNotificationTypes: granted ? 15 : 0];
             if (completionHandler)
                 completionHandler(granted);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -84,12 +84,15 @@ static dispatch_queue_t serialQueue;
     if (useCachedStatus)
         return OneSignal.currentPermissionState;
     
-    __block OSPermissionState* returnStatus;
+    __block OSPermissionState* returnStatus = OneSignal.currentPermissionState;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     dispatch_sync(serialQueue, ^{
         [self getNotificationPermissionState:^(OSPermissionState *status) {
             returnStatus = status;
+            dispatch_semaphore_signal(semaphore);
         }];
     });
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
     
     return returnStatus;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -34,7 +34,9 @@
 #import "OneSignalNotificationSettingsIOS7.h"
 
 
-@implementation OneSignalNotificationSettingsIOS7
+@implementation OneSignalNotificationSettingsIOS7 {
+    void (^notificationPromptReponseCallback)(BOOL);
+}
 
 - (void)getNotificationPermissionStatus:(void (^)(OSPermissionStatus *subcscriptionStatus))completionHandler {
     OSPermissionStatus *status = [OSPermissionStatus alloc];
@@ -66,7 +68,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-- (void)promptForNotifications {
+- (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler {
     [[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert];
     [OneSignal setWaitingForApnsResponse:true];
     [[NSUserDefaults standardUserDefaults] setObject:@YES forKey:@"GT_REGISTERED_WITH_APPLE"];
@@ -74,5 +76,17 @@
 }
 
 #pragma GCC diagnostic pop
+
+// Only iOS 8 & 9
+- (void)onNotificationPromptResponse:(int)notificationTypes {}
+
+// Only iOS 7
+- (void)onAPNsResponse:(BOOL)success {
+    if (notificationPromptReponseCallback) {
+        notificationPromptReponseCallback(success);
+        notificationPromptReponseCallback = nil;
+    }
+}
+
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -40,7 +40,7 @@
 
 - (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    OSPermissionState *status = [OSPermissionState alloc];
+    OSPermissionState* status = OneSignal.currentPermissionState;
     
     status.notificationTypes = [self getNotificationTypes];
     status.accepted = status.notificationTypes > 0;
@@ -86,6 +86,9 @@
         notificationPromptReponseCallback(success);
         notificationPromptReponseCallback = nil;
     }
+    
+    OneSignal.currentPermissionState.accepted = success;
+    OneSignal.currentPermissionState.anwseredPrompt = true;
 }
 
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -44,7 +44,7 @@
     
     status.notificationTypes = [self getNotificationTypes];
     status.accepted = status.notificationTypes > 0;
-    status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
+    status.answeredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
     
     completionHandler(status);
 }
@@ -88,7 +88,7 @@
     }
     
     OneSignal.currentPermissionState.accepted = success;
-    OneSignal.currentPermissionState.anwseredPrompt = true;
+    OneSignal.currentPermissionState.answeredPrompt = true;
 }
 
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -45,7 +45,6 @@
     status.notificationTypes = [self getNotificationTypes];
     status.accepted = status.notificationTypes > 0;
     status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
-    status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
     
     completionHandler(status);
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -38,8 +38,8 @@
     void (^notificationPromptReponseCallback)(BOOL);
 }
 
-- (void)getNotificationPermissionStatus:(void (^)(OSPermissionStatus *subcscriptionStatus))completionHandler {
-    OSPermissionStatus *status = [OSPermissionStatus alloc];
+- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
+    OSPermissionState *status = [OSPermissionState alloc];
     
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
@@ -50,14 +50,14 @@
     completionHandler(status);
 }
 
-- (OSPermissionStatus*)getNotificationPermissionStatus {
-    __block OSPermissionStatus* returnStatus = [OSPermissionStatus alloc];
+- (OSPermissionState*)getNotificationPermissionState {
+    __block OSPermissionState* returnState = [OSPermissionState alloc];
     
-    [self getNotificationPermissionStatus:^(OSPermissionStatus *status) {
-        returnStatus = status;
+    [self getNotificationPermissionState:^(OSPermissionState *state) {
+        returnState = state;
     }];
     
-    return returnStatus;
+    return returnState;
 }
 
 - (int) getNotificationTypes {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -39,13 +39,13 @@
 }
 
 - (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     OSPermissionState *status = [OSPermissionState alloc];
     
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
-    status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
     status.notificationTypes = [self getNotificationTypes];
     status.accepted = status.notificationTypes > 0;
+    status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
+    status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
     
     completionHandler(status);
 }
@@ -61,7 +61,7 @@
 }
 
 - (int) getNotificationTypes {
-    return [OneSignal getDeviceToken] == nil ? 0 : 7;
+    return OneSignal.currentSubscriptionState.pushToken == nil ? 0 : 7;
 }
 
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -69,6 +69,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 - (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler {
+    notificationPromptReponseCallback = completionHandler;
     [[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert];
     [OneSignal setWaitingForApnsResponse:true];
     [[NSUserDefaults standardUserDefaults] setObject:@YES forKey:@"GT_REGISTERED_WITH_APPLE"];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.h
@@ -30,6 +30,7 @@
 
 #import "OneSignalNotificationSettings.h"
 
+// Used for iOS 9 & 8
 @interface OneSignalNotificationSettingsIOS8 : NSObject <OneSignalNotificationSettings>
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.h
@@ -30,8 +30,6 @@
 
 #import "OneSignalNotificationSettings.h"
 
-#define NOTIFICATION_TYPE_ALL 7
-
 @interface OneSignalNotificationSettingsIOS8 : NSObject <OneSignalNotificationSettings>
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -37,8 +37,8 @@
     void (^notificationPromptReponseCallback)(BOOL);
 }
 
-- (void)getNotificationPermissionStatus:(void (^)(OSPermissionStatus *subcscriptionStatus))completionHandler {
-    OSPermissionStatus *status = [OSPermissionStatus alloc];
+- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
+    OSPermissionState *status = [OSPermissionState alloc];
     
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
@@ -49,10 +49,10 @@
     completionHandler(status);
 }
 
-- (OSPermissionStatus*)getNotificationPermissionStatus {
-    __block OSPermissionStatus* returnStatus = [OSPermissionStatus alloc];
+- (OSPermissionState*)getNotificationPermissionState {
+    __block OSPermissionState* returnStatus = [OSPermissionState alloc];
     
-    [self getNotificationPermissionStatus:^(OSPermissionStatus *status) {
+    [self getNotificationPermissionState:^(OSPermissionState *status) {
         returnStatus = status;
     }];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -43,7 +43,7 @@
     
     status.notificationTypes = [[UIApplication sharedApplication] currentUserNotificationSettings].types;
     status.accepted = status.notificationTypes > 0;
-    status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
+    status.answeredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
     
     completionHandler(status);
 }
@@ -85,7 +85,7 @@
     }
     
     OneSignal.currentPermissionState.accepted = accepted;
-    OneSignal.currentPermissionState.anwseredPrompt = true;
+    OneSignal.currentPermissionState.answeredPrompt = true;
 }
 
 // Only iOS 7 - The above is used for iOS 8 & 9

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -38,13 +38,13 @@
 }
 
 - (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     OSPermissionState *status = [OSPermissionState alloc];
     
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
-    status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
     status.notificationTypes = [[UIApplication sharedApplication] currentUserNotificationSettings].types;
     status.accepted = status.notificationTypes > 0;
+    status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
+    status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
     
     completionHandler(status);
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -44,7 +44,6 @@
     status.notificationTypes = [[UIApplication sharedApplication] currentUserNotificationSettings].types;
     status.accepted = status.notificationTypes > 0;
     status.anwseredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
-    status.hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"];
     
     completionHandler(status);
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -39,7 +39,7 @@
 
 - (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    OSPermissionState *status = [OSPermissionState alloc];
+    OSPermissionState* status = OneSignal.currentPermissionState;
     
     status.notificationTypes = [[UIApplication sharedApplication] currentUserNotificationSettings].types;
     status.accepted = status.notificationTypes > 0;
@@ -77,10 +77,15 @@
 }
 
 - (void)onNotificationPromptResponse:(int)notificationTypes {
+    BOOL accepted = notificationTypes > 0;
+    
     if (notificationPromptReponseCallback) {
-        notificationPromptReponseCallback(notificationTypes > 0);
+        notificationPromptReponseCallback(accepted);
         notificationPromptReponseCallback = nil;
     }
+    
+    OneSignal.currentPermissionState.accepted = accepted;
+    OneSignal.currentPermissionState.anwseredPrompt = true;
 }
 
 // Only iOS 7 - The above is used for iOS 8 & 9

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,8 @@
 
 #ifndef OneSignalSelectorHelpers_h
 #define OneSignalSelectorHelpers_h
+
+// Functions to help sizzle methods.
 
 BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector);
 Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
@@ -28,5 +28,9 @@
 #ifndef UIApplicationDelegate_OneSignal_h
 #define UIApplicationDelegate_OneSignal_h
 @interface OneSignalAppDelegate : NSObject
+
++ (void)sizzlePreiOS10MethodsPhase1;
++ (void)sizzlePreiOS10MethodsPhase2;
+
 @end
 #endif /* UIApplicationDelegate_OneSignal_h */

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -127,8 +127,9 @@ static NSArray* delegateSubclasses = nil;
     injectToProperClass(@selector(oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:),
                         @selector(application:handleActionWithIdentifier:forLocalNotification:completionHandler:), delegateSubclasses, [OneSignalAppDelegate class], delegateClass);
     
-    // TODO: May need to keep so we can catch events from other SDKs /
     // iOS 10 requestAuthorizationWithOptions has it's own callback
+    //   We also check the permssion status from applicationDidBecomeActive: each time.
+    //   Keeping for fallback in case of a race condidion where the focus event fires to soon.
     injectToProperClass(@selector(oneSignalDidRegisterUserNotifications:settings:),
                         @selector(application:didRegisterUserNotificationSettings:), delegateSubclasses, [OneSignalAppDelegate class], delegateClass);
 }
@@ -177,7 +178,7 @@ static NSArray* delegateSubclasses = nil;
 }
 
 
-// Notification opened! iOS 6 ONLY!
+// Fallback method - Normally this would not fire as oneSignalRemoteSilentNotification below will fire instead. Was needed for iOS 6 support in the past.
 - (void)oneSignalReceivedRemoteNotification:(UIApplication*)application userInfo:(NSDictionary*)userInfo {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalReceivedRemoteNotification:userInfo:"];
     

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -79,7 +79,7 @@ static NSArray* delegateSubclasses = nil;
     
     
     // UNUserNotificationCenter will already handle recieved / open events on iOS 10 so don't swizzle the deprecated ones.
-    BOOL notIos10 = [OneSignalHelper isIOSVersionGreaterOrEqual:10];
+    BOOL notIos10 = ![OneSignalHelper isIOSVersionGreaterOrEqual:10];
     
     Class newClass = [OneSignalAppDelegate class];
     
@@ -96,6 +96,7 @@ static NSArray* delegateSubclasses = nil;
         injectToProperClass(@selector(oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:),
                             @selector(application:handleActionWithIdentifier:forLocalNotification:completionHandler:), delegateSubclasses, newClass, delegateClass);
         
+        // iOS 10 requestAuthorizationWithOptions has it's own callback
         injectToProperClass(@selector(oneSignalDidRegisterUserNotifications:settings:),
                             @selector(application:didRegisterUserNotificationSettings:), delegateSubclasses, newClass, delegateClass);
     }
@@ -115,7 +116,6 @@ static NSArray* delegateSubclasses = nil;
         injectToProperClass(@selector(oneSignalReceivedRemoteNotification:userInfo:),
                             @selector(application:didReceiveRemoteNotification:), delegateSubclasses, newClass, delegateClass);
         
-        // iOS 10 requestAuthorizationWithOptions has it's own callback
         injectToProperClass(@selector(oneSignalLocalNotificationOpened:notification:),
                             @selector(application:didReceiveLocalNotification:), delegateSubclasses, newClass, delegateClass);
     }

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
@@ -30,10 +30,10 @@
 
 #import "OneSignal.h"
 
-#if XC8_AVAILABLE
-@interface swizzleUNUserNotif : NSObject
+@interface OneSignalUNUserNotificationCenter : NSObject
++ (void)swizzleSelectors;
++ (void)setUseiOS10_2_workaround:(BOOL)enable;
 @end
-#endif
 
 
 #endif /* UNUserNotificationCenter_OneSignal_h */

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -95,7 +95,7 @@ static UNNotificationSettings* cachedUNNotificationSettings;
     id wrapperBlock = ^(BOOL granted, NSError* error) {
         useCachedUNNotificationSettings = false;
         OneSignal.currentPermissionState.accepted = granted;
-        OneSignal.currentPermissionState.anwseredPrompt = true;
+        OneSignal.currentPermissionState.answeredPrompt = true;
         completionHandler(granted, error);
     };
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -551,14 +551,23 @@ static NSArray* preferredLanguagesArray;
 @end
 
 @implementation OSPermissionStateTestObserver
-
 static OSPermissionStateChanges* lastOSPermissionStateChanges;
-
 - (void)onChanged:(OSPermissionStateChanges*)stateChanges {
     lastOSPermissionStateChanges = stateChanges;
 }
-
 @end
+
+
+@interface OSSubscriptionStateTestObserver : NSObject<OSSubscriptionObserver>
+@end
+
+@implementation OSSubscriptionStateTestObserver
+static OSSubscriptionStateChanges* lastOSSubscriptionStateChanges;
+- (void)onChanged:(OSSubscriptionStateChanges*)stateChanges {
+    lastOSSubscriptionStateChanges = stateChanges;
+}
+@end
+
 
 // END - Test Classes
 
@@ -935,6 +944,8 @@ static BOOL setupUIApplicationDelegate = false;
     XCTAssertEqual(networkRequestCount, 1);
 }
 
+
+
 - (void)testPermissionChangeObserver {
     [self setCurrentNotificationPermissionAsUnanwsered];
     [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
@@ -949,6 +960,25 @@ static BOOL setupUIApplicationDelegate = false;
     XCTAssertEqual(lastOSPermissionStateChanges.from.accepted, false);
     XCTAssertEqual(lastOSPermissionStateChanges.to.accepted, true);
 }
+
+
+- (void)testSubscriptionChangeObserver {
+    [self setCurrentNotificationPermissionAsUnanwsered];
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:@{kOSSettingsKeyAutoPrompt: @false}];
+    
+    [OneSignal addSubscriptionObserver:[OSSubscriptionStateTestObserver alloc]];
+    [OneSignal registerForPushNotifications];
+    [self anwserNotifiationPrompt:true];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqual(lastOSSubscriptionStateChanges.from.subscribed, false);
+    XCTAssertEqual(lastOSSubscriptionStateChanges.to.subscribed, true);
+}
+
+
+
 
 - (void)testInitAcceptingNotificationsWithoutCapabilitesSet {
     [self backgroundModesDisabledInXcode];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -952,7 +952,7 @@ static BOOL setupUIApplicationDelegate = false;
             handleNotificationAction:nil
                             settings:@{kOSSettingsKeyAutoPrompt: @false}];
     
-    [OneSignal addPermissionObserver:[OSPermissionStateTestObserver alloc]];
+    [OneSignal addPermissionObserver:[OSPermissionStateTestObserver new]];
     [OneSignal registerForPushNotifications];
     [self anwserNotifiationPrompt:true];
     [self runBackgroundThreads];
@@ -1452,6 +1452,8 @@ static BOOL setupUIApplicationDelegate = false;
     [self initOneSignal];
     [self runBackgroundThreads];
     
+    [OneSignal addPermissionObserver:[OSPermissionStateTestObserver new]];
+    
     XCTAssertEqualObjects(lastHTTPRequset[@"notification_types"], @0);
     XCTAssertNil(lastHTTPRequset[@"identifier"]);
     
@@ -1462,6 +1464,9 @@ static BOOL setupUIApplicationDelegate = false;
     XCTAssertEqualObjects(lastHTTPRequset[@"notification_types"], @15);
     XCTAssertEqualObjects(lastHTTPRequset[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
     XCTAssertEqual(networkRequestCount, 2);
+    
+    XCTAssertEqual(lastOSPermissionStateChanges.from.accepted, false);
+    XCTAssertEqual(lastOSPermissionStateChanges.to.accepted, true);
 }
 
 - (void) testOnSessionWhenResuming {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -744,6 +744,16 @@ static BOOL setupUIApplicationDelegate = false;
     XCTAssertEqualObjects(lastHTTPRequset[@"device_type"], @0);
     XCTAssertEqualObjects(lastHTTPRequset[@"language"], @"en-US");
     
+    OSPermisionSubscriptionState* status = [OneSignal getPermisionSubscriptionState];
+    XCTAssertTrue(status.permissionStatus.accepted);
+    XCTAssertTrue(status.permissionStatus.hasPrompted);
+    XCTAssertTrue(status.permissionStatus.anwseredPrompt);
+    
+    XCTAssertEqual(status.subscriptionStatus.subscribed, true);
+    XCTAssertEqual(status.subscriptionStatus.userSubscriptionSetting, true);
+    XCTAssertEqual(status.subscriptionStatus.userId, @"1234");
+    XCTAssertEqualObjects(status.subscriptionStatus.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
+    
     // 2nd init call should not fire another on_session call.
     lastHTTPRequset = nil;
     [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -552,7 +552,7 @@ static NSArray* preferredLanguagesArray;
 
 @implementation OSPermissionStateTestObserver
 static OSPermissionStateChanges* lastOSPermissionStateChanges;
-- (void)onChanged:(OSPermissionStateChanges*)stateChanges {
+- (void)onOSPermissionChanged:(OSPermissionStateChanges *)stateChanges{
     lastOSPermissionStateChanges = stateChanges;
 }
 @end
@@ -563,7 +563,7 @@ static OSPermissionStateChanges* lastOSPermissionStateChanges;
 
 @implementation OSSubscriptionStateTestObserver
 static OSSubscriptionStateChanges* lastOSSubscriptionStateChanges;
-- (void)onChanged:(OSSubscriptionStateChanges*)stateChanges {
+- (void)onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
     lastOSSubscriptionStateChanges = stateChanges;
 }
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -975,6 +975,11 @@ static BOOL setupUIApplicationDelegate = false;
     
     XCTAssertEqual(lastOSSubscriptionStateChanges.from.subscribed, false);
     XCTAssertEqual(lastOSSubscriptionStateChanges.to.subscribed, true);
+    
+    [OneSignal setSubscription:false];
+    
+    XCTAssertEqual(lastOSSubscriptionStateChanges.from.subscribed, true);
+    XCTAssertEqual(lastOSSubscriptionStateChanges.to.subscribed, false);
 }
 
 


### PR DESCRIPTION
* Added new promptForPushNotificationWithUserResponse method
   - Can now prompt for push notifications and get a callback when the user answers the prompt.
   - Replaces registerForPushNotifications
* Added getPermissionSubscriptionState
   - Can now get current permission status and subscription status.
   - Returns OSPermissionSubscriptionState
* Added addPermissionObserver
   - Pass Observer that will fire when permission properties change.
* Added addSubscriptionObserver
   - Pass Observer that will fire when subscription properties change.
* remove option provided as well.

* Deprecated IdsAvailable - use getPermissionSubscriptionState or permission / subscription Observers instead

* New OSPermissionState class
  - Contains hasPrompted and status (NotDetermined, Denied, Authorized)
* New OSSubscriptionState class
  - Contains, subscribed, userSubscriptionSetting, uesrId, pushToken.
* New OSPermissionSubscriptionState class
  - Contains OSPermissionState  and OSSubscriptionState 

* Large refactor to use the observer pattern internally with a number of lazy loaded properties.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/217)
<!-- Reviewable:end -->
