### PR TITLE
Test invalid NSString.hexStringFromData values

### DIFF
--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2386,4 +2386,10 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"identifier"], UIApplicationOverrider.mockAPNSToken);
 }
 
+- (void)testHexStringFromDataWithInvalidValues {
+    XCTAssertNil([NSString hexStringFromData:nil]);
+    XCTAssertNil([NSString hexStringFromData:NULL]);
+    XCTAssertNil([NSString hexStringFromData:[NSData new]]);
+}
+
 @end


### PR DESCRIPTION
* Added tests for NSString.hexStringFromData to make sure it can handle nil, NULL, and an empty NSData.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/516)
<!-- Reviewable:end -->
