### PR TITLE
Fix Deliver Quietly

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -81,11 +81,11 @@ static dispatch_queue_t serialQueue;
                                      + (settings.lockScreenSetting == UNNotificationSettingEnabled ? 8 : 0);
             
             // check if using provisional notifications
-            // otherwise 'deliver quietly' is enabled.
+            if ([OneSignalHelper isIOSVersionGreaterOrEqual:12.0] && settings.authorizationStatus == provisionalStatus)
+                status.notificationTypes += PROVISIONAL_UNAUTHORIZATIONOPTION;
             
-            if ([OneSignalHelper isIOSVersionGreaterOrEqual:12.0] && status.notificationTypes == 0 && settings.authorizationStatus == provisionalStatus)
-                status.notificationTypes = PROVISIONAL_UNAUTHORIZATIONOPTION;
-            else if ([OneSignalHelper isIOSVersionGreaterOrEqual:10.0] && settings.notificationCenterSetting == UNNotificationSettingEnabled)
+            // also check if 'deliver quietly' is enabled.
+            if ([OneSignalHelper isIOSVersionGreaterOrEqual:10.0] && settings.notificationCenterSetting == UNNotificationSettingEnabled)
                 status.notificationTypes += 16;
             
             self.useCachedStatus = true;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -80,9 +80,13 @@ static dispatch_queue_t serialQueue;
                                      + (settings.alertSetting == UNNotificationSettingEnabled ? 4 : 0)
                                      + (settings.lockScreenSetting == UNNotificationSettingEnabled ? 8 : 0);
             
-            if ([OneSignalHelper isIOSVersionGreaterOrEqual:12.0])
-                if (status.notificationTypes == 0 && settings.authorizationStatus == provisionalStatus)
-                    status.notificationTypes = PROVISIONAL_UNAUTHORIZATIONOPTION;
+            // check if using provisional notifications
+            // otherwise 'deliver quietly' is enabled.
+            
+            if ([OneSignalHelper isIOSVersionGreaterOrEqual:12.0] && status.notificationTypes == 0 && settings.authorizationStatus == provisionalStatus)
+                status.notificationTypes = PROVISIONAL_UNAUTHORIZATIONOPTION;
+            else if ([OneSignalHelper isIOSVersionGreaterOrEqual:10.0] && settings.notificationCenterSetting == UNNotificationSettingEnabled)
+                status.notificationTypes += 16;
             
             self.useCachedStatus = true;
             completionHandler(status);

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.m
@@ -133,11 +133,13 @@ static void (^lastRequestAuthorizationWithOptionsBlock)(BOOL granted, NSError *e
         id retSettings = [UNNotificationSettings alloc];
         [retSettings setValue:authorizationStatus forKeyPath:@"authorizationStatus"];
         
-        if (notifTypesOverride >= 7) {
+        if (notifTypesOverride >= 7 && notifTypesOverride != 16) {
             [retSettings setValue:[NSNumber numberWithInt:UNNotificationSettingEnabled] forKeyPath:@"badgeSetting"];
             [retSettings setValue:[NSNumber numberWithInt:UNNotificationSettingEnabled] forKeyPath:@"soundSetting"];
             [retSettings setValue:[NSNumber numberWithInt:UNNotificationSettingEnabled] forKeyPath:@"alertSetting"];
             [retSettings setValue:[NSNumber numberWithInt:UNNotificationSettingEnabled] forKeyPath:@"lockScreenSetting"];
+        } else if (notifTypesOverride == 16) {
+            [retSettings setValue:[NSNumber numberWithInt:UNNotificationSettingEnabled] forKey:@"notificationCenterSetting"];
         }
         
         //if (getNotificationSettingsWithCompletionHandlerStackCount > 1)


### PR DESCRIPTION
• Our SDK was not detecting the 'deliver quietly' option of iOS 12 in some conditions
• This fix adds a notificationTypes check so that our backend does not assume the device has notifications disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/433)
<!-- Reviewable:end -->
