### PR TITLE
Prevent Request Caching

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -29,11 +29,7 @@
 #import "UIApplicationDelegate+OneSignal.h"
 #import "ReattemptRequest.h"
 #import "OneSignal.h"
-
-#define REATTEMPT_DELAY 30.0
-#define REQUEST_TIMEOUT_REQUEST 60.0 //for most HTTP requests
-#define REQUEST_TIMEOUT_RESOURCE 100.0 //for loading a resource like an image
-#define MAX_ATTEMPT_COUNT 3
+#import "OneSignalCommonDefines.h"
 
 @interface OneSignal (OneSignalClientExtra)
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName;
@@ -41,6 +37,7 @@
 
 @interface OneSignalClient ()
 @property (strong, nonatomic) NSURLSession *sharedSession;
+@property (strong, nonatomic) NSURLSession *noCacheSession;
 @end
 
 @implementation OneSignalClient
@@ -56,14 +53,23 @@
 
 -(instancetype)init {
     if (self = [super init]) {
-        let configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-        configuration.timeoutIntervalForRequest = REQUEST_TIMEOUT_REQUEST;
-        configuration.timeoutIntervalForResource = REQUEST_TIMEOUT_RESOURCE;
-        
-        _sharedSession = [NSURLSession sessionWithConfiguration:configuration];
+        _sharedSession = [NSURLSession sessionWithConfiguration:[self configurationWithCachingPolicy:NSURLRequestUseProtocolCachePolicy]];
+        _noCacheSession = [NSURLSession sessionWithConfiguration:[self configurationWithCachingPolicy:NSURLRequestReloadIgnoringLocalCacheData]];
     }
     
     return self;
+}
+
+- (NSURLSessionConfiguration *)configurationWithCachingPolicy:(NSURLRequestCachePolicy)policy {
+    let configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    configuration.timeoutIntervalForRequest = REQUEST_TIMEOUT_REQUEST;
+    configuration.timeoutIntervalForResource = REQUEST_TIMEOUT_RESOURCE;
+    
+    //prevent caching of requests, this mainly impacts OSRequestGetIosParams,
+    //since the OSRequestGetTags endpoint has a caching header policy
+    configuration.requestCachePolicy = policy;
+    
+    return configuration;
 }
 
 - (void)executeSimultaneousRequests:(NSDictionary<NSString *, OneSignalRequest *> *)requests withSuccess:(OSMultipleSuccessBlock)successBlock onFailure:(OSMultipleFailureBlock)failureBlock {
@@ -117,7 +123,15 @@
         return;
     }
     
-    let task = [self.sharedSession dataTaskWithRequest:request.request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    /*
+        None of our requests should currently be cached locally.
+        However, to avoid any future confusion, each OneSignalRequest
+        has a property indicating if local caching should be
+        explicitly disabled for that request. The default is false.
+    */
+    var session = request.disableLocalCaching ? self.noCacheSession : self.sharedSession;
+    
+    let task = [session dataTaskWithRequest:request.urlRequest completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         [self handleJSONNSURLResponse:response data:data error:error isAsync:true withRequest:request onSuccess:successBlock onFailure:failureBlock];
     }];
     
@@ -137,7 +151,7 @@
     
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    let dataTask = [self.sharedSession dataTaskWithRequest:request.request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    let dataTask = [self.sharedSession dataTaskWithRequest:request.urlRequest completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         httpResponse = response;
         httpError = error;
         
@@ -214,7 +228,7 @@
     let data = [NSJSONSerialization dataWithJSONObject:request.parameters options:NSJSONWritingPrettyPrinted error:&error];
     let jsonString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"HTTP Request (%@) with URL: %@, with parameters: %@", NSStringFromClass([request class]), request.request.URL.absoluteString, jsonString]];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"HTTP Request (%@) with URL: %@, with parameters: %@", NSStringFromClass([request class]), request.urlRequest.URL.absoluteString, jsonString]];
 }
 
 - (void)handleJSONNSURLResponse:(NSURLResponse*)response data:(NSData*)data error:(NSError*)error isAsync:(BOOL)async withRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -81,4 +81,13 @@
 
 #define ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES @[@"aiff", @"wav", @"mp3", @"mp4", @"jpg", @"jpeg", @"png", @"gif", @"mpeg", @"mpg", @"avi", @"m4a", @"m4v"]
 
+// OneSignal API Client Defines
+typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
+
+#define REATTEMPT_DELAY 30.0
+#define REQUEST_TIMEOUT_REQUEST 60.0 //for most HTTP requests
+#define REQUEST_TIMEOUT_RESOURCE 100.0 //for loading a resource like an image
+#define MAX_ATTEMPT_COUNT 3
+#define httpMethodString(enum) [@[@"GET", @"POST", @"HEAD", @"PUT", @"DELETE", @"OPTIONS", @"CONNECT", @"TRACE"] objectAtIndex:enum]
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
@@ -26,9 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-
-typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
-#define httpMethodString(enum) [@[@"GET", @"POST", @"HEAD", @"PUT", @"DELETE", @"OPTIONS", @"CONNECT", @"TRACE"] objectAtIndex:enum]
+#import "OneSignalCommonDefines.h"
 
 
 #ifndef OneSignalRequest_h
@@ -36,12 +34,14 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 
 @interface OneSignalRequest : NSObject
 
+@property (nonatomic) BOOL disableLocalCaching;
 @property (nonatomic) HTTPMethod method;
 @property (nonatomic, nonnull) NSString *path;
 @property (nonatomic, nullable) NSDictionary *parameters;
 @property (nonatomic) int reattemptCount;
 -(BOOL)missingAppId; //for requests that don't require an appId parameter, the subclass should override this method and return false
--(NSMutableURLRequest * _Nonnull )request;
+-(NSMutableURLRequest * _Nonnull )urlRequest;
+
 @end
 
 #endif

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
@@ -35,12 +35,13 @@
 - (id)init {
     if (self = [super init]) {
         self.reattemptCount = 0;
+        self.disableLocalCaching = false;
     }
     
     return self;
 }
 
--(NSMutableURLRequest *)request {
+-(NSMutableURLRequest *)urlRequest {
     //build URL
     let urlString = [[SERVER_URL stringByAppendingString:API_VERSION] stringByAppendingString:self.path];
     

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -29,6 +29,7 @@
 #import "Requests.h"
 #import "OneSignalRequest.h"
 #import "OneSignalHelper.h"
+#import "OneSignalCommonDefines.h"
 #import <stdlib.h>
 #import <stdio.h>
 #import <sys/types.h>
@@ -48,6 +49,12 @@
 }
 @end
 
+/*
+     NOTE: The OSRequestGetIosParams request will not return a Cache-Control header
+     this means that, by default, NSURLSession would cache the result
+     Since we do not want the parameters to be cached, we explicitly
+     disable this behavior using disableLocalCaching
+ */
 @implementation OSRequestGetIosParams
 + (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId {
     let request = [OSRequestGetIosParams new];
@@ -58,6 +65,7 @@
     
     request.method = GET;
     request.path = [NSString stringWithFormat:@"apps/%@/ios_params.js", appId];
+    request.disableLocalCaching = true;
     
     return request;
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -112,7 +112,7 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@?app_id=%@", testUserId, testAppId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
 }
 
 - (void)testBuildGetIosParams {
@@ -120,7 +120,7 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"apps/%@/ios_params.js?player_id=%@", testAppId, testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
 }
 
 - (void)testBuildPostNotification {
@@ -128,9 +128,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath(@"notifications");
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId}));
 }
 
 - (void)testSendTags {
@@ -138,9 +138,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId, @"tags" : @{}, @"net_type" : @0}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"tags" : @{}, @"net_type" : @0}));
 }
 
 - (void)testUpdateDeviceToken {
@@ -148,9 +148,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId, @"email" : testEmailAddress, @"notification_types" : @0, @"identifier" : @"test_device_token", @"parent_player_id" : @"test_parent_id"}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"email" : testEmailAddress, @"notification_types" : @0, @"identifier" : @"test_device_token", @"parent_player_id" : @"test_parent_id"}));
 }
 
 - (void)testCreateDevice {
@@ -158,9 +158,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath(@"players");
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId, @"device_type" : @0, @"identifier" : testEmailAddress, @"email_auth_hash" : [NSNull null], @"device_player_id" : testUserId}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"device_type" : @0, @"identifier" : testEmailAddress, @"email_auth_hash" : [NSNull null], @"device_player_id" : testUserId}));
 }
 
 - (void)testLogoutEmail {
@@ -168,9 +168,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@/email_logout", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"parent_player_id" : testEmailUserId, @"email_auth_hash" : [NSNull null], @"app_id" : testAppId}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"parent_player_id" : testEmailUserId, @"email_auth_hash" : [NSNull null], @"app_id" : testAppId}));
 }
 
 - (void)testUpdateNotificationTypes {
@@ -178,9 +178,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId, @"notification_types" : @0}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"notification_types" : @0}));
 }
 
 - (void)testSendPurchases {
@@ -188,15 +188,15 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@/on_purchase", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:standardRequest.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:standardRequest.urlRequest.URL.absoluteString]);
     
     let emailRequest = [OSRequestSendPurchases withUserId:testUserId emailAuthToken:@"email_auth_token" appId:testAppId withPurchases:@[]];
     
-    XCTAssertTrue([correctUrl isEqualToString:emailRequest.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:emailRequest.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(standardRequest.request.HTTPBody, @{@"app_id" : testAppId, @"purchases" : @[]}));
+    XCTAssertTrue(checkHttpBody(standardRequest.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"purchases" : @[]}));
     
-    XCTAssertTrue(checkHttpBody(emailRequest.request.HTTPBody, @{@"app_id" : testAppId, @"purchases" : @[], @"email_auth_hash" : @"email_auth_token"}));
+    XCTAssertTrue(checkHttpBody(emailRequest.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"purchases" : @[], @"email_auth_hash" : @"email_auth_token"}));
 }
 
 - (void)testSubmitNotificationOpened {
@@ -204,9 +204,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"notifications/%@", testMessageId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"player_id" : testUserId, @"app_id" : testAppId, @"opened" : @1}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"player_id" : testUserId, @"app_id" : testAppId, @"opened" : @1}));
 }
 
 - (void)testRegisterUser {
@@ -214,9 +214,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@/on_session", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"test_key" : @"test_value"}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"test_key" : @"test_value"}));
 }
 
 - (void)testSyncHashedEmail {
@@ -228,9 +228,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId, @"em_m" : md5Hash, @"em_s" : sha1Hash, @"net_type" : @1}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"em_m" : md5Hash, @"em_s" : sha1Hash, @"net_type" : @1}));
 }
 
 - (void)testSendLocation {
@@ -245,9 +245,9 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:request.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.request.HTTPBody, @{@"app_id" : testAppId, @"lat" : @3.0, @"long" : @4.0, @"loc_acc_vert" : @1.0, @"loc_acc" : @2.0, @"net_type" : @0, @"loc_bg" : @1}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"lat" : @3.0, @"long" : @4.0, @"loc_acc_vert" : @1.0, @"loc_acc" : @2.0, @"net_type" : @0, @"loc_bg" : @1}));
 }
 
 - (void)testOnFocus {
@@ -255,17 +255,17 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
-    XCTAssertTrue([correctUrl isEqualToString:firstRequest.request.URL.absoluteString]);
+    XCTAssertTrue([correctUrl isEqualToString:firstRequest.urlRequest.URL.absoluteString]);
     
     let secondRequest = [OSRequestOnFocus withUserId:testUserId appId:testAppId state:@"test_state" type:@1 activeTime:@2 netType:@3 emailAuthToken:nil];
     
     let secondCorrectUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@/on_focus", testUserId]);
     
-    XCTAssertTrue([secondCorrectUrl isEqualToString:secondRequest.request.URL.absoluteString]);
+    XCTAssertTrue([secondCorrectUrl isEqualToString:secondRequest.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(firstRequest.request.HTTPBody, @{@"app_id" : testAppId, @"badgeCount" : @0}));
+    XCTAssertTrue(checkHttpBody(firstRequest.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"badgeCount" : @0}));
     
-    XCTAssertTrue(checkHttpBody(secondRequest.request.HTTPBody, @{@"app_id" : testAppId, @"state" : @"test_state", @"type" : @1, @"active_time" : @2, @"net_type" : @3}));
+    XCTAssertTrue(checkHttpBody(secondRequest.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"state" : @"test_state", @"type" : @1, @"active_time" : @2, @"net_type" : @3}));
 }
 
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -113,12 +113,12 @@ static BOOL shouldUseProvisionalAuthorization = false; //new in iOS 12 (aka Dire
         
         NSMutableDictionary *parameters = [request.parameters mutableCopy];
         
-        if (!parameters[@"app_id"] && ![request.request.URL.absoluteString containsString:@"/apps/"])
+        if (!parameters[@"app_id"] && ![request.urlRequest.URL.absoluteString containsString:@"/apps/"])
             _XCTPrimitiveFail(currentTestInstance, @"All request should include an app_id");
         
         networkRequestCount++;
         
-        id url = [request.request URL];
+        id url = [request.urlRequest URL];
         NSLog(@"url: %@", url);
         NSLog(@"parameters: %@", parameters);
         

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1733,7 +1733,7 @@ didReceiveRemoteNotification:userInfo
     XCTAssert([request.parameters[@"tags"][@"tag1"] isEqualToString:@"test1"]);
     XCTAssert([request.path isEqualToString:@"players/12345"]);
     
-    let urlRequest = request.request;
+    let urlRequest = request.urlRequest;
     
     XCTAssert([urlRequest.URL.absoluteString isEqualToString:serverUrlWithPath(@"players/12345")]);
     XCTAssert([urlRequest.HTTPMethod isEqualToString:@"PUT"]);
@@ -1749,7 +1749,7 @@ didReceiveRemoteNotification:userInfo
     
     let request = [OSRequestSendTagsToServer withUserId:@"12345" appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" tags:invalidJson networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:nil];
     
-    let urlRequest = request.request;
+    let urlRequest = request.urlRequest;
     
     XCTAssertNil(urlRequest.HTTPBody);
     


### PR DESCRIPTION
• `NSURLSession`'s default configuration will cache resource requests locally (ie. our iOS Parameters request)
• Since we want changes to the iOS params to be reflected relatively quickly on clients, we need to disable caching
• None of our requests should actually be cached currently, but to avoid confusion, we will add a `disableLocalCaching` parameter to the `OneSignalRequest` class to control this behavior explicitly on a per-request basis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/385)
<!-- Reviewable:end -->
