### PR TITLE
Fix EXC_BAD_ACCESS

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
@@ -154,9 +154,18 @@
 -(void)parseActionButtons:(NSArray<NSDictionary*>*)buttons {
     NSMutableArray *buttonArray = [NSMutableArray new];
     for (NSDictionary *button in buttons) {
-        [buttonArray addObject: @{@"text" : button[@"n"],
-                                  @"id" : (button[@"i"] ?: button[@"n"])
-                                 }];
+        
+        // check to ensure the button object has the correct
+        // format before adding it to the array
+        if (!button[@"n"] ||
+            (!button[@"i"] && !button[@"n"])) {
+            continue;
+        }
+        
+        [buttonArray addObject: @{
+            @"text" : button[@"n"],
+            @"id" : (button[@"i"] ?: button[@"n"])
+        }];
     }
     
     _actionButtons = buttonArray;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2051,4 +2051,22 @@ didReceiveRemoteNotification:userInfo
     XCTAssertTrue(observer->last.to.userId != nil);
 }
 
+// Regression test to ensure improper button JSON format
+// does not cause a crash (iOS SDK issue #401)
+- (void)testInvalidButtonFormat {
+    NSDictionary *newFormat = @{@"aps": @{
+                             @"mutable-content": @1,
+                             @"alert": @"Message Body"
+                             },
+                     @"os_data": @{
+                             @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+                             @"buttons": @[@{@"i": @"id1", @"title": @"text1"}],
+                             @"att": @{ @"id": @"http://domain.com/file.jpg" }
+                             }};
+    
+    let notification = [OSNotificationPayload parseWithApns:newFormat];
+    
+    XCTAssertTrue(notification.actionButtons.count == 0);
+}
+
 @end


### PR DESCRIPTION
• Fixes an issue where improperly formatted button JSON would cause the SDK to insert nil objects into an NSDictionary instance, causing an EXC_BAD_ACCESS
• Adds a check to validate button format before attempting to parse it
• Fixes #401 