### PR TITLE
Add Authorization Options for Provisional Notifications

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -185,7 +185,9 @@ static dispatch_queue_t serialQueue;
         }];
     };
     
-    [center requestAuthorizationWithOptions:PROVISIONAL_UNAUTHORIZATIONOPTION completionHandler:responseBlock];
+    let options = PROVISIONAL_UNAUTHORIZATIONOPTION + UNAuthorizationOptionSound + UNAuthorizationOptionBadge + UNAuthorizationOptionAlert;
+    
+    [center requestAuthorizationWithOptions:options completionHandler:responseBlock];
 }
 
 // Ignore these 2 events, promptForNotifications: already takes care of these.


### PR DESCRIPTION
• When using provisional notifications, when a user receives a notifications and taps 'Deliver Prominently', they should be able to receive normal notifications with sound, badge, etc.
• However it appears that with the current SDK, when a user taps 'Deliver Prominently', the notifications don't make sounds/badges until the user opens the app again.
• This can be fixed by requesting full authorization options immediately when registering for provisional notifications