### PR TITLE
iOS 13 Token Fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
@@ -17,5 +17,8 @@
 - (NSString *)fileExtensionForMimeType;
 - (NSString *)supportedFileExtension;
 
+// returns a lower case hex representation of the data
++ (NSString *)hexStringFromData:(NSData *)data;
+
 @end
 #endif

--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
@@ -59,4 +59,15 @@
     return MIME_MAP[self];
 }
 
++ (NSString *)hexStringFromData:(NSData *)data
+{
+    NSMutableString *parsedDeviceToken = [NSMutableString new];
+    const char *byteArray = (char *)data.bytes;
+
+    for (int i = 0; i < data.length; i++)
+        [parsedDeviceToken appendFormat:@"%02.2hhx", byteArray[i]];
+
+    return [parsedDeviceToken copy];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2089,9 +2089,6 @@ static NSString *_lastnonActiveMessageId;
     if ([OneSignal shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
 
-    if (!app_id)
-        return;
-
     NSString *parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
 
     [OneSignal onesignal_Log:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];
@@ -2102,6 +2099,9 @@ static NSString *_lastnonActiveMessageId;
     }
     
     waitingForApnsResponse = false;
+
+    if (!app_id)
+        return;
     
     [OneSignal updateDeviceToken:parsedDeviceToken onSuccess:^(NSDictionary* results) {
         [OneSignal onesignal_Log:ONE_S_LL_INFO message:[NSString stringWithFormat: @"Device Registered with OneSignal: %@", self.currentSubscriptionState.userId]];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2084,20 +2084,24 @@ static NSString *_lastnonActiveMessageId;
         [self fireIdsAvailableCallback];
 }
 
-+ (void)didRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken {
++ (void)didRegisterForRemoteNotifications:(UIApplication *)app
+                              deviceToken:(NSData *)inDeviceToken {
     if ([OneSignal shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
-    
-    let trimmedDeviceToken = [[inDeviceToken description] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"<>"]];
-    let parsedDeviceToken = [[trimmedDeviceToken componentsSeparatedByString:@" "] componentsJoinedByString:@""];
-    
-    
-    [OneSignal onesignal_Log:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];
-    
-    waitingForApnsResponse = false;
-    
+
     if (!app_id)
         return;
+
+    NSString *parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
+
+    [OneSignal onesignal_Log:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];
+
+    if (!parsedDeviceToken) {
+        [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"Unable to convert APNS device token to a string"];
+        return;
+    }
+    
+    waitingForApnsResponse = false;
     
     [OneSignal updateDeviceToken:parsedDeviceToken onSuccess:^(NSDictionary* results) {
         [OneSignal onesignal_Log:ONE_S_LL_INFO message:[NSString stringWithFormat: @"Device Registered with OneSignal: %@", self.currentSubscriptionState.userId]];

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.h
@@ -35,6 +35,10 @@
 
 +(void)setCurrentUIApplicationState:(UIApplicationState)value;
 
++ (void)setAPNSTokenLength:(int)tokenLength;
+
++ (NSString *)mockAPNSToken;
+
 +(UILocalNotification*)lastUILocalNotification;
 
 +(void)runBackgroundThreads;

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.m
@@ -52,6 +52,8 @@ static BOOL blockApnsResponse;
 
 static NSURL* lastOpenedUrl;
 
+static int apnsTokenLength = 32;
+
 + (void)load {
     injectToProperClass(@selector(overrideRegisterForRemoteNotifications), @selector(registerForRemoteNotifications), @[], [UIApplicationOverrider class], [UIApplication class]);
     injectToProperClass(@selector(override_run), @selector(_run), @[], [UIApplicationOverrider class], [UIApplication class]);
@@ -73,6 +75,7 @@ static NSURL* lastOpenedUrl;
     didFailRegistarationErrorCode = 0;
     currentUIApplicationState = UIApplicationStateActive;
     lastUIUserNotificationSettings = nil;
+    apnsTokenLength = 32;
 }
 
 +(void)setCurrentUIApplicationState:(UIApplicationState)value {
@@ -96,6 +99,19 @@ static NSURL* lastOpenedUrl;
 
 +(void)setBlockApnsResponse:(BOOL)block {
     blockApnsResponse = true;
+}
+
++ (void)setAPNSTokenLength:(int)tokenLength {
+    apnsTokenLength = tokenLength;
+}
+
++ (NSString *)mockAPNSToken {
+    NSMutableString *token = [NSMutableString new];
+
+    for (int i = 0; i < apnsTokenLength * 2; i++)
+        [token appendString:@"0"];
+
+    return token;
 }
 
 // Keeps UIApplicationMain(...) from looping to continue to the next line.
@@ -130,9 +146,9 @@ static NSURL* lastOpenedUrl;
     id app = [UIApplication sharedApplication];
     id appDelegate = [[UIApplication sharedApplication] delegate];
     
-    char bytes[32];
-    memset(bytes, 0, 32);
-    id deviceToken = [NSData dataWithBytes:bytes length:32];
+    char bytes[apnsTokenLength];
+    memset(bytes, 0, apnsTokenLength);
+    id deviceToken = [NSData dataWithBytes:bytes length:apnsTokenLength];
     [appDelegate application:app didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -158,7 +158,7 @@
     NSLog(@"CHECKING LAST HTTP REQUEST");
     
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], UIApplicationOverrider.mockAPNSToken);
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @15);
     NSLog(@"RAN A FEW CONDITIONALS: %@", OneSignalClientOverrider.lastHTTPRequest);
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], @"x86_64");
@@ -2373,6 +2373,17 @@ didReceiveRemoteNotification:userInfo
         
         XCTAssertEqual(dummyDelegate.numberOfCalls, 1);
     }];
+}
+
+- (void)testAllowsIncreasedAPNSTokenSize
+{
+    [UIApplicationOverrider setAPNSTokenLength:64];
+
+    [UnitTestCommonMethods clearStateForAppRestart:self];
+    [UnitTestCommonMethods initOneSignal];
+    [UnitTestCommonMethods runBackgroundThreads];
+
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], UIApplicationOverrider.mockAPNSToken);
 }
 
 @end


### PR DESCRIPTION
- This PR fixes an issue where the SDK was relying on NSData's `description` field to convert the APNS token to a string
- This worked fine up until iOS 13 where Apple has changed NSData's `description` to be more like Swift, where it includes the byte length in addition to the data being encoded
- Our existing test suite would actually have caught this issue if ran in an iOS 13 environment. However I did add a test to make sure our SDK can handle variable length APNS tokens

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/509)
<!-- Reviewable:end -->
