### PR TITLE
Gdpr privacy

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -41,9 +41,8 @@
     [FIRApp configure];
     
     NSLog(@"Bundle URL: %@", [[NSBundle mainBundle] bundleURL]);
-    NSLog(@"[[NSUUID alloc] initWithUUIDString:nil]: %@", [[NSUUID alloc] initWithUUIDString:nil]);
     
-    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_WARN];
+    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_ERROR];
     
     OneSignal.inFocusDisplayType = OSNotificationDisplayTypeInAppAlert;
     

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Base.lproj/Main.storyboard
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -71,24 +72,53 @@
                                     <constraint firstAttribute="height" constant="20" id="bBI-BW-dmM"/>
                                 </constraints>
                             </activityIndicatorView>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="05S-ud-V2e">
+                                <rect key="frame" x="163" y="442" width="179" height="29"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="nSO-fn-AxS"/>
+                                </constraints>
+                                <segments>
+                                    <segment title="Not Granted"/>
+                                    <segment title="Granted"/>
+                                </segments>
+                                <connections>
+                                    <action selector="consentSegmentedControlValueChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="oL2-15-pJ0"/>
+                                </connections>
+                            </segmentedControl>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Consent Status:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j3e-42-uww">
+                                <rect key="frame" x="0.0" y="445" width="155" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="sCD-KJ-VyV"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="05S-ud-V2e" firstAttribute="leading" secondItem="j3e-42-uww" secondAttribute="trailing" constant="8" id="0VK-or-IQV"/>
                             <constraint firstItem="H3K-GA-smE" firstAttribute="centerX" secondItem="ebC-zs-TnD" secondAttribute="centerX" id="1J0-KC-Ike"/>
                             <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="top" secondItem="H3K-GA-smE" secondAttribute="bottom" constant="56" id="467-jK-M0h"/>
                             <constraint firstItem="ebC-zs-TnD" firstAttribute="top" secondItem="H3K-GA-smE" secondAttribute="bottom" constant="18" id="4gc-Du-Gk7"/>
+                            <constraint firstItem="05S-ud-V2e" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="centerX" constant="-24.5" id="8TC-JA-qOE"/>
                             <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="centerX" secondItem="H3K-GA-smE" secondAttribute="centerX" id="BET-RV-SSL"/>
+                            <constraint firstItem="05S-ud-V2e" firstAttribute="top" secondItem="0cV-KP-U0v" secondAttribute="bottom" constant="18" id="Doq-ct-llI"/>
                             <constraint firstItem="k3C-y9-O4O" firstAttribute="leading" secondItem="ebC-zs-TnD" secondAttribute="trailing" constant="8" id="EHn-dg-Gsx"/>
                             <constraint firstAttribute="trailingMargin" secondItem="ebC-zs-TnD" secondAttribute="trailing" constant="54" id="NSB-la-nXF"/>
                             <constraint firstItem="k3C-y9-O4O" firstAttribute="centerY" secondItem="ebC-zs-TnD" secondAttribute="centerY" id="WyY-eM-1NM"/>
+                            <constraint firstItem="j3e-42-uww" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="XLa-mE-TYD"/>
                             <constraint firstItem="ebC-zs-TnD" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Yug-OZ-HIr"/>
+                            <constraint firstAttribute="trailing" secondItem="05S-ud-V2e" secondAttribute="trailing" constant="33" id="en0-C1-hCf"/>
                             <constraint firstItem="0cV-KP-U0v" firstAttribute="centerX" secondItem="Kp7-Oh-BQ1" secondAttribute="centerX" id="rAQ-XU-eNr"/>
+                            <constraint firstItem="j3e-42-uww" firstAttribute="centerY" secondItem="05S-ud-V2e" secondAttribute="centerY" id="thm-36-AAy"/>
                             <constraint firstItem="ebC-zs-TnD" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="54" id="tp6-Bq-3wr"/>
                             <constraint firstItem="0cV-KP-U0v" firstAttribute="top" secondItem="Kp7-Oh-BQ1" secondAttribute="bottom" constant="8" id="wyD-rc-wek"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="activityIndicatorView" destination="k3C-y9-O4O" id="cIe-9k-ZJW"/>
+                        <outlet property="consentSegmentedControl" destination="05S-ud-V2e" id="9HS-Rj-OmM"/>
                         <outlet property="textField" destination="ebC-zs-TnD" id="Qds-Dp-amQ"/>
                     </connections>
                 </viewController>

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Onesignal_require_privacy_consent</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -35,6 +35,7 @@
 @interface ViewController ()
 @property (weak, nonatomic) IBOutlet UITextField *textField;
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
+@property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;
 
 @end
 
@@ -45,6 +46,8 @@
     // Do any additional setup after loading the view, typically from a nib.
     
     self.activityIndicatorView.hidden = true;
+    
+    self.consentSegmentedControl.selectedSegmentIndex = (NSInteger)![OneSignal requiresUserPrivacyConsent];
 }
 
 - (void)changeAnimationState:(BOOL)animating {
@@ -119,6 +122,11 @@
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+- (IBAction)consentSegmentedControlValueChanged:(UISegmentedControl *)sender {
+    NSLog(@"View controller consent granted: %i", (int)sender.selectedSegmentIndex);
+    [OneSignal consentGranted:(bool)sender.selectedSegmentIndex];
 }
 
 

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		CAABF34B205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
 		CAABF34C205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
 		CAABF34D205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */; };
+		CAB4112920852E48005A70D1 /* DelayedInitializationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */; };
+		CAB4112A20852E4C005A70D1 /* DelayedInitializationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */; };
+		CAB4112B20852E4C005A70D1 /* DelayedInitializationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */; };
 		CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = CA810FCF202BA97300A60FED /* OSEmailSubscription.h */; };
 /* End PBXBuildFile section */
 
@@ -292,6 +295,8 @@
 		CAA4ED0020646762005BD59B /* BadgeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BadgeTests.m; sourceTree = "<group>"; };
 		CAABF349205B15780042F8E5 /* OneSignalExtensionBadgeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalExtensionBadgeHandler.h; sourceTree = "<group>"; };
 		CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalExtensionBadgeHandler.m; sourceTree = "<group>"; };
+		CAB4112720852E48005A70D1 /* DelayedInitializationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DelayedInitializationParameters.h; sourceTree = "<group>"; };
+		CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DelayedInitializationParameters.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -443,6 +448,8 @@
 				91C7725D1E7CCE1000D612D0 /* OneSignalInternal.h */,
 				912411F01E73342200E41FD7 /* OneSignal.h */,
 				912411F11E73342200E41FD7 /* OneSignal.m */,
+				CAB4112720852E48005A70D1 /* DelayedInitializationParameters.h */,
+				CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */,
 				CA70E3332023D51000019273 /* OneSignalSetEmailParameters.h */,
 				CA70E3342023D51000019273 /* OneSignalSetEmailParameters.m */,
 				912411F41E73342200E41FD7 /* OneSignalHelper.h */,
@@ -731,6 +738,7 @@
 				9124123A1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
 				9124123E1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				912412261E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
+				CAB4112920852E48005A70D1 /* DelayedInitializationParameters.m in Sources */,
 				454F94F21FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m in Sources */,
 				912412321E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				CA70E3352023D51000019273 /* OneSignalSetEmailParameters.m in Sources */,
@@ -769,6 +777,7 @@
 				0338566B1FBBD2270002F7C1 /* OSNotificationPayload.m in Sources */,
 				912412431E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				9124123B1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
+				CAB4112A20852E4C005A70D1 /* DelayedInitializationParameters.m in Sources */,
 				9124123F1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				0338566C1FBBDB150002F7C1 /* OneSignalNotificationServiceExtensionHandler.m in Sources */,
 				CA70E3362023D51300019273 /* OneSignalSetEmailParameters.m in Sources */,
@@ -809,6 +818,7 @@
 				912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */,
 				4529DEE41FA82C6200CEAB1D /* NSURLSessionOverrider.m in Sources */,
 				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,
+				CAB4112B20852E4C005A70D1 /* DelayedInitializationParameters.m in Sources */,
 				912412341E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,
 				9124122C1E73342200E41FD7 /* OneSignalReachability.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/DelayedInitializationParameters.h
+++ b/iOS_SDK/OneSignalSDK/Source/DelayedInitializationParameters.h
@@ -30,12 +30,12 @@
 
 @interface DelayedInitializationParameters : NSObject
 
--(instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions withAppId:(NSString *)appId withHandleNotificationReceivedBlock:(OSHandleNotificationReceivedBlock)received withHandleNotificationActionBlock:(OSHandleNotificationActionBlock)action withSettings:(NSDictionary *)settings;
+-(instancetype _Nonnull)initWithLaunchOptions:(NSDictionary * _Nullable)launchOptions withAppId:(NSString * _Nullable)appId withHandleNotificationReceivedBlock:(OSHandleNotificationReceivedBlock _Nullable)received withHandleNotificationActionBlock:(OSHandleNotificationActionBlock _Nullable)action withSettings:(NSDictionary * _Nullable)settings;
 
-@property (strong, nonatomic) NSDictionary *launchOptions;
-@property (strong, nonatomic) NSString *appId;
-@property (strong, nonatomic) NSDictionary *settings;
-@property (nonatomic) OSHandleNotificationReceivedBlock receivedBlock;
-@property (nonatomic) OSHandleNotificationActionBlock actionBlock;
+@property (strong, nonatomic, nullable) NSDictionary *launchOptions;
+@property (strong, nonatomic, nullable) NSString *appId;
+@property (strong, nonatomic, nullable) NSDictionary *settings;
+@property (nonatomic, nullable) OSHandleNotificationReceivedBlock receivedBlock;
+@property (nonatomic, nullable) OSHandleNotificationActionBlock actionBlock;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/DelayedInitializationParameters.h
+++ b/iOS_SDK/OneSignalSDK/Source/DelayedInitializationParameters.h
@@ -1,0 +1,41 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "OneSignal.h"
+
+@interface DelayedInitializationParameters : NSObject
+
+-(instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions withAppId:(NSString *)appId withHandleNotificationReceivedBlock:(OSHandleNotificationReceivedBlock)received withHandleNotificationActionBlock:(OSHandleNotificationActionBlock)action withSettings:(NSDictionary *)settings;
+
+@property (strong, nonatomic) NSDictionary *launchOptions;
+@property (strong, nonatomic) NSString *appId;
+@property (strong, nonatomic) NSDictionary *settings;
+@property (nonatomic) OSHandleNotificationReceivedBlock receivedBlock;
+@property (nonatomic) OSHandleNotificationActionBlock actionBlock;
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/DelayedInitializationParameters.m
+++ b/iOS_SDK/OneSignalSDK/Source/DelayedInitializationParameters.m
@@ -1,0 +1,41 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "DelayedInitializationParameters.h"
+
+@implementation DelayedInitializationParameters
+
+-(instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions withAppId:(NSString *)appId withHandleNotificationReceivedBlock:(OSHandleNotificationReceivedBlock)received withHandleNotificationActionBlock:(OSHandleNotificationActionBlock)action withSettings:(NSDictionary *)settings {
+    self.launchOptions = launchOptions;
+    self.appId = appId;
+    self.receivedBlock = received;
+    self.actionBlock = action;
+    self.settings = settings;
+    return self;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -340,6 +340,10 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
 
+// - Privacy
++ (void)consentGranted:(BOOL)granted;
++ (BOOL)requiresUserPrivacyConsent; // tells your application if privacy consent is still needed from the current user
+
 @property (class) OSNotificationDisplayType inFocusDisplayType;
 
 + (NSString*)app_id;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1260,7 +1260,7 @@ static BOOL waitingForOneSReg = false;
     
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
-        return;
+        return false;
     
     if (waitingForOneSReg)
         return false;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -552,8 +552,10 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
 }
 
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName {
-    if (delayedInitializationForPrivacyConsent) {
-        [self onesignal_Log:ONE_S_LL_WARN message:[NSString stringWithFormat:@"Your application has called %@ before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent", methodName]];
+    if ([self requiresUserPrivacyConsent]) {
+        if (methodName) {
+            [self onesignal_Log:ONE_S_LL_WARN message:[NSString stringWithFormat:@"Your application has called %@ before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent", methodName]];
+        }
         return false;
     }
     
@@ -789,6 +791,11 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void) fireIdsAvailableCallback {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     if (!idsAvailableBlockWhenReady)
         return;
     if (!self.currentSubscriptionState.userId)
@@ -874,6 +881,11 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 // Called only with a delay to batch network calls.
 + (void) sendTagsToServer {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     if (!tagsToSend)
         return;
     
@@ -1179,6 +1191,11 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void)updateDeviceToken:(NSString*)deviceToken onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"updateDeviceToken:onSuccess:onFailure:"])
+        return;
+    
     onesignal_Log(ONE_S_LL_VERBOSE, @"updateDeviceToken:onSuccess:onFailure:");
     
     // iOS 7
@@ -1240,6 +1257,11 @@ static BOOL waitingForOneSReg = false;
 }
 
 +(BOOL)shouldRegisterNow {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     if (waitingForOneSReg)
         return false;
     
@@ -1273,6 +1295,11 @@ static dispatch_queue_t serialQueue;
 }
 
 + (void)registerUser {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     if (waitingForApnsResponse) {
         [self registerUserAfterDelay];
         return;
@@ -1287,6 +1314,11 @@ static dispatch_queue_t serialQueue;
 }
 
 + (void)registerUserInternal {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     // Make sure we only call create or on_session once per open of the app.
     if (![self shouldRegisterNow])
         return;
@@ -1500,6 +1532,11 @@ static dispatch_queue_t serialQueue;
 
 // Updates the server with the new user's notification setting or subscription status changes
 + (BOOL) sendNotificationTypesUpdate {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return false;
+    
     // User changed notification settings for the app.
     if ([self getNotificationTypes] != -1 && self.currentSubscriptionState.userId && mLastNotificationTypes != [self getNotificationTypes]) {
         if (!self.currentSubscriptionState.pushToken) {
@@ -1531,6 +1568,11 @@ static dispatch_queue_t serialQueue;
 }
 
 + (void)sendPurchases:(NSArray*)purchases {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     if (!self.currentSubscriptionState.userId)
         return;
     
@@ -1678,6 +1720,11 @@ static NSString *_lastnonActiveMessageId;
 }
 
 + (void)submitNotificationOpened:(NSString*)messageId {
+    
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    
     //(DUPLICATE Fix): Make sure we do not upload a notification opened twice for the same messageId
     //Keep track of the Id for the last message sent
     NSString* lastMessageId = [[NSUserDefaults standardUserDefaults] objectForKey:@"GT_LAST_MESSAGE_OPENED_"];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -47,6 +47,10 @@
 #define PROMPT_BEFORE_OPENING_PUSH_URL @"PROMPT_BEFORE_OPENING_PUSH_URL"
 #define DEPRECATED_SELECTORS @[@"application:didReceiveLocalNotification:", @"application:handleActionWithIdentifier:forLocalNotification:completionHandler:", @"application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:"]
 
+// GDPR Privacy Consent
+#define GDPR_CONSENT_GRANTED @"GDPR_CONSENT_GRANTED"
+#define ONESIGNAL_REQUIRE_PRIVACY_CONSENT @"Onesignal_require_privacy_consent"
+
 // Badge handling
 #define ONESIGNAL_DISABLE_BADGE_CLEARING @"OneSignal_disable_badge_clearing"
 #define ONESIGNAL_APP_GROUP_NAME_KEY @"OneSignal_app_groups_key"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -109,6 +109,10 @@ static OneSignalLocation* singleInstance = nil;
 
 + (void)onfocus:(BOOL)isActive {
     
+    // return if the user has not granted privacy permissions
+    if ([OneSignal requiresUserPrivacyConsent])
+        return;
+    
     if(!locationManager || !started) return;
     
     /**
@@ -207,6 +211,10 @@ static OneSignalLocation* singleInstance = nil;
 
 - (void)locationManager:(id)manager didUpdateLocations:(NSArray *)locations {
     
+    // return if the user has not granted privacy permissions
+    if ([OneSignal requiresUserPrivacyConsent])
+        return;
+    
     [manager performSelector:@selector(stopUpdatingLocation)];
     
     id location = locations.lastObject;
@@ -247,6 +255,11 @@ static OneSignalLocation* singleInstance = nil;
 }
 
 + (void)sendLocation {
+    
+    // return if the user has not granted privacy permissions
+    if ([OneSignal requiresUserPrivacyConsent])
+        return;
+    
     @synchronized(OneSignalLocation.mutexObjectForLastLocation) {
         if (!lastLocation || ![OneSignal mUserId]) return;
         


### PR DESCRIPTION
• Adds ability to require privacy consent and lets developers add privacy consent/revoke to their apps
• Uses `Onesignal_require_privacy_consent` info.plist key to let developers require consent
• Adds `consentGranted(boolean)` to indicate if the user gives their consent. Can also be used to revoke previously granted consent