### PR TITLE
Expose parseWithApns method of OSNotificationPayload

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -151,6 +151,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 /* iOS 10+ : Groups notifications into threads */
 @property(readonly)NSString *threadId;
++(instancetype)parseWithApns:(NSDictionary*)message;
 
 @end
 


### PR DESCRIPTION
Exposes `parseWithApns` method to allow parsing of raw APNS push payloads

Closes #506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/508)
<!-- Reviewable:end -->
