### PR TITLE
Moved shadow classes into their own files

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/xcshareddata/xcschemes/OneSignalDevApp.xcscheme
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/xcshareddata/xcschemes/OneSignalDevApp.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -39,12 +40,18 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -62,6 +69,16 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -14,6 +14,20 @@
 		37E6B2BB19D9CAF300D0C601 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		3E464ED71D88ED1F00DCF7E9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; };
 		3E66F5821D90A2C600E45A01 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */; };
+		4529DECB1FA43CDD00CEAB1D /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4529DEC91FA43CD400CEAB1D /* MobileCoreServices.framework */; };
+		4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DED11FA81EA800CEAB1D /* NSObjectOverrider.m */; };
+		4529DED51FA823B900CEAB1D /* TestHelperFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DED41FA823B900CEAB1D /* TestHelperFunctions.m */; };
+		4529DED81FA8253D00CEAB1D /* NSUserDefaultsOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DED71FA8253D00CEAB1D /* NSUserDefaultsOverrider.m */; };
+		4529DEDB1FA8284E00CEAB1D /* NSDataOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEDA1FA8284E00CEAB1D /* NSDataOverrider.m */; };
+		4529DEDE1FA828E500CEAB1D /* NSDateOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEDD1FA828E500CEAB1D /* NSDateOverrider.m */; };
+		4529DEE11FA82AB300CEAB1D /* NSBundleOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE01FA82AB300CEAB1D /* NSBundleOverrider.m */; };
+		4529DEE41FA82C6200CEAB1D /* NSURLConnectionOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE31FA82C6200CEAB1D /* NSURLConnectionOverrider.m */; };
+		4529DEE71FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE61FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m */; };
+		4529DEEA1FA8360C00CEAB1D /* UIApplicationOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE91FA8360C00CEAB1D /* UIApplicationOverrider.m */; };
+		4529DEED1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEEC1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m */; };
+		4529DEF01FA8433500CEAB1D /* NSLocaleOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEEF1FA8433500CEAB1D /* NSLocaleOverrider.m */; };
+		4529DEF31FA8440A00CEAB1D /* UIAlertViewOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEF21FA8440A00CEAB1D /* UIAlertViewOverrider.m */; };
+		4529DEF61FA8460C00CEAB1D /* UnitTestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEF51FA8460C00CEAB1D /* UnitTestAppDelegate.m */; };
 		911E2CBD1E398AB3003112A4 /* UnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 911E2CBC1E398AB3003112A4 /* UnitTests.m */; };
 		911E2CBF1E398AB3003112A4 /* libOneSignal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37747F9319147D6500558FAD /* libOneSignal.a */; };
 		911E2CC51E398B53003112A4 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */; };
@@ -138,6 +152,33 @@
 		3E2400381D4FFC31008BDE70 /* OneSignal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OneSignal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E24003B1D4FFC31008BDE70 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3E464ED91D88EE6A00DCF7E9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		4529DEC91FA43CD400CEAB1D /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		4529DED01FA81EA800CEAB1D /* NSObjectOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSObjectOverrider.h; sourceTree = "<group>"; };
+		4529DED11FA81EA800CEAB1D /* NSObjectOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSObjectOverrider.m; sourceTree = "<group>"; };
+		4529DED31FA823B900CEAB1D /* TestHelperFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestHelperFunctions.h; sourceTree = "<group>"; };
+		4529DED41FA823B900CEAB1D /* TestHelperFunctions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestHelperFunctions.m; sourceTree = "<group>"; };
+		4529DED61FA8253D00CEAB1D /* NSUserDefaultsOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSUserDefaultsOverrider.h; sourceTree = "<group>"; };
+		4529DED71FA8253D00CEAB1D /* NSUserDefaultsOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSUserDefaultsOverrider.m; sourceTree = "<group>"; };
+		4529DED91FA8284E00CEAB1D /* NSDataOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSDataOverrider.h; sourceTree = "<group>"; };
+		4529DEDA1FA8284E00CEAB1D /* NSDataOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDataOverrider.m; sourceTree = "<group>"; };
+		4529DEDC1FA828E500CEAB1D /* NSDateOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSDateOverrider.h; sourceTree = "<group>"; };
+		4529DEDD1FA828E500CEAB1D /* NSDateOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDateOverrider.m; sourceTree = "<group>"; };
+		4529DEDF1FA82AB300CEAB1D /* NSBundleOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSBundleOverrider.h; sourceTree = "<group>"; };
+		4529DEE01FA82AB300CEAB1D /* NSBundleOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSBundleOverrider.m; sourceTree = "<group>"; };
+		4529DEE21FA82C6200CEAB1D /* NSURLConnectionOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLConnectionOverrider.h; sourceTree = "<group>"; };
+		4529DEE31FA82C6200CEAB1D /* NSURLConnectionOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLConnectionOverrider.m; sourceTree = "<group>"; };
+		4529DEE51FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UNUserNotificationCenterOverrider.h; sourceTree = "<group>"; };
+		4529DEE61FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UNUserNotificationCenterOverrider.m; sourceTree = "<group>"; };
+		4529DEE81FA8360C00CEAB1D /* UIApplicationOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIApplicationOverrider.h; sourceTree = "<group>"; };
+		4529DEE91FA8360C00CEAB1D /* UIApplicationOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIApplicationOverrider.m; sourceTree = "<group>"; };
+		4529DEEB1FA83C5D00CEAB1D /* OneSignalHelperOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalHelperOverrider.h; sourceTree = "<group>"; };
+		4529DEEC1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalHelperOverrider.m; sourceTree = "<group>"; };
+		4529DEEE1FA8433500CEAB1D /* NSLocaleOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSLocaleOverrider.h; sourceTree = "<group>"; };
+		4529DEEF1FA8433500CEAB1D /* NSLocaleOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSLocaleOverrider.m; sourceTree = "<group>"; };
+		4529DEF11FA8440A00CEAB1D /* UIAlertViewOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIAlertViewOverrider.h; sourceTree = "<group>"; };
+		4529DEF21FA8440A00CEAB1D /* UIAlertViewOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIAlertViewOverrider.m; sourceTree = "<group>"; };
+		4529DEF41FA8460C00CEAB1D /* UnitTestAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnitTestAppDelegate.h; sourceTree = "<group>"; };
+		4529DEF51FA8460C00CEAB1D /* UnitTestAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UnitTestAppDelegate.m; sourceTree = "<group>"; };
 		911E2CBA1E398AB3003112A4 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		911E2CBC1E398AB3003112A4 /* UnitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UnitTests.m; sourceTree = "<group>"; };
 		911E2CBE1E398AB3003112A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -201,9 +242,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91719A9C1E80839500DBE43C /* UserNotifications.framework in Frameworks */,
 				3E66F5821D90A2C600E45A01 /* SystemConfiguration.framework in Frameworks */,
 				3E464ED71D88ED1F00DCF7E9 /* UIKit.framework in Frameworks */,
+				91719A9C1E80839500DBE43C /* UserNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,6 +252,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4529DECB1FA43CDD00CEAB1D /* MobileCoreServices.framework in Frameworks */,
 				911E2CC81E399834003112A4 /* UserNotifications.framework in Frameworks */,
 				911E2CC61E398B97003112A4 /* UIKit.framework in Frameworks */,
 				911E2CC51E398B53003112A4 /* SystemConfiguration.framework in Frameworks */,
@@ -245,6 +287,7 @@
 		37747F9519147D6500558FAD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4529DEC91FA43CD400CEAB1D /* MobileCoreServices.framework */,
 				911E2CC71E399834003112A4 /* UserNotifications.framework */,
 				3E464ED91D88EE6A00DCF7E9 /* Foundation.framework */,
 				3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */,
@@ -261,13 +304,47 @@
 			path = "OneSignal-Dynamic";
 			sourceTree = "<group>";
 		};
+		4529DECD1FA81DE000CEAB1D /* Shadows */ = {
+			isa = PBXGroup;
+			children = (
+				4529DED01FA81EA800CEAB1D /* NSObjectOverrider.h */,
+				4529DED11FA81EA800CEAB1D /* NSObjectOverrider.m */,
+				4529DED61FA8253D00CEAB1D /* NSUserDefaultsOverrider.h */,
+				4529DED71FA8253D00CEAB1D /* NSUserDefaultsOverrider.m */,
+				4529DED91FA8284E00CEAB1D /* NSDataOverrider.h */,
+				4529DEDA1FA8284E00CEAB1D /* NSDataOverrider.m */,
+				4529DEDC1FA828E500CEAB1D /* NSDateOverrider.h */,
+				4529DEDD1FA828E500CEAB1D /* NSDateOverrider.m */,
+				4529DEDF1FA82AB300CEAB1D /* NSBundleOverrider.h */,
+				4529DEE01FA82AB300CEAB1D /* NSBundleOverrider.m */,
+				4529DEE21FA82C6200CEAB1D /* NSURLConnectionOverrider.h */,
+				4529DEE31FA82C6200CEAB1D /* NSURLConnectionOverrider.m */,
+				4529DEE51FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.h */,
+				4529DEE61FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m */,
+				4529DEE81FA8360C00CEAB1D /* UIApplicationOverrider.h */,
+				4529DEE91FA8360C00CEAB1D /* UIApplicationOverrider.m */,
+				4529DEEB1FA83C5D00CEAB1D /* OneSignalHelperOverrider.h */,
+				4529DEEC1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m */,
+				4529DEEE1FA8433500CEAB1D /* NSLocaleOverrider.h */,
+				4529DEEF1FA8433500CEAB1D /* NSLocaleOverrider.m */,
+				4529DEF11FA8440A00CEAB1D /* UIAlertViewOverrider.h */,
+				4529DEF21FA8440A00CEAB1D /* UIAlertViewOverrider.m */,
+			);
+			path = Shadows;
+			sourceTree = "<group>";
+		};
 		911E2CBB1E398AB3003112A4 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				4529DECD1FA81DE000CEAB1D /* Shadows */,
 				911E2CBC1E398AB3003112A4 /* UnitTests.m */,
 				911E2CBE1E398AB3003112A4 /* Info.plist */,
 				91F60F7B1E80E49A00706E60 /* UncaughtExceptionHandler.h */,
 				91F60F7C1E80E4E400706E60 /* UncaughtExceptionHandler.m */,
+				4529DED31FA823B900CEAB1D /* TestHelperFunctions.h */,
+				4529DED41FA823B900CEAB1D /* TestHelperFunctions.m */,
+				4529DEF41FA8460C00CEAB1D /* UnitTestAppDelegate.h */,
+				4529DEF51FA8460C00CEAB1D /* UnitTestAppDelegate.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -580,27 +657,40 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4529DEF61FA8460C00CEAB1D /* UnitTestAppDelegate.m in Sources */,
 				91F58D8B1E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */,
 				91F60F7D1E80E4E400706E60 /* UncaughtExceptionHandler.m in Sources */,
 				912412201E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
 				912412381E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
+				4529DED81FA8253D00CEAB1D /* NSUserDefaultsOverrider.m in Sources */,
+				4529DEED1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m in Sources */,
 				912412301E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				91F58D851E7C88230017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */,
+				4529DEE41FA82C6200CEAB1D /* NSURLConnectionOverrider.m in Sources */,
+				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,
 				912412341E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,
 				9124122C1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
+				4529DED51FA823B900CEAB1D /* TestHelperFunctions.m in Sources */,
 				911E2CBD1E398AB3003112A4 /* UnitTests.m in Sources */,
 				91B6EA431E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				9124121C1E73342200E41FD7 /* OneSignalHTTPClient.m in Sources */,
+				4529DEDE1FA828E500CEAB1D /* NSDateOverrider.m in Sources */,
 				912412401E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				1AF75EAF1E8569710097B315 /* NSString+OneSignal.m in Sources */,
+				4529DEE71FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m in Sources */,
+				4529DEDB1FA8284E00CEAB1D /* NSDataOverrider.m in Sources */,
+				4529DEF31FA8440A00CEAB1D /* UIAlertViewOverrider.m in Sources */,
+				4529DEEA1FA8360C00CEAB1D /* UIApplicationOverrider.m in Sources */,
 				912412281E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				9129C6C01E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412141E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
+				4529DEE11FA82AB300CEAB1D /* NSBundleOverrider.m in Sources */,
 				912412441E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				9124123C1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
+				4529DEF01FA8433500CEAB1D /* NSLocaleOverrider.m in Sources */,
 				9129C6BA1E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				91F58D871E7C88250017D24D /* OneSignalNotificationSettingsIOS8.m in Sources */,
 			);

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -31,12 +32,18 @@
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -44,6 +51,11 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.h
@@ -1,0 +1,33 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSBundleOverrider : NSObject
++(void) setNsbundleDictionary:(NSDictionary*)value;
++(NSDictionary*) nsbundleDictionary;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.m
@@ -1,0 +1,78 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSBundleOverrider.h"
+
+#import "OneSignalSelectorHelpers.h"
+
+@implementation NSBundleOverrider
+
+static NSDictionary* nsbundleDictionary;
+
++ (void)load {
+    injectToProperClass(@selector(overrideBundleIdentifier), @selector(bundleIdentifier), @[], [NSBundleOverrider class], [NSBundle class]);
+    
+    injectToProperClass(@selector(overrideObjectForInfoDictionaryKey:), @selector(objectForInfoDictionaryKey:), @[], [NSBundleOverrider class], [NSBundle class]);
+    injectToProperClass(@selector(overrideURLForResource:withExtension:), @selector(URLForResource:withExtension:), @[], [NSBundleOverrider class], [NSBundle class]);
+    
+    // Doesn't work to swizzle for mocking. Both an NSDictionary and NSMutableDictionarys both throw odd selecotor not found errors.
+    // injectToProperClass(@selector(overrideInfoDictionary), @selector(infoDictionary), @[], [NSBundleOverrider class], [NSBundle class]);
+}
+
++(void) setNsbundleDictionary:(NSDictionary*)value {
+    nsbundleDictionary = value;
+}
+
++(NSDictionary*) nsbundleDictionary {
+    return nsbundleDictionary;
+}
+
+- (NSString*)overrideBundleIdentifier {
+    return @"com.onesignal.unittest";
+}
+
+- (nullable id)overrideObjectForInfoDictionaryKey:(NSString*)key {
+    return nsbundleDictionary[key];
+}
+
+- (NSURL*)overrideURLForResource:(NSString*)name withExtension:(NSString*)ext {
+    NSString *content = @"File Contents";
+    NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString* nameWithExt = [name stringByAppendingString:[@"." stringByAppendingString:ext]];
+    NSString* fullpath = [paths[0] stringByAppendingPathComponent:nameWithExt];
+    
+    [[NSFileManager defaultManager] createFileAtPath:fullpath
+                                            contents:fileContents
+                                          attributes:nil];
+    
+    NSLog(@"fullpath: %@", fullpath);
+    return [NSURL URLWithString:[@"file://" stringByAppendingString:fullpath]];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDataOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDataOverrider.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSDataOverrider : NSObject
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDataOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDataOverrider.m
@@ -1,0 +1,45 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSDataOverrider.h"
+
+#import "TestHelperFunctions.h"
+
+@implementation NSDataOverrider
++ (void)load {
+    injectStaticSelector([NSDataOverrider class], @selector(overrideDataWithContentsOfURL:), [NSData class], @selector(dataWithContentsOfURL:));
+}
+
+// Mock data being downloaded from a remote URL.
++ (NSData*) overrideDataWithContentsOfURL:(NSURL *)url {
+    char bytes[32];
+    memset(bytes, 1, 32);
+    
+    return [NSData dataWithBytes:bytes length:32];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDateOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDateOverrider.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSDateOverrider : NSObject
++(void) setTimeOffset:(NSTimeInterval)offset;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDateOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDateOverrider.m
@@ -1,0 +1,49 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSDateOverrider.h"
+
+#import "OneSignalSelectorHelpers.h"
+
+@implementation NSDateOverrider
+
+static NSTimeInterval timeOffset;
+
++ (void)load {
+    injectToProperClass(@selector(overrideTimeIntervalSince1970), @selector(timeIntervalSince1970), @[], [NSDateOverrider class], [NSDate class]);
+}
+
++(void) setTimeOffset:(NSTimeInterval)offset {
+    timeOffset = offset;
+}
+
+- (NSTimeInterval) overrideTimeIntervalSince1970 {
+    NSTimeInterval current = [self overrideTimeIntervalSince1970];
+    return current + timeOffset;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSLocaleOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSLocaleOverrider.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSLocaleOverrider : NSObject
++(void)setPreferredLanguagesArray:(NSArray*)value;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSLocaleOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSLocaleOverrider.m
@@ -1,0 +1,48 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSLocaleOverrider.h"
+
+#import "TestHelperFunctions.h"
+
+@implementation NSLocaleOverrider
+
+static NSArray* preferredLanguagesArray;
+
++ (void)load {
+    injectStaticSelector([NSLocaleOverrider class], @selector(overriderPreferredLanguages), [NSLocale class], @selector(preferredLanguages));
+}
+
++(void)setPreferredLanguagesArray:(NSArray*)value {
+    preferredLanguagesArray = value;
+}
+
++ (NSArray<NSString*> *) overriderPreferredLanguages {
+    return preferredLanguagesArray;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.h
@@ -1,0 +1,35 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSObjectOverrider : NSObject
++ (void)runPendingSelectors;
++ (void)reset;
++ (void)setInstantRunPerformSelectorAfterDelay:(BOOL)value;
++ (void)setSelectorNamesForInstantOnlyForFirstRun:(NSArray*)list;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.m
@@ -1,0 +1,99 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#import "NSObjectOverrider.h"
+
+#import "OneSignalSelectorHelpers.h"
+
+@interface SelectorToRun : NSObject
+@property NSObject* runOn;
+@property SEL selector;
+@property NSObject* withObject;
+@end
+
+@implementation SelectorToRun
+@end
+
+@implementation NSObjectOverrider
+
+static NSMutableArray* selectorsToRun;
+static BOOL instantRunPerformSelectorAfterDelay;
+static NSMutableArray* selectorNamesForInstantOnlyForFirstRun;
+
++ (void)load {
+    injectToProperClass(@selector(overridePerformSelector:withObject:afterDelay:), @selector(performSelector:withObject:afterDelay:), @[], [NSObjectOverrider class], [NSObject class]);
+    injectToProperClass(@selector(overridePerformSelector:withObject:), @selector(performSelector:withObject:), @[], [NSObjectOverrider class], [NSObject class]);
+}
+
++ (void)reset {
+    instantRunPerformSelectorAfterDelay = false;
+    selectorNamesForInstantOnlyForFirstRun = [@[] mutableCopy];
+    selectorsToRun = [[NSMutableArray alloc] init];
+}
+
++ (void)setInstantRunPerformSelectorAfterDelay:(BOOL)value {
+    instantRunPerformSelectorAfterDelay = value;
+}
++ (void)setSelectorNamesForInstantOnlyForFirstRun:(NSArray*)list {
+    selectorNamesForInstantOnlyForFirstRun = [list mutableCopy];
+}
+
+- (void)overridePerformSelector:(SEL)aSelector withObject:(nullable id)anArgument afterDelay:(NSTimeInterval)delay {
+    // TOOD: Add && for calling from our unit test queue looper.
+    /*
+     if (![[NSThread mainThread] isEqual:[NSThread currentThread]])
+     _XCTPrimitiveFail(currentTestInstance);
+     */
+    
+    if (instantRunPerformSelectorAfterDelay || [selectorNamesForInstantOnlyForFirstRun containsObject:NSStringFromSelector(aSelector)]) {
+        [selectorNamesForInstantOnlyForFirstRun removeObject:NSStringFromSelector(aSelector)];
+        [self performSelector:aSelector withObject:anArgument];
+    }
+    else {
+        SelectorToRun* selectorToRun = [SelectorToRun alloc];
+        selectorToRun.runOn = self;
+        selectorToRun.selector = aSelector;
+        selectorToRun.withObject = anArgument;
+        @synchronized(selectorsToRun) {
+            [selectorsToRun addObject:selectorToRun];
+        }
+    }
+}
+
+- (id)overridePerformSelector:(SEL)aSelector withObject:(id)anArgument {
+    return [self overridePerformSelector:aSelector withObject:anArgument];
+}
+
++ (void)runPendingSelectors {
+    @synchronized(selectorsToRun) {
+        for(SelectorToRun* selectorToRun in selectorsToRun)
+            [selectorToRun.runOn performSelector:selectorToRun.selector withObject:selectorToRun.withObject];
+        
+        [selectorsToRun removeAllObjects];
+    }
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLConnectionOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLConnectionOverrider.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSURLConnectionOverrider : NSObject
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLConnectionOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLConnectionOverrider.m
@@ -1,0 +1,50 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSURLConnectionOverrider.h"
+
+#import "TestHelperFunctions.h"
+
+@implementation NSURLConnectionOverrider
+
++ (void)load {
+    // Swizzle an injected method defined in OneSignalHelper
+    injectStaticSelector([NSURLConnectionOverrider class], @selector(overrideDownloadItemAtURL:toFile:error:), [NSURLConnection class], @selector(downloadItemAtURL:toFile:error:));
+}
+
+// Override downloading of media attachment
++ (BOOL)overrideDownloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError*)error {
+    NSString *content = @"File Contents";
+    NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
+    [[NSFileManager defaultManager] createFileAtPath:localPath
+                                            contents:fileContents
+                                          attributes:nil];
+    
+    return true;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSUserDefaultsOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSUserDefaultsOverrider.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSUserDefaultsOverrider : NSObject
++ (void)clearInternalDictionary;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSUserDefaultsOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSUserDefaultsOverrider.m
@@ -1,0 +1,98 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSUserDefaultsOverrider.h"
+#import "OneSignalSelectorHelpers.h"
+
+static NSMutableDictionary* defaultsDictionary;
+
+@implementation NSUserDefaultsOverrider
++ (void)load {
+    defaultsDictionary = [[NSMutableDictionary alloc] init];
+    
+    // Sets
+    injectToProperClass(@selector(overrideSetObject:forKey:), @selector(setObject:forKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    injectToProperClass(@selector(overrideSetString:forKey:), @selector(setString:forKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    injectToProperClass(@selector(overrideSetDouble:forKey:), @selector(setDouble:forKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    injectToProperClass(@selector(overrideSetBool:forKey:), @selector(setBool:forKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    
+    // Gets
+    injectToProperClass(@selector(overrideObjectForKey:), @selector(objectForKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    injectToProperClass(@selector(overrideStringForKey:), @selector(stringForKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    injectToProperClass(@selector(overrideDoubleForKey:), @selector(doubleForKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+    injectToProperClass(@selector(overrideBoolForKey:), @selector(boolForKey:), @[], [NSUserDefaultsOverrider class], [NSUserDefaults class]);
+}
+
++ (void)clearInternalDictionary {
+    defaultsDictionary = [[NSMutableDictionary alloc] init];
+}
+
+// Sets
+-(void)overrideSetObject:(id)value forKey:(NSString*)key {
+    defaultsDictionary[key] = value;
+}
+
+-(void)overrideSetString:(NSString*)value forKey:(NSString*)key {
+    defaultsDictionary[key] = value;
+}
+
+- (void)overrideSetDouble:(double)value forKey:(NSString*)key {
+    defaultsDictionary[key] = [NSNumber numberWithDouble:value];
+}
+
+- (void)overrideSetBool:(BOOL)value forKey:(NSString*)key {
+    defaultsDictionary[key] = [NSNumber numberWithBool:value];
+}
+
+- (void)overrideSetInteger:(NSInteger)value forKey:(NSString*)key {
+    defaultsDictionary[key] = [NSNumber numberWithInteger:value];
+}
+
+// Gets
+- (nullable id)overrideObjectForKey:(NSString*)key {
+    if ([key isEqualToString:@"XCTIDEConnectionTimeout"])
+        return [NSNumber numberWithInt:60];
+    
+    return defaultsDictionary[key];
+}
+
+- (NSString*)overrideStringForKey:(NSString*)key {
+    return defaultsDictionary[key];
+}
+
+-(double)overrideDoubleForKey:(NSString*)key {
+    if ([key isEqualToString:@"XCTIDEConnectionTimeout"])
+        return 60.0;
+    
+    return [defaultsDictionary[key] doubleValue];
+}
+
+- (BOOL)overrideBoolForKey:(NSString*)key {
+    return [defaultsDictionary[key] boolValue];
+}
+@end
+

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.h
@@ -1,0 +1,48 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface OneSignalHelperOverrider : NSObject
++(void)reset:(XCTestCase*)testInstance;
+
++(void)setMockIOSVersion:(float)value;
++(float)mockIOSVersion;
+
++(void)setLastHTTPRequset:(NSDictionary*)value;
++(NSDictionary*)lastHTTPRequset;
+
++(int)networkRequestCount;
+
++(void)setLastUrl:(NSString*)value;
++(NSString*)lastUrl;
+
++ (void)runBackgroundThreads;
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
@@ -1,0 +1,140 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "OneSignalHelperOverrider.h"
+
+#import "TestHelperFunctions.h"
+
+#import "OneSignal.h"
+#import "OneSignalHelper.h"
+
+@implementation OneSignalHelperOverrider
+
+static dispatch_queue_t serialMockMainLooper;
+static NSString* lastUrl;
+static NSDictionary* lastHTTPRequset;
+static int networkRequestCount;
+
+static XCTestCase* currentTestInstance;
+
+static float mockIOSVersion;
+
++ (void)load {
+    serialMockMainLooper = dispatch_queue_create("com.onesignal.unittest", DISPATCH_QUEUE_SERIAL);
+    
+    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideEnqueueRequest:onSuccess:onFailure:isSynchronous:), [OneSignalHelper class], @selector(enqueueRequest:onSuccess:onFailure:isSynchronous:));
+    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideGetAppName), [OneSignalHelper class], @selector(getAppName));
+    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideIsIOSVersionGreaterOrEqual:), [OneSignalHelper class], @selector(isIOSVersionGreaterOrEqual:));
+    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideDispatch_async_on_main_queue:), [OneSignalHelper class], @selector(dispatch_async_on_main_queue:));
+}
+
++(void)reset:(XCTestCase*)testInstance {
+    currentTestInstance = testInstance;
+    
+    networkRequestCount = 0;
+    lastUrl = nil;
+    lastHTTPRequset = nil;
+}
+
++(void)setMockIOSVersion:(float)value {
+    mockIOSVersion = value;
+}
++(float)mockIOSVersion {
+    return mockIOSVersion;
+}
+
++(void)setLastHTTPRequset:(NSDictionary*)value {
+    lastHTTPRequset = value;
+}
++(NSDictionary*)lastHTTPRequset {
+    return lastHTTPRequset;
+}
+
++(int)networkRequestCount {
+    return networkRequestCount;
+}
+
++(void)setLastUrl:(NSString*)value {
+    lastUrl = value;
+}
+
++(NSString*)lastUrl {
+    return lastUrl;
+}
+
++ (NSString*) overrideGetAppName {
+    return @"App Name";
+}
+
++ (void)overrideEnqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
+    NSError *error = nil;
+    
+    NSLog(@"request.URL: %@", request.URL);
+    
+    NSMutableDictionary *parameters;
+    
+    NSData* httpData = [request HTTPBody];
+    if (httpData)
+        parameters = [NSJSONSerialization JSONObjectWithData:[request HTTPBody] options:0 error:&error];
+    else {
+        NSURLComponents *components = [NSURLComponents componentsWithString:request.URL.absoluteString];
+        parameters = [NSMutableDictionary new];
+        for(NSURLQueryItem *item in components.queryItems) {
+            parameters[item.name] = item.value;
+        }
+    }
+    
+    // We should always send an app_id with every request.
+    if (!parameters[@"app_id"])
+        _XCTPrimitiveFail(currentTestInstance);
+    
+    networkRequestCount++;
+    
+    id url = [request URL];
+    NSLog(@"url: %@", url);
+    NSLog(@"parameters: %@", parameters);
+    
+    lastUrl = [url absoluteString];
+    lastHTTPRequset = parameters;
+    
+    if (successBlock)
+        successBlock(@{@"id": @"1234"});
+}
+
++ (BOOL)overrideIsIOSVersionGreaterOrEqual:(float)version {
+    return mockIOSVersion >= version;
+}
+
++ (void) overrideDispatch_async_on_main_queue:(void(^)())block {
+    dispatch_async(serialMockMainLooper, block);
+}
+
++ (void)runBackgroundThreads {
+    dispatch_sync(serialMockMainLooper, ^{});
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIAlertViewOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIAlertViewOverrider.h
@@ -1,0 +1,35 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIAlertViewOverrider : NSObject
++(void)reset;
++(int)uiAlertButtonArrayCount;
++(NSObject<UIAlertViewDelegate>*)lastUIAlertViewDelegate;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIAlertViewOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIAlertViewOverrider.m
@@ -1,0 +1,66 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "UIAlertViewOverrider.h"
+
+#import "OneSignalSelectorHelpers.h"
+
+@implementation UIAlertViewOverrider
+static NSMutableArray* uiAlertButtonArray;
+static NSObject<UIAlertViewDelegate>* lastUIAlertViewDelegate;
+
++ (void)load {
+    injectToProperClass(@selector(overrideAddButtonWithTitle:), @selector(addButtonWithTitle:), @[], [UIAlertViewOverrider class], [UIAlertView class]);
+    
+    injectToProperClass(@selector(overrideInitWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:),
+                        @selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:), @[],
+                        [UIAlertViewOverrider class], [UIAlertView class]);
+}
+
++(void)reset {
+    uiAlertButtonArray = [NSMutableArray new];
+}
+
++(int)uiAlertButtonArrayCount {
+    return uiAlertButtonArray.count;
+}
++(NSObject<UIAlertViewDelegate>*)lastUIAlertViewDelegate {
+    return lastUIAlertViewDelegate;
+}
+
+- (NSInteger)overrideAddButtonWithTitle:(nullable NSString*)title {
+    [uiAlertButtonArray addObject:title];
+    return 0;
+}
+
+- (instancetype)overrideInitWithTitle:(nullable NSString *)title message:(nullable NSString *)message delegate:(nullable id /*<UIAlertViewDelegate>*/)delegate cancelButtonTitle:(nullable NSString *)cancelButtonTitle otherButtonTitles:(nullable NSString *)otherButtonTitles, ... {
+    lastUIAlertViewDelegate = delegate;
+    return self;
+}
+
+@end
+

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.h
@@ -1,0 +1,46 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIApplicationOverrider : NSObject
++(void)reset;
+
++(void)setCurrentUIApplicationState:(UIApplicationState)value;
+
++(UILocalNotification*)lastUILocalNotification;
+
++(void)runBackgroundThreads;
+
++(BOOL)calledRegisterForRemoteNotifications;
++(BOOL)calledCurrentUserNotificationSettings;
+
++(void) setDidFailRegistarationErrorCode:(NSInteger)value;
+
++ (void)helperCallDidRegisterForRemoteNotificationsWithDeviceToken;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.m
@@ -1,0 +1,161 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "UIApplicationOverrider.h"
+
+#import "OneSignalSelectorHelpers.h"
+
+#import "UNUserNotificationCenterOverrider.h"
+
+@implementation UIApplicationOverrider
+
+static BOOL calledRegisterForRemoteNotifications;
+static BOOL calledCurrentUserNotificationSettings;
+
+static NSInteger didFailRegistarationErrorCode;
+static BOOL shouldFireDeviceToken;
+
+static UIApplicationState currentUIApplicationState;
+
+static UILocalNotification* lastUILocalNotification;
+
+static BOOL pendingRegiseterBlock;
+
++ (void)load {
+    injectToProperClass(@selector(overrideRegisterForRemoteNotifications), @selector(registerForRemoteNotifications), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectToProperClass(@selector(override_run), @selector(_run), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectToProperClass(@selector(overrideCurrentUserNotificationSettings), @selector(currentUserNotificationSettings), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectToProperClass(@selector(overrideRegisterForRemoteNotificationTypes:), @selector(registerForRemoteNotificationTypes:), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectToProperClass(@selector(overrideRegisterUserNotificationSettings:), @selector(registerUserNotificationSettings:), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectToProperClass(@selector(overrideApplicationState), @selector(applicationState), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectToProperClass(@selector(overrideScheduleLocalNotification:), @selector(scheduleLocalNotification:), @[], [UIApplicationOverrider class], [UIApplication class]);
+}
+
++(void)reset {
+    lastUILocalNotification = nil;
+    pendingRegiseterBlock = false;
+    shouldFireDeviceToken = true;
+    calledRegisterForRemoteNotifications = false;
+    calledCurrentUserNotificationSettings = false;
+    didFailRegistarationErrorCode = 0;
+    currentUIApplicationState = UIApplicationStateActive;
+}
+
++(void)setCurrentUIApplicationState:(UIApplicationState)value {
+    currentUIApplicationState = value;
+}
+
++(UILocalNotification*)lastUILocalNotification {
+    return lastUILocalNotification;
+}
+
++(BOOL)calledRegisterForRemoteNotifications {
+    return calledRegisterForRemoteNotifications;
+}
++(BOOL)calledCurrentUserNotificationSettings {
+    return calledCurrentUserNotificationSettings;
+}
+
++(void) setDidFailRegistarationErrorCode:(NSInteger)value {
+    didFailRegistarationErrorCode = value;
+}
+
+// Keeps UIApplicationMain(...) from looping to continue to the next line.
+- (void) override_run {
+    NSLog(@"override_run!!!!!!");
+}
+
++ (void)helperCallDidRegisterForRemoteNotificationsWithDeviceToken {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id app = [UIApplication sharedApplication];
+        id appDelegate = [[UIApplication sharedApplication] delegate];
+        
+        if (didFailRegistarationErrorCode) {
+            id error = [NSError errorWithDomain:@"any" code:didFailRegistarationErrorCode userInfo:nil];
+            [appDelegate application:app didFailToRegisterForRemoteNotificationsWithError:error];
+            return;
+        }
+        
+        if (!shouldFireDeviceToken)
+            return;
+        
+        pendingRegiseterBlock = true;
+    });
+}
+
+// callPendingApplicationDidRegisterForRemoteNotificaitonsWithDeviceToken
++ (void)runBackgroundThreads {
+    if (!pendingRegiseterBlock || currentUIApplicationState != UIApplicationStateActive)
+        return;
+    pendingRegiseterBlock = false;
+    
+    id app = [UIApplication sharedApplication];
+    id appDelegate = [[UIApplication sharedApplication] delegate];
+    
+    char bytes[32];
+    memset(bytes, 0, 32);
+    id deviceToken = [NSData dataWithBytes:bytes length:32];
+    [appDelegate application:app didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+// Called on iOS 8+
+- (void) overrideRegisterForRemoteNotifications {
+    calledRegisterForRemoteNotifications = true;
+    [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
+}
+
+// iOS 7
+- (void)overrideRegisterForRemoteNotificationTypes:(UIRemoteNotificationType)types {
+    // Just using this flag to mimic the non-prompted behavoir
+    if (UNUserNotificationCenterOverrider.authorizationStatus != [NSNumber numberWithInteger:UNAuthorizationStatusNotDetermined])
+        [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
+}
+
+
+// iOS 8 & 9 Only
+- (UIUserNotificationSettings*) overrideCurrentUserNotificationSettings {
+    calledCurrentUserNotificationSettings = true;
+    
+    // Check for this as it will create thread locks on a real device.
+    [UNUserNotificationCenterOverrider failIfInNotificationSettingsWithCompletionHandler];
+    
+    return [UIUserNotificationSettings settingsForTypes:UNUserNotificationCenterOverrider.notifTypesOverride categories:nil];
+}
+
+// KEEP - Used to prevent xctest from fowarding to the iOS 10 equivalent.
+- (void)overrideRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
+}
+
+- (UIApplicationState) overrideApplicationState {
+    return currentUIApplicationState;
+}
+
+- (void)overrideScheduleLocalNotification:(UILocalNotification*)notification {
+    lastUILocalNotification = notification;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.h
@@ -1,0 +1,50 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <UserNotifications/UserNotifications.h>
+
+#import <XCTest/XCTest.h>
+
+@interface UNUserNotificationCenterOverrider : NSObject
++(void) setNotifTypesOverride:(int)value;
++(int) notifTypesOverride;
+
++(void) setAuthorizationStatus:(NSNumber*)value;
++(NSNumber*) authorizationStatus;
+
++(int) lastSetCategoriesCount;
+
++(void)reset:(XCTestCase*)testInstance;
+
++(void) runBackgroundThreads;
+
++(void) fireLastRequestAuthorizationWithGranted:(BOOL)granted;
+
++ (void)failIfInNotificationSettingsWithCompletionHandler;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.h
@@ -1,0 +1,29 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+void DumpObjcMethods(Class clz);
+BOOL injectStaticSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);

--- a/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.m
@@ -1,0 +1,76 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+// Just for debugging
+void DumpObjcMethods(Class clz) {
+    unsigned int methodCount = 0;
+    Method *methods = class_copyMethodList(clz, &methodCount);
+    
+    
+    NSLog(@"Found %d methods on '%s'\n", methodCount, class_getName(clz));
+    
+    
+    for (unsigned int i = 0; i < methodCount; i++) {
+        Method method = methods[i];
+        
+        
+        NSLog(@"'%s' has method named '%s' of encoding '%s'\n",
+              class_getName(clz),
+              sel_getName(method_getName(method)),
+              method_getTypeEncoding(method));
+    }
+    
+    
+    free(methods);
+}
+
+BOOL injectStaticSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
+    Method newMeth = class_getClassMethod(newClass, newSel);
+    IMP imp = method_getImplementation(newMeth);
+    
+    const char* methodTypeEncoding = method_getTypeEncoding(newMeth);
+    // Keep - class_getInstanceMethod for existing detection.
+    //    class_addMethod will successfuly add if the addToClass was loaded twice into the runtime.
+    BOOL existing = class_getClassMethod(addToClass, makeLikeSel) != NULL;
+    
+    if (existing) {
+        // class_addMethod doesn't have a instance vs class name. It must just use the signature of the method.
+        class_addMethod(addToClass, newSel, imp, methodTypeEncoding);
+        // Even though we just added a static method we need to use getInstance here....
+        newMeth = class_getInstanceMethod(addToClass, newSel);
+        
+        Method orgMeth = class_getClassMethod(addToClass, makeLikeSel);
+        method_exchangeImplementations(orgMeth, newMeth);
+    }
+    else
+        class_addMethod(addToClass, makeLikeSel, imp, methodTypeEncoding);
+    
+    return existing;
+}

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestAppDelegate.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestAppDelegate.h
@@ -1,0 +1,33 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
+
+@interface UnitTestAppDelegate : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate>
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestAppDelegate.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestAppDelegate.m
@@ -1,0 +1,34 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "UnitTestAppDelegate.h"
+
+@implementation UnitTestAppDelegate
+- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    return true;
+}
+@end


### PR DESCRIPTION
* All Overrider / Shadow classes were contained in UnitTests.m
* Split these out into their own class files to make the testbase much more readable and decoupled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/295)
<!-- Reviewable:end -->
