### PR TITLE
Nullability Issue

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -50,6 +50,11 @@
 #import <UserNotifications/UserNotifications.h>
 #endif
 
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+
 /* The action type associated to an OSNotificationAction object */
 typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeOpened,
@@ -422,3 +427,5 @@ typedef void (^OSEmailSuccessBlock)();
 + (void)setEmail:(NSString * _Nonnull)email withEmailAuthHashToken:(NSString * _Nullable)hashToken;
 
 @end
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
• Since Nullability specifiers have been added to new methods (Email methods) in the SDK, Xcode will show compiler warnings since not all previous methods in OneSignal.h have these specifiers
• Since adding nullability flags to existing methods would be a breaking change we will not do this until the next major release.
• Until then, this commit adds a compiler flag to ignore nullability warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/340)
<!-- Reviewable:end -->
