### PR TITLE
Fix Incorrect Notification Opened Events

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1462,7 +1462,7 @@ static NSString *_lastnonActiveMessageId;
         }
         
         // Call Action Block
-        [OneSignal handleNotificationOpened:messageDict isActive:isActive actionType:type displayType:OSNotificationDisplayTypeNotification];
+        [OneSignal handleNotificationOpened:messageDict isActive:isActive actionType:type displayType:OneSignal.inFocusDisplayType];
     }
 }
 
@@ -1501,7 +1501,11 @@ static NSString *_lastnonActiveMessageId;
     
     //Call Action Block
     [OneSignalHelper lastMessageReceived:messageDict];
-    [OneSignalHelper handleNotificationAction:actionType actionID:actionID displayType:displayType];
+    
+    //ensures that if the app is open and display type == none, the handleNotificationAction block does not get called
+    if (displayType != OSNotificationDisplayTypeNone || (displayType == OSNotificationDisplayTypeNone && !isActive)) {
+        [OneSignalHelper handleNotificationAction:actionType actionID:actionID displayType:displayType];
+    }
 }
 
 + (BOOL)shouldPromptToShowURL {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1404,7 +1404,7 @@ static NSString *_lastnonActiveMessageId;
 //  - 2. Notification received
 //    - 2A. iOS 9  - Notification received while app is in focus.
 //    - 2B. iOS 10 - Notification received/displayed while app is in focus.
-+ (void)notificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive {
++ (void)notificationReceived:(NSDictionary*)messageDict isActive:(BOOL)isActive wasOpened:(BOOL)opened {
     
     if (!app_id)
         return;
@@ -1439,10 +1439,6 @@ static NSString *_lastnonActiveMessageId;
         // App is active and a notification was received without inApp display. Display type is none or notification
         // Call Received Block
         [OneSignalHelper handleNotificationReceived:self.inFocusDisplayType];
-        
-        // Notify backend that user opened the notification
-        NSString *messageId = [customDict objectForKey:@"i"];
-        [OneSignal submitNotificationOpened:messageId];
     } else {
         // Prevent duplicate calls
         let newId = [self checkForProcessedDups:customDict lastMessageId:_lastnonActiveMessageId];
@@ -1450,7 +1446,9 @@ static NSString *_lastnonActiveMessageId;
             return;
         if (newId)
             _lastnonActiveMessageId = newId;
-        
+    }
+    
+    if (opened) {
         //app was in background / not running and opened due to a tap on a notification or an action check what type
         NSString* actionSelected = NULL;
         OSNotificationActionType type = OSNotificationActionTypeOpened;
@@ -1464,7 +1462,6 @@ static NSString *_lastnonActiveMessageId;
         }
         
         // Call Action Block
-        [OneSignalHelper handleNotificationAction:type actionID:actionSelected displayType:OSNotificationDisplayTypeNotification];
         [OneSignal handleNotificationOpened:messageDict isActive:isActive actionType:type displayType:OSNotificationDisplayTypeNotification];
     }
 }
@@ -1669,9 +1666,13 @@ static NSString *_lastnonActiveMessageId;
     // Method was called due to a tap on a notification - Fire open notification
     else if (application.applicationState != UIApplicationStateBackground) {
         [OneSignalHelper lastMessageReceived:userInfo];
+        
         if (application.applicationState == UIApplicationStateActive)
             [OneSignalHelper handleNotificationReceived:OSNotificationDisplayTypeNotification];
-        [OneSignal notificationOpened:userInfo isActive:NO];
+        
+        if (![OneSignalHelper isRemoteSilentNotification:userInfo])
+            [OneSignal notificationReceived:userInfo isActive:NO wasOpened:YES];
+        
         return startedBackgroundJob;
     }
     // content-available notification received in the background - Fire handleNotificationReceived block in app
@@ -1697,7 +1698,7 @@ static NSString *_lastnonActiveMessageId;
         return;
     
     let isActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
-    [OneSignal notificationOpened:userInfo isActive:isActive];
+    [OneSignal notificationReceived:userInfo isActive:isActive wasOpened:YES];
     
     // Notification Tapped or notification Action Tapped
     if (!isActive)

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -40,7 +40,7 @@
 + (void) handleDidFailRegisterForRemoteNotification:(NSError*)error;
 + (void) updateNotificationTypes:(int)notificationTypes;
 + (NSString*) app_id;
-+ (void) notificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive;
++ (void)notificationReceived:(NSDictionary*)messageDict isActive:(BOOL)isActive wasOpened:(BOOL)opened;
 + (BOOL) remoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 + (void) processLocalActionBasedNotification:(UILocalNotification*) notification identifier:(NSString*)identifier;
 + (void) onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString*) message;
@@ -182,7 +182,7 @@ static NSArray* delegateSubclasses = nil;
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalReceivedRemoteNotification:userInfo:"];
     
     if ([OneSignal app_id])
-        [OneSignal notificationOpened:userInfo isActive:[application applicationState] == UIApplicationStateActive];
+        [OneSignal notificationReceived:userInfo isActive:[application applicationState] == UIApplicationStateActive wasOpened:true];
     
     if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)])
         [self oneSignalReceivedRemoteNotification:application userInfo:userInfo];
@@ -201,7 +201,7 @@ static NSArray* delegateSubclasses = nil;
     
     if ([OneSignal app_id]) {
         if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
-            [OneSignal notificationOpened:userInfo isActive:YES];
+            [OneSignal notificationReceived:userInfo isActive:YES wasOpened:NO];
         else
             startedBackgroundJob = [OneSignal remoteSilentNotification:application UserInfo:userInfo completionHandler:callExistingSelector ? nil : completionHandler];
     }

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -46,7 +46,7 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 @interface OneSignal (UN_extra)
-+ (void)notificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive;
++ (void)notificationReceived:(NSDictionary*)messageDict isActive:(BOOL)isActive wasOpened:(BOOL)opened;
 @end
 
 // This class hooks into the following iSO 10 UNUserNotificationCenterDelegate selectors:
@@ -159,9 +159,8 @@ static UNNotificationSettings* cachedUNNotificationSettings;
         default: break;
     }
     
-    if ([OneSignal app_id]) {
-        [OneSignal notificationOpened:notification.request.content.userInfo isActive:YES];
-    }
+    if ([OneSignal app_id])
+        [OneSignal notificationReceived:notification.request.content.userInfo isActive:YES wasOpened:false];
     
     // Call orginal selector if one was set.
     if ([self respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)])
@@ -239,7 +238,8 @@ static UNNotificationSettings* cachedUNNotificationSettings;
     let userInfo = [OneSignalHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo
                                                       identifier:response.actionIdentifier];
     
-    [OneSignal notificationOpened:userInfo isActive:isActive];
+    [OneSignal notificationReceived:userInfo isActive:isActive wasOpened:YES];
+    
 }
 
 // Calls depercated pre-iOS 10 selector if one is set on the AppDelegate.

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -159,8 +159,10 @@ static UNNotificationSettings* cachedUNNotificationSettings;
         default: break;
     }
     
+    let notShown = OneSignal.inFocusDisplayType == OSNotificationDisplayTypeNone && notification.request.content.body != nil;
+    
     if ([OneSignal app_id])
-        [OneSignal notificationReceived:notification.request.content.userInfo isActive:YES wasOpened:false];
+        [OneSignal notificationReceived:notification.request.content.userInfo isActive:YES wasOpened:notShown];
     
     // Call orginal selector if one was set.
     if ([self respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)])

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -415,7 +415,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 
 //when the user is logged in with email, on_focus requests should be duplicated for the email player id as well
 - (void)testOnFocusEmailRequest {
-    
     [UnitTestCommonMethods runBackgroundThreads];
     
     [self setupEmailTest];
@@ -435,7 +434,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertTrue([OneSignalClientOverrider.lastHTTPRequestType isEqualToString:NSStringFromClass([OSRequestOnFocus class])]);
+    XCTAssertTrue([OneSignalClientOverrider hasExecutedRequestOfType:[OSRequestOnFocus class]]);
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
     [OneSignalClientOverrider reset:self];
@@ -469,7 +468,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     [UnitTestCommonMethods runBackgroundThreads];
     
     // on_focus should fire off two requests, one for the email player ID and one for push player ID
-    XCTAssertTrue([OneSignalClientOverrider.lastHTTPRequestType isEqualToString:NSStringFromClass([OSRequestOnFocus class])]);
+    XCTAssertTrue([OneSignalClientOverrider hasExecutedRequestOfType:[OSRequestOnFocus class]]);
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
     
     [OneSignalClientOverrider setRequiresEmailAuth:false];

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -41,5 +41,6 @@
 +(void)runBackgroundThreads;
 +(NSString *)lastHTTPRequestType;
 +(void)setRequiresEmailAuth:(BOOL)required;
++(BOOL)hasExecutedRequestOfType:(Class)type;
 @end
 


### PR DESCRIPTION
• The SDK was previously incorrectly sending 'notification opened' HTTP requests when notifications were received
• Fixed the issue so that this event is only triggered when the user opens a notification
• Added a test to ensure it doesn't occur in the future

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/357)
<!-- Reviewable:end -->
