### PR TITLE
Nil Block Checks

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -108,7 +108,12 @@
 - (void)executeRequest:(OneSignalRequest *)request onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
     
     if (request.method != GET && [OneSignal shouldLogMissingPrivacyConsentErrorWithMethodName:nil]) {
-        failureBlock([NSError errorWithDomain:@"OneSignal Error" code:0 userInfo:@{@"error" : [NSString stringWithFormat:@"Attempted to perform an HTTP request (%@) before the user provided privacy consent.", NSStringFromClass(request.class)]}]);
+        if (failureBlock) {
+            failureBlock([NSError errorWithDomain:@"OneSignal Error" code:0
+                    userInfo:@{@"error" : [NSString stringWithFormat:
+                                    @"Attempted to perform an HTTP request (%@) before the user provided privacy consent.", NSStringFromClass(request.class)]}]);
+        }
+        
         return;
     }
     
@@ -156,7 +161,8 @@
     
     [OneSignal onesignal_Log:ONE_S_LL_ERROR message:errorDescription];
     
-    failureBlock([NSError errorWithDomain:@"OneSignalError" code:-1 userInfo:@{@"error" : errorDescription}]);
+    if (failureBlock)
+        failureBlock([NSError errorWithDomain:@"OneSignalError" code:-1 userInfo:@{@"error" : errorDescription}]);
 }
 
 - (BOOL)validRequest:(OneSignalRequest *)request {


### PR DESCRIPTION
• In the OneSignalClient class that handles network request logic, there were rare cases where the SDK was attempting to execute blocks that could potentially be nil
• Adds checks to ensure these blocks aren't executed if they're nil (fixes #391)