### PR TITLE
Generate Framework Symlinks

### DIFF
--- a/iOS_SDK/OneSignalSDK/build_fat_framework.sh
+++ b/iOS_SDK/OneSignalSDK/build_fat_framework.sh
@@ -42,5 +42,35 @@ rm "${FINAL_FRAMEWORK_LOCATION}/${ONESIGNAL_OUTPUT_NAME}"
 # use lipo to combine device & simulator binaries into one
 lipo -create -output "${EXECUTABLE_DESTINATION}" "${CURRENTCONFIG_DEVICE_DIR}/${ONESIGNAL_OUTPUT_NAME}" "${CURRENTCONFIG_SIMULATOR_DIR}/${ONESIGNAL_OUTPUT_NAME}"
 
+# Move framework files to the location Versions/A/* and create
+# symlinks at the root of the framework, and Versions/Current
+cd $FINAL_FRAMEWORK_LOCATION
+
+declare -a files=("Headers" "Modules" "${ONESIGNAL_OUTPUT_NAME}")
+
+# Create the Versions folders
+mkdir Versions
+mkdir Versions/A
+mkdir Versions/A/Resources
+
+# Move the framework files/folders
+for name in "${files[@]}"; do
+   mv ${name} Versions/A/${name}
+done
+
+# Create symlinks at the root of the framework
+for name in "${files[@]}"; do
+   ln -s Versions/A/${name} ${name}
+done
+
+# move info.plist into Resources and create appropriate symlinks
+mv Info.plist Versions/A/Resources/Info.plist
+ln -s Versions/A/Resources Resources
+
+# Create a symlink directory for 'Versions/A' called 'Current'
+cd Versions
+ln -s A Current
+
+# Copy the built product to the final destination in {repo}/iOS_SDK/OneSignalSDK/Framework
 rm -rf "${ONESIGNAL_DESTINATION_PATH}/${ONESIGNAL_OUTPUT_NAME}.framework"
 cp -a "${FINAL_FRAMEWORK_LOCATION}" "${ONESIGNAL_DESTINATION_PATH}/${ONESIGNAL_OUTPUT_NAME}.framework"


### PR DESCRIPTION
• We recently switched to using aggregate targets with build scripts to build our universal frameworks. However the script simply put all framework resources (the binary, headers folder, etc) into the root of the framework
• Apple recommends that frameworks are structured using symlinks instead, with all actual framework content residing in /Versions/A and using symlinks to the root & /Versions/Current
• This PR adds commands to the buildscript to generate these symlinks for both dynamic & static frameworks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/436)
<!-- Reviewable:end -->
