### PR TITLE
Fixed unit tests not working in Xcode 11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode11.1
 before_install:
   - cd iOS_SDK/OneSignalSDK
 script:
-  - xcodebuild -scheme UnitTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=12.0' test
+  - xcodebuild -scheme UnitTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=13.1' test

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.m
@@ -66,6 +66,8 @@ static BOOL privacyState = false;
 - (nullable id)overrideObjectForInfoDictionaryKey:(NSString*)key {
     if (privacyState && [key isEqualToString:ONESIGNAL_REQUIRE_PRIVACY_CONSENT])
         return @true;
+    else if ([@"CFBundlePackageType" isEqualToString:key])
+        return @"APPL";
     else
         return nsbundleDictionary[key];
 }


### PR DESCRIPTION
* This fixes the following error:
   - "Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'bundleProxyForCurrentProcess is nil: mainBundle.bundleURL"
* Updated travisCI to Xcode 11.1 and iOS 13.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/557)
<!-- Reviewable:end -->
