### PR TITLE
Add thread-id

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
@@ -170,6 +170,10 @@
     if (aps[@"mutable-content"])
         _mutableContent = (BOOL)aps[@"mutable-content"];
     
+    if (aps[@"thread-id"]) {
+        _threadId = (NSString *)aps[@"thread-id"];
+    }
+    
     _category = aps[@"category"];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -149,6 +149,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
  Keep the raw value for users that would like to root the push */
 @property(readonly)NSDictionary *rawPayload;
 
+/* iOS 10+ : Groups notifications into threads */
+@property(readonly)NSString *threadId;
+
 @end
 
 // ## OneSignal OSNotification

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1137,6 +1137,8 @@
         XCTAssertEqualObjects(result.notification.payload.actionButtons, actionButons);
         XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
         
+        XCTAssertEqualObjects(result.notification.payload.threadId, @"test1");
+        
         openedWasFire = true;
     };
     
@@ -1164,7 +1166,8 @@
                              @"mutable-content" : @1,
                              @"alert" : @{
                                      @"title" : @"Test Title"
-                                     }
+                                     },
+                             @"thread-id" : @"test1"
                              },
                      @"buttons" : @[@{@"i": @"id1", @"n": @"text1"}],
                      @"custom" : @{
@@ -1178,7 +1181,8 @@
 - (void)testNewFormatNotificationAlertButtonsDisplay {
     id newFormat = @{@"aps": @{
                              @"mutable-content": @1,
-                             @"alert": @{@"body": @"Message Body", @"title": @"title"}
+                             @"alert": @{@"body": @"Message Body", @"title": @"title"},
+                             @"thread-id": @"test1"
                              },
                      @"os_data": @{
                              @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bf",


### PR DESCRIPTION
• Adds `thread-id` as a parameter on `OSNotificationPayload`. `thread-id` groups related notifications together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/383)
<!-- Reviewable:end -->
