### PR TITLE
Cleaned up payload conversion implementation

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.h
@@ -18,7 +18,7 @@
 - (NSString *)supportedFileExtension;
 
 // returns a lower case hex representation of the data
-+ (NSString *)hexStringFromData:(NSData *)data;
++ (nullable NSString *)hexStringFromData:(nonnull NSData *)data;
 
 @end
 #endif

--- a/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSString+OneSignal.m
@@ -7,6 +7,7 @@
 
 #import "NSString+OneSignal.h"
 #import "OneSignalCommonDefines.h"
+#import "OneSignalHelper.h"
 
 #define MIME_MAP @{@"audio/aiff" : @"aiff", @"audio/x-wav" : @"wav", @"audio/mpeg" : @"mp3", @"video/mp4" : @"mp4", @"image/jpeg" : @"jpeg", @"image/jpg" : @"jpg", @"image/png" : @"png", @"image/gif" : @"gif", @"video/mpeg" : @"mpeg", @"video/mpg" : @"mpg", @"video/avi" : @"avi", @"sound/m4a" : @"m4a", @"video/m4v" : @"m4v"}
 
@@ -59,15 +60,19 @@
     return MIME_MAP[self];
 }
 
-+ (NSString *)hexStringFromData:(NSData *)data
-{
-    NSMutableString *parsedDeviceToken = [NSMutableString new];
-    const char *byteArray = (char *)data.bytes;
-
-    for (int i = 0; i < data.length; i++)
-        [parsedDeviceToken appendFormat:@"%02.2hhx", byteArray[i]];
-
-    return [parsedDeviceToken copy];
+// Converts a nonnull NSData into a NSString in a lower case hex format.
++ (nullable NSString *)hexStringFromData:(nonnull NSData *)data {
+    let dataLength = data.length;
+    if (dataLength == 0)
+        return nil;
+    
+    let dataBtyes = (unsigned char *)data.bytes;
+    let hexString  = [NSMutableString stringWithCapacity:dataLength * 2];
+    for (var i = 0; i < dataLength; i++)
+        [hexString appendFormat:@"%02x", dataBtyes[i]];
+    
+    // Copy to make immutable
+    return hexString.copy;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload+Internal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload+Internal.h
@@ -31,7 +31,7 @@
 #define OSNotificationPayload_Internal_h
 
 @interface OSNotificationPayload (Internal)
-+(instancetype)parseWithApns:(NSDictionary*)message;
++(instancetype)parseWithApns:(nonnull NSDictionary*)message;
 @end
 
 #endif /* OSNotificationPayload_Internal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationPayload.m
@@ -33,7 +33,7 @@
 
 @implementation OSNotificationPayload
 
-+(instancetype)parseWithApns:(NSDictionary*)message {
++(instancetype)parseWithApns:(nonnull NSDictionary*)message {
     if (!message)
         return nil;
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -151,7 +151,11 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 /* iOS 10+ : Groups notifications into threads */
 @property(readonly)NSString *threadId;
-+(instancetype)parseWithApns:(NSDictionary*)message;
+
+/* Parses an APS push payload into a OSNotificationPayload object.
+   Useful to call from your NotificationServiceExtension when the
+      didReceiveNotificationRequest:withContentHandler: method fires. */
++(instancetype)parseWithApns:(nonnull NSDictionary*)message;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2089,7 +2089,7 @@ static NSString *_lastnonActiveMessageId;
     if ([OneSignal shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
 
-    NSString *parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
+    let parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
 
     [OneSignal onesignal_Log:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];
 


### PR DESCRIPTION
* Also added nonnul to parseWithApns
* Confirmed payload parsing works on both iOS 9.3.6 and iPadOS 13 Beta 6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/511)
<!-- Reviewable:end -->
