### PR TITLE
Extension Badge Handling

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -148,6 +148,9 @@
 		CA97E14F2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */; };
 		CA97E1502051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */; };
 		CA97E1512051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */; };
+		CAABF34B205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
+		CAABF34C205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
+		CAABF34D205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
 		CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = CA810FCF202BA97300A60FED /* OSEmailSubscription.h */; };
 /* End PBXBuildFile section */
 
@@ -283,6 +286,8 @@
 		CA810FD0202BA97300A60FED /* OSEmailSubscription.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSEmailSubscription.m; sourceTree = "<group>"; };
 		CA97E14C2051C0A5003B8CB8 /* OneSignalWebOpenDialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalWebOpenDialog.h; sourceTree = "<group>"; };
 		CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalWebOpenDialog.m; sourceTree = "<group>"; };
+		CAABF349205B15780042F8E5 /* OneSignalExtensionBadgeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalExtensionBadgeHandler.h; sourceTree = "<group>"; };
+		CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalExtensionBadgeHandler.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -452,6 +457,8 @@
 				4529DF0B1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m */,
 				454F94F01FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.h */,
 				454F94F11FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m */,
+				CAABF349205B15780042F8E5 /* OneSignalExtensionBadgeHandler.h */,
+				CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -731,6 +738,7 @@
 				454F94F51FAD2E5A00D74CCF /* OSNotificationPayload.m in Sources */,
 				9129C6BE1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412361E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
+				CAABF34B205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */,
 				CA08FC7F1FE99B25004C445F /* Requests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -768,6 +776,7 @@
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
 				9129C6BF1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
+				CAABF34C205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */,
 				CA08FC801FE99B25004C445F /* Requests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -785,6 +794,7 @@
 				CA70E3372023D51300019273 /* OneSignalSetEmailParameters.m in Sources */,
 				4529DED81FA8253D00CEAB1D /* NSUserDefaultsOverrider.m in Sources */,
 				4529DEED1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m in Sources */,
+				CAABF34D205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */,
 				912412301E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				91F58D851E7C88230017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		CA97E14F2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */; };
 		CA97E1502051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */; };
 		CA97E1512051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */; };
+		CAA4ED0120646762005BD59B /* BadgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAA4ED0020646762005BD59B /* BadgeTests.m */; };
 		CAABF34B205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
 		CAABF34C205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
 		CAABF34D205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
@@ -286,6 +287,7 @@
 		CA810FD0202BA97300A60FED /* OSEmailSubscription.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSEmailSubscription.m; sourceTree = "<group>"; };
 		CA97E14C2051C0A5003B8CB8 /* OneSignalWebOpenDialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalWebOpenDialog.h; sourceTree = "<group>"; };
 		CA97E14D2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalWebOpenDialog.m; sourceTree = "<group>"; };
+		CAA4ED0020646762005BD59B /* BadgeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BadgeTests.m; sourceTree = "<group>"; };
 		CAABF349205B15780042F8E5 /* OneSignalExtensionBadgeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalExtensionBadgeHandler.h; sourceTree = "<group>"; };
 		CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalExtensionBadgeHandler.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -411,6 +413,7 @@
 			children = (
 				4529DECD1FA81DE000CEAB1D /* Shadows */,
 				911E2CBC1E398AB3003112A4 /* UnitTests.m */,
+				CAA4ED0020646762005BD59B /* BadgeTests.m */,
 				CA63AF8320211F7400E340FB /* EmailTests.m */,
 				CA63AF8520211FF800E340FB /* UnitTestCommonMethods.h */,
 				CA63AF8620211FF800E340FB /* UnitTestCommonMethods.m */,
@@ -798,6 +801,7 @@
 				912412301E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				91F58D851E7C88230017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
+				CAA4ED0120646762005BD59B /* BadgeTests.m in Sources */,
 				912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */,
 				4529DEE41FA82C6200CEAB1D /* NSURLSessionOverrider.m in Sources */,
 				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
@@ -118,6 +118,7 @@
     _launchURL = payload[@"u"];
     _templateID = payload[@"ti"];
     _templateName = payload[@"tn"];
+    _badgeIncrement = [_rawPayload[@"badge_inc"] integerValue];
 }
 
 -(void)parseApnsFields {

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
@@ -118,7 +118,7 @@
     _launchURL = payload[@"u"];
     _templateID = payload[@"ti"];
     _templateName = payload[@"tn"];
-    _badgeIncrement = [_rawPayload[@"badge_inc"] integerValue];
+    _badgeIncrement = [payload[@"badge_inc"] integerValue];
 }
 
 -(void)parseApnsFields {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -122,6 +122,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 /* The badge assigned to the application icon */
 @property(readonly)NSUInteger badge;
+@property(readonly)NSInteger badgeIncrement;
 
 /* The sound parameter passed to the notification
  By default set to UILocalNotificationDefaultSoundName */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1955,9 +1955,7 @@ static NSString *_lastnonActiveMessageId;
     We swizzle the 'setApplicationIconBadgeNumber()' to intercept these calls so we always know the latest count
 */
 - (void)onesignalSetApplicationIconBadgeNumber:(NSInteger)badge {
-    let defaults = [[NSUserDefaults alloc] initWithSuiteName:[OneSignalExtensionBadgeHandler appGroupName]];
-    [defaults setObject:@(badge) forKey:ONESIGNAL_BADGE_KEY];
-    [defaults synchronize];
+    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:badge];
     
     [self onesignalSetApplicationIconBadgeNumber:badge];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -50,6 +50,8 @@
 
 #import "OSObservable.h"
 
+#import "OneSignalExtensionBadgeHandler.h"
+
 #import <stdlib.h>
 #import <stdio.h>
 #import <sys/types.h>
@@ -908,14 +910,14 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
             
             onesignal_Log(ONE_S_LL_DEBUG, [NSString stringWithFormat: @"HTTP create notification success %@", jsonResultsString]);
             if (successBlock)
-            successBlock(result);
+                successBlock(result);
         });
     } onFailure:^(NSError *error) {
         dispatch_async(dispatch_get_main_queue(), ^{
             onesignal_Log(ONE_S_LL_ERROR, @"Create notification failed");
             onesignal_Log(ONE_S_LL_INFO, [NSString stringWithFormat: @"%@", error]);
             if (failureBlock)
-            failureBlock(error);
+                failureBlock(error);
         });
     }];
 }
@@ -1536,7 +1538,7 @@ static NSString *_lastnonActiveMessageId;
     
 + (BOOL) clearBadgeCount:(BOOL)fromNotifOpened {
     
-    NSNumber *disableBadgeNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"OneSignal_disable_badge_clearing"];
+    NSNumber *disableBadgeNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_BADGE_CLEARING];
     
     if (disableBadgeNumber)
         disableBadgeClearing = [disableBadgeNumber boolValue];
@@ -1555,6 +1557,10 @@ static NSString *_lastnonActiveMessageId;
         // iOS 8+ auto dismisses the notification you tap on so only clear the badge (and notifications [side-effect]) if it was set.
         [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];
         [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        
+        let defaults = [[NSUserDefaults alloc] initWithSuiteName:[OneSignalExtensionBadgeHandler appGroupName]];
+        [defaults setObject:@0 forKey:ONESIGNAL_BADGE_KEY];
+        [defaults synchronize];
     }
     
     return wasBadgeSet;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -394,8 +394,6 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
                  withUserDefaults:userDefaults
                      withSettings:settings];
     
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:23];
-    
     if (!success)
         return self;
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -1,10 +1,29 @@
-//
-//  OneSignalCommonDefines.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 2/1/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #ifndef OneSignalCommonDefines_h
 #define OneSignalCommonDefines_h

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -28,4 +28,15 @@
 #define PROMPT_BEFORE_OPENING_PUSH_URL @"PROMPT_BEFORE_OPENING_PUSH_URL"
 #define DEPRECATED_SELECTORS @[@"application:didReceiveLocalNotification:", @"application:handleActionWithIdentifier:forLocalNotification:completionHandler:", @"application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:"]
 
+// Badge handling
+#define ONESIGNAL_DISABLE_BADGE_CLEARING @"OneSignal_disable_badge_clearing"
+#define ONESIGNAL_APP_GROUP_NAME_KEY @"OneSignal_app_groups_key"
+#define ONESIGNAL_BADGE_KEY @"onesignalBadgeCount"
+
+// Firebase
+#define ONESIGNAL_FB_ENABLE_FIREBASE @"OS_ENABLE_FIREBASE_ANALYTICS"
+#define ONESIGNAL_FB_LAST_TIME_RECEIVED @"OS_LAST_RECIEVED_TIME"
+#define ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED @"OS_LAST_RECIEVED_GAF_CAMPAIGN"
+#define ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED @"OS_LAST_RECIEVED_NOTIFICATION_ID"
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.h
@@ -1,10 +1,29 @@
-//
-//  OneSignalExtensionBadgeHandler.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 3/15/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>
@@ -12,5 +31,7 @@
 
 @interface OneSignalExtensionBadgeHandler : NSObject
 + (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotificationPayload:(OSNotificationPayload *)payload withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
++ (void)updateCachedBadgeValue:(NSInteger)value;
++ (NSInteger)currentCachedBadgeValue;
 + (NSString *)appGroupName;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.h
@@ -1,0 +1,16 @@
+//
+//  OneSignalExtensionBadgeHandler.h
+//  OneSignal
+//
+//  Created by Brad Hesse on 3/15/18.
+//  Copyright © 2018 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+#import "OneSignal.h"
+
+@interface OneSignalExtensionBadgeHandler : NSObject
++ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotificationPayload:(OSNotificationPayload *)payload withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
++ (NSString *)appGroupName;
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
@@ -1,10 +1,29 @@
-//
-//  OneSignalExtensionBadgeHandler.m
-//  OneSignal
-//
-//  Created by Brad Hesse on 3/15/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "OneSignalExtensionBadgeHandler.h"
 #import "OneSignalCommonDefines.h"
@@ -16,23 +35,41 @@
 
 + (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotificationPayload:(OSNotificationPayload *)payload withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent {
     
-    if (!payload.badgeIncrement)
+    //if the user is setting the badge directly instead of incrementing/decrementing,
+    //make sure the OneSignal cached value is updated to this value
+    if (!payload.badgeIncrement) {
+        if (payload.badge)
+            [OneSignalExtensionBadgeHandler updateCachedBadgeValue:payload.badge];
+        
         return;
+    }
     
-    let appGroupName = [OneSignalExtensionBadgeHandler appGroupName];
-    
-    let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:appGroupName];
-    
-    var currentValue = [((NSNumber *)[userDefaults objectForKey:ONESIGNAL_BADGE_KEY] ?: @0) intValue];
+    var currentValue = (int)OneSignalExtensionBadgeHandler.currentCachedBadgeValue ?: 0;
     
     currentValue += (int)payload.badgeIncrement;
     
+    //cannot have negative badge values
     if (currentValue < 0)
         currentValue = 0;
     
     replacementContent.badge = @(currentValue);
     
-    [userDefaults setObject:@(currentValue) forKey:ONESIGNAL_BADGE_KEY];
+    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:currentValue];
+}
+
++ (NSInteger)currentCachedBadgeValue {
+    let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:OneSignalExtensionBadgeHandler.appGroupName];
+    
+    return [(NSNumber *)[userDefaults objectForKey:ONESIGNAL_BADGE_KEY] integerValue];
+}
+
++ (void)updateCachedBadgeValue:(NSInteger)value {
+    //since badge logic can be executed in an extension, we need to use app groups to get
+    //a shared NSUserDefaults from the app group suite name
+    let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:OneSignalExtensionBadgeHandler.appGroupName];
+    
+    [userDefaults setObject:@(value) forKey:ONESIGNAL_BADGE_KEY];
+    
     [userDefaults synchronize];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
@@ -1,0 +1,48 @@
+//
+//  OneSignalExtensionBadgeHandler.m
+//  OneSignal
+//
+//  Created by Brad Hesse on 3/15/18.
+//  Copyright © 2018 Hiptic. All rights reserved.
+//
+
+#import "OneSignalExtensionBadgeHandler.h"
+#import "OneSignalCommonDefines.h"
+#import "OneSignalHelper.h"
+#import "OneSignalTrackFirebaseAnalytics.h"
+#import "OSNotificationPayload+Internal.h"
+
+@implementation OneSignalExtensionBadgeHandler
+
++ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotificationPayload:(OSNotificationPayload *)payload withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent {
+    
+    if (!payload.badgeIncrement)
+        return;
+    
+    let appGroupName = [OneSignalExtensionBadgeHandler appGroupName];
+    
+    let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:appGroupName];
+    
+    var currentValue = [((NSNumber *)[userDefaults objectForKey:ONESIGNAL_BADGE_KEY] ?: @0) intValue];
+    
+    currentValue += (int)payload.badgeIncrement;
+    
+    if (currentValue < 0)
+        currentValue = 0;
+    
+    replacementContent.badge = @(currentValue);
+    
+    [userDefaults setObject:@(currentValue) forKey:ONESIGNAL_BADGE_KEY];
+    [userDefaults synchronize];
+}
+
++ (NSString *)appGroupName {
+    var appGroupName = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_APP_GROUP_NAME_KEY];
+    
+    if (!appGroupName)
+        appGroupName = [NSString stringWithFormat:@"group.%@.%@", [[NSBundle mainBundle] bundleIdentifier], @"onesignal"];
+    
+    return [appGroupName stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -26,7 +26,7 @@
  */
 
 #import "OneSignalNotificationServiceExtensionHandler.h"
-
+#import "OneSignalExtensionBadgeHandler.h"
 #import "OneSignalHelper.h"
 #import "OneSignalTrackFirebaseAnalytics.h"
 #import "OSNotificationPayload+Internal.h"
@@ -39,6 +39,9 @@
         replacementContent = [request.content mutableCopy];
     
     let payload = [OSNotificationPayload parseWithApns:request.content.userInfo];
+    
+    //handle badge count
+    [OneSignalExtensionBadgeHandler handleBadgeCountWithNotificationRequest:request withNotificationPayload:payload withMutableNotificationContent:replacementContent];
     
     // Track receieved
     [OneSignalTrackFirebaseAnalytics trackReceivedEvent:payload];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSetEmailParameters.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSetEmailParameters.h
@@ -1,10 +1,29 @@
-//
-//  OneSignalSetEmailParameters.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 2/1/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import "OneSignal.h"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSetEmailParameters.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSetEmailParameters.m
@@ -1,10 +1,29 @@
-//
-//  OneSignalSetEmailParameters.m
-//  OneSignal
-//
-//  Created by Brad Hesse on 2/1/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "OneSignalSetEmailParameters.h"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
@@ -27,6 +27,8 @@
 
 #import "OneSignalTrackFirebaseAnalytics.h"
 #import "OneSignalHelper.h"
+#import "OneSignalCommonDefines.h"
+#import "OneSignalExtensionBadgeHandler.h"
 
 @implementation OneSignalTrackFirebaseAnalytics
 
@@ -43,7 +45,7 @@ static var trackingEnabled = false;
 //         extension target to track inflenced opens.
 +(void)init {
     let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:[self appGroupKey]];
-    trackingEnabled = [userDefaults boolForKey:@"OS_ENABLE_FIREBASE_ANALYTICS"];
+    trackingEnabled = [userDefaults boolForKey:ONESIGNAL_FB_ENABLE_FIREBASE];
 }
 
 
@@ -51,14 +53,13 @@ static var trackingEnabled = false;
     trackingEnabled = (BOOL)params[@"fba"];
     let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:[self appGroupKey]];
     if (trackingEnabled)
-        [userDefaults setBool:true forKey:@"OS_ENABLE_FIREBASE_ANALYTICS"];
+        [userDefaults setBool:true forKey:ONESIGNAL_FB_ENABLE_FIREBASE];
     else
-        [userDefaults removeObjectForKey:@"OS_ENABLE_FIREBASE_ANALYTICS"];
+        [userDefaults removeObjectForKey:ONESIGNAL_FB_ENABLE_FIREBASE];
 }
 
 +(NSString*)appGroupKey {
-    NSString *groupKey = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"OneSignal_app_groups_key"];
-    return [groupKey stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    return [OneSignalExtensionBadgeHandler appGroupName];
 }
 
 +(void)logEventWithName:(NSString*)name parameters:(NSDictionary*)params {
@@ -105,9 +106,9 @@ static var trackingEnabled = false;
     
     let campaign = [self getCampaignNameFromPayload:payload];
     let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:[self appGroupKey]];
-    [userDefaults setObject:payload.notificationID forKey:@"OS_LAST_RECIEVED_NOTIFICATION_ID"];
-    [userDefaults setObject:campaign forKey:@"OS_LAST_RECIEVED_GAF_CAMPAIGN"];
-    [userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:@"OS_LAST_RECIEVED_TIME"];
+    [userDefaults setObject:payload.notificationID forKey:ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED];
+    [userDefaults setObject:campaign forKey:ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED];
+    [userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:ONESIGNAL_FB_LAST_TIME_RECEIVED];
     [userDefaults synchronize];
     
     [self logEventWithName:@"os_notification_received"
@@ -124,7 +125,7 @@ static var trackingEnabled = false;
         return;
     
     let userDefaults = [[NSUserDefaults alloc] initWithSuiteName:[self appGroupKey]];
-    NSTimeInterval lastTimeReceived = [userDefaults doubleForKey:@"OS_LAST_RECIEVED_TIME"];
+    NSTimeInterval lastTimeReceived = [userDefaults doubleForKey:ONESIGNAL_FB_LAST_TIME_RECEIVED];
     
     if (lastTimeReceived == 0)
         return;
@@ -140,8 +141,8 @@ static var trackingEnabled = false;
     if (now - lastOpenedTime < 30)
         return;
     
-    NSString *notificationId = [userDefaults objectForKey:@"OS_LAST_RECIEVED_NOTIFICATION_ID"];
-    NSString *campaign = [userDefaults objectForKey:@"OS_LAST_RECIEVED_GAF_CAMPAIGN"];
+    NSString *notificationId = [userDefaults objectForKey:ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED];
+    NSString *campaign = [userDefaults objectForKey:ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED];
     
     [self logEventWithName:@"os_notification_influence_open"
                 parameters:@{

--- a/iOS_SDK/OneSignalSDK/Source/ReattemptRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/ReattemptRequest.h
@@ -1,10 +1,29 @@
-//
-//  ReattemptRequest.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 1/31/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import "OneSignal.h"

--- a/iOS_SDK/OneSignalSDK/Source/ReattemptRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/ReattemptRequest.m
@@ -1,10 +1,29 @@
-//
-//  ReattemptRequest.m
-//  OneSignal
-//
-//  Created by Brad Hesse on 1/31/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "ReattemptRequest.h"
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/BadgeTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/BadgeTests.m
@@ -1,0 +1,159 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "UnitTestCommonMethods.h"
+#import "OneSignalExtensionBadgeHandler.h"
+#import "NSUserDefaultsOverrider.h"
+#import "UNUserNotificationCenterOverrider.h"
+#import "UNUserNotificationCenter+OneSignal.h"
+#import "OneSignalHelperOverrider.h"
+#import "OneSignalHelper.h"
+
+@interface BadgeTests : XCTestCase
+
+@end
+
+@implementation BadgeTests
+
+- (void)setUp {
+    [super setUp];
+    
+    OneSignalHelperOverrider.mockIOSVersion = 10;
+    
+    [OneSignalUNUserNotificationCenter setUseiOS10_2_workaround:true];
+    
+    UNUserNotificationCenterOverrider.notifTypesOverride = 7;
+    UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusAuthorized];
+    
+    [NSUserDefaultsOverrider clearInternalDictionary];
+    
+    [UnitTestCommonMethods clearStateForAppRestart:self];
+    
+    [UnitTestCommonMethods beforeAllTest];
+}
+- (void)testBadgeExtensionUpdate {
+    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:0];
+    
+    //test that manually setting the badge number also updates NSUserDefaults for our app group
+    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];
+    
+    XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 1);
+    
+    NSMutableDictionary * userInfo = [@{
+        @"aps": @{
+            @"mutable-content": @1,
+            @"alert": @"Message Body"
+        },
+        @"os_data": @{
+            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+            @"badge_inc" : @2
+        }
+    } mutableCopy];
+    
+    UNNotificationResponse *notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    //test that receiving a notification with badge_inc updates the badge icon number
+    [OneSignal didReceiveNotificationExtensionRequest:notifResponse.notification.request withMutableNotificationContent:nil];
+    
+    XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 3);
+    
+    //test that a negative badge_inc value decrements correctly
+    [userInfo setObject:@{@"badge_inc" : @-1, @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"} forKey:@"os_data"];
+    
+    UNNotificationResponse *newNotifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    [OneSignal didReceiveNotificationExtensionRequest:newNotifResponse.notification.request withMutableNotificationContent:nil];
+    
+    XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 2);
+}
+
+//tests to make sure that setting the badge works along with incrementing/decrementing
+- (void)testSetBadgeExtensionUpdate {
+    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:0];
+    
+    NSMutableDictionary * userInfo = [@{
+        @"aps": @{
+            @"mutable-content": @1,
+            @"alert": @"Message Body",
+            @"badge" : @54
+        },
+        @"os_data": @{
+            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+        }
+    } mutableCopy];
+    
+    UNNotificationResponse *notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    //test that receiving a notification with badge_inc updates the badge icon number
+    [OneSignal didReceiveNotificationExtensionRequest:notifResponse.notification.request withMutableNotificationContent:nil];
+    
+    XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 54);
+    
+    [userInfo setObject:@{@"mutable-content" : @1, @"alert" : @"test msg"} forKey:@"aps"];
+    [userInfo setObject:@{@"badge_inc" : @-1, @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"} forKey:@"os_data"];
+    
+    UNNotificationResponse *newNotifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    UNMutableNotificationContent *mutableContent = [newNotifResponse.notification.request.content mutableCopy];
+    
+    //tests to make sure the extension is correctly modifying the badge value of the replacement content
+    let replacementContent = [OneSignal didReceiveNotificationExtensionRequest:newNotifResponse.notification.request withMutableNotificationContent:mutableContent];
+    
+    XCTAssert([replacementContent.badge intValue] == 53);
+    
+    XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 53);
+}
+
+//tests to make sure that the SDK never tries to set negative badge values
+- (void)testDecrementZeroValue {
+    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:0];
+    
+    NSMutableDictionary * userInfo = [@{
+        @"aps": @{
+            @"mutable-content": @1,
+            @"alert": @"Message Body"
+        },
+        @"os_data": @{
+            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+            @"badge_inc" : @-5
+        }
+    } mutableCopy];
+    
+    UNNotificationResponse *notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    UNMutableNotificationContent *mutableContent = [notifResponse.notification.request.content mutableCopy];
+    
+    //Since the notification is trying to set a negative value, the SDK should keep the badge count == 0
+    let replacementContent = [OneSignal didReceiveNotificationExtensionRequest:notifResponse.notification.request withMutableNotificationContent:mutableContent];
+    
+    XCTAssert(replacementContent.badge.intValue == 0);
+    
+    XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 0);
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -1,10 +1,29 @@
-//
-//  EmailTests.m
-//  UnitTests
-//
-//  Created by Brad Hesse on 1/30/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <XCTest/XCTest.h>
 #import "OneSignal.h"

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -1,10 +1,29 @@
-//
-//  OneSignalClientOverrider.h
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -1,18 +1,29 @@
-//
-//  OneSignalClientOverrider.m
-//  OneSignal
-//
-//  Created by Brad Hesse on 12/19/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
-
-//
-//  OneSignalClientOverrider.m
-//  UnitTests
-//
-//  Created by Brad Hesse on 12/18/17.
-//  Copyright © 2017 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "OneSignalClientOverrider.h"
 #import "TestHelperFunctions.h"

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -10,6 +10,8 @@
 #import <XCTest/XCTest.h>
 #import "OneSignal.h"
 
+NSString * serverUrlWithPath(NSString *path);
+
 @interface UnitTestCommonMethods : NSObject
 
 + (void)setCurrentNotificationPermissionAsUnanswered;
@@ -18,6 +20,7 @@
 + (void)runBackgroundThreads;
 + (void)beforeAllTest;
 + (void)clearStateForAppRestart:(XCTestCase *)testCase;
++ (UNNotificationResponse*)createBasiciOSNotificationResponseWithPayload:(NSDictionary*)userInfo;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -1,10 +1,29 @@
-//
-//  UnitTestCommonMethods.h
-//  UnitTests
-//
-//  Created by Brad Hesse on 1/30/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -22,6 +22,12 @@
 #import "OneSignalTrackFirebaseAnalyticsOverrider.h"
 #import "UIAlertViewOverrider.h"
 #import "NSObjectOverrider.h"
+#import "OneSignalCommonDefines.h"
+
+
+NSString * serverUrlWithPath(NSString *path) {
+    return [NSString stringWithFormat:@"%@%@%@", SERVER_URL, API_VERSION, path];
+}
 
 @interface OneSignal (UN_extra)
 + (dispatch_queue_t) getRegisterQueue;
@@ -59,6 +65,28 @@
     }
     
     NSLog(@"END runBackgroundThreads");
+}
+
++ (UNNotificationResponse*)createBasiciOSNotificationResponseWithPayload:(NSDictionary*)userInfo {
+    // Mocking an iOS 10 notification
+    // Setting response.notification.request.content.userInfo
+    UNNotificationResponse *notifResponse = [UNNotificationResponse alloc];
+    
+    // Normal tap on notification
+    [notifResponse setValue:@"com.apple.UNNotificationDefaultActionIdentifier" forKeyPath:@"actionIdentifier"];
+    
+    UNNotificationContent *unNotifContent = [UNNotificationContent alloc];
+    UNNotification *unNotif = [UNNotification alloc];
+    UNNotificationRequest *unNotifRequqest = [UNNotificationRequest alloc];
+    // Set as remote push type
+    [unNotifRequqest setValue:[UNPushNotificationTrigger alloc] forKey:@"trigger"];
+    
+    [unNotif setValue:unNotifRequqest forKeyPath:@"request"];
+    [notifResponse setValue:unNotif forKeyPath:@"notification"];
+    [unNotifRequqest setValue:unNotifContent forKeyPath:@"content"];
+    [unNotifContent setValue:userInfo forKey:@"userInfo"];
+    
+    return notifResponse;
 }
 
 + (void)clearStateForAppRestart:(XCTestCase *)testCase {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -1,10 +1,29 @@
-//
-//  UnitTestCommonMethods.m
-//  UnitTests
-//
-//  Created by Brad Hesse on 1/30/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "UnitTestCommonMethods.h"
 #import "OneSignalClientOverrider.h"

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1811,45 +1811,4 @@ didReceiveRemoteNotification:userInfo
     XCTAssertTrue(observer->last.to.subscribed);
 }
 
-- (void)testBadgeExtensionUpdate {
-    
-    let defaults = [[NSUserDefaults alloc] initWithSuiteName:[OneSignalExtensionBadgeHandler appGroupName]];
-    [defaults setObject:@2 forKey:ONESIGNAL_BADGE_KEY];
-    [defaults synchronize];
-    
-    //test that manually setting the badge number also updates NSUserDefaults for our app group
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-    
-    XCTAssert([(NSNumber *)[defaults objectForKey:ONESIGNAL_BADGE_KEY] isEqualToNumber:@0]);
-    
-    NSMutableDictionary * userInfo = [@{
-        @"aps": @{
-            @"mutable-content": @1,
-            @"alert": @"Message Body"
-        },
-        @"os_data": @{
-            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
-            @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
-            @"att": @{ @"id": @"http://domain.com/file.jpg" }
-        },
-        @"badge_inc" : @3
-    } mutableCopy];
-    
-    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    
-    //test that receiving a notification with badge_inc updates the badge icon number
-    [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
-    
-    XCTAssert([(NSNumber *)[defaults objectForKey:ONESIGNAL_BADGE_KEY] isEqualToNumber:@3]);
-    
-    //test that a negative badge_inc value decrements correctly
-    [userInfo setObject:@-1 forKey:@"badge_inc"];
-    
-    id newNotifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    
-    [OneSignal didReceiveNotificationExtensionRequest:[newNotifResponse notification].request withMutableNotificationContent:nil];
-    
-    XCTAssert([(NSNumber *)[defaults objectForKey:ONESIGNAL_BADGE_KEY] isEqualToNumber:@2]);
-}
-
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -58,6 +58,8 @@
 
 #import "UnitTestAppDelegate.h"
 
+#import "OneSignalExtensionBadgeHandler.h"
+
 // Shadows
 #import "NSObjectOverrider.h"
 #import "NSUserDefaultsOverrider.h"
@@ -77,10 +79,6 @@
 #import "OneSignalClientOverrider.h"
 #import "OneSignalCommonDefines.h"
 
-
-NSString * serverUrlWithPath(NSString *path) {
-    return [NSString stringWithFormat:@"%@%@%@", SERVER_URL, API_VERSION, path];
-}
 
 @interface UnitTests : XCTestCase
 
@@ -175,35 +173,13 @@ NSString * serverUrlWithPath(NSString *path) {
     UIApplication *sharedApp = [UIApplication sharedApplication];
     [sharedApp.delegate applicationWillResignActive:sharedApp];
 }
-
-- (UNNotificationResponse*)createBasiciOSNotificationResponseWithPayload:(NSDictionary*)userInfo {
-    // Mocking an iOS 10 notification
-    // Setting response.notification.request.content.userInfo
-    UNNotificationResponse *notifResponse = [UNNotificationResponse alloc];
-    
-    // Normal tap on notification
-    [notifResponse setValue:@"com.apple.UNNotificationDefaultActionIdentifier" forKeyPath:@"actionIdentifier"];
-    
-    UNNotificationContent *unNotifContent = [UNNotificationContent alloc];
-    UNNotification *unNotif = [UNNotification alloc];
-    UNNotificationRequest *unNotifRequqest = [UNNotificationRequest alloc];
-    // Set as remote push type
-    [unNotifRequqest setValue:[UNPushNotificationTrigger alloc] forKey:@"trigger"];
-    
-    [unNotif setValue:unNotifRequqest forKeyPath:@"request"];
-    [notifResponse setValue:unNotif forKeyPath:@"notification"];
-    [unNotifRequqest setValue:unNotifContent forKeyPath:@"content"];
-    [unNotifContent setValue:userInfo forKey:@"userInfo"];
-    
-    return notifResponse;
-}
                                                                           
 - (UNNotificationResponse*)createBasiciOSNotificationResponse {
   id userInfo = @{@"custom":
                       @{@"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"}
                   };
   
-  return [self createBasiciOSNotificationResponseWithPayload:userInfo];
+  return [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
 }
 
 
@@ -949,7 +925,7 @@ NSString * serverUrlWithPath(NSString *path) {
                           }
                     };
     
-    return [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    return [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
 }
 
 - (void)testFirebaseAnalyticsNotificationOpen {
@@ -1072,7 +1048,7 @@ NSString * serverUrlWithPath(NSString *path) {
                             }
                     };
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
     
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
@@ -1120,7 +1096,7 @@ NSString * serverUrlWithPath(NSString *path) {
                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
                             }};
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
     
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
@@ -1163,7 +1139,7 @@ NSString * serverUrlWithPath(NSString *path) {
     [UnitTestCommonMethods resumeApp];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     [notifResponse setValue:@"id1" forKeyPath:@"actionIdentifier"];
     
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
@@ -1224,7 +1200,7 @@ NSString * serverUrlWithPath(NSString *path) {
                       @"a": @{ @"foo": @"bar" }
                   }};
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
     id notifCenterDelegate = notifCenter.delegate;
     
@@ -1243,7 +1219,7 @@ NSString * serverUrlWithPath(NSString *path) {
                          @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bc"
                          },
                  @"foo": @"bar"};
-    notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
     XCTAssertEqual(openedWasFire, true);
     */
@@ -1264,7 +1240,7 @@ NSString * serverUrlWithPath(NSString *path) {
                             settings:nil];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    let notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
     let notifCenterDelegate = notifCenter.delegate;
     
@@ -1639,7 +1615,7 @@ didReceiveRemoteNotification:userInfo
 
 // iOS 10 - Notification Service Extension test
 - (void) didReceiveNotificationExtensionRequestDontOverrideCateogoryWithUserInfo:(NSDictionary *)userInfo {
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
     [[notifResponse notification].request.content setValue:@"some_category" forKey:@"categoryIdentifier"];
     
@@ -1695,7 +1671,7 @@ didReceiveRemoteNotification:userInfo
                             @"att": @{ @"id": @"http://domain.com/file.jpg" }
                             }};
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
     [[notifResponse notification].request.content setValue:@"some_category" forKey:@"categoryIdentifier"];
     
@@ -1719,7 +1695,7 @@ didReceiveRemoteNotification:userInfo
                             @"att": @{ @"id": @"file.jpg" }
                             }};
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
     UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
 
@@ -1740,7 +1716,7 @@ didReceiveRemoteNotification:userInfo
                         @"att": @{ @"id": @"http://domain.com/file.jpg" }
                     }};
     
-    id notifResponse = [self createBasiciOSNotificationResponseWithPayload:userInfo];
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
     UNMutableNotificationContent* content = [OneSignal serviceExtensionTimeWillExpireRequest:[notifResponse notification].request withMutableNotificationContent:nil];
     
@@ -1833,6 +1809,47 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertTrue(observer->last.to.subscribed);
+}
+
+- (void)testBadgeExtensionUpdate {
+    
+    let defaults = [[NSUserDefaults alloc] initWithSuiteName:[OneSignalExtensionBadgeHandler appGroupName]];
+    [defaults setObject:@2 forKey:ONESIGNAL_BADGE_KEY];
+    [defaults synchronize];
+    
+    //test that manually setting the badge number also updates NSUserDefaults for our app group
+    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+    
+    XCTAssert([(NSNumber *)[defaults objectForKey:ONESIGNAL_BADGE_KEY] isEqualToNumber:@0]);
+    
+    NSMutableDictionary * userInfo = [@{
+        @"aps": @{
+            @"mutable-content": @1,
+            @"alert": @"Message Body"
+        },
+        @"os_data": @{
+            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+            @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+            @"att": @{ @"id": @"http://domain.com/file.jpg" }
+        },
+        @"badge_inc" : @3
+    } mutableCopy];
+    
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    //test that receiving a notification with badge_inc updates the badge icon number
+    [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
+    
+    XCTAssert([(NSNumber *)[defaults objectForKey:ONESIGNAL_BADGE_KEY] isEqualToNumber:@3]);
+    
+    //test that a negative badge_inc value decrements correctly
+    [userInfo setObject:@-1 forKey:@"badge_inc"];
+    
+    id newNotifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    [OneSignal didReceiveNotificationExtensionRequest:[newNotifResponse notification].request withMutableNotificationContent:nil];
+    
+    XCTAssert([(NSNumber *)[defaults objectForKey:ONESIGNAL_BADGE_KEY] isEqualToNumber:@2]);
 }
 
 @end


### PR DESCRIPTION
• Moves badge increment/decrement logic from the OneSignal backend to the application itself
• This is accomplished using an app extension with an 'app group' to allow communication of data between the host app and it's notification extension service
• This allows the app to maintain a consistent badge count
• Also cleaned up some Firebase code and moved common strings to a definitions file
• Changed the SDK so that it will default to group.{bundle_id}.onesignal as the App Group name if one is not provided in Info.plist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/352)
<!-- Reviewable:end -->
