### PR TITLE
Ios11 startup crash fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
@@ -90,22 +90,22 @@ void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasse
 }
 
 NSArray* ClassGetSubclasses(Class parentClass) {
-    
     int numClasses = objc_getClassList(NULL, 0);
-    Class *classes = NULL;
+    Class *classes = (Class*)malloc(sizeof(Class) * numClasses);
     
-    classes = (Class *)malloc(sizeof(Class) * numClasses);
-    numClasses = objc_getClassList(classes, numClasses);
+    objc_getClassList(classes, numClasses);
     
     NSMutableArray *result = [NSMutableArray array];
+    
     for (NSInteger i = 0; i < numClasses; i++) {
         Class superClass = classes[i];
+        
         while(superClass && superClass != parentClass) {
             superClass = class_getSuperclass(superClass);
         }
         
-        if (superClass == nil) continue;
-        [result addObject:classes[i]];
+        if (superClass)
+            [result addObject:classes[i]];
     }
     
     free(classes);


### PR DESCRIPTION
This fixes a startup an intermittent startup crash on class_getSuperclass.

* Resolves #293
* Resolves #278

Re-based history , commit with testing with pointer range check.
12a2a7a870891d4d437a59e6cf27e2fff025684c

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/301)
<!-- Reviewable:end -->
