### PR TITLE
Request reattempt fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -1147,6 +1147,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 99SW8E36CT;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"OS_TEST=1",
+				);
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -208,7 +208,8 @@
         
         if (async) {
             //retry again in 15 seconds
-            [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Re-scheduling request (%@) to be re-attempted in %i seconds due to failed HTTP request with status code %i", NSStringFromClass([request class]), (int)REATTEMPT_DELAY, (int)statusCode]];
+            [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Re-scheduling request (%@) to be re-attempted in %.3f seconds due to failed HTTP request with status code %i", NSStringFromClass([request class]), REATTEMPT_DELAY, (int)statusCode]];
+            NSLog(@"Delay: %f", REATTEMPT_DELAY);
             
             [OneSignalHelper performSelector:@selector(reattemptRequest:) onMainThreadOnObject:self withObject:reattempt afterDelay:REATTEMPT_DELAY];
         } else {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -29,11 +29,7 @@
 #import "UIApplicationDelegate+OneSignal.h"
 #import "ReattemptRequest.h"
 #import "OneSignal.h"
-
-#define REATTEMPT_DELAY 30.0
-#define REQUEST_TIMEOUT_REQUEST 60.0 //for most HTTP requests
-#define REQUEST_TIMEOUT_RESOURCE 100.0 //for loading a resource like an image
-#define MAX_ATTEMPT_COUNT 3
+#import "OneSignalCommonDefines.h"
 
 @interface OneSignal (OneSignalClientExtra)
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName;
@@ -66,6 +62,14 @@
     return self;
 }
 
+- (NSError *)privacyConsentErrorWithRequestType:(NSString *)type {
+    return [NSError errorWithDomain:@"OneSignal Error" code:0 userInfo:@{@"error" : [NSString stringWithFormat: @"Attempted to perform an HTTP request (%@) before the user provided privacy consent.", type]}];
+}
+
+- (NSError *)genericTimedOutError {
+    return [NSError errorWithDomain:@"OneSignal Error" code:0 userInfo:@{@"error" : @"The request timed out"}];
+}
+
 - (void)executeSimultaneousRequests:(NSDictionary<NSString *, OneSignalRequest *> *)requests withSuccess:(OSMultipleSuccessBlock)successBlock onFailure:(OSMultipleFailureBlock)failureBlock {
     if (requests.allKeys.count == 0)
         return;
@@ -92,7 +96,15 @@
             }];
         }
         
-        dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, REQUEST_TIMEOUT_REQUEST * NSEC_PER_SEC));
+        // Will wait for up to (maxTimeout) seconds and will then give up and call
+        // the failure block if the request times out.
+        let timedOut = (bool)(0 != dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, MAX_TIMEOUT)));
+        
+        // add a generic 'timed out' error if the request timed out
+        // and there are no other errors present.
+        if (timedOut && errors.allKeys.count == 0)
+            for (NSString *key in requests.allKeys)
+                errors[key] = [self genericTimedOutError];
         
         //requests should all be completed at this point
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -109,9 +121,7 @@
     
     if (request.method != GET && [OneSignal shouldLogMissingPrivacyConsentErrorWithMethodName:nil]) {
         if (failureBlock) {
-            failureBlock([NSError errorWithDomain:@"OneSignal Error" code:0
-                    userInfo:@{@"error" : [NSString stringWithFormat:
-                                    @"Attempted to perform an HTTP request (%@) before the user provided privacy consent.", NSStringFromClass(request.class)]}]);
+            failureBlock([self privacyConsentErrorWithRequestType:NSStringFromClass(request.class)]);
         }
         
         return;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -86,11 +86,25 @@
 // before registering the user anyways
 #define APNS_TIMEOUT 25.0
 
-// OneSignal API Client Defines
-#define REATTEMPT_DELAY 30.0
-#define REQUEST_TIMEOUT_REQUEST 120.0 //for most HTTP requests
-#define REQUEST_TIMEOUT_RESOURCE 120.0 //for loading a resource like an image
-#define MAX_ATTEMPT_COUNT 3
+#ifndef OS_TEST
+    // OneSignal API Client Defines
+    #define REATTEMPT_DELAY 30.0
+    #define REQUEST_TIMEOUT_REQUEST 120.0 //for most HTTP requests
+    #define REQUEST_TIMEOUT_RESOURCE 120.0 //for loading a resource like an image
+    #define MAX_ATTEMPT_COUNT 3
+
+    // Send tags batch delay
+    #define SEND_TAGS_DELAY 5.0
+#else
+    // Test defines for API Client
+    #define REATTEMPT_DELAY 0.04
+    #define REQUEST_TIMEOUT_REQUEST 0.2 //for most HTTP requests
+    #define REQUEST_TIMEOUT_RESOURCE 0.2 //for loading a resource like an image
+    #define MAX_ATTEMPT_COUNT 3
+
+    // Send tags batch delay
+    #define SEND_TAGS_DELAY 0.05
+#endif
 
 // A max timeout for a request, which might include multiple reattempts
 #define MAX_TIMEOUT ((REQUEST_TIMEOUT_REQUEST * MAX_ATTEMPT_COUNT) + (REATTEMPT_DELAY * MAX_ATTEMPT_COUNT)) * NSEC_PER_SEC

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -86,4 +86,13 @@
 // before registering the user anyways
 #define APNS_TIMEOUT 25.0
 
+// OneSignal API Client Defines
+#define REATTEMPT_DELAY 30.0
+#define REQUEST_TIMEOUT_REQUEST 120.0 //for most HTTP requests
+#define REQUEST_TIMEOUT_RESOURCE 120.0 //for loading a resource like an image
+#define MAX_ATTEMPT_COUNT 3
+
+// A max timeout for a request, which might include multiple reattempts
+#define MAX_TIMEOUT ((REQUEST_TIMEOUT_REQUEST * MAX_ATTEMPT_COUNT) + (REATTEMPT_DELAY * MAX_ATTEMPT_COUNT)) * NSEC_PER_SEC
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.h
@@ -30,3 +30,8 @@
 @interface NSURLSessionOverrider : NSObject
 
 @end
+
+
+@interface MockNSURLSessionDataTask : NSURLSessionDataTask
+-(void)resume;
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.h
@@ -42,5 +42,6 @@
 +(NSString *)lastHTTPRequestType;
 +(void)setRequiresEmailAuth:(BOOL)required;
 +(BOOL)hasExecutedRequestOfType:(Class)type;
++ (void)disableExecuteRequestOverride:(BOOL)disable;
 @end
 


### PR DESCRIPTION
• Fixes an issue where network requests were not being allowed to finish all allocated reattempts
• Fixes an issue where calling `sendTags()` (and other requests) with no active internet connection would result in the `success` block eventually getting called even though the request did not succeed
• Adds regression testing to verify reattempt logic