### PR TITLE
Fix HTTP Race Condition

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -117,14 +117,6 @@
         return;
     }
     
-    NSData *requestData = request.request.HTTPBody;
-    
-    if (requestData) {
-        NSString *json = [[NSString alloc] initWithData:requestData encoding:NSUTF8StringEncoding];
-        
-        NSLog(@"Executing request %@ with json: %@", NSStringFromClass([request class]), json);
-    }
-    
     let task = [self.sharedSession dataTaskWithRequest:request.request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         [self handleJSONNSURLResponse:response data:data error:error isAsync:true withRequest:request onSuccess:successBlock onFailure:failureBlock];
     }];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -72,7 +72,7 @@
     
     //execute on a background thread or the semaphore will block the caller thread
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+        dispatch_group_t group = dispatch_group_create();
         
         __block NSMutableDictionary<NSString *, NSError *> *errors = [NSMutableDictionary new];
         __block NSMutableDictionary<NSString *, NSDictionary *> *results = [NSMutableDictionary new];
@@ -80,18 +80,19 @@
         for (NSString *identifier in requests.allKeys) {
             let request = requests[identifier];
             
+            //use a dispatch_group instead of a semaphore, in case the failureBlock gets called synchronously
+            //this will prevent the SDK from waiting/blocking on a request that instantly failed
+            dispatch_group_enter(group);
             [self executeRequest:request onSuccess:^(NSDictionary *result) {
                 results[identifier] = result;
-                dispatch_semaphore_signal(semaphore);
+                dispatch_group_leave(group);
             } onFailure:^(NSError *error) {
                 errors[identifier] = error;
-                dispatch_semaphore_signal(semaphore);
+                dispatch_group_leave(group);
             }];
         }
         
-        for (int i = 0; i < requests.count; i++) {
-            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-        }
+        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
         
         //requests should all be completed at this point
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -114,6 +115,14 @@
     if (![self validRequest:request]) {
         [self handleMissingAppIdError:failureBlock withRequest:request];
         return;
+    }
+    
+    NSData *requestData = request.request.HTTPBody;
+    
+    if (requestData) {
+        NSString *json = [[NSString alloc] initWithData:requestData encoding:NSUTF8StringEncoding];
+        
+        NSLog(@"Executing request %@ with json: %@", NSStringFromClass([request class]), json);
     }
     
     let task = [self.sharedSession dataTaskWithRequest:request.request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -79,6 +79,10 @@ static BOOL lastOnFocusWasToBackground = YES;
 
 + (void)onFocus:(BOOL)toBackground {
     
+    // return if the user has not granted privacy permissions
+    if ([OneSignal requiresUserPrivacyConsent])
+        return;
+    
     // Prevent the onFocus to be called twice when app being terminated
     //    - Both WillResignActive and willTerminate
     if (lastOnFocusWasToBackground == toBackground)


### PR DESCRIPTION
• Fixes a relatively rare issue that would be encountered if the SDK attempted to make concurrent HTTP requests during an invalid situation, such as after the user has revoked GDPR consent, or if the SDK hasn't received the app ID yet. 
• The SDK was previously using a semaphore to wait for a batch of HTTP requests to finish.
• However, if the SDK immediately fails the request (synchronously), the request would fail before the SDK started waiting for the request to finish, resulting in a permanently blocked queue.
• Switched to using a dispatch_group which would handle this situation better. Also added a missing GDPR consent check to the onFocus methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/372)
<!-- Reviewable:end -->
