### PR TITLE
Delay Subscription Observer Notification

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -69,6 +69,9 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 - (void)setAccepted:(BOOL)inAccpeted;
 - (void)persistAsFrom;
 - (BOOL)compare:(OSSubscriptionState*)from;
+
+@property (nonatomic) BOOL delayedObserverUpdate;
+
 @end
 
 // Redefine OSSubscriptionStateChanges

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -126,6 +126,12 @@
 
 - (void)setAccepted:(BOOL)inAccpeted {
     BOOL lastSubscribed = self.subscribed;
+    
+    if ([OneSignal shouldDelaySubscriptionSettingsUpdate]) {
+        self.delayedObserverUpdate = true;
+        return;
+    }
+    
     _accpeted = inAccpeted;
     if (lastSubscribed != self.subscribed)
         [self.observable notifyChange:self];

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -28,6 +28,9 @@
 #import "OSSubscription.h"
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
 @implementation OSSubscriptionState
 
 - (ObserableSubscriptionStateType*)observable {
@@ -131,7 +134,7 @@
     // This is to prevent a problem where the observer gets updated
     // before the OneSignal server does. (11f7f49841339317a334c5ec928db7edccb21cfe)
     
-    if ([OneSignal shouldDelaySubscriptionSettingsUpdate]) {
+    if ([OneSignal performSelector:@selector(shouldDelaySubscriptionSettingsUpdate)]) {
         self.delayedObserverUpdate = true;
         return;
     }

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -127,6 +127,10 @@
 - (void)setAccepted:(BOOL)inAccpeted {
     BOOL lastSubscribed = self.subscribed;
     
+    // checks to see if we should delay the observer update
+    // This is to prevent a problem where the observer gets updated
+    // before the OneSignal server does. (11f7f49841339317a334c5ec928db7edccb21cfe)
+    
     if ([OneSignal shouldDelaySubscriptionSettingsUpdate]) {
         self.delayedObserverUpdate = true;
         return;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -341,8 +341,6 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)deleteTags:(NSArray*)keys onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
 + (void)deleteTags:(NSArray*)keys;
 + (void)deleteTagsWithJsonString:(NSString*)jsonString;
-+ (BOOL)shouldDelaySubscriptionSettingsUpdate;
-
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
 // Sends as MD5 and SHA1 of the provided email
 + (void)syncHashedEmail:(NSString*)email;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -341,6 +341,7 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)deleteTags:(NSArray*)keys onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock;
 + (void)deleteTags:(NSArray*)keys;
 + (void)deleteTagsWithJsonString:(NSString*)jsonString;
++ (BOOL)shouldDelaySubscriptionSettingsUpdate;
 
 // Optional method that sends us the user's email as an anonymized hash so that we can better target and personalize notifications sent to that user across their devices.
 // Sends as MD5 and SHA1 of the provided email

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -296,10 +296,6 @@ static ObserableSubscriptionStateChangesType* _subscriptionStateChangesObserver;
     _currentSubscriptionState = nil;
     
     _permissionStateChangesObserver = nil;
-//    _subscriptionStateChangesObserver = nil;
-    
-    // this function is only called for unit testing
-    //commented out so we can have a single synchronized observer in tests
 }
 
 // Set to false as soon as it's read.

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -10,9 +10,6 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-//when mocking a networking request with a delay, this setting determines how long to delay the completion block for
-#define EXECUTION_DELAY 0.01
-
 @interface OneSignalClientOverrider : NSObject
 +(void)reset:(XCTestCase*)testInstance;
 +(void)setLastHTTPRequest:(NSDictionary*)value;

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -10,6 +10,9 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+//when mocking a networking request with a delay, this setting determines how long to delay the completion block for
+#define EXECUTION_DELAY 0.01
+
 @interface OneSignalClientOverrider : NSObject
 +(void)reset:(XCTestCase*)testInstance;
 +(void)setLastHTTPRequest:(NSDictionary*)value;
@@ -17,6 +20,7 @@
 +(int)networkRequestCount;
 +(void)setLastUrl:(NSString*)value;
 +(NSString*)lastUrl;
-
++(void)setShouldExecuteInstantaneously:(BOOL)instant;
++ (dispatch_queue_t)getHTTPQueue;
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.m
@@ -32,6 +32,9 @@
 #import "OneSignal.h"
 #import "OneSignalHelper.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
 @implementation OneSignalHelperOverrider
 
 static dispatch_queue_t serialMockMainLooper;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -115,8 +115,6 @@
 
 @interface UnitTests : XCTestCase
 
-@property (strong, atomic) NSLock *subscriptionLock;
-
 @end
 
 @implementation UnitTests
@@ -171,8 +169,6 @@
 // Called before each test.
 - (void)setUp {
     [super setUp];
-    
-    self.subscriptionLock = [NSLock new];
     
     OneSignalHelperOverrider.mockIOSVersion = 10;
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -114,6 +114,9 @@
 
 
 @interface UnitTests : XCTestCase
+
+@property (strong, atomic) NSLock *subscriptionLock;
+
 @end
 
 @implementation UnitTests
@@ -168,6 +171,8 @@
 // Called before each test.
 - (void)setUp {
     [super setUp];
+    
+    self.subscriptionLock = [NSLock new];
     
     OneSignalHelperOverrider.mockIOSVersion = 10;
     
@@ -241,14 +246,15 @@
     if (triggerDidRegisterForRemoteNotfications && NSBundleOverrider.nsbundleDictionary[@"UIBackgroundModes"])
         [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
     
-    if (OneSignalHelperOverrider.mockIOSVersion > 9)
+    if (OneSignalHelperOverrider.mockIOSVersion > 9) {
         [UNUserNotificationCenterOverrider fireLastRequestAuthorizationWithGranted:accept];
-    else if (OneSignalHelperOverrider.mockIOSVersion > 7) {
+    } else if (OneSignalHelperOverrider.mockIOSVersion > 7) {
         UIApplication *sharedApp = [UIApplication sharedApplication];
         [sharedApp.delegate application:sharedApp didRegisterUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:UNUserNotificationCenterOverrider.notifTypesOverride categories:nil]];
     }
-    else // iOS 7 - Only support accepted for now.
+    else  { // iOS 7 - Only support accepted for now.
         [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
+    }
 }
 
 - (void)backgroundApp {
@@ -269,7 +275,9 @@
     
     [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
     
-    dispatch_queue_t registerUserQueue, notifSettingsQueue;
+    // the httpQueue makes sure all HTTP request mocks are sync'ed
+    
+    dispatch_queue_t registerUserQueue, notifSettingsQueue, httpQueue;
     for(int i = 0; i < 10; i++) {
         [OneSignalHelperOverrider runBackgroundThreads];
         
@@ -280,6 +288,10 @@
         registerUserQueue = [OneSignal getRegisterQueue];
         if (registerUserQueue)
             dispatch_sync(registerUserQueue, ^{});
+        
+        httpQueue = [OneSignalClientOverrider getHTTPQueue];
+        if (httpQueue)
+            dispatch_sync(httpQueue, ^{});
         
         [UNUserNotificationCenterOverrider runBackgroundThreads];
         
@@ -337,34 +349,32 @@
 - (void)testBasicInitTest {
     NSLog(@"iOS VERSION: %@", [[UIDevice currentDevice] systemVersion]);
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self initOneSignal];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
-        
-        OSPermissionSubscriptionState* status = [OneSignal getPermissionSubscriptionState];
-        XCTAssertTrue(status.permissionStatus.accepted);
-        XCTAssertTrue(status.permissionStatus.hasPrompted);
-        XCTAssertTrue(status.permissionStatus.answeredPrompt);
-        
-        XCTAssertEqual(status.subscriptionStatus.subscribed, true);
-        XCTAssertEqual(status.subscriptionStatus.userSubscriptionSetting, true);
-        XCTAssertEqual(status.subscriptionStatus.userId, @"1234");
-        XCTAssertEqualObjects(status.subscriptionStatus.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
-        
-        // 2nd init call should not fire another on_session call.
-        OneSignalClientOverrider.lastHTTPRequest = nil;
-        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-    }
+    [self initOneSignal];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
+    
+    OSPermissionSubscriptionState* status = [OneSignal getPermissionSubscriptionState];
+    XCTAssertTrue(status.permissionStatus.accepted);
+    XCTAssertTrue(status.permissionStatus.hasPrompted);
+    XCTAssertTrue(status.permissionStatus.answeredPrompt);
+    
+    XCTAssertEqual(status.subscriptionStatus.subscribed, true);
+    XCTAssertEqual(status.subscriptionStatus.userSubscriptionSetting, true);
+    XCTAssertEqual(status.subscriptionStatus.userId, @"1234");
+    XCTAssertEqualObjects(status.subscriptionStatus.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
+    
+    // 2nd init call should not fire another on_session call.
+    OneSignalClientOverrider.lastHTTPRequest = nil;
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 - (void)testVersionStringLength {
@@ -397,31 +407,27 @@
 }
 
 - (void)testRegisterationOniOS7 {
+    OneSignalHelperOverrider.mockIOSVersion = 7;
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        OneSignalHelperOverrider.mockIOSVersion = 7;
-        
-        [self initOneSignalAndThreadWait];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
-        
-        // 2nd init call should not fire another on_session call.
-        OneSignalClientOverrider.lastHTTPRequest = nil;
-        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-        
-        // Make the following methods were not called as they are not available on iOS 7
-        XCTAssertFalse(UIApplicationOverrider.calledRegisterForRemoteNotifications);
-        XCTAssertFalse(UIApplicationOverrider.calledCurrentUserNotificationSettings);
-    }
+    [self initOneSignalAndThreadWait];
     
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
+    
+    // 2nd init call should not fire another on_session call.
+    OneSignalClientOverrider.lastHTTPRequest = nil;
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    
+    // Make the following methods were not called as they are not available on iOS 7
+    XCTAssertFalse(UIApplicationOverrider.calledRegisterForRemoteNotifications);
+    XCTAssertFalse(UIApplicationOverrider.calledCurrentUserNotificationSettings);
 }
 
 // Test exists since we've seen a few rare crash reports where
@@ -432,30 +438,28 @@
 }
 
 - (void)testInitOnSimulator {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self setCurrentNotificationPermissionAsUnanswered];
-        [self backgroundModesDisabledInXcode];
-        UIApplicationOverrider.didFailRegistarationErrorCode = 3010;
-        
-        [self initOneSignalAndThreadWait];
-        
-        [self answerNotifiationPrompt:true];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-15);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
-        
-        // 2nd init call should not fire another on_session call.
-        OneSignalClientOverrider.lastHTTPRequest = nil;
-        [self initOneSignalAndThreadWait];
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-    }
+    [self setCurrentNotificationPermissionAsUnanswered];
+    [self backgroundModesDisabledInXcode];
+    UIApplicationOverrider.didFailRegistarationErrorCode = 3010;
+    
+    [self initOneSignalAndThreadWait];
+    
+    [self answerNotifiationPrompt:true];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-15);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
+    
+    // 2nd init call should not fire another on_session call.
+    OneSignalClientOverrider.lastHTTPRequest = nil;
+    [self initOneSignalAndThreadWait];
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 
@@ -477,33 +481,30 @@
 }
 
 - (void)testCallingMethodsBeforeInit {
+    [self setCurrentNotificationPermission:true];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self setCurrentNotificationPermission:true];
-        
-        [OneSignal sendTag:@"key" value:@"value"];
-        [OneSignal setSubscription:true];
-        [OneSignal promptLocation];
-        [OneSignal promptForPushNotificationsWithUserResponse:nil];
-        [self runBackgroundThreads];
-        
-        [self initOneSignalAndThreadWait];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-        
-        [self clearStateForAppRestart];
-        
-        [OneSignal sendTag:@"key" value:@"value"];
-        [OneSignal setSubscription:true];
-        [OneSignal promptLocation];
-        [OneSignal promptForPushNotificationsWithUserResponse:nil];
-        [self runBackgroundThreads];
-        
-        [self initOneSignalAndThreadWait];
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
-    }
+    [OneSignal sendTag:@"key" value:@"value"];
+    [OneSignal setSubscription:true];
+    [OneSignal promptLocation];
+    [OneSignal promptForPushNotificationsWithUserResponse:nil];
+    [self runBackgroundThreads];
+    
+    [self initOneSignalAndThreadWait];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    
+    [self clearStateForAppRestart];
+    
+    [OneSignal sendTag:@"key" value:@"value"];
+    [OneSignal setSubscription:true];
+    [OneSignal promptLocation];
+    [OneSignal promptForPushNotificationsWithUserResponse:nil];
+    [self runBackgroundThreads];
+    
+    [self initOneSignalAndThreadWait];
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
 }
 
 - (void)testPermissionChangeObserverIOS10 {
@@ -800,6 +801,7 @@
     
     OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
     [OneSignal addSubscriptionObserver:observer];
+    
     [self registerForPushNotifications];
     [self answerNotifiationPrompt:true];
     [self runBackgroundThreads];
@@ -808,6 +810,7 @@
     XCTAssertEqual(observer->last.to.subscribed, true);
     
     [OneSignal setSubscription:false];
+    [self runBackgroundThreads];
     
     XCTAssertEqual(observer->last.from.subscribed, true);
     XCTAssertEqual(observer->last.to.subscribed, false);
@@ -856,26 +859,24 @@
     
     // Device should be reported a subscribed now as all condiditions are true.
     [OneSignal setSubscription:true];
+    [self runBackgroundThreads];
     XCTAssertFalse(observer->last.from.subscribed);
     XCTAssertTrue(observer->last.to.subscribed);
 }
 
 - (void)testInitAcceptingNotificationsWithoutCapabilitesSet {
+    [self backgroundModesDisabledInXcode];
+    UIApplicationOverrider.didFailRegistarationErrorCode = 3000;
+    [self setCurrentNotificationPermissionAsUnanswered];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self backgroundModesDisabledInXcode];
-        UIApplicationOverrider.didFailRegistarationErrorCode = 3000;
-        [self setCurrentNotificationPermissionAsUnanswered];
-        
-        [self initOneSignal];
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        
-        [self answerNotifiationPrompt:true];
-        [self runBackgroundThreads];
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-13);
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-    }
+    [self initOneSignal];
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    
+    [self answerNotifiationPrompt:true];
+    [self runBackgroundThreads];
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-13);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 
@@ -928,81 +929,69 @@
 
 
 - (void)testPromptedButNeveranswerNotificationPrompt {
+    [self setCurrentNotificationPermissionAsUnanswered];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self setCurrentNotificationPermissionAsUnanswered];
-        
-        [self initOneSignalAndThreadWait];
-        
-        // Don't make a network call right away.
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        
-        // Triggers the 30 fallback to register device right away.
-        [OneSignal performSelector:NSSelectorFromString(@"registerUser")];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-19);
-    }
+    [self initOneSignalAndThreadWait];
+    
+    // Don't make a network call right away.
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    
+    // Triggers the 30 fallback to register device right away.
+    [OneSignal performSelector:NSSelectorFromString(@"registerUser")];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-19);
 }
 
 - (void)testNotificationTypesWhenAlreadyAcceptedWithAutoPromptOffOnFristStartPreIos10 {
+    OneSignalHelperOverrider.mockIOSVersion = 8;
+    [self setCurrentNotificationPermission:true];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        OneSignalHelperOverrider.mockIOSVersion = 8;
-        [self setCurrentNotificationPermission:true];
-        
-        [OneSignal initWithLaunchOptions:nil
-                                   appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
-                handleNotificationAction:nil
-                                settings:@{kOSSettingsKeyAutoPrompt: @false}];
-        
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
-    }
+    [OneSignal initWithLaunchOptions:nil
+                               appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:@{kOSSettingsKeyAutoPrompt: @false}];
+    
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
 }
 
 
 - (void)testNeverPromptedStatus {
+    [self setCurrentNotificationPermissionAsUnanswered];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self setCurrentNotificationPermissionAsUnanswered];
-        
-        [OneSignal initWithLaunchOptions:nil
-                                   appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
-                handleNotificationAction:nil
-                                settings:@{kOSSettingsKeyAutoPrompt: @false}];
-        
-        [self runBackgroundThreads];
-        // Triggers the 30 fallback to register device right away.
-        [NSObjectOverrider runPendingSelectors];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-18);
-    }
+    [OneSignal initWithLaunchOptions:nil
+                               appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:@{kOSSettingsKeyAutoPrompt: @false}];
+    
+    [self runBackgroundThreads];
+    // Triggers the 30 fallback to register device right away.
+    [NSObjectOverrider runPendingSelectors];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-18);
 }
 
 - (void)testNotAcceptingNotificationsWithoutBackgroundModes {
+    [self setCurrentNotificationPermissionAsUnanswered];
+    [self backgroundModesDisabledInXcode];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self setCurrentNotificationPermissionAsUnanswered];
-        [self backgroundModesDisabledInXcode];
-        
-        [self initOneSignal];
-        
-        // Don't make a network call right away.
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        
-        [self answerNotifiationPrompt:false];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/players");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
-    }
+    [self initOneSignal];
+    
+    // Don't make a network call right away.
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    
+    [self answerNotifiationPrompt:false];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/players");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
 }
 
 - (void)testIdsAvailableNotAcceptingNotifications {
@@ -1041,39 +1030,36 @@
 
 // Tests that a normal notification opened on iOS 10 triggers the handleNotificationAction.
 - (void)testNotificationOpen {
+    __block BOOL openedWasFire = false;
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        __block BOOL openedWasFire = false;
-        
-        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" handleNotificationAction:^(OSNotificationOpenedResult *result) {
-            XCTAssertNil(result.notification.payload.additionalData);
-            XCTAssertEqual(result.action.type, OSNotificationActionTypeOpened);
-            XCTAssertNil(result.action.actionID);
-            openedWasFire = true;
-        }];
-        [self runBackgroundThreads];
-        
-        id notifResponse = [self createBasiciOSNotificationResponse];
-        UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
-        id notifCenterDelegate = notifCenter.delegate;
-        // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
-        [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
-        
-        // Make sure open tracking network call was made.
-        XCTAssertEqual(openedWasFire, true);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
-        
-        // Make sure if the device recieved a duplicate we don't fire the open network call again.
-        OneSignalClientOverrider.lastUrl = nil;
-        OneSignalClientOverrider.lastHTTPRequest = nil;
-        [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
-        
-        XCTAssertNil(OneSignalClientOverrider.lastUrl);
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-    }
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" handleNotificationAction:^(OSNotificationOpenedResult *result) {
+        XCTAssertNil(result.notification.payload.additionalData);
+        XCTAssertEqual(result.action.type, OSNotificationActionTypeOpened);
+        XCTAssertNil(result.action.actionID);
+        openedWasFire = true;
+    }];
+    [self runBackgroundThreads];
+    
+    id notifResponse = [self createBasiciOSNotificationResponse];
+    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    id notifCenterDelegate = notifCenter.delegate;
+    // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    
+    // Make sure open tracking network call was made.
+    XCTAssertEqual(openedWasFire, true);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
+    
+    // Make sure if the device recieved a duplicate we don't fire the open network call again.
+    OneSignalClientOverrider.lastUrl = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    
+    XCTAssertNil(OneSignalClientOverrider.lastUrl);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 
@@ -1189,101 +1175,96 @@
 
 // Testing iOS 10 - old pre-2.4.0 button fromat - with original aps payload format
 - (void)testNotificationOpenFromButtonPress {
+    __block BOOL openedWasFire = false;
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        __block BOOL openedWasFire = false;
-        
-        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" handleNotificationAction:^(OSNotificationOpenedResult *result) {
-            XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
-            XCTAssertEqual(result.action.type, OSNotificationActionTypeActionTaken);
-            XCTAssertEqualObjects(result.action.actionID, @"id1");
-            openedWasFire = true;
-        }];
-        [self runBackgroundThreads];
-        UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
-        
-        id userInfo = @{@"aps": @{@"content_available": @1},
-                        @"m": @"alert body only",
-                        @"o": @[@{@"i": @"id1", @"n": @"text1"}],
-                        @"custom": @{
-                                @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bb"
-                                }
-                        };
-        
-        id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
-        [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
-        
-        UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
-        id notifCenterDelegate = notifCenter.delegate;
-        
-        // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
-        [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
-        
-        // Make sure open tracking network call was made.
-        XCTAssertEqual(openedWasFire, true);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
-        
-        // Make sure if the device recieved a duplicate we don't fire the open network call again.
-        OneSignalClientOverrider.lastUrl = nil;
-        OneSignalClientOverrider.lastHTTPRequest = nil;
-        [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
-        
-        XCTAssertNil(OneSignalClientOverrider.lastUrl);
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-    }
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" handleNotificationAction:^(OSNotificationOpenedResult *result) {
+        XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
+        XCTAssertEqual(result.action.type, OSNotificationActionTypeActionTaken);
+        XCTAssertEqualObjects(result.action.actionID, @"id1");
+        openedWasFire = true;
+    }];
+    [self runBackgroundThreads];
+    UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
+    
+    id userInfo = @{@"aps": @{@"content_available": @1},
+                    @"m": @"alert body only",
+                    @"o": @[@{@"i": @"id1", @"n": @"text1"}],
+                    @"custom": @{
+                            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bb"
+                            }
+                    };
+    
+    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
+    
+    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    id notifCenterDelegate = notifCenter.delegate;
+    
+    // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    
+    // Make sure open tracking network call was made.
+    XCTAssertEqual(openedWasFire, true);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
+    
+    // Make sure if the device recieved a duplicate we don't fire the open network call again.
+    OneSignalClientOverrider.lastUrl = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    
+    XCTAssertNil(OneSignalClientOverrider.lastUrl);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 
 // Testing iOS 10 - 2.4.0+ button fromat - with os_data aps payload format
 - (void)testNotificationOpenFromButtonPressWithNewformat {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        __block BOOL openedWasFire = false;
-        
-        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" handleNotificationAction:^(OSNotificationOpenedResult *result) {
-            XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
-            XCTAssertEqual(result.action.type, OSNotificationActionTypeActionTaken);
-            XCTAssertEqualObjects(result.action.actionID, @"id1");
-            openedWasFire = true;
-        }];
-        [self runBackgroundThreads];
-        UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
-        
-        id userInfo = @{@"aps": @{
-                                @"mutable-content": @1,
-                                @"alert": @"Message Body"
-                                },
-                        @"os_data": @{
-                                @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bb",
-                                @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
-                                }};
-        
-        id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
-        [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
-        
-        UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
-        id notifCenterDelegate = notifCenter.delegate;
-        
-        // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
-        [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
-        
-        // Make sure open tracking network call was made.
-        XCTAssertEqual(openedWasFire, true);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
-        
-        // Make sure if the device recieved a duplicate we don't fire the open network call again.
-        OneSignalClientOverrider.lastUrl = nil;
-        OneSignalClientOverrider.lastHTTPRequest = nil;
-        [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
-        
-        XCTAssertNil(OneSignalClientOverrider.lastUrl);
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-    }
+    __block BOOL openedWasFire = false;
+    
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" handleNotificationAction:^(OSNotificationOpenedResult *result) {
+        XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
+        XCTAssertEqual(result.action.type, OSNotificationActionTypeActionTaken);
+        XCTAssertEqualObjects(result.action.actionID, @"id1");
+        openedWasFire = true;
+    }];
+    [self runBackgroundThreads];
+    UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
+    
+    id userInfo = @{@"aps": @{
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body"
+                            },
+                    @"os_data": @{
+                            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bb",
+                            @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+                            }};
+    
+    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
+    
+    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    id notifCenterDelegate = notifCenter.delegate;
+    
+    // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    
+    // Make sure open tracking network call was made.
+    XCTAssertEqual(openedWasFire, true);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://onesignal.com/api/v1/notifications/b2f7f966-d8cc-11e4-bed1-df8f05be55bb");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"opened"], @1);
+    
+    // Make sure if the device recieved a duplicate we don't fire the open network call again.
+    OneSignalClientOverrider.lastUrl = nil;
+    OneSignalClientOverrider.lastHTTPRequest = nil;
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    
+    XCTAssertNil(OneSignalClientOverrider.lastUrl);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
 }
 
 // Testing iOS 10 - 2.4.0+ button fromat - with os_data aps payload format
@@ -1507,80 +1488,75 @@ didReceiveRemoteNotification:userInfo
 }
 
 - (void)testSendTags {
+    [self initOneSignalAndThreadWait];
     
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self initOneSignalAndThreadWait];
-        
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-        
-        // Simple test with a sendTag and sendTags call.
-        [OneSignal sendTag:@"key" value:@"value"];
-        [OneSignal sendTags:@{@"key1": @"value1", @"key2": @"value2"}];
-        
-        // Make sure all 3 sets of tags where send in 1 network call.
-        [NSObjectOverrider runPendingSelectors];
-        [self runBackgroundThreads];
-        [NSObjectOverrider runPendingSelectors];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key1"], @"value1");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], @"value2");
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-        
-        // More advanced test with callbacks.
-        __block BOOL didRunSuccess1, didRunSuccess2, didRunSuccess3;
-        
-        [OneSignal sendTag:@"key10" value:@"value10" onSuccess:^(NSDictionary *result) {
-            didRunSuccess1 = true;
-        } onFailure:^(NSError *error) {}];
-        [OneSignal sendTags:@{@"key11": @"value11", @"key12": @"value12"} onSuccess:^(NSDictionary *result) {
-            didRunSuccess2 = true;
-        } onFailure:^(NSError *error) {}];
-        
-        [OneSignal sendTag:@"key13" value:@"value13" onSuccess:^(NSDictionary *result) {
-            didRunSuccess3 = true;
-        } onFailure:^(NSError *error) {}];
-        
-        [self runBackgroundThreads];
-        [NSObjectOverrider runPendingSelectors];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key10"], @"value10");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key11"], @"value11");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key12"], @"value12");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key13"], @"value13");
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
-        
-        XCTAssertEqual(didRunSuccess1, true);
-        XCTAssertEqual(didRunSuccess2, true);
-        XCTAssertEqual(didRunSuccess3, true);
-    }
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    
+    // Simple test with a sendTag and sendTags call.
+    [OneSignal sendTag:@"key" value:@"value"];
+    [OneSignal sendTags:@{@"key1": @"value1", @"key2": @"value2"}];
+    
+    // Make sure all 3 sets of tags where send in 1 network call.
+    [NSObjectOverrider runPendingSelectors];
+    [self runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key1"], @"value1");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], @"value2");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    
+    // More advanced test with callbacks.
+    __block BOOL didRunSuccess1, didRunSuccess2, didRunSuccess3;
+    
+    [OneSignal sendTag:@"key10" value:@"value10" onSuccess:^(NSDictionary *result) {
+        didRunSuccess1 = true;
+    } onFailure:^(NSError *error) {}];
+    [OneSignal sendTags:@{@"key11": @"value11", @"key12": @"value12"} onSuccess:^(NSDictionary *result) {
+        didRunSuccess2 = true;
+    } onFailure:^(NSError *error) {}];
+    
+    [OneSignal sendTag:@"key13" value:@"value13" onSuccess:^(NSDictionary *result) {
+        didRunSuccess3 = true;
+    } onFailure:^(NSError *error) {}];
+    
+    [self runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key10"], @"value10");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key11"], @"value11");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key12"], @"value12");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key13"], @"value13");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
+    
+    XCTAssertEqual(didRunSuccess1, true);
+    XCTAssertEqual(didRunSuccess2, true);
+    XCTAssertEqual(didRunSuccess3, true);
 }
 
 - (void)testDeleteTags {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self initOneSignalAndThreadWait];
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-        
-        NSLog(@"Calling sendTag and deleteTag");
-        // send 2 tags and delete 1 before they get sent off.
-        [OneSignal sendTag:@"key" value:@"value"];
-        [OneSignal sendTag:@"key2" value:@"value2"];
-        [OneSignal deleteTag:@"key"];
-        NSLog(@"Finished calling sendTag and deleteTag");
-        
-        // Make sure only 1 network call is made and only key2 gets sent.
-        [NSObjectOverrider runPendingSelectors];
-        [self runBackgroundThreads];
-        [NSObjectOverrider runPendingSelectors];
-        
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"]);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], @"value2");
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-        
-        [OneSignal sendTags:@{@"someKey": @NO}];
-        [OneSignal deleteTag:@"someKey"];
-    }
+    [self initOneSignalAndThreadWait];
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    
+    NSLog(@"Calling sendTag and deleteTag");
+    // send 2 tags and delete 1 before they get sent off.
+    [OneSignal sendTag:@"key" value:@"value"];
+    [OneSignal sendTag:@"key2" value:@"value2"];
+    [OneSignal deleteTag:@"key"];
+    NSLog(@"Finished calling sendTag and deleteTag");
+    
+    // Make sure only 1 network call is made and only key2 gets sent.
+    [NSObjectOverrider runPendingSelectors];
+    [self runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], @"value2");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    
+    [OneSignal sendTags:@{@"someKey": @NO}];
+    [OneSignal deleteTag:@"someKey"];
 }
 
 - (void)testGetTags {
@@ -1650,91 +1626,85 @@ didReceiveRemoteNotification:userInfo
 }
 
 - (void)testSendTagsBeforeRegisterComplete {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self setCurrentNotificationPermissionAsUnanswered];
-        
-        [self initOneSignalAndThreadWait];
-        
-        NSObjectOverrider.selectorNamesForInstantOnlyForFirstRun = [@[@"sendTagsToServer"] mutableCopy];
-        
-        [OneSignal sendTag:@"key" value:@"value"];
-        [self runBackgroundThreads];
-        
-        // Do not try to send tag update yet as there isn't a player_id yet.
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
-        
-        [self answerNotifiationPrompt:false];
-        [self runBackgroundThreads];
-        
-        // A single POST player create call should be made with tags included.
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-    }
+    [self setCurrentNotificationPermissionAsUnanswered];
+    
+    [self initOneSignalAndThreadWait];
+    
+    NSObjectOverrider.selectorNamesForInstantOnlyForFirstRun = [@[@"sendTagsToServer"] mutableCopy];
+    
+    [OneSignal sendTag:@"key" value:@"value"];
+    [self runBackgroundThreads];
+    
+    // Do not try to send tag update yet as there isn't a player_id yet.
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 0);
+    
+    [self answerNotifiationPrompt:false];
+    [self runBackgroundThreads];
+    
+    // A single POST player create call should be made with tags included.
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
 }
 
 - (void)testPostNotification {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self initOneSignalAndThreadWait];
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-        
-        
-        // Normal post should auto add add_id.
-        [OneSignal postNotification:@{@"contents": @{@"en": @"message body"}}];
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"contents"][@"en"], @"message body");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-        
-        // Should allow overriding the app_id
-        [OneSignal postNotification:@{@"contents": @{@"en": @"message body"}, @"app_id": @"override_app_UUID"}];
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"contents"][@"en"], @"message body");
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"override_app_UUID");
-    }
+    [self initOneSignalAndThreadWait];
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+    
+    
+    // Normal post should auto add add_id.
+    [OneSignal postNotification:@{@"contents": @{@"en": @"message body"}}];
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"contents"][@"en"], @"message body");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    
+    // Should allow overriding the app_id
+    [OneSignal postNotification:@{@"contents": @{@"en": @"message body"}, @"app_id": @"override_app_UUID"}];
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"contents"][@"en"], @"message body");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"override_app_UUID");
 }
 
 
 - (void)testFirstInitWithNotificationsAlreadyDeclined {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self backgroundModesDisabledInXcode];
-        UNUserNotificationCenterOverrider.notifTypesOverride = 0;
-        UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusDenied];
-        
-        [self initOneSignalAndThreadWait];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
-    }
+    [self backgroundModesDisabledInXcode];
+    UNUserNotificationCenterOverrider.notifTypesOverride = 0;
+    UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusDenied];
+    
+    [self initOneSignalAndThreadWait];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 - (void)testPermissionChangedInSettingsOutsideOfApp {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self backgroundModesDisabledInXcode];
-        UNUserNotificationCenterOverrider.notifTypesOverride = 0;
-        UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusDenied];
-        
-        [self initOneSignalAndThreadWait];
-        
-        OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
-        
-        [OneSignal addPermissionObserver:observer];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
-        
-        [self backgroundApp];
-        [self setCurrentNotificationPermission:true];
-        [self resumeApp];
-        [self runBackgroundThreads];
-        
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
-        XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
-        XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
-        
-        XCTAssertEqual(observer->last.from.accepted, false);
-        XCTAssertEqual(observer->last.to.accepted, true);
-    }
+    [self clearStateForAppRestart];
+    
+    [self backgroundModesDisabledInXcode];
+    UNUserNotificationCenterOverrider.notifTypesOverride = 0;
+    UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusDenied];
+    
+    [self initOneSignalAndThreadWait];
+    
+    OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
+    
+    [OneSignal addPermissionObserver:observer];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
+    
+    [self backgroundApp];
+    [self setCurrentNotificationPermission:true];
+    [self resumeApp];
+    [self runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    
+    XCTAssertEqual(observer->last.from.accepted, false);
+    XCTAssertEqual(observer->last.to.accepted, true);
 }
 
 - (void) testOnSessionWhenResuming {
@@ -1919,29 +1889,75 @@ didReceiveRemoteNotification:userInfo
 }
 
 -(void)testInvalidJSONTags {
-    @synchronized(OneSignalClientOverrider.lastHTTPRequest) {
-        [self initOneSignalAndThreadWait];
-        
-        //this test will also print invalid JSON warnings to console
-        
-        let invalidJson = @{@{@"invalid1" : @"invalid2"} : @"test"}; //Keys are required to be strings, this would crash the app if not handled appropriately
-        
-        let request = [OSRequestSendTagsToServer withUserId:@"12345" appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55bb" tags:invalidJson networkType:[OneSignalHelper getNetType]];
-        
-        let urlRequest = request.request;
-        
-        XCTAssertNil(urlRequest.HTTPBody);
-        
-        //test OneSignal sendTags method
-        [OneSignal sendTags:invalidJson];
-        
-        [NSObjectOverrider runPendingSelectors];
-        [self runBackgroundThreads];
-        [NSObjectOverrider runPendingSelectors];
-        
-        //the request should fail and the HTTP request should not contain the invalid tags
-        XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"tags"]);
-    }
+    [self initOneSignalAndThreadWait];
+    
+    //this test will also print invalid JSON warnings to console
+    
+    let invalidJson = @{@{@"invalid1" : @"invalid2"} : @"test"}; //Keys are required to be strings, this would crash the app if not handled appropriately
+    
+    let request = [OSRequestSendTagsToServer withUserId:@"12345" appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55bb" tags:invalidJson networkType:[OneSignalHelper getNetType]];
+    
+    let urlRequest = request.request;
+    
+    XCTAssertNil(urlRequest.HTTPBody);
+    
+    //test OneSignal sendTags method
+    [OneSignal sendTags:invalidJson];
+    
+    [NSObjectOverrider runPendingSelectors];
+    [self runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    
+    //the request should fail and the HTTP request should not contain the invalid tags
+    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"tags"]);
+}
+
+/*
+     When subscription state changes, the OSSubscriptionStateObserver will delay the update
+     until the HTTP request to update the backend is finished. This prevents rare race
+     conditions where an app instantly posts a new notification in response to a
+     subscription change. This test checks to make sure it is delayed as it should be
+ */
+
+-(void)testDelayedSubscriptionUpdate {
+    [self setCurrentNotificationPermissionAsUnanswered];
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:@{kOSSettingsKeyAutoPrompt: @false}];
+    
+    OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
+    [OneSignal addSubscriptionObserver:observer];
+    [self runBackgroundThreads];
+    
+    // Triggers the 30 fallback to register device right away.
+    [self runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    [self runBackgroundThreads];
+    
+    [OneSignal setSubscription:false];
+    [self runBackgroundThreads];
+    
+    // Prompt and accept notifications
+    [self registerForPushNotifications];
+    [self answerNotifiationPrompt:true];
+    [self runBackgroundThreads];
+    
+    // Shouldn't be subscribed yet as we called setSubscription:false before
+    XCTAssertFalse(observer->last.from.subscribed);
+    XCTAssertFalse(observer->last.to.subscribed);
+    
+    // Device should be reported a subscribed now as all condiditions are true.
+    [OneSignalClientOverrider setShouldExecuteInstantaneously:false];
+    [OneSignal setSubscription:true];
+    
+    [OneSignalClientOverrider setShouldExecuteInstantaneously:true];
+    XCTAssertFalse(observer->last.to.subscribed);
+    
+    [self runBackgroundThreads];
+    
+    XCTAssertTrue(observer->last.to.subscribed);
+    
+    
 }
 
 @end


### PR DESCRIPTION
• Fixes an issue where the Subscription observer would fire instantly the moment the user accepted permission to send push notifications. This fixes a race condition where sending push notifications would occasionally fail if sent from the subscription observer (since the OneSignal backend wasn't yet notified of the subscription status change)

• Adds exception handler to the OneSignalNotificationServiceExtension so that if there is a problem downloading an attachment (ie. no free disk space available), it will not crash the extension and cause a spurious crash report being sent to the developer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/327)
<!-- Reviewable:end -->
