### PR TITLE
Fixes an issue with the in-app webview during device rotation

### DIFF
--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -87,9 +87,33 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* Unique Message Identifier */
 @property(readonly)NSString* notificationID;
 
-/* Provide this key with a value of 1 to indicate that new content is available.
- Including this key and value means that when your app is launched in the background or resumed application:didReceiveRemoteNotification:fetchCompletionHandler: is called. */
+/* Unique Template Identifier */
+@property(readonly)NSString* templateID;
+
+/* Name of Template */
+@property(readonly)NSString* templateName;
+
+/* True when the key content-available is set to 1 in the aps payload.
+   content-available is used to wake your app when the payload is received.
+   See Apple's documenation for more details.
+  https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application
+*/
 @property(readonly)BOOL contentAvailable;
+
+/* True when the key mutable-content is set to 1 in the aps payload.
+ mutable-content is used to wake your Notification Service Extension to modify a notification.
+ See Apple's documenation for more details.
+ https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension
+ */
+@property(readonly)BOOL mutableContent;
+
+/*
+ Notification category key previously registered to display with.
+ This overrides OneSignal's actionButtons.
+ See Apple's documenation for more details.
+ https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/SupportingNotificationsinYourApp.html#//apple_ref/doc/uid/TP40008194-CH4-SW26
+*/
+@property(readonly)NSString* category;
 
 /* The badge assigned to the application icon */
 @property(readonly)NSUInteger badge;
@@ -121,6 +145,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @end
 
+// ## OneSignal OSNotification
 @interface OSNotification : NSObject
 
 /* Notification Payload */

--- a/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Framework/OneSignal.framework/Versions/A/Headers/OneSignal.h
@@ -87,33 +87,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* Unique Message Identifier */
 @property(readonly)NSString* notificationID;
 
-/* Unique Template Identifier */
-@property(readonly)NSString* templateID;
-
-/* Name of Template */
-@property(readonly)NSString* templateName;
-
-/* True when the key content-available is set to 1 in the aps payload.
-   content-available is used to wake your app when the payload is received.
-   See Apple's documenation for more details.
-  https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application
-*/
+/* Provide this key with a value of 1 to indicate that new content is available.
+ Including this key and value means that when your app is launched in the background or resumed application:didReceiveRemoteNotification:fetchCompletionHandler: is called. */
 @property(readonly)BOOL contentAvailable;
-
-/* True when the key mutable-content is set to 1 in the aps payload.
- mutable-content is used to wake your Notification Service Extension to modify a notification.
- See Apple's documenation for more details.
- https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension
- */
-@property(readonly)BOOL mutableContent;
-
-/*
- Notification category key previously registered to display with.
- This overrides OneSignal's actionButtons.
- See Apple's documenation for more details.
- https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/SupportingNotificationsinYourApp.html#//apple_ref/doc/uid/TP40008194-CH4-SW26
-*/
-@property(readonly)NSString* category;
 
 /* The badge assigned to the application icon */
 @property(readonly)NSUInteger badge;
@@ -145,7 +121,6 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @end
 
-// ## OneSignal OSNotification
 @interface OSNotification : NSObject
 
 /* Notification Payload */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -838,6 +838,12 @@ static OneSignal* singleInstance = nil;
     
     inAppLaunch = [[[NSUserDefaults standardUserDefaults] objectForKey:@"ONESIGNAL_INAPP_LAUNCH_URL"] boolValue];
     
+    // If the URL contains itunes.apple.com, it's an app store link
+    // that should be opened using sharedApplication openURL
+    if ([[url absoluteString] containsString:@"itunes.apple.com"]) {
+        inAppLaunch = NO;
+    }
+    
     if (inAppLaunch && [self isWWWScheme:url]) {
         if (!webVC)
             webVC = [[OneSignalWebView alloc] init];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
@@ -40,12 +40,14 @@ UIViewController *viewControllerForPresentation;
 
 -(void)viewDidLoad {
     [super viewDidLoad];
-
-    _webView = [[UIWebView alloc] initWithFrame:self.view.frame];
+    
+    _webView = [[UIWebView alloc] init];
     _webView.delegate = self;
     [self.view addSubview:_webView];
     
-    [self.view setBackgroundColor:[UIColor blackColor]];
+    [self pinSubviewToMarginsWithSubview:_webView withSuperview:self.view];
+    
+    self.view.backgroundColor = [UIColor redColor];
     
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismiss:)];
     
@@ -68,7 +70,7 @@ UIViewController *viewControllerForPresentation;
         //clear web view
         [_webView loadHTMLString:@"" baseURL:nil];
         if (viewControllerForPresentation)
-           [viewControllerForPresentation.view removeFromSuperview];
+            [viewControllerForPresentation.view removeFromSuperview];
     }];
 }
 
@@ -84,6 +86,19 @@ UIViewController *viewControllerForPresentation;
 
 -(void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     [OneSignal onesignal_Log:ONE_S_LL_ERROR message:error.localizedDescription];
+}
+
+-(void)pinSubviewToMarginsWithSubview:(UIView *)subview withSuperview:(UIView *)superview {
+    subview.translatesAutoresizingMaskIntoConstraints = false;
+    
+    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *leadingConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeLeading multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *trailingConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0.0];
+    
+    [superview addConstraints:@[topConstraint, bottomConstraint, leadingConstraint, trailingConstraint]];
+    
+    [superview layoutIfNeeded];
 }
 
 
@@ -110,9 +125,9 @@ UIViewController *viewControllerForPresentation;
     
     if (!viewControllerForPresentation.view.superview)
         [mainWindow addSubview:[viewControllerForPresentation view]];
-
+    
     @try {
-       [viewControllerForPresentation presentViewController:navController animated:YES completion:nil];
+        [viewControllerForPresentation presentViewController:navController animated:YES completion:nil];
     }
     @catch(NSException* exception) { }
 }
@@ -120,3 +135,5 @@ UIViewController *viewControllerForPresentation;
 
 
 @end
+
+

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
@@ -28,6 +28,7 @@
 #import <UIKit/UIKit.h>
 #import "OneSignalWebView.h"
 #import "OneSignal.h"
+#import "OneSignalHelper.h"
 
 @interface OneSignal ()
 + (void) onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString*) message;
@@ -41,13 +42,11 @@ UIViewController *viewControllerForPresentation;
 -(void)viewDidLoad {
     [super viewDidLoad];
     
-    _webView = [[UIWebView alloc] init];
+    _webView = [UIWebView new];
     _webView.delegate = self;
     [self.view addSubview:_webView];
     
     [self pinSubviewToMarginsWithSubview:_webView withSuperview:self.view];
-    
-    self.view.backgroundColor = [UIColor redColor];
     
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismiss:)];
     
@@ -91,12 +90,12 @@ UIViewController *viewControllerForPresentation;
 -(void)pinSubviewToMarginsWithSubview:(UIView *)subview withSuperview:(UIView *)superview {
     subview.translatesAutoresizingMaskIntoConstraints = false;
     
-    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *leadingConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeLeading multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *trailingConstraint = [NSLayoutConstraint constraintWithItem:subview attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0.0];
+    let attributes = @[@(NSLayoutAttributeTop), @(NSLayoutAttributeBottom), @(NSLayoutAttributeLeading), @(NSLayoutAttributeTrailing)];
     
-    [superview addConstraints:@[topConstraint, bottomConstraint, leadingConstraint, trailingConstraint]];
+    for (NSNumber *layoutAttribute in attributes) {
+        let attribute = (NSLayoutAttribute)[layoutAttribute longValue];
+        [self.view addConstraint:[NSLayoutConstraint constraintWithItem:subview attribute:attribute relatedBy:NSLayoutRelationEqual toItem:superview attribute:attribute multiplier:1.0 constant:0.0]];
+    }
     
     [superview layoutIfNeeded];
 }


### PR DESCRIPTION
* When a user received a push notification with launchUrl specified, and the app displayed the webview, this webview was being manually added as a subview but had no layout constraints. This meant that when the device orientation changed the webview didn't change its frame to match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/317)
<!-- Reviewable:end -->
