### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1658,16 +1658,10 @@ static NSString *_lastnonActiveMessageId;
     
     if (opened) {
         //app was in background / not running and opened due to a tap on a notification or an action check what type
-        NSString* actionSelected = NULL;
         OSNotificationActionType type = OSNotificationActionTypeOpened;
-        if (messageDict[@"custom"][@"a"][@"actionSelected"]) {
-            actionSelected = messageDict[@"custom"][@"a"][@"actionSelected"];
+        
+        if (messageDict[@"custom"][@"a"][@"actionSelected"] || messageDict[@"actionSelected"])
             type = OSNotificationActionTypeActionTaken;
-        }
-        if (messageDict[@"actionSelected"]) {
-            actionSelected = messageDict[@"actionSelected"];
-            type = OSNotificationActionTypeActionTaken;
-        }
         
         // Call Action Block
         [OneSignal handleNotificationOpened:messageDict isActive:isActive actionType:type displayType:OneSignal.inFocusDisplayType];
@@ -2017,7 +2011,8 @@ static NSString *_lastnonActiveMessageId;
     
     //checks to make sure that if email_auth is required, the user has passed in a hash token
     if (self.currentEmailSubscriptionState.requiresEmailAuth && (!emailAuthToken || emailAuthToken.length == 0)) {
-        failureBlock([NSError errorWithDomain:@"com.onesignal.email" code:0 userInfo:@{@"error" : @"Email authentication (auth token) is set to REQUIRED for this application. Please provide an auth token from your backend server or change the setting in the OneSignal dashboard."}]);
+        if (failureBlock)
+            failureBlock([NSError errorWithDomain:@"com.onesignal.email" code:0 userInfo:@{@"error" : @"Email authentication (auth token) is set to REQUIRED for this application. Please provide an auth token from your backend server or change the setting in the OneSignal dashboard."}]);
         return;
     }
     
@@ -2204,6 +2199,7 @@ static NSString *_lastnonActiveMessageId;
         [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"Already swizzled UIApplication.setDelegate. Make sure the OneSignal library wasn't loaded into the runtime twice!"];
         return;
     }
+    
     
     // Swizzle - UIApplication delegate
     injectToProperClass(@selector(setOneSignalDelegate:), @selector(setDelegate:), @[], [OneSignalAppDelegate class], [UIApplication class]);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -108,12 +108,12 @@
 @end
 
 @interface NSURLSession (DirectDownload)
-+ (NSString *)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error;
++ (NSString *)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError **)error;
 @end
 
 @implementation NSURLSession (DirectDownload)
 
-+ (NSString *)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError *)error {
++ (NSString *)downloadItemAtURL:(NSURL *)url toFile:(NSString *)localPath error:(NSError **)error {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     
     DirectDownloadDelegate *delegate = [[DirectDownloadDelegate alloc] initWithFilePath:localPath];
@@ -132,9 +132,8 @@
     
     NSError *downloadError = [delegate error];
     if (downloadError != nil) {
-        if (error != nil) {
-            error = downloadError;
-        }
+        if (error)
+            *error = downloadError;
         return nil;
     }
     
@@ -753,8 +752,8 @@ static OneSignal* singleInstance = nil;
     //guard against situations where for example, available storage is too low
     
     @try {
-        NSError* error = nil;
-        let mimeType = [NSURLSession downloadItemAtURL:url toFile:filePath error:error];
+        NSError* error;
+        let mimeType = [NSURLSession downloadItemAtURL:url toFile:filePath error:&error];
         
         if (error) {
             [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error while attempting to download file with URL: %@", error]];

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
@@ -37,7 +37,7 @@
 }
 
 // Override downloading of media attachment
-+ (NSString *)overrideDownloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError*)error {
++ (NSString *)overrideDownloadItemAtURL:(NSURL*)url toFile:(NSString*)localPath error:(NSError**)error {
     NSString *content = @"File Contents";
     NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
     [[NSFileManager defaultManager] createFileAtPath:localPath


### PR DESCRIPTION
• Fixes an issue where the download method for attachments wasn't correctly implemented with a double pointer. It accepted NSError as a parameter, but because this pointer gets copied, any new assignments will apply to the copied pointer, not the original.
• Fixes an issue in `setEmail()` where the failure block was being called without verifying that it is nonnull, which could cause crashes.
• Cleans up the `notificationReceived()` method, which created a string (actionSelected) but doesn't use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/370)
<!-- Reviewable:end -->
