### PR TITLE
Check Registration

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -82,4 +82,8 @@
 // Registration delay
 #define REGISTRATION_DELAY_SECONDS 30.0
 
+// How long the SDK will wait for APNS to respond
+// before registering the user anyways
+#define APNS_TIMEOUT 25.0
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -64,4 +64,22 @@
 
 #define ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES @[@"aiff", @"wav", @"mp3", @"mp4", @"jpg", @"jpeg", @"png", @"gif", @"mpeg", @"mpg", @"avi", @"m4a", @"m4v"]
 
+// Notification types
+#define NOTIFICATION_TYPE_NONE 0
+#define NOTIFICATION_TYPE_BADGE 1
+#define NOTIFICATION_TYPE_SOUND 2
+#define NOTIFICATION_TYPE_ALERT 4
+#define NOTIFICATION_TYPE_ALL 7
+
+#define ERROR_PUSH_CAPABLILITY_DISABLED    -13
+#define ERROR_PUSH_DELEGATE_NEVER_FIRED    -14
+#define ERROR_PUSH_SIMULATOR_NOT_SUPPORTED -15
+#define ERROR_PUSH_UNKNOWN_APNS_ERROR      -16
+#define ERROR_PUSH_OTHER_3000_ERROR        -17
+#define ERROR_PUSH_NEVER_PROMPTED          -18
+#define ERROR_PUSH_PROMPT_NEVER_ANSWERED   -19
+
+// Registration delay
+#define REGISTRATION_DELAY_SECONDS 30.0
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.h
@@ -31,6 +31,8 @@
 @interface UIApplicationOverrider : NSObject
 +(void)reset;
 
++(void)setBlockApnsResponse:(BOOL)block;
+
 +(void)setCurrentUIApplicationState:(UIApplicationState)value;
 
 +(UILocalNotification*)lastUILocalNotification;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -43,6 +43,12 @@ NSString * serverUrlWithPath(NSString *path);
 
 @end
 
+// Expose OneSignal test methods
+@interface OneSignal (UN_extra)
++ (dispatch_queue_t) getRegisterQueue;
++ (void)setDelayIntervals:(NSTimeInterval)apnsMaxWait withRegistrationDelay:(NSTimeInterval)registrationDelay;
+@end
+
 // START - Start Observers
 
 @interface OSPermissionStateTestObserver : NSObject<OSPermissionObserver> {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -48,10 +48,6 @@ NSString * serverUrlWithPath(NSString *path) {
     return [NSString stringWithFormat:@"%@%@%@", SERVER_URL, API_VERSION, path];
 }
 
-@interface OneSignal (UN_extra)
-+ (dispatch_queue_t) getRegisterQueue;
-@end
-
 @implementation UnitTestCommonMethods
 
 // Runs any blocks passed to dispatch_async()


### PR DESCRIPTION
• In rare cases, if APNS does not respond with a push token or an error, our SDK was not correctly registering the user regardless.
• This commit adds an additional check to make sure that the user get registered and gets a OneSignal user ID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/397)
<!-- Reviewable:end -->
