### PR TITLE
MIME Checking

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -132,6 +132,10 @@
 		CA08FC801FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
 		CA08FC811FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
 		CA08FC871FE99BB4004C445F /* OneSignalClientOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */; };
+		CA36A42C208FDEFB003EFA9A /* NSURL+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = CA36A42A208FDEFB003EFA9A /* NSURL+OneSignal.h */; };
+		CA36A42D208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
+		CA36A42E208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
+		CA36A42F208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
 		CA63AF8420211F7400E340FB /* EmailTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA63AF8320211F7400E340FB /* EmailTests.m */; };
 		CA63AF8720211FF800E340FB /* UnitTestCommonMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = CA63AF8620211FF800E340FB /* UnitTestCommonMethods.m */; };
 		CA63AFC22022670A00E340FB /* ReattemptRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CA63AFC02022670A00E340FB /* ReattemptRequest.h */; };
@@ -277,6 +281,8 @@
 		CA08FC7D1FE99B25004C445F /* Requests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Requests.m; sourceTree = "<group>"; };
 		CA08FC821FE99BB4004C445F /* OneSignalClientOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalClientOverrider.h; sourceTree = "<group>"; };
 		CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalClientOverrider.m; sourceTree = "<group>"; };
+		CA36A42A208FDEFB003EFA9A /* NSURL+OneSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURL+OneSignal.h"; sourceTree = "<group>"; };
+		CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURL+OneSignal.m"; sourceTree = "<group>"; };
 		CA63AF8320211F7400E340FB /* EmailTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EmailTests.m; sourceTree = "<group>"; };
 		CA63AF8520211FF800E340FB /* UnitTestCommonMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnitTestCommonMethods.h; sourceTree = "<group>"; };
 		CA63AF8620211FF800E340FB /* UnitTestCommonMethods.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UnitTestCommonMethods.m; sourceTree = "<group>"; };
@@ -498,6 +504,8 @@
 				912412091E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m */,
 				9124120A1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.h */,
 				9124120B1E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m */,
+				CA36A42A208FDEFB003EFA9A /* NSURL+OneSignal.h */,
+				CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -560,6 +568,7 @@
 				912412291E73342200E41FD7 /* OneSignalReachability.h in Headers */,
 				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
 				91F58D7A1E7C7D3F0017D24D /* OneSignalNotificationSettings.h in Headers */,
+				CA36A42C208FDEFB003EFA9A /* NSURL+OneSignal.h in Headers */,
 				CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */,
 				91F58D811E7C80C30017D24D /* OneSignalNotificationSettingsIOS8.h in Headers */,
 				CA08FC7E1FE99B25004C445F /* Requests.h in Headers */,
@@ -731,6 +740,7 @@
 				91F58D7D1E7C7F330017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				9129C6B81E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				912412121E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
+				CA36A42D208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
 				912412421E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				CA97E14F2051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */,
 				9124123A1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
@@ -769,6 +779,7 @@
 				0338566D1FBBDB190002F7C1 /* OneSignalTrackFirebaseAnalytics.m in Sources */,
 				91F58D841E7C88220017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				9129C6B91E89E59B009CB6A0 /* OSPermission.m in Sources */,
+				CA36A42E208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
 				912412131E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
 				CA97E1502051C0A5003B8CB8 /* OneSignalWebOpenDialog.m in Sources */,
 				0338566B1FBBD2270002F7C1 /* OSNotificationPayload.m in Sources */,
@@ -824,6 +835,7 @@
 				4529DED51FA823B900CEAB1D /* TestHelperFunctions.m in Sources */,
 				911E2CBD1E398AB3003112A4 /* UnitTests.m in Sources */,
 				CA63AF8420211F7400E340FB /* EmailTests.m in Sources */,
+				CA36A42F208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
 				91B6EA431E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				4529DEDE1FA828E500CEAB1D /* NSDateOverrider.m in Sources */,
 				CA08FC871FE99BB4004C445F /* OneSignalClientOverrider.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
@@ -14,6 +14,7 @@
 - (NSString*)one_getVersionForRange:(NSRange)range;
 - (NSString*)one_substringAfter:(NSString *)needle;
 - (NSString*)one_getSemanticVersion;
+- (NSString *)fileExtensionForMimeType;
 
 @end
 #endif

--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
@@ -15,6 +15,7 @@
 - (NSString*)one_substringAfter:(NSString *)needle;
 - (NSString*)one_getSemanticVersion;
 - (NSString *)fileExtensionForMimeType;
+- (NSString *)supportedFileExtension;
 
 @end
 #endif

--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
@@ -6,6 +6,7 @@
 //
 
 #import "NSString+OneSignal.h"
+#import "OneSignalCommonDefines.h"
 
 #define MIME_MAP @{@"audio/aiff" : @"aiff", @"audio/x-wav" : @"wav", @"audio/mpeg" : @"mp3", @"video/mp4" : @"mp4", @"image/jpeg" : @"jpeg", @"image/jpg" : @"jpg", @"image/png" : @"png", @"image/gif" : @"gif", @"video/mpeg" : @"mpeg", @"video/mpg" : @"mpg", @"video/avi" : @"avi", @"sound/m4a" : @"m4a", @"video/m4v" : @"m4v"}
 
@@ -43,6 +44,15 @@
 	}
 
 	return (NSString*)tmpstr;
+}
+
+- (NSString *)supportedFileExtension {
+    NSArray <NSString *> *components = [self componentsSeparatedByString:@"."];
+    
+    if (components.count >= 2 && [ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES containsObject:components.lastObject])
+        return components.lastObject;
+    
+    return nil;
 }
 
 - (NSString *)fileExtensionForMimeType {

--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
@@ -7,6 +7,8 @@
 
 #import "NSString+OneSignal.h"
 
+#define MIME_MAP @{@"audio/aiff" : @"aiff", @"audio/x-wav" : @"wav", @"audio/mpeg" : @"mp3", @"video/mp4" : @"mp4", @"image/jpeg" : @"jpeg", @"image/jpg" : @"jpg", @"image/png" : @"png", @"image/gif" : @"gif", @"video/mpeg" : @"mpeg", @"video/mpg" : @"mpg", @"video/avi" : @"avi", @"sound/m4a" : @"m4a", @"video/m4v" : @"m4v"}
+
 @implementation NSString (OneSignal)
 
 
@@ -43,5 +45,8 @@
 	return (NSString*)tmpstr;
 }
 
+- (NSString *)fileExtensionForMimeType {
+    return MIME_MAP[self];
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.h
@@ -25,26 +25,10 @@
  * THE SOFTWARE.
  */
 
-#import "NSURLSessionOverrider.h"
+#import <Foundation/Foundation.h>
 
-#import "TestHelperFunctions.h"
+@interface NSURL (OneSignal)
 
-@implementation NSURLSessionOverrider
-
-+ (void)load {
-    // Swizzle an injected method defined in OneSignalHelper
-    injectStaticSelector([NSURLSessionOverrider class], @selector(overrideDownloadItemAtURL:toFile:error:), [NSURLSession class], @selector(downloadItemAtURL:toFile:error:));
-}
-
-// Override downloading of media attachment
-+ (NSString *)overrideDownloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError*)error {
-    NSString *content = @"File Contents";
-    NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
-    [[NSFileManager defaultManager] createFileAtPath:localPath
-                                            contents:fileContents
-                                          attributes:nil];
-    
-    return @"image/jpg";
-}
+- (NSString *)valueForQueryParameter:(NSString *)parameter;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
@@ -25,26 +25,16 @@
  * THE SOFTWARE.
  */
 
-#import "NSURLSessionOverrider.h"
+#import "NSURL+OneSignal.h"
 
-#import "TestHelperFunctions.h"
-
-@implementation NSURLSessionOverrider
-
-+ (void)load {
-    // Swizzle an injected method defined in OneSignalHelper
-    injectStaticSelector([NSURLSessionOverrider class], @selector(overrideDownloadItemAtURL:toFile:error:), [NSURLSession class], @selector(downloadItemAtURL:toFile:error:));
-}
-
-// Override downloading of media attachment
-+ (NSString *)overrideDownloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError*)error {
-    NSString *content = @"File Contents";
-    NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
-    [[NSFileManager defaultManager] createFileAtPath:localPath
-                                            contents:fileContents
-                                          attributes:nil];
+@implementation NSURL (OneSignal)
+- (NSString *)valueForQueryParameter:(NSString *)parameter {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:false];
     
-    return @"image/jpg";
+    for(NSURLQueryItem *item in components.queryItems)
+        if([item.name isEqualToString:parameter])
+            return item.value;
+    
+    return nil;
 }
-
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -58,4 +58,6 @@
 #define ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED @"OS_LAST_RECIEVED_GAF_CAMPAIGN"
 #define ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED @"OS_LAST_RECIEVED_NOTIFICATION_ID"
 
+#define ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES @[@"aiff", @"wav", @"mp3", @"mp4", @"jpg", @"jpeg", @"png", @"gif", @"mpeg", @"mpg", @"avi", @"m4a", @"m4v"]
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -41,6 +41,9 @@
 #import "OneSignalWebOpenDialog.h"
 #import "OneSignalInternal.h"
 
+#import "NSString+OneSignal.h"
+#import "NSURL+OneSignal.h"
+
 #define NOTIFICATION_TYPE_ALL 7
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
@@ -103,12 +106,12 @@
 @end
 
 @interface NSURLSession (DirectDownload)
-+ (BOOL)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error;
++ (NSString *)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error;
 @end
 
 @implementation NSURLSession (DirectDownload)
 
-+ (BOOL)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error {
++ (NSString *)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     
     DirectDownloadDelegate *delegate = [[DirectDownloadDelegate alloc] initWithFilePath:localPath];
@@ -130,10 +133,10 @@
         if (error != nil) {
             error = downloadError;
         }
-        return false;
+        return nil;
     }
     
-    return true;
+    return delegate.response.MIMEType;
 }
 
 @end
@@ -728,19 +731,30 @@ static OneSignal* singleInstance = nil;
     NSArray<NSString*>* supportedExtensions = @[@"aiff", @"wav", @"mp3", @"mp4", @"jpg", @"jpeg", @"png", @"gif", @"mpeg", @"mpg", @"avi", @"m4a", @"m4v"];
     NSArray* components = [url componentsSeparatedByString:@"."];
     
-    // URL is not to a file
-    if ([components count] < 2)
-        return NULL;
-    NSString* extension = [components lastObject];
+    NSString* extension;
     
-    // Unrecognized extention
-    if (![supportedExtensions containsObject:extension])
-        return NULL;
+    // URL is not to a file
+    if ([components count] >= 2) {
+        extension = inputUrl.pathExtension;
+        
+        if ([extension isEqualToString:@""])
+            extension = nil;
+        
+        // Unrecognized extention
+        if (extension != nil && ![supportedExtensions containsObject:extension])
+            return nil;
+    }
+    
+    if (!extension)
+        extension = [[NSURL URLWithString:urlString] valueForQueryParameter:@"file_type"];
     
     NSURL* URL = [NSURL URLWithString:url];
     
+    var name = [self randomStringWithLength:10];
     
-    NSString* name = [[self randomStringWithLength:10] stringByAppendingString:[NSString stringWithFormat:@".%@", extension]];
+    if (extension)
+        name = [name stringByAppendingString:[NSString stringWithFormat:@".%@", extension]];
+    
     NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString* filePath = [paths[0] stringByAppendingPathComponent:name];
     
@@ -748,7 +762,31 @@ static OneSignal* singleInstance = nil;
     
     @try {
         NSError* error = nil;
-        [NSURLSession downloadItemAtURL:URL toFile:filePath error:error];
+        let mimeType = [NSURLSession downloadItemAtURL:URL toFile:filePath error:error];
+        
+        if (error) {
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error while attempting to download file with URL: %@", error]];
+            return nil;
+        }
+        
+        if (!extension) {
+            NSString *newExtension = mimeType.fileExtensionForMimeType;
+            
+            if (!newExtension || ![supportedExtensions containsObject:newExtension])
+                return nil;
+            
+            name = [NSString stringWithFormat:@"%@.%@", name, newExtension];
+            
+            let newPath = [paths[0] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@", name]];
+            
+            [[NSFileManager defaultManager] moveItemAtPath:filePath toPath:newPath error:&error];
+        }
+        
+        if (error) {
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error while attempting to download file with URL: %@", error]];
+            return nil;
+        }
+        
         NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:@"CACHED_MEDIA"];
         NSMutableArray* appendedCache;
         if (cachedFiles) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -731,28 +731,16 @@ static OneSignal* singleInstance = nil;
 */
 + (NSString*)downloadMediaAndSaveInBundle:(NSString*)urlString {
     
-    let inputUrl = [NSURL URLWithString:urlString];
+    let url = [NSURL URLWithString:urlString];
     
-    //removes any unnecessary query parameters that would break extension type checking
-    let url = [[NSURL alloc] initWithScheme:inputUrl.scheme host:inputUrl.host path:inputUrl.path].absoluteString;
+    NSString* extension = url.pathExtension;
     
-    NSArray* components = [url componentsSeparatedByString:@"."];
+    if ([extension isEqualToString:@""])
+        extension = nil;
     
-    NSString* extension;
-    
-    // URL is not to a file
-    if ([components count] >= 2) {
-        extension = inputUrl.pathExtension;
-        
-        if ([extension isEqualToString:@""])
-            extension = nil;
-        
-        // Unrecognized extention
-        if (extension != nil && ![ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES containsObject:extension])
-            return nil;
-    }
-    
-    NSURL* URL = [NSURL URLWithString:url];
+    // Unrecognized extention
+    if (extension != nil && ![ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES containsObject:extension])
+        return nil;
     
     var name = [self randomStringWithLength:10];
     
@@ -766,7 +754,7 @@ static OneSignal* singleInstance = nil;
     
     @try {
         NSError* error = nil;
-        let mimeType = [NSURLSession downloadItemAtURL:URL toFile:filePath error:error];
+        let mimeType = [NSURLSession downloadItemAtURL:url toFile:filePath error:error];
         
         if (error) {
             [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error while attempting to download file with URL: %@", error]];

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
@@ -44,7 +44,12 @@
                                             contents:fileContents
                                           attributes:nil];
     
-    return @"image/jpg";
+    if ([url.absoluteString isEqualToString:@"http://domain.com/file"])
+        return @"image/png";
+    else if ([url.absoluteString isEqualToString:@"http://domain.com/secondFile"])
+        return nil;
+    else
+        return @"image/jpg";
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1876,4 +1876,66 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqual(swizzled, newSwizzled);
 }
 
+- (UNNotificationAttachment *)deliverNotificationWithJSON:(id)json {
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:json];
+    
+    [[notifResponse notification].request.content setValue:@"some_category" forKey:@"categoryIdentifier"];
+    
+    UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
+    
+    return content.attachments.firstObject;
+}
+
+- (void)testExtractFileExtensionFromMimeType {
+    //test to make sure the MIME type parsing works correctly
+    //NSURLSessionOverrider returns image/png for this URL
+    id pngFormat = @{@"aps": @{
+                             @"mutable-content": @1,
+                             @"alert": @"Message Body"
+                             },
+                     @"os_data": @{
+                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+                             @"att": @{ @"id": @"http://domain.com/file" }
+                             }};
+    
+    let downloadedPngFilename = [self deliverNotificationWithJSON:pngFormat].URL.lastPathComponent;
+    XCTAssertTrue([downloadedPngFilename.supportedFileExtension isEqualToString:@"png"]);
+}
+
+- (void)testExtractFileExtensionFromQueryParameter {
+    // we allow developers to add ?filename=test.jpg (for example) to attachment URL's in cases where there is no extension & no mime type
+    // tests to make sure the SDK correctly extracts the file extension from the `filename` URL query parameter
+    // NSURLSessionOverrider returns nil for this URL
+    id jpgFormat = @{@"aps": @{
+                             @"mutable-content": @1,
+                             @"alert": @"Message Body"
+                             },
+                     @"os_data": @{
+                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+                             @"att": @{ @"id": @"http://domain.com/secondFile?filename=test.jpg" }
+                             }};
+    
+    let downloadedJpgFilename = [self deliverNotificationWithJSON:jpgFormat].URL.lastPathComponent;
+    XCTAssertTrue([downloadedJpgFilename.supportedFileExtension isEqualToString:@"jpg"]);
+}
+
+- (void)testFileExtensionPrioritizesURLFileExtension {
+    //tests to make sure that the URL's file extension is prioritized above the MIME type and URL query param
+    //this attachment URL will have a file extension, a MIME type, and a filename query parameter. It should prioritize the URL file extension (gif)
+    //NSURLSessionOverrider returns image/png for this URL
+    id gifFormat = @{@"aps": @{
+                             @"mutable-content": @1,
+                             @"alert": @"Message Body"
+                             },
+                     @"os_data": @{
+                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+                             @"att": @{ @"id": @"http://domain.com/file.gif?filename=test.png" }
+                             }};
+    let downloadedGifFilename = [self deliverNotificationWithJSON:gifFormat].URL.lastPathComponent;
+    XCTAssertTrue([downloadedGifFilename.supportedFileExtension isEqualToString:@"gif"]);
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1886,18 +1886,22 @@ didReceiveRemoteNotification:userInfo
     return content.attachments.firstObject;
 }
 
+- (id)exampleNotificationJSONWithMediaURL:(NSString *)urlString {
+    return @{@"aps": @{
+                     @"mutable-content": @1,
+                     @"alert": @"Message Body"
+                     },
+             @"os_data": @{
+                     @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+                     @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+                     @"att": @{ @"id": urlString }
+                     }};
+}
+
 - (void)testExtractFileExtensionFromMimeType {
     //test to make sure the MIME type parsing works correctly
     //NSURLSessionOverrider returns image/png for this URL
-    id pngFormat = @{@"aps": @{
-                             @"mutable-content": @1,
-                             @"alert": @"Message Body"
-                             },
-                     @"os_data": @{
-                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
-                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
-                             @"att": @{ @"id": @"http://domain.com/file" }
-                             }};
+    id pngFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/file"];
     
     let downloadedPngFilename = [self deliverNotificationWithJSON:pngFormat].URL.lastPathComponent;
     XCTAssertTrue([downloadedPngFilename.supportedFileExtension isEqualToString:@"png"]);
@@ -1907,15 +1911,7 @@ didReceiveRemoteNotification:userInfo
     // we allow developers to add ?filename=test.jpg (for example) to attachment URL's in cases where there is no extension & no mime type
     // tests to make sure the SDK correctly extracts the file extension from the `filename` URL query parameter
     // NSURLSessionOverrider returns nil for this URL
-    id jpgFormat = @{@"aps": @{
-                             @"mutable-content": @1,
-                             @"alert": @"Message Body"
-                             },
-                     @"os_data": @{
-                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
-                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
-                             @"att": @{ @"id": @"http://domain.com/secondFile?filename=test.jpg" }
-                             }};
+    id jpgFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/secondFile?filename=test.jpg"];
     
     let downloadedJpgFilename = [self deliverNotificationWithJSON:jpgFormat].URL.lastPathComponent;
     XCTAssertTrue([downloadedJpgFilename.supportedFileExtension isEqualToString:@"jpg"]);
@@ -1925,15 +1921,8 @@ didReceiveRemoteNotification:userInfo
     //tests to make sure that the URL's file extension is prioritized above the MIME type and URL query param
     //this attachment URL will have a file extension, a MIME type, and a filename query parameter. It should prioritize the URL file extension (gif)
     //NSURLSessionOverrider returns image/png for this URL
-    id gifFormat = @{@"aps": @{
-                             @"mutable-content": @1,
-                             @"alert": @"Message Body"
-                             },
-                     @"os_data": @{
-                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
-                             @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
-                             @"att": @{ @"id": @"http://domain.com/file.gif?filename=test.png" }
-                             }};
+    id gifFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/file.gif?filename=test.png"];
+    
     let downloadedGifFilename = [self deliverNotificationWithJSON:gifFormat].URL.lastPathComponent;
     XCTAssertTrue([downloadedGifFilename.supportedFileExtension isEqualToString:@"gif"]);
 }


### PR DESCRIPTION
• Adds the ability for the SDK to use attachments with no file extension
• Also adds the ability to specify the file type using the URL query parameter "file_type"
• If a media attachment URL does not contain a file extension, the SDK will now download the file and check the MIME type of the request to make sure it is a valid file type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/366)
<!-- Reviewable:end -->
