### PR TITLE
Address two Clang Static Analyzer warnings

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReachability.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReachability.m
@@ -57,6 +57,10 @@
             returnValue->_reachabilityRef = reachability;
             returnValue->_alwaysReturnLocalWiFiStatus = NO;
         }
+        else
+        {
+            CFRelease(reachability);
+        }
     }
     return returnValue;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
@@ -39,6 +39,8 @@ UINavigationController *navController;
 UIViewController *viewControllerForPresentation;
 
 -(void)viewDidLoad {
+    [super viewDidLoad];
+
     _webView = [[UIWebView alloc] initWithFrame:self.view.frame];
     _webView.delegate = self;
     [self.view addSubview:_webView];


### PR DESCRIPTION
Hello OneSignal!

### What's in this pull request?

Addressed two warnings via the Clang Static Analyzer:

- Added missing call to `super.viewDidLoad()`
- Added missing `CFRelease` call to prevent possible mem leak

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/244)
<!-- Reviewable:end -->
