### PR TITLE
Improve Test Reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode10
 before_install:
   - cd iOS_SDK/OneSignalSDK
 script:
-  - xcodebuild -list
-  - xcodebuild -scheme UnitTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=11.0' test
+  - xcodebuild -scheme UnitTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=12.0' test

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -97,13 +97,13 @@
     #define SEND_TAGS_DELAY 5.0
 #else
     // Test defines for API Client
-    #define REATTEMPT_DELAY 0.04
-    #define REQUEST_TIMEOUT_REQUEST 0.2 //for most HTTP requests
-    #define REQUEST_TIMEOUT_RESOURCE 0.2 //for loading a resource like an image
+    #define REATTEMPT_DELAY 0.004
+    #define REQUEST_TIMEOUT_REQUEST 0.02 //for most HTTP requests
+    #define REQUEST_TIMEOUT_RESOURCE 0.02 //for loading a resource like an image
     #define MAX_ATTEMPT_COUNT 3
 
     // Send tags batch delay
-    #define SEND_TAGS_DELAY 0.05
+    #define SEND_TAGS_DELAY 0.005
 #endif
 
 // A max timeout for a request, which might include multiple reattempts

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.m
@@ -45,7 +45,6 @@ static NSMutableArray* selectorNamesForInstantOnlyForFirstRun;
 
 + (void)load {
     injectToProperClass(@selector(overridePerformSelector:withObject:afterDelay:), @selector(performSelector:withObject:afterDelay:), @[], [NSObjectOverrider class], [NSObject class]);
-    injectToProperClass(@selector(overridePerformSelector:withObject:), @selector(performSelector:withObject:), @[], [NSObjectOverrider class], [NSObject class]);
 }
 
 + (void)reset {
@@ -81,10 +80,6 @@ static NSMutableArray* selectorNamesForInstantOnlyForFirstRun;
             [selectorsToRun addObject:selectorToRun];
         }
     }
-}
-
-- (id)overridePerformSelector:(SEL)aSelector withObject:(id)anArgument {
-    return [self overridePerformSelector:aSelector withObject:anArgument];
 }
 
 + (void)runPendingSelectors {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2087,7 +2087,7 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods runBackgroundThreads];
     [NSObjectOverrider runPendingSelectors];
     
-    [self waitForExpectations:@[expectation] timeout:10.0];
+    [self waitForExpectations:@[expectation] timeout:0.5];
     
     // revert the swizzle back to the standard state for tests
     [OneSignalClientOverrider disableExecuteRequestOverride:false];


### PR DESCRIPTION
• We recently started seeing large percentages of test failures in Travis that we could not reproduce locally
• Determined the issue was specific to iOS 11, which Travis used.
• Removed the unnecessary `NSObject` swizzle that was causing the crashes
• Updated our Travis configuration to use Xcode 10 + iOS 12
• Sped up the `testHTTPClientTimeout` test which was using unnecessarily long delay definitions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/424)
<!-- Reviewable:end -->
