### PR TITLE
removed UNLegacyNotificationTrigger

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/+OneSignal.m
@@ -240,8 +240,7 @@ static UNNotificationSettings* cachedUNNotificationSettings;
     UIApplication *sharedApp = [UIApplication sharedApplication];
     
     // trigger is nil when UIApplication.presentLocalNotificationNow: is used.
-    //  However it will be UNLegacyNotificationTrigger when UIApplication.scheduleLocalNotification: is used
-    BOOL isLegacyLocalNotif = !notification.request.trigger || [notification.request.trigger isKindOfClass:NSClassFromString(@"UNLegacyNotificationTrigger")];
+    BOOL isLegacyLocalNotif = !notification.request.trigger;
     BOOL isCustomAction = actionIdentifier && ![@"com.apple.UNNotificationDefaultActionIdentifier" isEqualToString:actionIdentifier];
     BOOL isRemote = [notification.request.trigger isKindOfClass:NSClassFromString(@"UNPushNotificationTrigger")];
     


### PR DESCRIPTION
due to app rejection - non-public APIs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/348)
<!-- Reviewable:end -->
