### PR TITLE
Bundle ID Improvement

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -59,8 +59,6 @@
     
     id notificationReceiverBlock = ^(OSNotification *notification) {
         NSLog(@"Received Notification - %@", notification.payload.notificationID);
-        
-        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:11];
     };
     
     [OneSignal initWithLaunchOptions:launchOptions

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>OneSignal_require_privacy_consent</key>
-	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -31,10 +29,8 @@
 	<string>Test Location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Test Location2</string>
-	<key>OneSignal_app_groups_key</key>
-	<string> group.com.onesignal.example.testgroup </string>
-	<key>OneSignal_disable_badge_clearing</key>
-	<true/>
+	<key>OneSignal_require_privacy_consent</key>
+	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
@@ -47,6 +43,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>OneSignal_disable_badge_clearing</key>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/Info.plist
+++ b/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>OneSignal_app_groups_key</key>
-	<string>group.com.onesignal.example.testgroup</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
@@ -63,6 +63,17 @@
     return [(NSNumber *)[userDefaults objectForKey:ONESIGNAL_BADGE_KEY] integerValue];
 }
 
+//gets the NSBundle of the primary application - NOT the app extension
+//this way we can determine the bundle ID for the host (primary) application.
++ (NSString *)primaryBundleIdentifier {
+    NSBundle *bundle = [NSBundle mainBundle];
+    if ([[bundle.bundleURL pathExtension] isEqualToString:@"appex"])
+        bundle = [NSBundle bundleWithURL:[[bundle.bundleURL URLByDeletingLastPathComponent] URLByDeletingLastPathComponent]];
+    
+    return [bundle bundleIdentifier];
+    
+}
+
 + (void)updateCachedBadgeValue:(NSInteger)value {
     //since badge logic can be executed in an extension, we need to use app groups to get
     //a shared NSUserDefaults from the app group suite name
@@ -77,7 +88,7 @@
     var appGroupName = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_APP_GROUP_NAME_KEY];
     
     if (!appGroupName)
-        appGroupName = [NSString stringWithFormat:@"group.%@.%@", [[NSBundle mainBundle] bundleIdentifier], @"onesignal"];
+        appGroupName = [NSString stringWithFormat:@"group.%@.%@", OneSignalExtensionBadgeHandler.primaryBundleIdentifier, @"onesignal"];
     
     return [appGroupName stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }


### PR DESCRIPTION
• In order to allow communication between the App Extension and the host/primary application, OneSignal SDK uses an app group to perform communication
• For most developers, the name of the app group will simply be group.{your_bundle_id}.onesignal
• The SDK can automatically retrieve this bundle ID, but previously, for the app extension service, this was broken because it was only retrieving the bundle ID for the OneSignalNotificationServiceExtension
• This means the bundle ID's would not have matched and badge count would be inconsistent. This commit fixes the issue by using a method to retrieve the host app's bundle ID.

### Note 1
Users can override this app group name by adding a `OneSignal_app_groups_key` value to their `info.plist` for both the main app and extension service.

### Note 2
This PR also changes the example/demo app in a few ways to avoid confusion. We removed a method that would set the badge count to 11 whenever a notification is received, and we enabled automatic badge clearing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/377)
<!-- Reviewable:end -->
