### PR TITLE
Fix URLs

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -710,7 +710,12 @@ static OneSignal* singleInstance = nil;
 
 // Synchroneously downloads a media
 // On success returns bundle resource name, otherwise returns nil
-+ (NSString*)downloadMediaAndSaveInBundle:(NSString*)url {
++ (NSString*)downloadMediaAndSaveInBundle:(NSString*)urlString {
+    
+    let inputUrl = [NSURL URLWithString:urlString];
+    
+    //removes any unnecessary query parameters that would break extension type checking
+    let url = [[NSURL alloc] initWithScheme:inputUrl.scheme host:inputUrl.host path:inputUrl.path].absoluteString;
     
     NSArray<NSString*>* supportedExtensions = @[@"aiff", @"wav", @"mp3", @"mp4", @"jpg", @"jpeg", @"png", @"gif", @"mpeg", @"mpg", @"avi", @"m4a", @"m4v"];
     NSArray* components = [url componentsSeparatedByString:@"."];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -79,6 +79,10 @@
 #import "OneSignalClientOverrider.h"
 #import "OneSignalCommonDefines.h"
 
+@interface OneSignalHelper (TestHelper)
++ (NSString*)downloadMediaAndSaveInBundle:(NSString*)urlString;
+@end
+
 
 @interface UnitTests : XCTestCase
 
@@ -1809,6 +1813,15 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertTrue(observer->last.to.subscribed);
+}
+
+// Checks to make sure that media URL's will not fail the extension-type check if they have query parameters
+- (void)testHandlingMediaUrlExtensions {
+    let testUrl = @"https://images.pexels.com/photos/104827/cat-pet-animal-domestic-104827.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100";
+    
+    let cacheName = [OneSignalHelper downloadMediaAndSaveInBundle:testUrl];
+    
+    XCTAssertNotNil(cacheName);
 }
 
 @end


### PR DESCRIPTION
• Sending an image URL with query parameters used to not work.
• The SDK was checking the end of URL's to make sure they were an image or other media type (ie. making sure it ended in .jpeg, .mp3, etc)
• Changed the SDK so that it will now remove query parameters from the end of URL's before attempting to type check the file extension

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/356)
<!-- Reviewable:end -->
