### PR TITLE
Filter Out Non-OneSignal Notifications in Extension Methods

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1959,6 +1959,9 @@ static NSString *_lastnonActiveMessageId;
 // Called from the app's Notification Service Extension
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
     
+    if (![OneSignalHelper isOneSignalPayload:request.content.userInfo])
+        return replacementContent;
+    
     return [OneSignalNotificationServiceExtensionHandler
             didReceiveNotificationExtensionRequest:request
             withMutableNotificationContent:replacementContent];
@@ -1967,6 +1970,10 @@ static NSString *_lastnonActiveMessageId;
 
 // Called from the app's Notification Service Extension
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
+    
+    if (![OneSignalHelper isOneSignalPayload:request.content.userInfo])
+        return replacementContent;
+    
     return [OneSignalNotificationServiceExtensionHandler
             serviceExtensionTimeWillExpireRequest:request
             withMutableNotificationContent:replacementContent];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -40,6 +40,7 @@ NSString * serverUrlWithPath(NSString *path);
 + (void)beforeAllTest;
 + (void)clearStateForAppRestart:(XCTestCase *)testCase;
 + (UNNotificationResponse*)createBasiciOSNotificationResponseWithPayload:(NSDictionary*)userInfo;
++ (UNNotificationRequest *)nonOneSignalRequest;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -176,6 +176,32 @@ NSString * serverUrlWithPath(NSString *path) {
     [sharedApp.delegate applicationDidBecomeActive:sharedApp];
 }
 
++ (UNNotificationRequest *)nonOneSignalRequest {
+    let userInfo = @{
+                     @"aps": @{
+                             @"mutable-content": @1,
+                             @"alert": @{
+                                     @"body": @"Message Body",
+                                     @"title": @"title"
+                                     }
+                             },
+                     @"os_data" : @{
+                             @"att": @{
+                                     @"id": @"https://www.onesignal.com/test.png"
+                                     }
+                             }
+                     };
+    
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.userInfo = userInfo;
+    
+    UNNotificationRequest *request = [UNNotificationRequest alloc];
+    [request setValue:[UNPushNotificationTrigger alloc] forKey:@"trigger"];
+    [request setValue:content forKey:@"content"];
+    
+    return request;
+}
+
 @end
 
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -176,6 +176,11 @@ NSString * serverUrlWithPath(NSString *path) {
     [sharedApp.delegate applicationDidBecomeActive:sharedApp];
 }
 
+/* 
+   This notification payload uses a similar format to OneSignal notifications. However
+   it is missing the OneSignal ID. This payload is used to test to make sure that 
+   non-onesignal notifications do not get handled by our SDK/extension service methods.
+*/
 + (UNNotificationRequest *)nonOneSignalRequest {
     let userInfo = @{
                      @"aps": @{

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2007,4 +2007,16 @@ didReceiveRemoteNotification:userInfo
     XCTAssertTrue([downloadedGifFilename.supportedFileExtension isEqualToString:@"gif"]);
 }
 
+- (void)testNonOneSignalNotificationWithExtensionService {
+    let request = [UnitTestCommonMethods nonOneSignalRequest];
+    
+    UNMutableNotificationContent *mutableContent = [request.content mutableCopy];
+
+    [OneSignal didReceiveNotificationExtensionRequest:request withMutableNotificationContent:mutableContent];
+
+    // since this is not a OneSignal notification,
+    // attachments should not be added.
+    XCTAssert(mutableContent.attachments.count == 0);
+}
+
 @end


### PR DESCRIPTION
• We currently have logic to avoid processing push notifications if they weren't sent through OneSignal, to prevent issues with other providers.
• However we don't currently do any filtering with the extension service methods.
• Adds a check to make sure that the extension doesn't process non-OS notifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/398)
<!-- Reviewable:end -->
