### PR TITLE
Refactored REST Requests

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		4529DEDB1FA8284E00CEAB1D /* NSDataOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEDA1FA8284E00CEAB1D /* NSDataOverrider.m */; };
 		4529DEDE1FA828E500CEAB1D /* NSDateOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEDD1FA828E500CEAB1D /* NSDateOverrider.m */; };
 		4529DEE11FA82AB300CEAB1D /* NSBundleOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE01FA82AB300CEAB1D /* NSBundleOverrider.m */; };
-		4529DEE41FA82C6200CEAB1D /* NSURLConnectionOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE31FA82C6200CEAB1D /* NSURLConnectionOverrider.m */; };
+		4529DEE41FA82C6200CEAB1D /* NSURLSessionOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE31FA82C6200CEAB1D /* NSURLSessionOverrider.m */; };
 		4529DEE71FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE61FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m */; };
 		4529DEEA1FA8360C00CEAB1D /* UIApplicationOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEE91FA8360C00CEAB1D /* UIApplicationOverrider.m */; };
 		4529DEED1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEEC1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m */; };
@@ -184,8 +184,8 @@
 		4529DEDD1FA828E500CEAB1D /* NSDateOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDateOverrider.m; sourceTree = "<group>"; };
 		4529DEDF1FA82AB300CEAB1D /* NSBundleOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSBundleOverrider.h; sourceTree = "<group>"; };
 		4529DEE01FA82AB300CEAB1D /* NSBundleOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSBundleOverrider.m; sourceTree = "<group>"; };
-		4529DEE21FA82C6200CEAB1D /* NSURLConnectionOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLConnectionOverrider.h; sourceTree = "<group>"; };
-		4529DEE31FA82C6200CEAB1D /* NSURLConnectionOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLConnectionOverrider.m; sourceTree = "<group>"; };
+		4529DEE21FA82C6200CEAB1D /* NSURLSessionOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionOverrider.h; sourceTree = "<group>"; };
+		4529DEE31FA82C6200CEAB1D /* NSURLSessionOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionOverrider.m; sourceTree = "<group>"; };
 		4529DEE51FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UNUserNotificationCenterOverrider.h; sourceTree = "<group>"; };
 		4529DEE61FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UNUserNotificationCenterOverrider.m; sourceTree = "<group>"; };
 		4529DEE81FA8360C00CEAB1D /* UIApplicationOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIApplicationOverrider.h; sourceTree = "<group>"; };
@@ -349,8 +349,8 @@
 				4529DEEF1FA8433500CEAB1D /* NSLocaleOverrider.m */,
 				4529DED01FA81EA800CEAB1D /* NSObjectOverrider.h */,
 				4529DED11FA81EA800CEAB1D /* NSObjectOverrider.m */,
-				4529DEE21FA82C6200CEAB1D /* NSURLConnectionOverrider.h */,
-				4529DEE31FA82C6200CEAB1D /* NSURLConnectionOverrider.m */,
+				4529DEE21FA82C6200CEAB1D /* NSURLSessionOverrider.h */,
+				4529DEE31FA82C6200CEAB1D /* NSURLSessionOverrider.m */,
 				4529DED61FA8253D00CEAB1D /* NSUserDefaultsOverrider.h */,
 				4529DED71FA8253D00CEAB1D /* NSUserDefaultsOverrider.m */,
 				4529DEEB1FA83C5D00CEAB1D /* OneSignalHelperOverrider.h */,
@@ -746,7 +746,7 @@
 				91F58D851E7C88230017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */,
-				4529DEE41FA82C6200CEAB1D /* NSURLConnectionOverrider.m in Sources */,
+				4529DEE41FA82C6200CEAB1D /* NSURLSessionOverrider.m in Sources */,
 				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,
 				912412341E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -124,6 +124,18 @@
 		91F58D8A1E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */ = {isa = PBXBuildFile; fileRef = 91F58D881E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m */; };
 		91F58D8B1E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m in Sources */ = {isa = PBXBuildFile; fileRef = 91F58D881E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m */; };
 		91F60F7D1E80E4E400706E60 /* UncaughtExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 91F60F7C1E80E4E400706E60 /* UncaughtExceptionHandler.m */; };
+		CA08FC731FE99AFD004C445F /* OneSignalClient.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC721FE99AFD004C445F /* OneSignalClient.m */; };
+		CA08FC741FE99AFF004C445F /* OneSignalClient.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC721FE99AFD004C445F /* OneSignalClient.m */; };
+		CA08FC751FE99B00004C445F /* OneSignalClient.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC721FE99AFD004C445F /* OneSignalClient.m */; };
+		CA08FC781FE99B13004C445F /* OneSignalRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CA08FC761FE99B13004C445F /* OneSignalRequest.h */; };
+		CA08FC791FE99B13004C445F /* OneSignalRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC771FE99B13004C445F /* OneSignalRequest.m */; };
+		CA08FC7A1FE99B13004C445F /* OneSignalRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC771FE99B13004C445F /* OneSignalRequest.m */; };
+		CA08FC7B1FE99B13004C445F /* OneSignalRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC771FE99B13004C445F /* OneSignalRequest.m */; };
+		CA08FC7E1FE99B25004C445F /* Requests.h in Headers */ = {isa = PBXBuildFile; fileRef = CA08FC7C1FE99B25004C445F /* Requests.h */; };
+		CA08FC7F1FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
+		CA08FC801FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
+		CA08FC811FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
+		CA08FC871FE99BB4004C445F /* OneSignalClientOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -240,6 +252,14 @@
 		91F58D881E7C9A240017D24D /* OneSignalNotificationSettingsIOS7.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OneSignalNotificationSettingsIOS7.m; sourceTree = "<group>"; };
 		91F60F7B1E80E49A00706E60 /* UncaughtExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UncaughtExceptionHandler.h; sourceTree = "<group>"; };
 		91F60F7C1E80E4E400706E60 /* UncaughtExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UncaughtExceptionHandler.m; sourceTree = "<group>"; };
+		CA08FC711FE99AFD004C445F /* OneSignalClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalClient.h; sourceTree = "<group>"; };
+		CA08FC721FE99AFD004C445F /* OneSignalClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalClient.m; sourceTree = "<group>"; };
+		CA08FC761FE99B13004C445F /* OneSignalRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalRequest.h; sourceTree = "<group>"; };
+		CA08FC771FE99B13004C445F /* OneSignalRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalRequest.m; sourceTree = "<group>"; };
+		CA08FC7C1FE99B25004C445F /* Requests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Requests.h; sourceTree = "<group>"; };
+		CA08FC7D1FE99B25004C445F /* Requests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Requests.m; sourceTree = "<group>"; };
+		CA08FC821FE99BB4004C445F /* OneSignalClientOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalClientOverrider.h; sourceTree = "<group>"; };
+		CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalClientOverrider.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -279,6 +299,7 @@
 			isa = PBXGroup;
 			children = (
 				912411EE1E73342200E41FD7 /* Source */,
+				CA08FC701FE99AE6004C445F /* API */,
 				911E2CBB1E398AB3003112A4 /* UnitTests */,
 				37747F9519147D6500558FAD /* Frameworks */,
 				3E2400391D4FFC31008BDE70 /* OneSignal-Dynamic */,
@@ -334,6 +355,8 @@
 				4529DED71FA8253D00CEAB1D /* NSUserDefaultsOverrider.m */,
 				4529DEEB1FA83C5D00CEAB1D /* OneSignalHelperOverrider.h */,
 				4529DEEC1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m */,
+				CA08FC821FE99BB4004C445F /* OneSignalClientOverrider.h */,
+				CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */,
 				03389F671FB548A0006537F0 /* OneSignalTrackFirebaseAnalyticsOverrider.h */,
 				03389F681FB548A0006537F0 /* OneSignalTrackFirebaseAnalyticsOverrider.m */,
 				4529DEF11FA8440A00CEAB1D /* UIAlertViewOverrider.h */,
@@ -459,6 +482,20 @@
 			name = NotificationSettings;
 			sourceTree = "<group>";
 		};
+		CA08FC701FE99AE6004C445F /* API */ = {
+			isa = PBXGroup;
+			children = (
+				CA08FC711FE99AFD004C445F /* OneSignalClient.h */,
+				CA08FC721FE99AFD004C445F /* OneSignalClient.m */,
+				CA08FC761FE99B13004C445F /* OneSignalRequest.h */,
+				CA08FC771FE99B13004C445F /* OneSignalRequest.m */,
+				CA08FC7C1FE99B25004C445F /* Requests.h */,
+				CA08FC7D1FE99B25004C445F /* Requests.m */,
+			);
+			name = API;
+			path = Source;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -467,11 +504,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				9124124B1E7337A800E41FD7 /* OneSignal.h in Headers */,
+				CA08FC781FE99B13004C445F /* OneSignalRequest.h in Headers */,
 				912412211E73342200E41FD7 /* OneSignalLocation.h in Headers */,
 				912412291E73342200E41FD7 /* OneSignalReachability.h in Headers */,
 				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
 				91F58D7A1E7C7D3F0017D24D /* OneSignalNotificationSettings.h in Headers */,
 				91F58D811E7C80C30017D24D /* OneSignalNotificationSettingsIOS8.h in Headers */,
+				CA08FC7E1FE99B25004C445F /* Requests.h in Headers */,
 				912412411E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.h in Headers */,
 				91B6EA451E86555200B5CF01 /* OSObservable.h in Headers */,
 				912412351E73342200E41FD7 /* OneSignalTrackIAP.h in Headers */,
@@ -629,8 +668,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				9124120E1E73342200E41FD7 /* OneSignal.m in Sources */,
+				CA08FC731FE99AFD004C445F /* OneSignalClient.m in Sources */,
 				91F58D831E7C80DA0017D24D /* OneSignalNotificationSettingsIOS8.m in Sources */,
 				9124121E1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
+				CA08FC791FE99B13004C445F /* OneSignalRequest.m in Sources */,
 				912412471E73369600E41FD7 /* OneSignalHelper.m in Sources */,
 				9124122E1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122A1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
@@ -652,6 +693,7 @@
 				454F94F51FAD2E5A00D74CCF /* OSNotificationPayload.m in Sources */,
 				9129C6BE1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412361E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
+				CA08FC7F1FE99B25004C445F /* Requests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -660,8 +702,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				9124120F1E73342200E41FD7 /* OneSignal.m in Sources */,
+				CA08FC741FE99AFF004C445F /* OneSignalClient.m in Sources */,
 				91F58D861E7C88250017D24D /* OneSignalNotificationSettingsIOS8.m in Sources */,
 				9124121F1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
+				CA08FC7A1FE99B13004C445F /* OneSignalRequest.m in Sources */,
 				912412481E73369700E41FD7 /* OneSignalHelper.m in Sources */,
 				9124122F1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122B1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
@@ -683,6 +727,7 @@
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
 				9129C6BF1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
+				CA08FC801FE99B25004C445F /* Requests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -707,11 +752,14 @@
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,
 				9124122C1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				03389F691FB548A0006537F0 /* OneSignalTrackFirebaseAnalyticsOverrider.m in Sources */,
+				CA08FC811FE99B25004C445F /* Requests.m in Sources */,
+				CA08FC7B1FE99B13004C445F /* OneSignalRequest.m in Sources */,
 				4529DED51FA823B900CEAB1D /* TestHelperFunctions.m in Sources */,
 				911E2CBD1E398AB3003112A4 /* UnitTests.m in Sources */,
 				91B6EA431E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				9124121C1E73342200E41FD7 /* OneSignalHTTPClient.m in Sources */,
 				4529DEDE1FA828E500CEAB1D /* NSDateOverrider.m in Sources */,
+				CA08FC871FE99BB4004C445F /* OneSignalClientOverrider.m in Sources */,
 				912412401E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				1AF75EAF1E8569710097B315 /* NSString+OneSignal.m in Sources */,
 				4529DEE71FA82CDC00CEAB1D /* UNUserNotificationCenterOverrider.m in Sources */,
@@ -725,6 +773,7 @@
 				912412441E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				9124123C1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
 				4529DEF01FA8433500CEAB1D /* NSLocaleOverrider.m in Sources */,
+				CA08FC751FE99B00004C445F /* OneSignalClient.m in Sources */,
 				9129C6BA1E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				91F58D871E7C88250017D24D /* OneSignalNotificationSettingsIOS8.m in Sources */,
 			);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -461,7 +461,7 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
 }
 
 +(void)downloadIOSParams {
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestGetIosParams withUserId:self.currentSubscriptionState.userId appId:self.app_id] onSuccess:^(NSDictionary *result) {
+    [OneSignalClient.sharedClient executeRequest:[OSRequestGetIosParams withUserId:self.currentSubscriptionState.userId appId:self.app_id] onSuccess:^(NSDictionary *result) {
         [OneSignalTrackFirebaseAnalytics updateFromDownloadParams:result];
     } onFailure:nil];
 }
@@ -671,7 +671,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     NSArray* nowProcessingCallbacks = pendingSendTagCallbacks;
     pendingSendTagCallbacks = nil;
     
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestSendTagsToServer withUserId:self.currentSubscriptionState.userId appId:self.app_id tags:nowSendingTags networkType:[OneSignalHelper getNetType]] onSuccess:^(NSDictionary *result) {
+    [OneSignalClient.sharedClient executeRequest:[OSRequestSendTagsToServer withUserId:self.currentSubscriptionState.userId appId:self.app_id tags:nowSendingTags networkType:[OneSignalHelper getNetType]] onSuccess:^(NSDictionary *result) {
         if (nowProcessingCallbacks)
             for (OSPendingCallbacks *callbackSet in nowProcessingCallbacks)
                 if (callbackSet.successBlock)
@@ -699,7 +699,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
         return;
     }
     
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestGetTags withUserId:self.currentSubscriptionState.userId appId:self.app_id] onSuccess:^(NSDictionary *result) {
+    [OneSignalClient.sharedClient executeRequest:[OSRequestGetTags withUserId:self.currentSubscriptionState.userId appId:self.app_id] onSuccess:^(NSDictionary *result) {
         successBlock([result objectForKey:@"tags"]);
     } onFailure:failureBlock];
     
@@ -756,7 +756,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void)postNotification:(NSDictionary*)jsonData onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestPostNotification withAppId:self.app_id withJson:[jsonData mutableCopy]] onSuccess:^(NSDictionary *result) {
+    [OneSignalClient.sharedClient executeRequest:[OSRequestPostNotification withAppId:self.app_id withJson:[jsonData mutableCopy]] onSuccess:^(NSDictionary *result) {
         NSData* jsonData = [NSJSONSerialization dataWithJSONObject:result options:0 error:nil];
         NSString* jsonResultsString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         
@@ -894,7 +894,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Calling OneSignal PUT updated pushToken!"];
     
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.app_id deviceToken:deviceToken notificationTypes:@([self getNotificationTypes])] onSuccess:successBlock onFailure:failureBlock];
+    [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.app_id deviceToken:deviceToken notificationTypes:@([self getNotificationTypes])] onSuccess:successBlock onFailure:failureBlock];
     
     [self fireIdsAvailableCallback];
 }
@@ -1043,7 +1043,7 @@ static dispatch_queue_t serialQueue;
         [OneSignalLocation clearLastLocation];
     }
     
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestRegisterUser withData:dataDic userId:self.currentSubscriptionState.userId] onSuccess:^(NSDictionary *result) {
+    [OneSignalClient.sharedClient executeRequest:[OSRequestRegisterUser withData:dataDic userId:self.currentSubscriptionState.userId] onSuccess:^(NSDictionary *result) {
         waitingForOneSReg = false;
         
         // Success, no more high priority
@@ -1110,7 +1110,7 @@ static dispatch_queue_t serialQueue;
         
         mLastNotificationTypes = [self getNotificationTypes];
         
-        [[OneSignalClient sharedClient] executeRequest:[OSRequestUpdateNotificationTypes withUserId:self.currentSubscriptionState.userId appId:self.app_id notificationTypes:@([self getNotificationTypes])] onSuccess:nil onFailure:nil];
+        [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateNotificationTypes withUserId:self.currentSubscriptionState.userId appId:self.app_id notificationTypes:@([self getNotificationTypes])] onSuccess:nil onFailure:nil];
         
         if ([self getUsableDeviceToken])
             [self fireIdsAvailableCallback];
@@ -1125,7 +1125,7 @@ static dispatch_queue_t serialQueue;
     if (!self.currentSubscriptionState.userId)
         return;
     
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestSendPurchases withUserId:self.currentSubscriptionState.userId appId:self.app_id withPurchases:purchases] onSuccess:nil onFailure:nil];
+    [OneSignalClient.sharedClient executeRequest:[OSRequestSendPurchases withUserId:self.currentSubscriptionState.userId appId:self.app_id withPurchases:purchases] onSuccess:nil onFailure:nil];
 }
 
 
@@ -1260,7 +1260,7 @@ static NSString *_lastnonActiveMessageId;
     NSString* lastMessageId = [[NSUserDefaults standardUserDefaults] objectForKey:@"GT_LAST_MESSAGE_OPENED_"];
     //Only submit request if messageId not nil and: (lastMessage is nil or not equal to current one)
     if(messageId && (!lastMessageId || ![lastMessageId isEqualToString:messageId])) {
-        [[OneSignalClient sharedClient] executeRequest:[OSRequestSubmitNotificationOpened withUserId:self.currentSubscriptionState.userId appId:self.app_id wasOpened:YES messageId:messageId] onSuccess:nil onFailure:nil];
+        [OneSignalClient.sharedClient executeRequest:[OSRequestSubmitNotificationOpened withUserId:self.currentSubscriptionState.userId appId:self.app_id wasOpened:YES messageId:messageId] onSuccess:nil onFailure:nil];
         [[NSUserDefaults standardUserDefaults] setObject:messageId forKey:@"GT_LAST_MESSAGE_OPENED_"];
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
@@ -1451,7 +1451,7 @@ static NSString *_lastnonActiveMessageId;
         return;
     }
     
-    [[OneSignalClient sharedClient] executeRequest:[OSRequestSyncHashedEmail withUserId:self.currentSubscriptionState.userId appId:self.app_id email:trimmedEmail networkType:[OneSignalHelper getNetType]] onSuccess:nil onFailure:nil];
+    [OneSignalClient.sharedClient executeRequest:[OSRequestSyncHashedEmail withUserId:self.currentSubscriptionState.userId appId:self.app_id email:trimmedEmail networkType:[OneSignalHelper getNetType]] onSuccess:nil onFailure:nil];
 }
 
 // Called from the app's Notification Service Extension

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.h
@@ -1,0 +1,22 @@
+//
+//  OneSignalClient.h
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "OneSignalHelper.h"
+#import "OneSignalRequest.h"
+
+#ifndef OneSignalClient_h
+#define OneSignalClient_h
+
+@interface OneSignalClient : NSObject
++ (OneSignalClient *)sharedClient;
+- (void)executeRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
+- (void)executeSynchronousRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
+@end
+
+#endif

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.h
@@ -1,10 +1,29 @@
-//
-//  OneSignalClient.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2016 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import "OneSignalHelper.h"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -1,0 +1,69 @@
+//
+//  OneSignalClient.m
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import "OneSignalClient.h"
+#import "UIApplicationDelegate+OneSignal.h"
+
+@implementation OneSignalClient
+
++ (OneSignalClient *)sharedClient {
+    static OneSignalClient *sharedClient = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        sharedClient = [OneSignalClient new];
+    });
+    return sharedClient;
+}
+
+- (void)executeRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
+    if (!request.hasAppId) {
+        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:@"HTTP Requests must contain app_id parameter"];
+        return;
+    }
+    
+    let sess = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    
+    let task = [sess dataTaskWithRequest:request.request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        [OneSignalHelper handleJSONNSURLResponse:response data:data error:error onSuccess:successBlock onFailure:failureBlock];
+        
+        if (error || ((NSHTTPURLResponse *)response).statusCode > 300) {
+            NSLog(@"Request with subclass name %@ failed with error: %@ with status code: %i", NSStringFromClass([request class]), error, (int)((NSHTTPURLResponse *)response).statusCode);
+        }
+    }];
+    
+    [task resume];
+}
+
+- (void)executeSynchronousRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
+    if (!request.hasAppId) {
+        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:@"HTTP Requests must contain app_id parameter"];
+        return;
+    }
+    
+    let sess = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    
+    __block NSURLResponse *httpResponse;
+    __block NSError *httpError;
+    
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    
+    let dataTask = [sess dataTaskWithRequest:request.request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        httpResponse = response;
+        httpError = error;
+        
+        dispatch_semaphore_signal(semaphore);
+    }];
+    
+    [dataTask resume];
+    
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    
+    [OneSignalHelper handleJSONNSURLResponse:httpResponse data:nil error:httpError onSuccess:successBlock onFailure:failureBlock];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -62,8 +62,6 @@
 
 // - Networking
 + (NSNumber*)getNetType;
-+ (void)enqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
-+ (void)enqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous;
 + (void)handleJSONNSURLResponse:(NSURLResponse*) response data:(NSData*) data error:(NSError*) error onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
 
 // Threading

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -62,7 +62,6 @@
 
 // - Networking
 + (NSNumber*)getNetType;
-+ (void)handleJSONNSURLResponse:(NSURLResponse*) response data:(NSData*) data error:(NSError*) error onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
 
 // Threading
 + (void)runOnMainThread:(void(^)())block;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -766,41 +766,6 @@ static OneSignal* singleInstance = nil;
     return NO;
 }
 
-+ (void)handleJSONNSURLResponse:(NSURLResponse*) response data:(NSData*) data error:(NSError*) error onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
-    
-    NSHTTPURLResponse* HTTPResponse = (NSHTTPURLResponse*)response;
-    NSInteger statusCode = [HTTPResponse statusCode];
-    NSError* jsonError = nil;
-    NSMutableDictionary* innerJson;
-    
-    if (data != nil && [data length] > 0) {
-        innerJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&jsonError];
-        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"network response: %@", innerJson]];
-        if (jsonError) {
-            if (failureBlock != nil)
-                failureBlock([NSError errorWithDomain:@"OneSignal Error" code:statusCode userInfo:@{@"returned" : jsonError}]);
-            return;
-        }
-    }
-    
-    if (error == nil && statusCode == 200) {
-        if (successBlock != nil) {
-            if (innerJson != nil)
-                successBlock(innerJson);
-            else
-                successBlock(nil);
-        }
-    }
-    else if (failureBlock != nil) {
-        if (innerJson != nil && error == nil)
-            failureBlock([NSError errorWithDomain:@"OneSignalError" code:statusCode userInfo:@{@"returned" : innerJson}]);
-        else if (error != nil)
-            failureBlock([NSError errorWithDomain:@"OneSignalError" code:statusCode userInfo:@{@"error" : error}]);
-        else
-            failureBlock([NSError errorWithDomain:@"OneSignalError" code:statusCode userInfo:nil]);
-    }
-}
-
 + (BOOL)isWWWScheme:(NSURL*)url {
     NSString* urlScheme = [url.scheme lowercaseString];
     return [urlScheme isEqualToString:@"http"] || [urlScheme isEqualToString:@"https"];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -51,7 +51,7 @@
 
 
 
-@interface DirectDownloadDelegate : NSObject {
+@interface DirectDownloadDelegate : NSObject <NSURLSessionDataDelegate> {
     NSError* error;
     NSURLResponse* response;
     BOOL done;
@@ -66,6 +66,28 @@
 @implementation DirectDownloadDelegate
 @synthesize error, response, done;
 
+-(void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data {
+    [outputHandle writeData:data];
+}
+
+-(void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)aResponse completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler {
+    response = aResponse;
+    completionHandler(NSURLSessionResponseAllow);
+}
+
+-(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)anError {
+    error = anError;
+    done = YES;
+    
+    [outputHandle closeFile];
+}
+
+-(void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)anError {
+    done = YES;
+    error = anError;
+    [outputHandle closeFile];
+}
+
 - (id)initWithFilePath:(NSString*)path {
     if (self = [super init]) {
         if ([[NSFileManager defaultManager] fileExistsAtPath:path])
@@ -76,53 +98,40 @@
     }
     return self;
 }
-
-- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError*)anError {
-    error = anError;
-    [self connectionDidFinishLoading:connection];
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData*)someData {
-    [outputHandle writeData:someData];
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse*)aResponse {
-    response = aResponse;
-}
-
-- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
-    done = YES;
-    [outputHandle closeFile];
-}
 @end
 
-
-
-@interface NSURLConnection (DirectDownload)
-+ (BOOL)downloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError*)error;
+@interface NSURLSession (DirectDownload)
++ (BOOL)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error;
 @end
 
-@implementation NSURLConnection (DirectDownload)
+@implementation NSURLSession (DirectDownload)
 
-+ (BOOL)downloadItemAtURL:(NSURL*)url toFile:(NSString *)localPath error:(NSError*)error {
-    NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:url];
++ (BOOL)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error {
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     
-    DirectDownloadDelegate* delegate = [[DirectDownloadDelegate alloc] initWithFilePath:localPath];
-    [NSURLConnection connectionWithRequest:request delegate:delegate];
+    DirectDownloadDelegate *delegate = [[DirectDownloadDelegate alloc] initWithFilePath:localPath];
     
-    while ([delegate isDone] == NO) {
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:delegate delegateQueue:nil];
+    
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request];
+    
+    [task resume];
+    
+    while (![delegate isDone]) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
     }
     
-    NSError* downloadError = [delegate error];
+    NSError *downloadError = [delegate error];
     if (downloadError != nil) {
-        if (error != nil)
+        if (error != nil) {
             error = downloadError;
-        return NO;
+        }
+        return false;
     }
     
-    return YES;
+    return true;
 }
+
 @end
 
 @interface UIApplication (Swizzling)
@@ -715,7 +724,7 @@ static OneSignal* singleInstance = nil;
     NSString* filePath = [paths[0] stringByAppendingPathComponent:name];
     
     NSError* error = nil;
-    [NSURLConnection downloadItemAtURL:URL toFile:filePath error:error];
+    [NSURLSession downloadItemAtURL:URL toFile:filePath error:error];
     NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:@"CACHED_MEDIA"];
     NSMutableArray* appendedCache;
     if (cachedFiles) {
@@ -755,36 +764,6 @@ static OneSignal* singleInstance = nil;
     }
     
     return NO;
-}
-
-+ (void)enqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
-    [self enqueueRequest:request onSuccess:successBlock onFailure:failureBlock isSynchronous:false];
-}
-
-+ (void)enqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"network request to: %@", request.URL]];
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"request.body: %@", [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]]];
-    
-    if (isSynchronous) {
-        NSURLResponse* response = nil;
-        NSError* error = nil;
-        
-        [NSURLConnection sendSynchronousRequest:request
-                              returningResponse:&response
-                                          error:&error];
-        
-        [OneSignalHelper handleJSONNSURLResponse:response data:nil error:error onSuccess:successBlock onFailure:failureBlock];
-    }
-    else {
-        [NSURLConnection
-         sendAsynchronousRequest:request
-         queue:[[NSOperationQueue alloc] init]
-         completionHandler:^(NSURLResponse* response,
-                             NSData* data,
-                             NSError* error) {
-             [OneSignalHelper handleJSONNSURLResponse:response data:data error:error onSuccess:successBlock onFailure:failureBlock];
-         }];
-    }
 }
 
 + (void)handleJSONNSURLResponse:(NSURLResponse*) response data:(NSData*) data error:(NSError*) error onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -251,7 +251,7 @@ static OneSignalLocation* singleInstance = nil;
         
         initialLocationSent = YES;
         
-        [[OneSignalClient sharedClient] executeRequest:[OSRequestSendLocation withUserId:[OneSignal mUserId] appId:[OneSignal app_id] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive)] onSuccess:nil onFailure:nil];
+        [OneSignalClient.sharedClient executeRequest:[OSRequestSendLocation withUserId:[OneSignal mUserId] appId:[OneSignal app_id] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive)] onSuccess:nil onFailure:nil];
     }
     
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
@@ -1,10 +1,29 @@
-//
-//  OneSignalRequest.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
@@ -1,0 +1,27 @@
+//
+//  OneSignalRequest.h
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
+#define httpMethodString(enum) [@[@"GET", @"POST", @"HEAD", @"PUT", @"DELETE", @"OPTIONS", @"CONNECT", @"TRACE"] objectAtIndex:enum]
+
+
+#ifndef OneSignalRequest_h
+#define OneSignalRequest_h
+
+@interface OneSignalRequest : NSObject
+
+@property (nonatomic) HTTPMethod method;
+@property (nonatomic, nonnull) NSString *path;
+@property (nonatomic, nullable) NSDictionary *parameters;
+-(NSMutableURLRequest * _Nonnull )request;
+-(BOOL)hasAppId;
+@end
+
+#endif

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
@@ -1,10 +1,29 @@
-//
-//  OneSignalRequest.m
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "OneSignalRequest.h"
 #import "OneSignalHelper.h"
@@ -42,8 +61,6 @@
         default:
             break;
     }
-    
-    NSLog(@"BUILT %@ HTTP REQUEST: \nURL: %@\nMETHOD: %@\nPARAMETERS: %@\nHEADER FIELDS: %@", NSStringFromClass([self class]), request.URL.absoluteString, request.HTTPMethod, self.parameters, request.allHTTPHeaderFields);
     
     return request;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
@@ -1,0 +1,92 @@
+//
+//  OneSignalRequest.m
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import "OneSignalRequest.h"
+#import "OneSignalHelper.h"
+#import "Requests.h"
+
+#define API_VERSION @"api/v1/"
+#define SERVER_URL @"https://onesignal.com/"
+
+@implementation OneSignalRequest
+- (id)init {
+    self = [super init];
+    
+    return self;
+}
+
+-(NSMutableURLRequest *)request {
+    //build URL
+    let urlString = [[SERVER_URL stringByAppendingString:API_VERSION] stringByAppendingString:self.path];
+    
+    let request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
+    
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [request setHTTPMethod:httpMethodString(self.method)];
+    
+    switch (self.method) {
+        case GET:
+        case DELETE:
+            [self attachQueryParametersToRequest:request withParameters:self.parameters];
+            break;
+        case POST:
+        case PUT:
+            [self attachBodyToRequest:request withParameters:self.parameters];
+            break;
+        default:
+            break;
+    }
+    
+    NSLog(@"BUILT %@ HTTP REQUEST: \nURL: %@\nMETHOD: %@\nPARAMETERS: %@\nHEADER FIELDS: %@", NSStringFromClass([self class]), request.URL.absoluteString, request.HTTPMethod, self.parameters, request.allHTTPHeaderFields);
+    
+    return request;
+}
+
+-(BOOL)hasAppId {
+    return self.parameters[@"app_id"] != nil && [self.parameters[@"app_id"] length] > 0;
+}
+
+-(void)attachBodyToRequest:(NSMutableURLRequest *)request withParameters:(NSDictionary *)parameters {
+    if (!self.parameters)
+        return;
+    
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:parameters options:NSJSONWritingPrettyPrinted error:&error];
+    
+    request.HTTPBody = jsonData;
+}
+
+-(void)attachQueryParametersToRequest:(NSMutableURLRequest *)request withParameters:(NSDictionary *)parameters {
+    if (!parameters)
+        return;
+    
+    NSString *urlString = [request.URL absoluteString];
+    
+    NSString *queryString = [self queryStringForParameters:parameters];
+    
+    if (queryString && queryString.length > 0) {
+        urlString = [urlString stringByAppendingString:@"?"];
+        urlString = [urlString stringByAppendingString:queryString];
+    }
+    
+    request.URL = [NSURL URLWithString:urlString];
+}
+
+-(NSString *)queryStringForParameters:(NSDictionary *)parameters {
+    NSEnumerator *enumerator = [parameters keyEnumerator];
+    id key;
+    NSString *result = @"";
+    while (key = [enumerator nextObject]) {
+        result = [result stringByAppendingFormat:@"%@=%@&", key, [parameters objectForKey:key]];
+    }
+    result = [result substringToIndex:result.length - 1];
+    return [result stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -120,7 +120,7 @@ static BOOL lastOnFocusWasToBackground = YES;
     
     // If resuming and badge was set, clear it on the server as well.
     if (wasBadgeSet && !toBackground) {
-        [[OneSignalClient sharedClient] executeRequest:[OSRequestOnFocus withUserId:[OneSignal mUserId] appId:[OneSignal app_id] badgeCount:@0] onSuccess:nil onFailure:nil];
+        [OneSignalClient.sharedClient executeRequest:[OSRequestOnFocus withUserId:[OneSignal mUserId] appId:[OneSignal app_id] badgeCount:@0] onSuccess:nil onFailure:nil];
         
         return;
     }
@@ -131,7 +131,7 @@ static BOOL lastOnFocusWasToBackground = YES;
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             [OneSignalTracker beginBackgroundFocusTask];
             
-            [[OneSignalClient sharedClient] executeSynchronousRequest:[OSRequestOnFocus withUserId:[OneSignal mUserId] appId:[OneSignal app_id] state:@"ping" type:@1 activeTime:@(timeToPingWith) netType:[OneSignalHelper getNetType]] onSuccess:nil onFailure:nil];
+            [OneSignalClient.sharedClient executeSynchronousRequest:[OSRequestOnFocus withUserId:[OneSignal mUserId] appId:[OneSignal app_id] state:@"ping" type:@1 activeTime:@(timeToPingWith) netType:[OneSignalHelper getNetType]] onSuccess:nil onFailure:nil];
             
             [OneSignalTracker endBackgroundFocusTask];
         });

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -1,10 +1,29 @@
-//
-//  Requests.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import "OneSignalRequest.h"
@@ -14,10 +33,6 @@
 #define OneSignalRequests_h
 
 NS_ASSUME_NONNULL_BEGIN
-
-@interface OSRequestRegisterDevice : OneSignalRequest
-+ (instancetype)withAppId:(NSString *)appId withDeviceType:(NSNumber *)deviceType withAdId:(NSString *)adId withSDKVersion:(NSString *)sdkVersion withIdentifier:(NSString *)identifier;
-@end
 
 @interface OSRequestGetTags : OneSignalRequest
 + (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId;

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -1,0 +1,74 @@
+//
+//  Requests.h
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "OneSignalRequest.h"
+#import "OneSignalLocation.h"
+
+#ifndef OneSignalRequests_h
+#define OneSignalRequests_h
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OSRequestRegisterDevice : OneSignalRequest
++ (instancetype)withAppId:(NSString *)appId withDeviceType:(NSNumber *)deviceType withAdId:(NSString *)adId withSDKVersion:(NSString *)sdkVersion withIdentifier:(NSString *)identifier;
+@end
+
+@interface OSRequestGetTags : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId;
+@end
+
+@interface OSRequestGetIosParams : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId;
+@end
+
+@interface OSRequestSendTagsToServer : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId tags:(NSDictionary *)tags networkType:(NSNumber *)netType;
+@end
+
+@interface OSRequestPostNotification : OneSignalRequest
++ (instancetype)withAppId:(NSString *)appId withJson:(NSMutableDictionary *)json;
+@end
+
+@interface OSRequestUpdateDeviceToken : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId deviceToken:(NSString *)identifier notificationTypes:(NSNumber *)notificationTypes;
+@end
+
+@interface OSRequestUpdateNotificationTypes : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId notificationTypes:(NSNumber *)notificationTypes;
+@end
+
+@interface OSRequestSendPurchases : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId withPurchases:(NSArray *)purchases;
+@end
+
+@interface OSRequestSubmitNotificationOpened : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId wasOpened:(BOOL)opened messageId:(NSString *)messageId;
+@end
+
+@interface OSRequestSyncHashedEmail : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId email:(NSString *)email networkType:(NSNumber *)netType;
+@end
+
+@interface OSRequestSendLocation : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId location:(os_last_location *)coordinate networkType:(NSNumber *)netType backgroundState:(BOOL)backgroundState;
+@end
+
+@interface OSRequestOnFocus : OneSignalRequest
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId badgeCount:(NSNumber *)badgeCount;
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId state:(NSString *)state type:(NSNumber *)type activeTime:(NSNumber *)activeTime netType:(NSNumber *)netType;
+@end
+
+NS_ASSUME_NONNULL_END
+
+@interface OSRequestRegisterUser : OneSignalRequest
++ (instancetype _Nonnull)withData:(NSDictionary * _Nonnull)registrationData userId:(NSString * _Nullable)userId;
+@end
+
+#endif /* Requests_h */
+

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -1,0 +1,217 @@
+//
+//  Requests.m
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Requests.h"
+#import "OneSignalRequest.h"
+#import "OneSignalHelper.h"
+#import <stdlib.h>
+#import <stdio.h>
+#import <sys/types.h>
+#import <sys/utsname.h>
+#import <sys/sysctl.h>
+
+// SUBCLASSES - These subclasses each represent an individual request
+
+@implementation OSRequestRegisterDevice
++ (instancetype)withAppId:(NSString *)appId withDeviceType:(NSNumber *)deviceType withAdId:(NSString *)adId withSDKVersion:(NSString *)sdkVersion withIdentifier:(NSString *)identifier {
+    let request = [OSRequestRegisterDevice new];
+    
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    let deviceModel = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    request.parameters = @{
+                           @"app_id" : appId,
+                           @"device_model" : deviceModel,
+                           @"device_os" : [[UIDevice currentDevice] systemVersion],
+                           @"timezone" : [NSNumber numberWithInt:(int)[[NSTimeZone localTimeZone] secondsFromGMT]],
+                           @"device_type" : deviceType,
+                           @"ad_id" : adId,
+                           @"sdk" : sdkVersion,
+                           @"identifier" : identifier
+                           };
+    
+    request.method = POST;
+    request.path = @"players";
+    
+    return request;
+}
+@end
+
+@implementation OSRequestGetTags
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId {
+    let request = [OSRequestGetTags new];
+    
+    request.parameters = @{@"app_id" : appId};
+    request.method = GET;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestGetIosParams
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId {
+    let request = [OSRequestGetIosParams new];
+    
+    if (userId) {
+        request.parameters = @{@"player_id" : userId};
+    }
+    
+    request.method = GET;
+    request.path = [NSString stringWithFormat:@"apps/%@/ios_params.js", appId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestSendTagsToServer
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId tags:(NSDictionary *)tags networkType:(NSNumber *)netType {
+    let request = [OSRequestSendTagsToServer new];
+    
+    request.parameters = @{@"app_id" : appId, @"tags" : tags, @"net_type" : netType};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestPostNotification
++ (instancetype)withAppId:(NSString *)appId withJson:(NSMutableDictionary *)json {
+    let request = [OSRequestPostNotification new];
+    if (!json[@"app_id"]) {
+        json[@"app_id"] = appId;
+    }
+    
+    request.parameters = json;
+    request.method = POST;
+    request.path = @"notifications";
+    
+    return request;
+}
+@end
+
+@implementation OSRequestUpdateDeviceToken
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId deviceToken:(NSString *)identifier notificationTypes:(NSNumber *)notificationTypes {
+    let request = [OSRequestUpdateDeviceToken new];
+    
+    request.parameters = @{
+                           @"app_id" : appId,
+                           @"identifier" : identifier,
+                           @"notification_types" : notificationTypes
+                           };
+    
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+@end
+
+
+@implementation OSRequestUpdateNotificationTypes
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId notificationTypes:(NSNumber *)notificationTypes {
+    let request = [OSRequestUpdateNotificationTypes new];
+    
+    request.parameters = @{@"app_id" : appId, @"notificatioon_types" : notificationTypes};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestSendPurchases
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId withPurchases:(NSArray *)purchases {
+    let request = [OSRequestSendPurchases new];
+    
+    request.parameters = @{@"app_id" : appId, @"purchases" : purchases};
+    request.method = POST;
+    request.path = [NSString stringWithFormat:@"players/%@/on_purchase", purchases];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestSubmitNotificationOpened
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId wasOpened:(BOOL)opened messageId:(NSString *)messageId {
+    let request = [OSRequestSubmitNotificationOpened new];
+    
+    request.parameters = @{@"player_id" : userId, @"app_id" : appId, @"opened" : @(opened)};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"notifications/%@", messageId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestRegisterUser
++ (instancetype _Nonnull)withData:(NSDictionary * _Nonnull)registrationData userId:(NSString * _Nullable)userId {
+    
+    let request = [OSRequestRegisterUser new];
+    
+    request.parameters = registrationData;
+    request.method = POST;
+    request.path = userId ? [NSString stringWithFormat:@"players/%@/on_session", userId] : @"players";
+    
+    return request;
+}
+@end
+
+@implementation OSRequestSyncHashedEmail
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId email:(NSString *)email networkType:(NSNumber *)netType {
+    let request = [OSRequestSyncHashedEmail new];
+    
+    let lowerCase = [email lowercaseString];
+    let md5Hash = [OneSignalHelper hashUsingMD5:lowerCase];
+    let sha1Hash = [OneSignalHelper hashUsingSha1:lowerCase];
+    
+    [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"%@ - MD5: %@, SHA1:%@", lowerCase, md5Hash, sha1Hash]];
+    
+    request.parameters = @{@"app_id" : appId, @"em_m" : md5Hash, @"em_s" : sha1Hash, @"net_type" : netType};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestSendLocation
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId location:(os_last_location *)coordinate networkType:(NSNumber *)netType backgroundState:(BOOL)backgroundState {
+    let request = [OSRequestSendLocation new];
+    
+    request.parameters = @{@"app_id" : appId, @"lat" : @(coordinate->cords.latitude), @"long" : @(coordinate->cords.longitude), @"loc_acc_vert" : @(coordinate->verticalAccuracy), @"loc_acc" : @(coordinate->horizontalAccuracy), @"net_type" : netType, @"loc_bg" : @(backgroundState)};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+@end
+
+@implementation OSRequestOnFocus
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId badgeCount:(NSNumber *)badgeCount {
+    let request = [OSRequestOnFocus new];
+    
+    request.parameters = @{@"app_id" : appId, @"badge_count" : badgeCount};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId state:(NSString *)state type:(NSNumber *)type activeTime:(NSNumber *)activeTime netType:(NSNumber *)netType {
+    let request = [OSRequestOnFocus new];
+    
+    request.parameters = @{@"app_id" : appId, @"state" : state, @"type" : type, @"active_time" : activeTime, @"net_type" : netType};
+    request.method = POST;
+    request.path = [NSString stringWithFormat:@"players/%@/on_focus", userId];
+    
+    return request;
+}
+@end

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -1,10 +1,29 @@
-//
-//  Requests.m
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import "Requests.h"
@@ -17,32 +36,6 @@
 #import <sys/sysctl.h>
 
 // SUBCLASSES - These subclasses each represent an individual request
-
-@implementation OSRequestRegisterDevice
-+ (instancetype)withAppId:(NSString *)appId withDeviceType:(NSNumber *)deviceType withAdId:(NSString *)adId withSDKVersion:(NSString *)sdkVersion withIdentifier:(NSString *)identifier {
-    let request = [OSRequestRegisterDevice new];
-    
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    let deviceModel = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-    request.parameters = @{
-                           @"app_id" : appId,
-                           @"device_model" : deviceModel,
-                           @"device_os" : [[UIDevice currentDevice] systemVersion],
-                           @"timezone" : [NSNumber numberWithInt:(int)[[NSTimeZone localTimeZone] secondsFromGMT]],
-                           @"device_type" : deviceType,
-                           @"ad_id" : adId,
-                           @"sdk" : sdkVersion,
-                           @"identifier" : identifier
-                           };
-    
-    request.method = POST;
-    request.path = @"players";
-    
-    return request;
-}
-@end
-
 @implementation OSRequestGetTags
 + (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId {
     let request = [OSRequestGetTags new];
@@ -119,7 +112,7 @@
 + (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId notificationTypes:(NSNumber *)notificationTypes {
     let request = [OSRequestUpdateNotificationTypes new];
     
-    request.parameters = @{@"app_id" : appId, @"notificatioon_types" : notificationTypes};
+    request.parameters = @{@"app_id" : appId, @"notification_types" : notificationTypes};
     request.method = PUT;
     request.path = [NSString stringWithFormat:@"players/%@", userId];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSURLSessionOverrider : NSObject
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
@@ -1,0 +1,50 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSURLSessionOverrider.h"
+
+#import "TestHelperFunctions.h"
+
+@implementation NSURLSessionOverrider
+
++ (void)load {
+    // Swizzle an injected method defined in OneSignalHelper
+    injectStaticSelector([NSURLSessionOverrider class], @selector(overrideDownloadItemAtURL:toFile:error:), [NSURLSession class], @selector(downloadItemAtURL:toFile:error:));
+}
+
+// Override downloading of media attachment
++ (BOOL)overrideDownloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError*)error {
+    NSString *content = @"File Contents";
+    NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
+    [[NSFileManager defaultManager] createFileAtPath:localPath
+                                            contents:fileContents
+                                          attributes:nil];
+    
+    return true;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -1,0 +1,22 @@
+//
+//  OneSignalClientOverrider.h
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface OneSignalClientOverrider : NSObject
++(void)reset:(XCTestCase*)testInstance;
++(void)setLastHTTPRequest:(NSDictionary*)value;
++(NSDictionary*)lastHTTPRequest;
++(int)networkRequestCount;
++(void)setLastUrl:(NSString*)value;
++(NSString*)lastUrl;
+
+@end
+

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -43,10 +43,7 @@ static XCTestCase* currentTestInstance;
     NSMutableDictionary *parameters = [request.parameters mutableCopy];
     
     if (!parameters[@"app_id"] && ![request.request.URL.absoluteString containsString:@"/apps/"])
-        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
-    
-    if (!parameters[@"app_id"] && ![request.request.URL.absoluteString containsString:@"/apps/"])
-        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
+        _XCTPrimitiveFail(currentTestInstance, @"All request should include an app_id");
     
     networkRequestCount++;
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -1,0 +1,96 @@
+//
+//  OneSignalClientOverrider.m
+//  OneSignal
+//
+//  Created by Brad Hesse on 12/19/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+//
+//  OneSignalClientOverrider.m
+//  UnitTests
+//
+//  Created by Brad Hesse on 12/18/17.
+//  Copyright © 2017 Hiptic. All rights reserved.
+//
+
+#import "OneSignalClientOverrider.h"
+#import "TestHelperFunctions.h"
+
+#import "OneSignal.h"
+#import "OneSignalHelper.h"
+#import "OneSignalClient.h"
+#import "OneSignalRequest.h"
+#import "OneSignalSelectorHelpers.h"
+
+@implementation OneSignalClientOverrider
+
+static dispatch_queue_t serialMockMainLooper;
+static NSString* lastUrl;
+static int networkRequestCount;
+static NSDictionary* lastHTTPRequest;
+static XCTestCase* currentTestInstance;
+
++ (void)load {
+    serialMockMainLooper = dispatch_queue_create("com.onesignal.unittest", DISPATCH_QUEUE_SERIAL);
+    
+    
+    //with refactored networking code, need to replace the implementation of the execute request method so tests don't actually execite HTTP requests
+    injectToProperClass(@selector(overrideExecuteRequest:onSuccess:onFailure:), @selector(executeRequest:onSuccess:onFailure:), @[], [OneSignalClientOverrider class], [OneSignalClient class]);
+}
+
+- (void)overrideExecuteRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
+    NSMutableDictionary *parameters = [request.parameters mutableCopy];
+    
+    if (!parameters[@"app_id"] && ![request.request.URL.absoluteString containsString:@"/apps/"])
+        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
+    
+    if (!parameters[@"app_id"] && ![request.request.URL.absoluteString containsString:@"/apps/"])
+        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
+    
+    networkRequestCount++;
+    
+    id url = [request.request URL];
+    NSLog(@"url: %@", url);
+    NSLog(@"parameters: %@", parameters);
+    
+    lastUrl = [url absoluteString];
+    lastHTTPRequest = parameters;
+    
+    if (successBlock) {
+        if ([request.request.URL.absoluteString hasPrefix:@"https://onesignal.com/api/v1/apps/"])
+            successBlock(@{@"fba": @true});
+        else
+            successBlock(@{@"id": @"1234"});
+    }
+}
+
++(void)reset:(XCTestCase*)testInstance {
+    currentTestInstance = testInstance;
+    
+    networkRequestCount = 0;
+    lastUrl = nil;
+    lastHTTPRequest = nil;
+}
+
++(void)setLastHTTPRequest:(NSDictionary*)value {
+    lastHTTPRequest = value;
+}
++(NSDictionary*)lastHTTPRequest {
+    return lastHTTPRequest;
+}
+
++(int)networkRequestCount {
+    return networkRequestCount;
+}
+
++(void)setLastUrl:(NSString*)value {
+    lastUrl = value;
+}
+
++(NSString*)lastUrl {
+    return lastUrl;
+}
+
+@end
+

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.h
@@ -30,18 +30,9 @@
 #import <XCTest/XCTest.h>
 
 @interface OneSignalHelperOverrider : NSObject
-+(void)reset:(XCTestCase*)testInstance;
 
 +(void)setMockIOSVersion:(float)value;
 +(float)mockIOSVersion;
-
-+(void)setLastHTTPRequset:(NSDictionary*)value;
-+(NSDictionary*)lastHTTPRequset;
-
-+(int)networkRequestCount;
-
-+(void)setLastUrl:(NSString*)value;
-+(NSString*)lastUrl;
 
 + (void)runBackgroundThreads;
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
@@ -35,9 +35,6 @@
 @implementation OneSignalHelperOverrider
 
 static dispatch_queue_t serialMockMainLooper;
-static NSString* lastUrl;
-static NSDictionary* lastHTTPRequset;
-static int networkRequestCount;
 
 static XCTestCase* currentTestInstance;
 
@@ -46,18 +43,10 @@ static float mockIOSVersion;
 + (void)load {
     serialMockMainLooper = dispatch_queue_create("com.onesignal.unittest", DISPATCH_QUEUE_SERIAL);
     
-    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideEnqueueRequest:onSuccess:onFailure:isSynchronous:), [OneSignalHelper class], @selector(enqueueRequest:onSuccess:onFailure:isSynchronous:));
+//    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideEnqueueRequest:onSuccess:onFailure:isSynchronous:), [OneSignalHelper class], @selector(enqueueRequest:onSuccess:onFailure:isSynchronous:));
     injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideGetAppName), [OneSignalHelper class], @selector(getAppName));
     injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideIsIOSVersionGreaterOrEqual:), [OneSignalHelper class], @selector(isIOSVersionGreaterOrEqual:));
     injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideDispatch_async_on_main_queue:), [OneSignalHelper class], @selector(dispatch_async_on_main_queue:));
-}
-
-+(void)reset:(XCTestCase*)testInstance {
-    currentTestInstance = testInstance;
-    
-    networkRequestCount = 0;
-    lastUrl = nil;
-    lastHTTPRequset = nil;
 }
 
 +(void)setMockIOSVersion:(float)value {
@@ -67,66 +56,47 @@ static float mockIOSVersion;
     return mockIOSVersion;
 }
 
-+(void)setLastHTTPRequset:(NSDictionary*)value {
-    lastHTTPRequset = value;
-}
-+(NSDictionary*)lastHTTPRequset {
-    return lastHTTPRequset;
-}
-
-+(int)networkRequestCount {
-    return networkRequestCount;
-}
-
-+(void)setLastUrl:(NSString*)value {
-    lastUrl = value;
-}
-
-+(NSString*)lastUrl {
-    return lastUrl;
-}
-
 + (NSString*) overrideGetAppName {
     return @"App Name";
 }
 
-+ (void)overrideEnqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
-    NSError *error = nil;
-    
-    NSLog(@"request.URL: %@", request.URL);
-    
-    NSMutableDictionary *parameters;
-    
-    NSData* httpData = [request HTTPBody];
-    if (httpData)
-        parameters = [NSJSONSerialization JSONObjectWithData:[request HTTPBody] options:0 error:&error];
-    else {
-        NSURLComponents *components = [NSURLComponents componentsWithString:request.URL.absoluteString];
-        parameters = [NSMutableDictionary new];
-        for(NSURLQueryItem *item in components.queryItems) {
-            parameters[item.name] = item.value;
-        }
-    }
-    
-    if (!parameters[@"app_id"] && ![request.URL.absoluteString containsString:@"/apps/"])
-        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
-    
-    networkRequestCount++;
-    
-    id url = [request URL];
-    NSLog(@"url: %@", url);
-    NSLog(@"parameters: %@", parameters);
-    
-    lastUrl = [url absoluteString];
-    lastHTTPRequset = parameters;
-    
-    if (successBlock) {
-        if ([request.URL.absoluteString hasPrefix:@"https://onesignal.com/api/v1/apps/"])
-            successBlock(@{@"fba": @true});
-        else
-            successBlock(@{@"id": @"1234"});
-    }
-}
+//+ (void)overrideEnqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
+//    NSError *error = nil;
+//
+//    NSLog(@"request.URL: %@", request.URL);
+//
+//    NSMutableDictionary *parameters;
+//
+//    NSData* httpData = [request HTTPBody];
+//    if (httpData)
+//        parameters = [NSJSONSerialization JSONObjectWithData:[request HTTPBody] options:0 error:&error];
+//    else {
+//        NSURLComponents *components = [NSURLComponents componentsWithString:request.URL.absoluteString];
+//        parameters = [NSMutableDictionary new];
+//        for(NSURLQueryItem *item in components.queryItems) {
+//            parameters[item.name] = item.value;
+//        }
+//    }
+//
+//    if (!parameters[@"app_id"] && ![request.URL.absoluteString containsString:@"/apps/"])
+//        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
+//
+//    networkRequestCount++;
+//
+//    id url = [request URL];
+//    NSLog(@"url: %@", url);
+//    NSLog(@"parameters: %@", parameters);
+//
+//    lastUrl = [url absoluteString];
+//    lastHTTPRequset = parameters;
+//
+//    if (successBlock) {
+//        if ([request.URL.absoluteString hasPrefix:@"https://onesignal.com/api/v1/apps/"])
+//            successBlock(@{@"fba": @true});
+//        else
+//            successBlock(@{@"id": @"1234"});
+//    }
+//}
 
 + (BOOL)overrideIsIOSVersionGreaterOrEqual:(float)version {
     return mockIOSVersion >= version;

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
@@ -43,7 +43,6 @@ static float mockIOSVersion;
 + (void)load {
     serialMockMainLooper = dispatch_queue_create("com.onesignal.unittest", DISPATCH_QUEUE_SERIAL);
     
-//    injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideEnqueueRequest:onSuccess:onFailure:isSynchronous:), [OneSignalHelper class], @selector(enqueueRequest:onSuccess:onFailure:isSynchronous:));
     injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideGetAppName), [OneSignalHelper class], @selector(getAppName));
     injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideIsIOSVersionGreaterOrEqual:), [OneSignalHelper class], @selector(isIOSVersionGreaterOrEqual:));
     injectStaticSelector([OneSignalHelperOverrider class], @selector(overrideDispatch_async_on_main_queue:), [OneSignalHelper class], @selector(dispatch_async_on_main_queue:));
@@ -59,44 +58,6 @@ static float mockIOSVersion;
 + (NSString*) overrideGetAppName {
     return @"App Name";
 }
-
-//+ (void)overrideEnqueueRequest:(NSURLRequest*)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock isSynchronous:(BOOL)isSynchronous {
-//    NSError *error = nil;
-//
-//    NSLog(@"request.URL: %@", request.URL);
-//
-//    NSMutableDictionary *parameters;
-//
-//    NSData* httpData = [request HTTPBody];
-//    if (httpData)
-//        parameters = [NSJSONSerialization JSONObjectWithData:[request HTTPBody] options:0 error:&error];
-//    else {
-//        NSURLComponents *components = [NSURLComponents componentsWithString:request.URL.absoluteString];
-//        parameters = [NSMutableDictionary new];
-//        for(NSURLQueryItem *item in components.queryItems) {
-//            parameters[item.name] = item.value;
-//        }
-//    }
-//
-//    if (!parameters[@"app_id"] && ![request.URL.absoluteString containsString:@"/apps/"])
-//        _XCTPrimitiveFail(currentTestInstance, @"All requesst should include an app_id");
-//
-//    networkRequestCount++;
-//
-//    id url = [request URL];
-//    NSLog(@"url: %@", url);
-//    NSLog(@"parameters: %@", parameters);
-//
-//    lastUrl = [url absoluteString];
-//    lastHTTPRequset = parameters;
-//
-//    if (successBlock) {
-//        if ([request.URL.absoluteString hasPrefix:@"https://onesignal.com/api/v1/apps/"])
-//            successBlock(@{@"fba": @true});
-//        else
-//            successBlock(@{@"id": @"1234"});
-//    }
-//}
 
 + (BOOL)overrideIsIOSVersionGreaterOrEqual:(float)version {
     return mockIOSVersion >= version;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -69,6 +69,11 @@
 #import "OneSignalTrackFirebaseAnalyticsOverrider.h"
 #import "OneSignalClientOverrider.h"
 
+// Networking
+#import "OneSignalClient.h"
+#import "Requests.h"
+#import "OneSignalClientOverrider.h"
+
 @interface OneSignal (UN_extra)
 + (dispatch_queue_t) getRegisterQueue;
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -67,6 +67,7 @@
 #import "NSLocaleOverrider.h"
 #import "UIAlertViewOverrider.h"
 #import "OneSignalTrackFirebaseAnalyticsOverrider.h"
+#import "OneSignalClientOverrider.h"
 
 @interface OneSignal (UN_extra)
 + (dispatch_queue_t) getRegisterQueue;
@@ -135,7 +136,7 @@
     NSLog(@"=======  APP RESTART ======\n\n");
     
     NSDateOverrider.timeOffset = 0;
-    [OneSignalHelperOverrider reset:self];
+    [OneSignalClientOverrider reset:self];
     [UNUserNotificationCenterOverrider reset:self];
     [UIApplicationOverrider reset];
     [OneSignalTrackFirebaseAnalyticsOverrider reset];
@@ -334,12 +335,12 @@
     [self initOneSignal];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @15);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"device_model"], @"x86_64");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"device_type"], @0);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"language"], @"en-US");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
     
     OSPermissionSubscriptionState* status = [OneSignal getPermissionSubscriptionState];
     XCTAssertTrue(status.permissionStatus.accepted);
@@ -352,11 +353,11 @@
     XCTAssertEqualObjects(status.subscriptionStatus.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
     
     // 2nd init call should not fire another on_session call.
-    OneSignalHelperOverrider.lastHTTPRequset = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
     [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 - (void)testVersionStringLength {
@@ -393,19 +394,19 @@
     
     [self initOneSignalAndThreadWait];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @7);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"device_model"], @"x86_64");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"device_type"], @0);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"language"], @"en-US");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
     
     // 2nd init call should not fire another on_session call.
-    OneSignalHelperOverrider.lastHTTPRequset = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
     [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     // Make the following methods were not called as they are not available on iOS 7
     XCTAssertFalse(UIApplicationOverrider.calledRegisterForRemoteNotifications);
@@ -429,19 +430,19 @@
     [self answerNotifiationPrompt:true];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"]);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @-15);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"device_model"], @"x86_64");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"device_type"], @0);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"language"], @"en-US");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-15);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
     
     // 2nd init call should not fire another on_session call.
-    OneSignalHelperOverrider.lastHTTPRequset = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
     [self initOneSignalAndThreadWait];
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 
@@ -473,9 +474,9 @@
     
     [self initOneSignalAndThreadWait];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key"], @"value");
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     [self clearStateForAppRestart];
     
@@ -486,7 +487,7 @@
     [self runBackgroundThreads];
     
     [self initOneSignalAndThreadWait];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 0);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
     
 }
 
@@ -850,13 +851,13 @@
     [self setCurrentNotificationPermissionAsUnanswered];
     
     [self initOneSignal];
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
     [self answerNotifiationPrompt:true];
     [self runBackgroundThreads];
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @-13);
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-13);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 
@@ -914,14 +915,14 @@
     [self initOneSignalAndThreadWait];
     
     // Don't make a network call right away.
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
     // Triggers the 30 fallback to register device right away.
     [OneSignal performSelector:NSSelectorFromString(@"registerUser")];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @-19);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-19);
 }
 
 - (void)testNotificationTypesWhenAlreadyAcceptedWithAutoPromptOffOnFristStartPreIos10 {
@@ -935,7 +936,7 @@
     
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @7);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
 }
 
 
@@ -952,8 +953,8 @@
     [NSObjectOverrider runPendingSelectors];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @-18);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-18);
 }
 
 - (void)testNotAcceptingNotificationsWithoutBackgroundModes {
@@ -963,15 +964,15 @@
     [self initOneSignal];
     
     // Don't make a network call right away.
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
     [self answerNotifiationPrompt:false];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastUrl, @"https://onesignal.com/api/v1/players");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"]);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/players");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
 }
 
 - (void)testIdsAvailableNotAcceptingNotifications {
@@ -1028,18 +1029,18 @@
     
     // Make sure open tracking network call was made.
     XCTAssertEqual(openedWasFire, true);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"opened"], @1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
     
     // Make sure if the device recieved a duplicate we don't fire the open network call again.
-    OneSignalHelperOverrider.lastUrl = nil;
-    OneSignalHelperOverrider.lastHTTPRequset = nil;
+    OneSignalClientOverrider.lastUrl = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
     
-    XCTAssertNil(OneSignalHelperOverrider.lastUrl);
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertNil(OneSignalClientOverrider.lastUrl);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 
@@ -1185,18 +1186,18 @@
     
     // Make sure open tracking network call was made.
     XCTAssertEqual(openedWasFire, true);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"opened"], @1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
     
     // Make sure if the device recieved a duplicate we don't fire the open network call again.
-    OneSignalHelperOverrider.lastUrl = nil;
-    OneSignalHelperOverrider.lastHTTPRequset = nil;
+    OneSignalClientOverrider.lastUrl = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
     
-    XCTAssertNil(OneSignalHelperOverrider.lastUrl);
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertNil(OneSignalClientOverrider.lastUrl);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 
@@ -1233,18 +1234,18 @@
     
     // Make sure open tracking network call was made.
     XCTAssertEqual(openedWasFire, true);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"opened"], @1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
     
     // Make sure if the device recieved a duplicate we don't fire the open network call again.
-    OneSignalHelperOverrider.lastUrl = nil;
-    OneSignalHelperOverrider.lastHTTPRequset = nil;
+    OneSignalClientOverrider.lastUrl = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
     
-    XCTAssertNil(OneSignalHelperOverrider.lastUrl);
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset);
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertNil(OneSignalClientOverrider.lastUrl);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 // Testing iOS 10 - 2.4.0+ button fromat - with os_data aps payload format
@@ -1470,7 +1471,7 @@ didReceiveRemoteNotification:userInfo
 - (void)testSendTags {
     [self initOneSignalAndThreadWait];
     
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     // Simple test with a sendTag and sendTags call.
     [OneSignal sendTag:@"key" value:@"value"];
@@ -1481,10 +1482,10 @@ didReceiveRemoteNotification:userInfo
     [self runBackgroundThreads];
     [NSObjectOverrider runPendingSelectors];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key"], @"value");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key1"], @"value1");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key2"], @"value2");
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key1"], @"value1");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], @"value2");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
     
     // More advanced test with callbacks.
     __block BOOL didRunSuccess1, didRunSuccess2, didRunSuccess3;
@@ -1504,11 +1505,11 @@ didReceiveRemoteNotification:userInfo
     [NSObjectOverrider runPendingSelectors];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key10"], @"value10");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key11"], @"value11");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key12"], @"value12");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key13"], @"value13");
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 3);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key10"], @"value10");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key11"], @"value11");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key12"], @"value12");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key13"], @"value13");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
     
     XCTAssertEqual(didRunSuccess1, true);
     XCTAssertEqual(didRunSuccess2, true);
@@ -1517,7 +1518,7 @@ didReceiveRemoteNotification:userInfo
 
 - (void)testDeleteTags {
     [self initOneSignalAndThreadWait];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     NSLog(@"Calling sendTag and deleteTag");
     // send 2 tags and delete 1 before they get sent off.
@@ -1531,9 +1532,9 @@ didReceiveRemoteNotification:userInfo
     [self runBackgroundThreads];
     [NSObjectOverrider runPendingSelectors];
     
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key"]);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key2"], @"value2");
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], @"value2");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
     
     [OneSignal sendTags:@{@"someKey": @NO}];
     [OneSignal deleteTag:@"someKey"];
@@ -1541,7 +1542,7 @@ didReceiveRemoteNotification:userInfo
 
 - (void)testGetTags {
     [self initOneSignalAndThreadWait];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     __block BOOL fireGetTags = false;
     
@@ -1560,7 +1561,7 @@ didReceiveRemoteNotification:userInfo
 - (void)testGetTagsBeforePlayerId {
     [self initOneSignalAndThreadWait];
     
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     __block BOOL fireGetTags = false;
     
@@ -1601,7 +1602,7 @@ didReceiveRemoteNotification:userInfo
     [NSObjectOverrider runPendingSelectors];
     
     // create, ge tags, then sendTags call.
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 3);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
     XCTAssertTrue(fireDeleteTags);
 }
 
@@ -1616,34 +1617,34 @@ didReceiveRemoteNotification:userInfo
     [self runBackgroundThreads];
     
     // Do not try to send tag update yet as there isn't a player_id yet.
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 0);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
     
     [self answerNotifiationPrompt:false];
     [self runBackgroundThreads];
     
     // A single POST player create call should be made with tags included.
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"tags"][@"key"], @"value");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @0);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
 }
 
 - (void)testPostNotification {
     [self initOneSignalAndThreadWait];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     
     // Normal post should auto add add_id.
     [OneSignal postNotification:@{@"contents": @{@"en": @"message body"}}];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"contents"][@"en"], @"message body");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"contents"][@"en"], @"message body");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
     
     // Should allow overriding the app_id
     [OneSignal postNotification:@{@"contents": @{@"en": @"message body"}, @"app_id": @"override_app_UUID"}];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 3);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"contents"][@"en"], @"message body");
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"app_id"], @"override_app_UUID");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"contents"][@"en"], @"message body");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"override_app_UUID");
 }
 
 
@@ -1654,8 +1655,8 @@ didReceiveRemoteNotification:userInfo
     
     [self initOneSignalAndThreadWait];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @0);
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 - (void)testPermissionChangedInSettingsOutsideOfApp {
@@ -1669,17 +1670,17 @@ didReceiveRemoteNotification:userInfo
     
     [OneSignal addPermissionObserver:observer];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @0);
-    XCTAssertNil(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
     
     [self backgroundApp];
     [self setCurrentNotificationPermission:true];
     [self resumeApp];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"notification_types"], @15);
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastHTTPRequset[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
     
     XCTAssertEqual(observer->last.from.accepted, false);
     XCTAssertEqual(observer->last.to.accepted, true);
@@ -1693,7 +1694,7 @@ didReceiveRemoteNotification:userInfo
     NSDateOverrider.timeOffset = 10;
     [self resumeApp];
     [self runBackgroundThreads];
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 1);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     // Anything over 30 secounds should count as a session.
     [self backgroundApp];
@@ -1701,8 +1702,8 @@ didReceiveRemoteNotification:userInfo
     [self resumeApp];
     [self runBackgroundThreads];
     
-    XCTAssertEqualObjects(OneSignalHelperOverrider.lastUrl, @"https://onesignal.com/api/v1/players/1234/on_session");
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 2);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/players/1234/on_session");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 // Tests that a slient content-available 1 notification doesn't trigger an on_session or count it has opened.
@@ -1727,7 +1728,7 @@ didReceiveRemoteNotification:userInfo
     [self runBackgroundThreads];
     
     XCTAssertEqual(receivedWasFire, true);
-    XCTAssertEqual(OneSignalHelperOverrider.networkRequestCount, 0);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
 }
 
 -(UNNotificationCategory*)unNotificagionCategoryWithId:(NSString*)identifier {
@@ -1851,4 +1852,19 @@ didReceiveRemoteNotification:userInfo
     //   We should not try to download attachemts as iOS is about to kill the extension and this will take to much time.
     XCTAssertNil(content.attachments);
 }
+
+-(void)testBuildOSRequest {
+    let request = [OSRequestSendTagsToServer withUserId:@"12345" appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55bb" tags:@{@"tag1" : @"test1", @"tag2" : @"test2"} networkType:[OneSignalHelper getNetType]];
+    
+    XCTAssert([request.parameters[@"app_id"] isEqualToString:@"b2f7f966-d8cc-11e4-bed1-df8f05be55bb"]);
+    XCTAssert([request.parameters[@"tags"][@"tag1"] isEqualToString:@"test1"]);
+    XCTAssert([request.path isEqualToString:@"players/12345"]);
+    
+    let urlRequest = request.request;
+    
+    XCTAssert([urlRequest.URL.absoluteString isEqualToString:@"https://onesignal.com/api/v1/players/12345"]);
+    XCTAssert([urlRequest.HTTPMethod isEqualToString:@"PUT"]);
+    XCTAssert([urlRequest.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+}
+
 @end


### PR DESCRIPTION
* Instead of manually building NSURLRequests, where we need to manually set different request properties (like the HTTP method) each time we make the request in code, I've refactored the project to use subclassed representations of the different requests. 
* This results in less code duplication and less potential for bugs
* Refactored the unit tests and added a new test to make sure the new requests are being built & formatted correctly.
* Also removes usage of NSURLConnection (#292 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/320)
<!-- Reviewable:end -->
