### PR TITLE
Provisional null check

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -668,8 +668,7 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
                 delayedEmailParameters = nil;
             }
         }
-        
-        if (!usesAutoPrompt && result[IOS_USES_PROVISIONAL_AUTHORIZATION] && [result[IOS_USES_PROVISIONAL_AUTHORIZATION] boolValue]) {
+        if (!usesAutoPrompt && result[IOS_USES_PROVISIONAL_AUTHORIZATION] && result[IOS_USES_PROVISIONAL_AUTHORIZATION] != [NSNull null] && [result[IOS_USES_PROVISIONAL_AUTHORIZATION] boolValue]) {
             let defaults = [NSUserDefaults standardUserDefaults];
             
             [defaults setObject:@true forKey:USES_PROVISIONAL_AUTHORIZATION];


### PR DESCRIPTION
• In situations where developers send an invalid app ID, the backend returns <null> as the iOS parameter for the `uses_provisional_auth` setting
• This was crashing the app, because in Objective-C, the parameter was being set to `NSNull` and not `nil`. The SDK was only checking to make sure it wasn't nil (not null) before attempting to cast it to a boolean value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/387)
<!-- Reviewable:end -->
