### PR TITLE
Add Display Type Overrider Delegate

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignal/OneSignal.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSNotificationDisplayTypeDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -77,6 +77,8 @@
     [OneSignal addSubscriptionObserver:self];
     [OneSignal addEmailSubscriptionObserver:self];
     
+    [OneSignal setInFocusNotificationDisplayTypeDelegate:self];
+    
     NSLog(@"UNUserNotificationCenter.delegate: %@", UNUserNotificationCenter.currentNotificationCenter.delegate);
     
     return YES;
@@ -95,6 +97,14 @@
 -(void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {
     NSLog(@"onOSEmailSubscriptionChanged: %@", stateChanges);
     
+}
+
+- (void)willPresentInFocusNotificationWithPayload:(OSNotificationPayload *)payload forDisplayType:(OSNotificationDisplayType *)type {
+    if (payload.additionalData[@"overrideDisplayType"]) {
+        OSNotificationDisplayType newType = (OSNotificationDisplayType)[payload.additionalData[@"displayType"] intValue];
+        
+        *type = newType;
+    }
 }
 
 

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		CA08FC801FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
 		CA08FC811FE99B25004C445F /* Requests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC7D1FE99B25004C445F /* Requests.m */; };
 		CA08FC871FE99BB4004C445F /* OneSignalClientOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */; };
+		CA15C4132235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CA15C4122235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.m */; };
 		CA1A6E6920DC2E31001C41B9 /* OneSignalDialogController.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1A6E6720DC2E31001C41B9 /* OneSignalDialogController.h */; };
 		CA1A6E6A20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1A6E6820DC2E31001C41B9 /* OneSignalDialogController.m */; };
 		CA1A6E6B20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1A6E6820DC2E31001C41B9 /* OneSignalDialogController.m */; };
@@ -312,6 +313,8 @@
 		CA08FC7D1FE99B25004C445F /* Requests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Requests.m; sourceTree = "<group>"; };
 		CA08FC821FE99BB4004C445F /* OneSignalClientOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalClientOverrider.h; sourceTree = "<group>"; };
 		CA08FC831FE99BB4004C445F /* OneSignalClientOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalClientOverrider.m; sourceTree = "<group>"; };
+		CA15C4112235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DummyNotificationDisplayTypeDelegate.h; sourceTree = "<group>"; };
+		CA15C4122235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DummyNotificationDisplayTypeDelegate.m; sourceTree = "<group>"; };
 		CA1A6E6720DC2E31001C41B9 /* OneSignalDialogController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalDialogController.h; sourceTree = "<group>"; };
 		CA1A6E6820DC2E31001C41B9 /* OneSignalDialogController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalDialogController.m; sourceTree = "<group>"; };
 		CA1A6E6D20DC2E73001C41B9 /* OneSignalDialogRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalDialogRequest.h; sourceTree = "<group>"; };
@@ -480,6 +483,8 @@
 				4529DEF51FA8460C00CEAB1D /* UnitTestAppDelegate.m */,
 				CAB411AC208931EE005A70D1 /* DummyNotificationCenterDelegate.h */,
 				CAB411AD208931EE005A70D1 /* DummyNotificationCenterDelegate.m */,
+				CA15C4112235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.h */,
+				CA15C4122235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -909,6 +914,7 @@
 				4529DEE41FA82C6200CEAB1D /* NSURLSessionOverrider.m in Sources */,
 				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,
 				CA42CAC320D99CB90001F2F2 /* ProvisionalAuthorizationTests.m in Sources */,
+				CA15C4132235C34E00A432F0 /* DummyNotificationDisplayTypeDelegate.m in Sources */,
 				CAB4112B20852E4C005A70D1 /* DelayedInitializationParameters.m in Sources */,
 				912412341E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				912412101E73342200E41FD7 /* OneSignal.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -213,6 +213,11 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
     OSNotificationPermissionProvisional
 };
 
+// Notification Display Type Delegate
+// Allows apps to customize per-notification display-type
+@protocol OSNotificationDisplayTypeDelegate <NSObject>
+- (void)willPresentInFocusNotificationWithPayload:(OSNotificationPayload *)payload forDisplayType:(OSNotificationDisplayType *)type;
+@end
 
 
 // Permission Classes
@@ -401,6 +406,10 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)IdsAvailable:(OSIdsAvailableBlock)idsAvailableBlock __deprecated_msg("Please use getPermissionSubscriptionState or addSubscriptionObserver and addPermissionObserver instead.");
 
 + (OSPermissionSubscriptionState*)getPermissionSubscriptionState;
+
+// When the app is in-focus, this allows you to add a delegate that can customize the
+// display type for specific notifications
++ (void)setNotificationDisplayTypeDelegate:(NSObject<OSNotificationDisplayTypeDelegate>*)delegate;
 
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer;

--- a/iOS_SDK/OneSignalSDK/UnitTests/DummyNotificationCenterDelegate.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/DummyNotificationCenterDelegate.h
@@ -1,10 +1,29 @@
-//
-//  DummyNotificationCenterDelegate.h
-//  UnitTests
-//
-//  Created by Brad Hesse on 4/19/18.
-//  Copyright © 2018 Hiptic. All rights reserved.
-//
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>

--- a/iOS_SDK/OneSignalSDK/UnitTests/DummyNotificationDisplayTypeDelegate.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/DummyNotificationDisplayTypeDelegate.h
@@ -25,16 +25,21 @@
  * THE SOFTWARE.
  */
 
-#import "DummyNotificationCenterDelegate.h"
+#import <Foundation/Foundation.h>
+#import "OneSignal.h"
 
-@implementation DummyNotificationCenterDelegate
+NS_ASSUME_NONNULL_BEGIN
 
--(void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-    
-}
+@interface DummyNotificationDisplayTypeDelegate : NSObject <OSNotificationDisplayTypeDelegate>
 
--(void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
-    
-}
+@property (strong, nonatomic) NSString *notificationId;
+
+@property (nonatomic) OSNotificationDisplayType overrideDisplayType;
+
+// Each time the OSNotificationDisplayTypeDelegate.willPresentNotificationWithPayload()
+// method is called, this int is incremented
+@property (nonatomic) int numberOfCalls;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/DummyNotificationDisplayTypeDelegate.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/DummyNotificationDisplayTypeDelegate.m
@@ -25,16 +25,24 @@
  * THE SOFTWARE.
  */
 
-#import "DummyNotificationCenterDelegate.h"
+#import "DummyNotificationDisplayTypeDelegate.h"
+#import "OneSignal.h"
 
-@implementation DummyNotificationCenterDelegate
+@implementation DummyNotificationDisplayTypeDelegate
 
--(void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+- (instancetype)init {
+    if (self = [super init])
+        _numberOfCalls = 0;
     
+    return self;
 }
 
--(void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+- (void)willPresentInFocusNotificationWithPayload:(OSNotificationPayload *)payload forDisplayType:(OSNotificationDisplayType *)type {
+    _notificationId = payload.notificationID;
     
+    *type = _overrideDisplayType;
+    
+    _numberOfCalls += 1;
 }
 
 @end


### PR DESCRIPTION
• This PR adds the ability to customize the display type for individual push notifications.
• This is useful for example in messaging apps, where you do not need to show an alert/notification for messages received if you are already viewing a thread with the same person.

• This PR adds the following method to OneSignal:

`[OneSignal setNotificationDisplayTypeDelegate:delegate]`

• When a notification is received, the following method on the delegate will fire:

```objc
- (void)willPresentInFocusNotificationWithPayload:(OSNotificationPayload *)payload forDisplayType:(OSNotificationDisplayType *)type
```

• The display type is passed in as a pointer that the app can set (or not). If the developer wants to set the `NONE` display type for this specific notification, they would do so like this:

```objc
- (void)willPresentInFocusNotificationWithPayload:(OSNotificationPayload *)payload forDisplayType:(OSNotificationDisplayType *)type {
   *type = OSNotificationDisplayTypeNone;
}
```

• Setting the display type for this notification does not effect any future notifications that may be received, and the SDK will always default to whatever was set with `[OneSignal setInFocusDisplayOption:]`

• Adds a test to ensure that the behavior works correctly
• Adds this delegate to the demo project, it can be tested by sending `overrideDisplayType` in the `additionalData` of a push notification and setting it to `0` (none), `1` (alert), or `2` (notification)