### PR TITLE
check for nil before creating alert dictionary

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -376,7 +376,7 @@ OSHandleNotificationActionBlock handleNotificationAction;
         additionalData = nil;
     else if (remoteUserInfo[@"os_data"]) {
         [userInfo addEntriesFromDictionary:additionalData];
-        if (!is2dot4Format)
+        if (!is2dot4Format && userInfo[@"os_data"][@"buttons"])
             userInfo[@"aps"] = @{@"alert" : userInfo[@"os_data"][@"buttons"][@"m"]};
     }
     


### PR DESCRIPTION
### Description 

Check that the buttons dictionary exists before creating a dictionary with its contents. This prevents the error: `attempt to insert nil object from objects[0]`.

### Reproduction Steps:

Tap a notification action that was added to a notification using notification categories in the client, rather than when creating the push in the dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/410)
<!-- Reviewable:end -->
