### PR TITLE
Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
   <img src="https://onesignal.com/assets/common/logo_onesignal_color.png"/>
 </p>
 
-### OneSignal iOS SDK
+### OneSignal iOS SDK (beta)
 [![CocoaPods](https://img.shields.io/cocoapods/v/OneSignal.svg)](https://cocoapods.org/pods/OneSignal) [![CocoaPods](https://img.shields.io/cocoapods/dm/OneSignal.svg)](https://cocoapods.org/pods/OneSignal) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage) [![Build Status](https://travis-ci.org/OneSignal/OneSignal-iOS-SDK.svg?branch=master)](https://travis-ci.org/OneSignal/OneSignal-iOS-SDK)
 
 ---
 
 [OneSignal](https://www.onesignal.com) is a free push notification service for mobile apps. This plugin makes it easy to integrate your native iOS app with OneSignal.
+
+This branch contains code for the iOS 12 beta.
 
 ![alt text](https://onesignal.com/images/ios_10_notification_image.gif)
 

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		CA36A42D208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
 		CA36A42E208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
 		CA36A42F208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
+		CA42CAC320D99CB90001F2F2 /* ProvisionalAuthorizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA42CAC220D99CB90001F2F2 /* ProvisionalAuthorizationTests.m */; };
 		CA63AF8420211F7400E340FB /* EmailTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA63AF8320211F7400E340FB /* EmailTests.m */; };
 		CA63AF8720211FF800E340FB /* UnitTestCommonMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = CA63AF8620211FF800E340FB /* UnitTestCommonMethods.m */; };
 		CA63AFC22022670A00E340FB /* ReattemptRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CA63AFC02022670A00E340FB /* ReattemptRequest.h */; };
@@ -286,6 +287,7 @@
 		CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalClientOverrider.m; sourceTree = "<group>"; };
 		CA36A42A208FDEFB003EFA9A /* NSURL+OneSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURL+OneSignal.h"; sourceTree = "<group>"; };
 		CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURL+OneSignal.m"; sourceTree = "<group>"; };
+		CA42CAC220D99CB90001F2F2 /* ProvisionalAuthorizationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProvisionalAuthorizationTests.m; sourceTree = "<group>"; };
 		CA63AF8320211F7400E340FB /* EmailTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EmailTests.m; sourceTree = "<group>"; };
 		CA63AF8520211FF800E340FB /* UnitTestCommonMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnitTestCommonMethods.h; sourceTree = "<group>"; };
 		CA63AF8620211FF800E340FB /* UnitTestCommonMethods.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UnitTestCommonMethods.m; sourceTree = "<group>"; };
@@ -432,6 +434,7 @@
 				CA85C15220604AEA003AB529 /* RequestTests.m */,
 				CAA4ED0020646762005BD59B /* BadgeTests.m */,
 				CA63AF8320211F7400E340FB /* EmailTests.m */,
+				CA42CAC220D99CB90001F2F2 /* ProvisionalAuthorizationTests.m */,
 				CA63AF8520211FF800E340FB /* UnitTestCommonMethods.h */,
 				CA63AF8620211FF800E340FB /* UnitTestCommonMethods.m */,
 				911E2CBE1E398AB3003112A4 /* Info.plist */,
@@ -834,6 +837,7 @@
 				912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */,
 				4529DEE41FA82C6200CEAB1D /* NSURLSessionOverrider.m in Sources */,
 				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,
+				CA42CAC320D99CB90001F2F2 /* ProvisionalAuthorizationTests.m in Sources */,
 				CAB4112B20852E4C005A70D1 /* DelayedInitializationParameters.m in Sources */,
 				912412341E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,
@@ -980,6 +984,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				DSTROOT = /tmp/OneSignal.dst;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -999,6 +1005,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				DSTROOT = /tmp/OneSignal.dst;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
@@ -170,6 +170,10 @@
     if (aps[@"mutable-content"])
         _mutableContent = (BOOL)aps[@"mutable-content"];
     
+    if (aps[@"thread-id"]) {
+        _threadId = (NSString *)aps[@"thread-id"];
+    }
+    
     _category = aps[@"category"];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.m
@@ -79,8 +79,9 @@ SEL changeSelector;
                 
                 [self callObserver:observer withSelector:changeSelector withState:state];
                 
-            } else
+            } else {
                 [observer onChanged:state];
+            }
         }
     }
     

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.h
@@ -48,6 +48,8 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 @property (readwrite, nonatomic) BOOL hasPrompted;
 @property (readwrite, nonatomic) BOOL answeredPrompt;
 @property (readwrite, nonatomic) BOOL accepted;
+@property (readwrite, nonatomic) BOOL provisional; //internal flag
+@property (readwrite, nonatomic) BOOL reachable;
 @property int notificationTypes;
 
 @property (nonatomic) ObserablePermissionStateType* observable;

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -29,6 +29,8 @@
 
 #import "OneSignalInternal.h"
 
+#import "OneSignalCommonDefines.h"
+
 @implementation OSPermissionState
 
 - (ObserablePermissionStateType*)observable {
@@ -46,9 +48,11 @@
 - (instancetype)initAsFrom {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     
-    _hasPrompted = [userDefaults boolForKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
-    _answeredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
-    _accepted  = [userDefaults boolForKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
+    _hasPrompted = [userDefaults boolForKey:PERMISSION_HAS_PROMPTED];
+    _answeredPrompt = [userDefaults boolForKey:PERMISSION_ANSWERED_PROMPT];
+    _accepted  = [userDefaults boolForKey:PERMISSION_ACCEPTED];
+    _provisional = [userDefaults boolForKey:PERMISSION_PROVISIONAL_STATUS];
+    
     
     return self;
 }
@@ -56,9 +60,10 @@
 - (void)persistAsFrom {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     
-    [userDefaults setBool:_hasPrompted forKey:@"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"];
-    [userDefaults setBool:_answeredPrompt forKey:@"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"];
-    [userDefaults setBool:_accepted forKey:@"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"];
+    [userDefaults setBool:_hasPrompted forKey:PERMISSION_HAS_PROMPTED];
+    [userDefaults setBool:_answeredPrompt forKey:PERMISSION_ANSWERED_PROMPT];
+    [userDefaults setBool:_accepted forKey:PERMISSION_ACCEPTED];
+    [userDefaults setBool:_provisional forKey:PERMISSION_PROVISIONAL_STATUS];
     
     [userDefaults synchronize];
 }
@@ -71,6 +76,7 @@
         copy->_hasPrompted = _hasPrompted;
         copy->_answeredPrompt = _answeredPrompt;
         copy->_accepted = _accepted;
+        copy->_provisional = _provisional;
     }
     
     return copy;
@@ -94,6 +100,29 @@
     if (self.answeredPrompt) // self. triggers getter
         return true;
     return _hasPrompted;
+}
+
+-(BOOL)reachable {
+    return self.provisional || self.accepted;
+}
+
+- (void)setProvisional:(BOOL)provisional {
+    if (_provisional != provisional) {
+        NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults setBool:provisional forKey:@"ONESIGNAL_PROVISIONAL_AUTHORIZATION"];
+        [userDefaults synchronize];
+    }
+    
+    BOOL previous = _provisional;
+    _provisional = provisional;
+    
+    if (previous != _provisional) {
+        [self.observable notifyChange:self];
+    }
+}
+
+- (BOOL)isProvisional {
+    return _provisional;
 }
 
 - (void)setAnsweredPrompt:(BOOL)inansweredPrompt {
@@ -123,6 +152,10 @@
     
     if (self.answeredPrompt)
         return OSNotificationPermissionDenied;
+    
+    if (self.provisional)
+        return OSNotificationPermissionProvisional;
+    
     return OSNotificationPermissionNotDetermined;
 }
 
@@ -134,6 +167,8 @@
             return @"Authorized";
         case OSNotificationPermissionDenied:
             return @"Denied";
+        case OSNotificationPermissionProvisional:
+            return @"Provisional";
     }
     return @"NotDetermined";
 }
@@ -145,13 +180,14 @@
 }
 
 - (NSString*)description {
-    static NSString* format = @"<OSPermissionState: hasPrompted: %d, status: %@>";
-    return [NSString stringWithFormat:format, self.hasPrompted, self.statusAsString];
+    static NSString* format = @"<OSPermissionState: hasPrompted: %d, status: %@, provisional: %d>";
+    return [NSString stringWithFormat:format, self.hasPrompted, self.statusAsString, self.provisional];
 }
 
 - (NSDictionary*)toDictionary {
     return @{@"hasPrompted": @(self.hasPrompted),
-             @"status": @(self.status)};
+             @"status": @(self.status),
+             @"provisional" : @(self.provisional)};
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -207,7 +207,10 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
     OSNotificationPermissionDenied,
     
     // The application is authorized to post user notifications.
-    OSNotificationPermissionAuthorized
+    OSNotificationPermissionAuthorized,
+    
+    // the application is only authorized to post Provisional notifications (direct to history)
+    OSNotificationPermissionProvisional
 };
 
 
@@ -215,6 +218,7 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 // Permission Classes
 @interface OSPermissionState : NSObject
 
+@property (readonly, nonatomic) BOOL reachable;
 @property (readonly, nonatomic) BOOL hasPrompted;
 @property (readonly, nonatomic) OSNotificationPermission status;
 - (NSDictionary*)toDictionary;
@@ -357,6 +361,7 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 // Only use if you set kOSSettingsKeyAutoPrompt to false
 + (void)registerForPushNotifications __deprecated_msg("Please use promptForPushNotificationsWithUserResponse instead.");
 + (void)promptForPushNotificationsWithUserResponse:(void(^)(BOOL accepted))completionHandler;
++ (void)registerForProvisionalAuthorization:(void(^)(BOOL accepted))completionHandler;
 
 // - Logging
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -149,6 +149,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
  Keep the raw value for users that would like to root the push */
 @property(readonly)NSDictionary *rawPayload;
 
+/* iOS 10+ : Groups notifications into threads */
+@property(readonly)NSString *threadId;
+
 @end
 
 // ## OneSignal OSNotification

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -46,6 +46,20 @@
 #define EMAIL_ADDRESS @"EMAIL_ADDRESS"
 #define PROMPT_BEFORE_OPENING_PUSH_URL @"PROMPT_BEFORE_OPENING_PUSH_URL"
 #define DEPRECATED_SELECTORS @[@"application:didReceiveLocalNotification:", @"application:handleActionWithIdentifier:forLocalNotification:completionHandler:", @"application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:"]
+#define USES_PROVISIONAL_AUTHORIZATION @"ONESIGNAL_USES_PROVISIONAL_PUSH_AUTHORIZATION"
+#define PERMISSION_HAS_PROMPTED @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"
+#define PERMISSION_ANSWERED_PROMPT @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"
+#define PERMISSION_ACCEPTED @"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"
+#define PERMISSION_PROVISIONAL_STATUS @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"
+
+// To avoid undefined symbol compiler errors on older versions of Xcode,
+// instead of using UNAuthorizationOptionProvisional directly, we will use
+// it indirectly with this macro
+#define PROVISIONAL_UNAUTHORIZATIONOPTION (UNAuthorizationOptions)(1 << 6)
+
+// iOS Parameter Names
+#define IOS_USES_PROVISIONAL_AUTHORIZATION @"uses_provisional_auth"
+#define IOS_REQUIRES_EMAIL_AUTHENTICATION @"require_email_auth"
 
 // GDPR Privacy Consent
 #define GDPR_CONSENT_GRANTED @"GDPR_CONSENT_GRANTED"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettings.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettings.h
@@ -36,9 +36,9 @@
 
 - (int) getNotificationTypes;
 - (OSPermissionState*)getNotificationPermissionState;
-- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionState))completionHandler;
+- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subscriptionState))completionHandler;
 - (void)promptForNotifications:(void(^)(BOOL accepted))completionHandler;
-
+- (void)registerForProvisionalAuthorization:(void(^)(BOOL accepted))completionHandler;
 // Only used for iOS 8 & 9
 - (void)onNotificationPromptResponse:(int)notificationTypes;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -39,7 +39,7 @@
     void (^notificationPromptReponseCallback)(BOOL);
 }
 
-- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
+- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subscriptionStatus))completionHandler {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     OSPermissionState* status = OneSignal.currentPermissionState;
     
@@ -47,6 +47,7 @@
     status.notificationTypes = [userDefaults stringForKey:DEVICE_TOKEN] == nil ? 0 : 7;
     status.accepted = status.notificationTypes > 0;
     status.answeredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
+    status.provisional = false;
     
     completionHandler(status);
 }
@@ -81,6 +82,7 @@
 
 // Only iOS 8 & 9
 - (void)onNotificationPromptResponse:(int)notificationTypes {}
+- (void)registerForProvisionalAuthorization:(void(^)(BOOL accepted))completionHandler {}
 
 // Only iOS 7
 - (void)onAPNsResponse:(BOOL)success {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -37,13 +37,14 @@
     void (^notificationPromptReponseCallback)(BOOL);
 }
 
-- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subcscriptionStatus))completionHandler {
+- (void)getNotificationPermissionState:(void (^)(OSPermissionState *subscriptionStatus))completionHandler {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     OSPermissionState* status = OneSignal.currentPermissionState;
     
     status.notificationTypes = [[UIApplication sharedApplication] currentUserNotificationSettings].types;
     status.accepted = status.notificationTypes > 0;
     status.answeredPrompt = [userDefaults boolForKey:@"OS_NOTIFICATION_PROMPT_ANSWERED"];
+    status.provisional = false;
     
     completionHandler(status);
 }
@@ -90,6 +91,7 @@
 
 // Only iOS 7 - The above is used for iOS 8 & 9
 - (void)onAPNsResponse:(BOOL)success {}
+- (void)registerForProvisionalAuthorization:(void(^)(BOOL accepted))completionHandler {}
 
 #pragma GCC diagnostic pop
 

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -35,6 +35,7 @@
 #import "OneSignalHelper.h"
 #import "OneSignalSelectorHelpers.h"
 #import "UIApplicationDelegate+OneSignal.h"
+#import "OneSignalCommonDefines.h"
 
 
 #if XC8_AVAILABLE
@@ -94,13 +95,20 @@ static BOOL useCachedUNNotificationSettings;
 static UNNotificationSettings* cachedUNNotificationSettings;
 
 - (void)onesignalRequestAuthorizationWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError *__nullable error))completionHandler {
-    OneSignal.currentPermissionState.hasPrompted = true;
+    
+    BOOL notProvisionalRequest = options != PROVISIONAL_UNAUTHORIZATIONOPTION;
+    
+    //we don't want to modify these settings if the authorization is provisional (iOS 12 'Direct to History')
+    if (notProvisionalRequest)
+        OneSignal.currentPermissionState.hasPrompted = true;
     
     useCachedUNNotificationSettings = true;
     id wrapperBlock = ^(BOOL granted, NSError* error) {
         useCachedUNNotificationSettings = false;
-        OneSignal.currentPermissionState.accepted = granted;
-        OneSignal.currentPermissionState.answeredPrompt = true;
+        if (notProvisionalRequest) {
+            OneSignal.currentPermissionState.accepted = granted;
+            OneSignal.currentPermissionState.answeredPrompt = true;
+        }
         completionHandler(granted, error);
     };
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -428,6 +428,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     
     [OneSignalTracker onFocus:false];
     
+    [UnitTestCommonMethods runBackgroundThreads];
+    
     [OneSignalTracker setLastOpenedTime:now - 4000];
     
     [OneSignalTracker onFocus:true];
@@ -460,6 +462,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     [OneSignalTracker setLastOpenedTime:now - 4000];
     
     [OneSignalTracker onFocus:false];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
     
     [OneSignalTracker setLastOpenedTime:now - 4000];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
@@ -1,0 +1,193 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "UnitTestCommonMethods.h"
+#import "OneSignalExtensionBadgeHandler.h"
+#import "NSUserDefaultsOverrider.h"
+#import "UNUserNotificationCenterOverrider.h"
+#import "UNUserNotificationCenter+OneSignal.h"
+#import "OneSignalHelperOverrider.h"
+#import "OneSignalHelper.h"
+#import "OneSignalCommonDefines.h"
+#import "OneSignalClientOverrider.h"
+
+@interface ProvisionalAuthorizationTests : XCTestCase
+
+@end
+
+@interface OSPermissionState ()
+@property (nonatomic) BOOL provisional;
+@end
+
+@implementation ProvisionalAuthorizationTests
+
+- (OSPermissionStateTestObserver *)setupProvisionalTest {
+    [UnitTestCommonMethods clearStateForAppRestart:self];
+    
+    [UNUserNotificationCenterOverrider setNotifTypesOverride:0];
+    [UNUserNotificationCenterOverrider setAuthorizationStatus:@0];
+    
+    OneSignalHelperOverrider.mockIOSVersion = 12;
+    
+    [OneSignalClientOverrider setShouldUseProvisionalAuth:true];
+    
+    OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
+    [OneSignal addPermissionObserver:observer];
+    return observer;
+}
+
+// Tests to make sure that apps set to use Provisional authorization work & register correctly
+- (void)testProvisionalPermissionState {
+    if (@available(iOS 12, *)) {
+        OSPermissionStateTestObserver* observer = [self setupProvisionalTest];
+        [UNUserNotificationCenterOverrider setShouldSetProvisionalAuthorizationStatus:true];
+        
+        OSSubscriptionStateTestObserver *subscriptionObserver = [OSSubscriptionStateTestObserver new];
+        [OneSignal addSubscriptionObserver:subscriptionObserver];
+        
+        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+                handleNotificationAction:nil
+                                settings:@{kOSSettingsKeyAutoPrompt: @false}];
+        
+        let state = [OneSignal getPermissionSubscriptionState];
+        
+        XCTAssertFalse(state.permissionStatus.reachable);
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        [UNUserNotificationCenterOverrider fireLastRequestAuthorizationWithGranted:true];
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        XCTAssertTrue(UNUserNotificationCenterOverrider.lastRequestedAuthorizationOptions == PROVISIONAL_UNAUTHORIZATIONOPTION);
+        
+        XCTAssertTrue(observer->last.to.provisional);
+        XCTAssertFalse(observer->last.from.provisional);
+        
+        XCTAssertTrue(observer->last.to.reachable);
+        XCTAssertFalse(observer->last.from.reachable);
+        
+        XCTAssertEqual(observer->last.from.status, OSNotificationPermissionNotDetermined);
+        XCTAssertEqual(observer->last.to.status, OSNotificationPermissionProvisional);
+        
+        //make sure registration occurred
+        XCTAssertEqual(subscriptionObserver->last.to.userId, @"1234");
+    }
+}
+
+// tests to make sure that apps can still prompt for regular
+// push authorization when they use Provisional authorization
+- (void)testPromptWorksWithProvisional {
+    if (@available(iOS 12, *)) {
+        OSPermissionStateTestObserver* observer = [self setupProvisionalTest];
+        [UNUserNotificationCenterOverrider setShouldSetProvisionalAuthorizationStatus:true];
+        
+        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+                handleNotificationAction:nil
+                                settings:@{kOSSettingsKeyAutoPrompt: @false}];
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        [UNUserNotificationCenterOverrider fireLastRequestAuthorizationWithGranted:true];
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        XCTAssertTrue(observer->last.to.provisional);
+        XCTAssertFalse(observer->last.from.provisional);
+        
+        XCTAssertTrue(observer->last.to.reachable);
+        XCTAssertFalse(observer->last.from.reachable);
+        
+        XCTAssertEqual(observer->last.from.status, OSNotificationPermissionNotDetermined);
+        XCTAssertEqual(observer->last.to.status, OSNotificationPermissionProvisional);
+        
+        [OneSignal promptForPushNotificationsWithUserResponse:nil];
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        [UnitTestCommonMethods answerNotificationPrompt:true];
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        XCTAssertTrue(observer->last.to.reachable);
+        XCTAssertTrue(observer->last.from.reachable);
+        
+        XCTAssertFalse(UNUserNotificationCenterOverrider.lastRequestedAuthorizationOptions == PROVISIONAL_UNAUTHORIZATIONOPTION);
+        XCTAssertFalse(observer->last.to.provisional);
+        XCTAssertTrue(observer->last.from.provisional);
+        
+        XCTAssertEqual(observer->last.to.status, OSNotificationPermissionAuthorized);
+    }
+}
+
+// if the app sets autoPrompt to true, there is no point in requesting provisional authorization
+// thus, the SDK should never request it if autoPrompt = true.
+- (void)testProvisionalOverridenByAutoPrompt {
+    if (@available(iOS 12, *)) {
+        OSPermissionStateTestObserver* observer = [self setupProvisionalTest];
+        
+        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+                handleNotificationAction:nil
+                                settings:@{kOSSettingsKeyAutoPrompt: @true}];
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        //ensure the SDK did not request provisional authorization
+        XCTAssertFalse(observer->last.to.provisional);
+        XCTAssertFalse(observer->last.from.provisional);
+    }
+}
+
+- (void)testNoProvisionalAuthorization {
+    if (@available(iOS 12, *)) {
+        [UnitTestCommonMethods clearStateForAppRestart:self];
+        
+        [UNUserNotificationCenterOverrider setNotifTypesOverride:0];
+        [UNUserNotificationCenterOverrider setAuthorizationStatus:@0];
+        
+        OneSignalHelperOverrider.mockIOSVersion = 12;
+        
+        [OneSignalClientOverrider setShouldUseProvisionalAuth:false];
+        
+        OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
+        [OneSignal addPermissionObserver:observer];
+        
+        [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+                handleNotificationAction:nil
+                                settings:@{kOSSettingsKeyAutoPrompt: @false}];
+        
+        [UnitTestCommonMethods runBackgroundThreads];
+        
+        //ensure the SDK did not request provisional authorization
+        XCTAssertFalse(observer->last.to.provisional);
+        XCTAssertFalse(observer->last.from.provisional);
+        
+        XCTAssertEqual(observer->last.to.status, OSNotificationPermissionNotDetermined);
+    }
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -42,5 +42,6 @@
 +(NSString *)lastHTTPRequestType;
 +(void)setRequiresEmailAuth:(BOOL)required;
 +(BOOL)hasExecutedRequestOfType:(Class)type;
++(void)setShouldUseProvisionalAuth:(BOOL)provisional;
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -34,6 +34,7 @@
 #import "OneSignalRequest.h"
 #import "OneSignalSelectorHelpers.h"
 #import "Requests.h"
+#import "OneSignalCommonDefines.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -49,6 +50,7 @@ static dispatch_queue_t executionQueue;
 static NSString *lastHTTPRequestType;
 static BOOL requiresEmailAuth = false;
 static NSMutableArray<NSString *> *executedRequestTypes;
+static BOOL shouldUseProvisionalAuthorization = false; //new in iOS 12 (aka Direct to History)
 
 + (void)load {
     serialMockMainLooper = dispatch_queue_create("com.onesignal.unittest", DISPATCH_QUEUE_SERIAL);
@@ -126,7 +128,7 @@ static NSMutableArray<NSString *> *executedRequestTypes;
         
         if (successBlock) {
             if ([request isKindOfClass:[OSRequestGetIosParams class]])
-                successBlock(@{@"fba": @true, @"require_email_auth" : @(requiresEmailAuth)});
+                successBlock(@{@"fba": @true, IOS_REQUIRES_EMAIL_AUTHENTICATION : @(requiresEmailAuth), IOS_USES_PROVISIONAL_AUTHORIZATION : @(shouldUseProvisionalAuthorization)});
             else
                 successBlock(@{@"id": @"1234"});
         }
@@ -155,7 +157,7 @@ static NSMutableArray<NSString *> *executedRequestTypes;
 
 +(void)reset:(XCTestCase*)testInstance {
     currentTestInstance = testInstance;
-    
+    shouldUseProvisionalAuthorization = false;
     networkRequestCount = 0;
     lastUrl = nil;
     lastHTTPRequest = nil;
@@ -187,6 +189,10 @@ static NSMutableArray<NSString *> *executedRequestTypes;
 
 +(void)setRequiresEmailAuth:(BOOL)required {
     requiresEmailAuth = required;
+}
+
++(void)setShouldUseProvisionalAuth:(BOOL)provisional {
+    shouldUseProvisionalAuthorization = provisional;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.h
@@ -47,4 +47,8 @@
 +(void) fireLastRequestAuthorizationWithGranted:(BOOL)granted;
 
 + (void)failIfInNotificationSettingsWithCompletionHandler;
+
++(void)setShouldSetProvisionalAuthorizationStatus:(BOOL)provisional;
+
++ (UNAuthorizationOptions)lastRequestedAuthorizationOptions;
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -40,6 +40,8 @@ NSString * serverUrlWithPath(NSString *path);
 + (void)beforeAllTest;
 + (void)clearStateForAppRestart:(XCTestCase *)testCase;
 + (UNNotificationResponse*)createBasiciOSNotificationResponseWithPayload:(NSDictionary*)userInfo;
++ (void)answerNotificationPrompt:(BOOL)accept;
++ (void)setCurrentNotificationPermission:(BOOL)accepted;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -42,6 +42,7 @@
 #import "UIAlertViewOverrider.h"
 #import "NSObjectOverrider.h"
 #import "OneSignalCommonDefines.h"
+#import "NSBundleOverrider.h"
 
 
 NSString * serverUrlWithPath(NSString *path) {
@@ -58,7 +59,7 @@ NSString * serverUrlWithPath(NSString *path) {
 + (void)runBackgroundThreads {
     NSLog(@"START runBackgroundThreads");
     
-    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
     
     // the httpQueue makes sure all HTTP request mocks are sync'ed
     
@@ -174,6 +175,47 @@ NSString * serverUrlWithPath(NSString *path) {
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateActive;
     UIApplication *sharedApp = [UIApplication sharedApplication];
     [sharedApp.delegate applicationDidBecomeActive:sharedApp];
+}
+
++ (void)setCurrentNotificationPermission:(BOOL)accepted {
+    if (accepted) {
+        UNUserNotificationCenterOverrider.notifTypesOverride = 7;
+        UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusAuthorized];
+    }
+    else {
+        UNUserNotificationCenterOverrider.notifTypesOverride = 0;
+        UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusDenied];
+    }
+}
+
++ (void)answerNotificationPrompt:(BOOL)accept {
+    // iOS 10.2.1 Real device obserserved sequence of events:
+    //   1. Call requestAuthorizationWithOptions to prompt for notifications.
+    ///  2. App goes out of focus when the prompt is shown.
+    //   3. User press ACCPET! and focus event fires.
+    //   4. *(iOS bug?)* We check permission with currentNotificationCenter.getNotificationSettingsWithCompletionHandler and it show up as UNAuthorizationStatusDenied!?!?!
+    //   5. Callback passed to getNotificationSettingsWithCompletionHandler then fires with Accpeted as TRUE.
+    //   6. Check getNotificationSettingsWithCompletionHandler and it is then correctly reporting UNAuthorizationStatusAuthorized
+    //   7. Note: If remote notification background modes are on then application:didRegisterForRemoteNotificationsWithDeviceToken: will fire after #5 on it's own.
+    BOOL triggerDidRegisterForRemoteNotfications = (UNUserNotificationCenterOverrider.authorizationStatus == [NSNumber numberWithInteger:UNAuthorizationStatusNotDetermined] && accept);
+    if (triggerDidRegisterForRemoteNotfications)
+        [self setCurrentNotificationPermission:false];
+    
+    [UnitTestCommonMethods resumeApp];
+    [self setCurrentNotificationPermission:accept];
+    
+    if (triggerDidRegisterForRemoteNotfications && NSBundleOverrider.nsbundleDictionary[@"UIBackgroundModes"])
+        [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
+    
+    if (OneSignalHelperOverrider.mockIOSVersion > 9) {
+        [UNUserNotificationCenterOverrider fireLastRequestAuthorizationWithGranted:accept];
+    } else if (OneSignalHelperOverrider.mockIOSVersion > 7) {
+        UIApplication *sharedApp = [UIApplication sharedApplication];
+        [sharedApp.delegate application:sharedApp didRegisterUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:UNUserNotificationCenterOverrider.notifTypesOverride categories:nil]];
+    }
+    else  { // iOS 7 - Only support accepted for now.
+        [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
+    }
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -128,50 +128,9 @@
     NSBundleOverrider.nsbundleDictionary = @{};
 }
 
-- (void)setCurrentNotificationPermission:(BOOL)accepted {
-    if (accepted) {
-        UNUserNotificationCenterOverrider.notifTypesOverride = 7;
-        UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusAuthorized];
-    }
-    else {
-        UNUserNotificationCenterOverrider.notifTypesOverride = 0;
-        UNUserNotificationCenterOverrider.authorizationStatus = [NSNumber numberWithInteger:UNAuthorizationStatusDenied];
-    }
-}
-
 - (void)registerForPushNotifications {
     [OneSignal registerForPushNotifications];
     [self backgroundApp];
-}
-
-- (void)answerNotifiationPrompt:(BOOL)accept {
-    // iOS 10.2.1 Real device obserserved sequence of events:
-    //   1. Call requestAuthorizationWithOptions to prompt for notifications.
-    ///  2. App goes out of focus when the prompt is shown.
-    //   3. User press ACCPET! and focus event fires.
-    //   4. *(iOS bug?)* We check permission with currentNotificationCenter.getNotificationSettingsWithCompletionHandler and it show up as UNAuthorizationStatusDenied!?!?!
-    //   5. Callback passed to getNotificationSettingsWithCompletionHandler then fires with Accpeted as TRUE.
-    //   6. Check getNotificationSettingsWithCompletionHandler and it is then correctly reporting UNAuthorizationStatusAuthorized
-    //   7. Note: If remote notification background modes are on then application:didRegisterForRemoteNotificationsWithDeviceToken: will fire after #5 on it's own.
-    BOOL triggerDidRegisterForRemoteNotfications = (UNUserNotificationCenterOverrider.authorizationStatus == [NSNumber numberWithInteger:UNAuthorizationStatusNotDetermined] && accept);
-    if (triggerDidRegisterForRemoteNotfications)
-        [self setCurrentNotificationPermission:false];
-    
-    [UnitTestCommonMethods resumeApp];
-    [self setCurrentNotificationPermission:accept];
-    
-    if (triggerDidRegisterForRemoteNotfications && NSBundleOverrider.nsbundleDictionary[@"UIBackgroundModes"])
-        [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
-    
-    if (OneSignalHelperOverrider.mockIOSVersion > 9) {
-        [UNUserNotificationCenterOverrider fireLastRequestAuthorizationWithGranted:accept];
-    } else if (OneSignalHelperOverrider.mockIOSVersion > 7) {
-        UIApplication *sharedApp = [UIApplication sharedApplication];
-        [sharedApp.delegate application:sharedApp didRegisterUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:UNUserNotificationCenterOverrider.notifTypesOverride categories:nil]];
-    }
-    else  { // iOS 7 - Only support accepted for now.
-        [UIApplicationOverrider helperCallDidRegisterForRemoteNotificationsWithDeviceToken];
-    }
 }
 
 - (void)backgroundApp {
@@ -216,6 +175,7 @@
     XCTAssertTrue(status.permissionStatus.accepted);
     XCTAssertTrue(status.permissionStatus.hasPrompted);
     XCTAssertTrue(status.permissionStatus.answeredPrompt);
+    XCTAssertFalse(status.permissionStatus.provisional);
     
     NSLog(@"CURRENT USER ID: %@", status.subscriptionStatus);
     
@@ -308,7 +268,7 @@
     
     [self initOneSignalAndThreadWait];
     
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
@@ -344,7 +304,7 @@
 }
 
 - (void)testCallingMethodsBeforeInit {
-    [self setCurrentNotificationPermission:true];
+    [UnitTestCommonMethods setCurrentNotificationPermission:true];
     
     [OneSignal sendTag:@"key" value:@"value"];
     [OneSignal setSubscription:true];
@@ -401,8 +361,10 @@
     XCTAssertEqual(observer->last.to.hasPrompted, true);
     XCTAssertEqual(observer->last.to.answeredPrompt, false);
     XCTAssertEqual(observer->fireCount, 1);
+    XCTAssertEqual(observer->last.from.provisional, false);
+    XCTAssertEqual(observer->last.to.provisional, false);
     
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->last.from.accepted, false);
@@ -411,10 +373,8 @@
     
     // Make sure it doesn't fire for answeredPrompt then again right away for accepted
     XCTAssertEqual(observer->fireCount, 2);
-    
-    XCTAssertEqualObjects([observer->last description], @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: NotDetermined>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized>\n>");
+    XCTAssertEqualObjects([observer->last description], @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: NotDetermined, provisional: 0>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>\n>");
 }
-
 
 - (void)testPermissionChangeObserverWhenAlreadyAccepted {
     [self initOneSignalAndThreadWait];
@@ -438,7 +398,7 @@
     
     // User kills app, turns off notifications, then opnes it agian.
     [UnitTestCommonMethods clearStateForAppRestart:self];
-    [self setCurrentNotificationPermission:false];
+    [UnitTestCommonMethods setCurrentNotificationPermission:false];
     [self initOneSignalAndThreadWait];
     
     // Added Observer should be notified of the change right away.
@@ -475,7 +435,7 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Restart App
@@ -501,7 +461,7 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     [self registerForPushNotifications];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
@@ -535,7 +495,7 @@
     
     // User kills app, turns off notifications, then opnes it agian.
     [UnitTestCommonMethods clearStateForAppRestart:self];
-    [self setCurrentNotificationPermission:false];
+    [UnitTestCommonMethods setCurrentNotificationPermission:false];
     [self initOneSignalAndThreadWait];
     
     // Added Observer should be notified of the change right away.
@@ -564,16 +524,17 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->fireCount, 1);
+    NSLog(@"Sub desc: %@", [observer->last description]);
     XCTAssertEqualObjects([observer->last description],
-                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 0, status: NotDetermined>,\nto:   <OSPermissionState: hasPrompted: 1, status: NotDetermined>\n>");
+                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 0, status: NotDetermined, provisional: 0>,\nto:   <OSPermissionState: hasPrompted: 1, status: NotDetermined, provisional: 0>\n>");
     
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Make sure it doesn't fire for answeredPrompt then again right away for accepted
     XCTAssertEqual(observer->fireCount, 2);
     XCTAssertEqualObjects([observer->last description],
-                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: NotDetermined>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized>\n>");
+                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: NotDetermined, provisional: 0>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>\n>");
 }
 
 // Yes, this starts with testTest, we are testing our Unit Test behavior!
@@ -594,13 +555,13 @@
                           completionHandler:^(BOOL granted, NSError* error) {}];
     [self backgroundApp];
     // Full bug details explained in answerNotifiationPrompt
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->fireCount, 3);
     
     XCTAssertEqualObjects([observer->last description],
-                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: Denied>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized>\n>");
+                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: Denied, provisional: 0>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>\n>");
 }
 
 - (void)testPermissionChangeObserverWithDecline {
@@ -621,7 +582,7 @@
     XCTAssertEqual(observer->last.to.answeredPrompt, false);
     XCTAssertEqual(observer->fireCount, 1);
     
-    [self answerNotifiationPrompt:false];
+    [UnitTestCommonMethods answerNotificationPrompt:false];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->last.from.accepted, false);
@@ -647,7 +608,7 @@
     [OneSignal removeSubscriptionObserver:subscriptionObserver];
     
     [self registerForPushNotifications];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertNil(permissionObserver->last);
@@ -664,7 +625,7 @@
     [OneSignal addSubscriptionObserver:observer];
     
     [self registerForPushNotifications];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->last.from.subscribed, false);
@@ -708,7 +669,7 @@
     
     // Prompt and accept notifications
     [self registerForPushNotifications];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Shouldn't be subscribed yet as we called setSubscription:false before
@@ -731,7 +692,7 @@
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
     [UnitTestCommonMethods runBackgroundThreads];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
@@ -750,7 +711,7 @@
         didAccept = accepted;
     }];
     [self backgroundApp];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(didAccept);
 }
@@ -766,7 +727,7 @@
         didAccept = accepted;
     }];
     [self backgroundApp];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(didAccept);
 }
@@ -782,7 +743,7 @@
         didAccept = accepted;
     }];
     [self backgroundApp];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(didAccept);
 }
@@ -806,7 +767,7 @@
 
 - (void)testNotificationTypesWhenAlreadyAcceptedWithAutoPromptOffOnFristStartPreIos10 {
     OneSignalHelperOverrider.mockIOSVersion = 8;
-    [self setCurrentNotificationPermission:true];
+    [UnitTestCommonMethods setCurrentNotificationPermission:true];
     
     [OneSignal initWithLaunchOptions:nil
                                appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
@@ -845,7 +806,7 @@
     // Don't make a network call right away.
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
-    [self answerNotifiationPrompt:false];
+    [UnitTestCommonMethods answerNotificationPrompt:false];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, serverUrlWithPath(@"players"));
@@ -869,7 +830,7 @@
     
     [self registerForPushNotifications];
     
-    [self answerNotifiationPrompt:false];
+    [UnitTestCommonMethods answerNotificationPrompt:false];
     
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(idsAvailable1Called);
@@ -1527,7 +1488,7 @@ didReceiveRemoteNotification:userInfo
     // Do not try to send tag update yet as there isn't a player_id yet.
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
     
-    [self answerNotifiationPrompt:false];
+    [UnitTestCommonMethods answerNotificationPrompt:false];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // A single POST player create call should be made with tags included.
@@ -1584,7 +1545,7 @@ didReceiveRemoteNotification:userInfo
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
     
     [self backgroundApp];
-    [self setCurrentNotificationPermission:true];
+    [UnitTestCommonMethods setCurrentNotificationPermission:true];
     [UnitTestCommonMethods resumeApp];
     [UnitTestCommonMethods runBackgroundThreads];
     
@@ -1828,7 +1789,7 @@ didReceiveRemoteNotification:userInfo
     
     // Prompt and accept notifications
     [self registerForPushNotifications];
-    [self answerNotifiationPrompt:true];
+    [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Shouldn't be subscribed yet as we called setSubscription:false before

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1137,6 +1137,8 @@
         XCTAssertEqualObjects(result.notification.payload.actionButtons, actionButons);
         XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
         
+        XCTAssertEqualObjects(result.notification.payload.threadId, @"test1");
+        
         openedWasFire = true;
     };
     
@@ -1164,7 +1166,8 @@
                              @"mutable-content" : @1,
                              @"alert" : @{
                                      @"title" : @"Test Title"
-                                     }
+                                     },
+                             @"thread-id" : @"test1"
                              },
                      @"buttons" : @[@{@"i": @"id1", @"n": @"text1"}],
                      @"custom" : @{
@@ -1178,7 +1181,8 @@
 - (void)testNewFormatNotificationAlertButtonsDisplay {
     id newFormat = @{@"aps": @{
                              @"mutable-content": @1,
-                             @"alert": @{@"body": @"Message Body", @"title": @"title"}
+                             @"alert": @{@"body": @"Message Body", @"title": @"title"},
+                             @"thread-id": @"test1"
                              },
                      @"os_data": @{
                              @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55bf",


### PR DESCRIPTION
**NOTE**: Test fails because `answerNotifiationPrompt` was misspelled and corrected, will be corrected after merge

• Adds support in the SDK for Provisional notification authorization
• This allows developers to send notifications directly without prompting for permission, however, the notification is sent directly to Notification Center (History) without alerting the user.
• This will be configurable through the Dashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/384)
<!-- Reviewable:end -->
