### PR TITLE
Give user the ability to disable onesignal load

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1595,6 +1595,11 @@ static NSString *_lastnonActiveMessageId;
 @implementation UIApplication (OneSignal)
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
 + (void)load {
+    
+    if ([self shouldDisableBasedOnProcessArguments]) {
+        [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"OneSignal method swizzling is disabled. Make sure the feature is enabled for production."];
+        return;
+    }
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"UIApplication(OneSignal) LOADED!"];
     
     // Prevent Xcode storyboard rendering process from crashing with custom IBDesignable Views
@@ -1626,6 +1631,12 @@ static NSString *_lastnonActiveMessageId;
     [OneSignalHelper registerAsUNNotificationCenterDelegate];
 }
 
++(BOOL) shouldDisableBasedOnProcessArguments {
+    if ([NSProcessInfo.processInfo.arguments containsObject: @"DISABLE_ONESIGNAL_SWIZZLING"]) {
+        return YES;
+    }
+    return NO;
+}
 @end
 
 


### PR DESCRIPTION
Users of one signal (including me) are experiencing crash in Simulator
mode. This commit allows users the option to turn off oneSignal
functionality by using NSProcessInfo arguments.

To disable, use “DISABLE_ONESIGNAL_SWIZZLING” in “arguments passed on launch” in
the scheme setup

<img width="885" alt="Screenshot 2021-03-05 at 10 29 12 AM" src="https://user-images.githubusercontent.com/3168294/110058806-078e4080-7d9e-11eb-8ee9-7509056aabc5.png">

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/297)
<!-- Reviewable:end -->

