### PR TITLE
Don't swizzle UIApplication and UNUserNotificaion delegate for tests

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2382,7 +2382,10 @@ static NSString *_lastnonActiveMessageId;
     NSProcessInfo *processInfo = [NSProcessInfo processInfo];
     if ([[processInfo processName] isEqualToString:@"IBDesignablesAgentCocoaTouch"] || [[processInfo processName] isEqualToString:@"IBDesignablesAgent-iOS"])
         return;
-    
+
+	if ([[processInfo processName] isEqualToString:@"xctest"])
+		return;
+
     if (SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(@"7.0"))
         return;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2500,8 +2500,9 @@ static NSString *_lastnonActiveMessageId;
 	if ([[processInfo processName] isEqualToString:@"xctest"])
 		return;
 
-    if (SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(@"8.0"))
-        return;
+	if ([OneSignalHelper isIOSVersionLessThan:@"8.0"]) {
+		return;
+	}
 
     // Double loading of class detection.
     BOOL existing = injectSelector([OneSignalAppDelegate class], @selector(oneSignalLoadedTagSelector:), self, @selector(oneSignalLoadedTagSelector:));


### PR DESCRIPTION
As described in #229 tests will not run if there is not host application. This PR just returns early from `load` before all the swizzling and access to the `currentNotificationCenter`.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/485)
<!-- Reviewable:end -->

