### PR TITLE
Fix Debug Logging Crash

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -245,7 +245,14 @@
         return;
     
     NSError *error;
+    
     let data = [NSJSONSerialization dataWithJSONObject:request.parameters options:NSJSONWritingPrettyPrinted error:&error];
+    
+    if (error || !data) {
+        [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Unable to print the parameters of %@ with JSON serialization error: %@.", NSStringFromClass([request class]), error.description]];
+        return;
+    }
+    
     let jsonString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"HTTP Request (%@) with URL: %@, with parameters: %@", NSStringFromClass([request class]), request.urlRequest.URL.absoluteString, jsonString]];


### PR DESCRIPTION
• The SDK will print (verbose mode) log statements for every HTTP request the SDK makes
• To be more informative, the SDK prints all HTTP request parameters as prettified JSON. However when serializing the parameters to JSON, the SDK was not checking to see if an error occurred which could lead to crashes in rare circumstances.

Fixes #449 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/448)
<!-- Reviewable:end -->
