### PR TITLE
Fix setLocationShared for Wrapper SDK's

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -423,7 +423,7 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
     if (!success)
         return self;
     
-    if (mShareLocation)
+    if (appId && mShareLocation)
        [OneSignalLocation getLocation:false];
     
     if (self) {


### PR DESCRIPTION
• Most OneSignal Wrapper SDK's call init() twice, the first time calls it with a nil appID as the first initialization step, and then init() gets called later on as the wrapper runtime (ie. the React Native runtime) is loaded and initialized
• The problem with this approach is that the SDK also checks to see if it should start sharing location in init()
• So when init() gets called automatically with a nil app ID by wrapper SDK's (before the runtime is loaded), the SDK started sharing location
• This meant location was shared even if developers later on called setLocationShared(false), even if they call it before they called init() with their app ID
• This commit fixes the issue by checking to make sure the app ID exists before checking if it should share location
• Init needs to be refactored in general to be simpler, but this should work as a quick fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/403)
<!-- Reviewable:end -->
