### PR TITLE
Setting External ID's

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -457,6 +457,9 @@ typedef void (^OSEmailSuccessBlock)();
 + (void)setEmail:(NSString * _Nonnull)email;
 + (void)setEmail:(NSString * _Nonnull)email withEmailAuthHashToken:(NSString * _Nullable)hashToken;
 
++ (void)setExternalUserId:(NSString * _Nonnull)externalId;
++ (void)removeExternalUserId;
+
 @end
 
 #pragma clang diagnostic pop

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -94,5 +94,9 @@ NS_ASSUME_NONNULL_END
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId state:(NSString * _Nonnull)state type:(NSNumber * _Nonnull)type activeTime:(NSNumber * _Nonnull)activeTime netType:(NSNumber * _Nonnull)netType emailAuthToken:(NSString * _Nullable)emailAuthHash;
 @end
 
+@interface OSRequestUpdateExternalUserId : OneSignalRequest
++ (instancetype _Nonnull)withUserId:(NSString * _Nullable)externalId withOneSignalUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId;
+@end
+
 #endif /* Requests_h */
 

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -319,3 +319,17 @@
     return request;
 }
 @end
+
+@implementation OSRequestUpdateExternalUserId
+
++ (instancetype _Nonnull)withUserId:(NSString * _Nullable)externalId withOneSignalUserId:(NSString *)userId appId:(NSString *)appId {
+    let request = [OSRequestUpdateExternalUserId new];
+    NSLog(@"App ID: %@, external ID: %@", appId, externalId);
+    request.parameters = @{@"app_id" : appId, @"external_user_id" : externalId ?: @""};
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -268,6 +268,14 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     XCTAssertTrue(checkHttpBody(secondRequest.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"state" : @"test_state", @"type" : @1, @"active_time" : @2, @"net_type" : @3}));
 }
 
-
+- (void)testSendExternalUserId {
+    let request = [OSRequestUpdateExternalUserId withUserId:@"test_external" withOneSignalUserId:testUserId appId:testAppId];
+    
+    let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
+    
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
+    
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"external_user_id" : @"test_external"}));
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2152,4 +2152,54 @@ didReceiveRemoteNotification:userInfo
     XCTAssertTrue(notification.actionButtons.count == 0);
 }
 
+- (void)testSetExternalUserIdWithRegistration {
+    let testExternalId = @"i_am_a_test_external_id";
+    
+    [OneSignal setExternalUserId:testExternalId];
+    
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"], testExternalId);
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+}
+
+- (void)testSetExternalUserIdAfterRegistration {
+    let testExternalId = @"i_am_a_test_external_id";
+    
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    [OneSignal setExternalUserId:testExternalId];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestUpdateExternalUserId class]));
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"], testExternalId);
+}
+
+- (void)testRemoveExternalUserId {
+    [OneSignal setExternalUserId:@"i_am_a_test_external_id"];
+    
+    [OneSignal initWithLaunchOptions:nil appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"
+            handleNotificationAction:nil
+                            settings:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    [OneSignal removeExternalUserId];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestUpdateExternalUserId class]));
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"], @"");
+}
+
 @end


### PR DESCRIPTION
• Adds setExternalUserId() and removeExternalUserId() as public functions to the OneSignal SDK
• Adds tests to verify the request is working correctly and the API request is correctly formatted
• Adds a test to verify that removeExternalUserId() works the same except it sends an empty string (which is what the API wants)