### PR TITLE
Improvements

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSIndirectNotification.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSIndirectNotification.h
@@ -25,7 +25,7 @@
  THE SOFTWARE.
  */
 
-@interface OSIndirectNotification : NSObject
+@interface OSIndirectNotification : NSObject <NSCoding>
 
 @property (nonatomic, readonly) NSString *notificationId;
 @property (nonatomic, readonly) double timestamp; // seconds

--- a/iOS_SDK/OneSignalSDK/Source/OSIndirectNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSIndirectNotification.m
@@ -30,21 +30,21 @@
 
 @implementation OSIndirectNotification
 
-- (id)initWithParamsNotificationId:(NSString *)notificationId timestamp:(double)timestamp {
+- (instancetype)initWithParamsNotificationId:(NSString *)notificationId timestamp:(double)timestamp {
     _notificationId = notificationId;
     _timestamp = timestamp;
     return self;
 }
 
-- (void)encodeWithCoder:(NSCoder *)encoder {
-    [encoder encodeObject:_notificationId forKey:@"notificationId"];
-    [encoder encodeDouble:_timestamp forKey:@"timestamp"];
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeObject:_notificationId forKey:@"notificationId"];
+    [coder encodeDouble:_timestamp forKey:@"timestamp"];
 }
 
-- (id)initWithCoder:(NSCoder *)decoder {
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
     if (self = [super init]) {
-        _notificationId = [decoder decodeObjectForKey:@"notificationId"];
-        _timestamp = [decoder decodeDoubleForKey:@"timestamp"];
+        _notificationId = [coder decodeObjectForKey:@"notificationId"];
+        _timestamp = [coder decodeDoubleForKey:@"timestamp"];
     }
     return self;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.h
@@ -29,12 +29,16 @@
 #import "OneSignal.h"
 #import "OSJSONHandling.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OSOutcomeEvent () <OSJSONEncodable>
 
 - (instancetype)initWithSession:(Session)session
-                notificationIds:(NSArray * _Nullable)notificationIds
-                           name:(NSString * _Nonnull)name
-                      timestamp:(NSNumber * _Nonnull)timestamp
-                         weight:(NSNumber * _Nonnull)value;
+                notificationIds:(NSArray *_Nullable)notificationIds
+                           name:(NSString *)name
+                      timestamp:(NSNumber *)timestamp
+                         weight:(NSNumber *)value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.h
@@ -29,12 +29,12 @@
 #import "OneSignal.h"
 #import "OSJSONHandling.h"
 
-@interface OSOutcomeEvent () <OSJSONDecodable>
+@interface OSOutcomeEvent () <OSJSONEncodable>
 
-- (id _Nonnull)initWithSession:(Session)session
-               notificationIds:(NSArray * _Nullable)notificationIds
-                          name:(NSString * _Nonnull)name
-                     timestamp:(NSNumber * _Nonnull)timestamp
-                        weight:(NSNumber * _Nonnull)value;
+- (instancetype)initWithSession:(Session)session
+                notificationIds:(NSArray * _Nullable)notificationIds
+                           name:(NSString * _Nonnull)name
+                      timestamp:(NSNumber * _Nonnull)timestamp
+                         weight:(NSNumber * _Nonnull)value;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
@@ -30,12 +30,12 @@
 
 @implementation OSOutcomeEvent
 
-- (id _Nonnull)initWithSession:(Session)session
-               notificationIds:(NSArray * _Nullable)notificationIds
-                          name:(NSString * _Nonnull)name
-                     timestamp:(NSNumber * _Nonnull)timestamp
-                        weight:(NSNumber * _Nonnull)value {
-    
+- (instancetype)initWithSession:(Session)session
+                notificationIds:(NSArray * _Nullable)notificationIds
+                           name:(NSString * _Nonnull)name
+                      timestamp:(NSNumber * _Nonnull)timestamp
+                         weight:(NSNumber * _Nonnull)value {
+
     if (self = [super init]) {
         _session = session;
         _notificationIds = notificationIds;

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
@@ -28,13 +28,15 @@
 #import "OSOutcomeEvent.h"
 #import "OneSignalCommonDefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation OSOutcomeEvent
 
 - (instancetype)initWithSession:(Session)session
-                notificationIds:(NSArray * _Nullable)notificationIds
-                           name:(NSString * _Nonnull)name
-                      timestamp:(NSNumber * _Nonnull)timestamp
-                         weight:(NSNumber * _Nonnull)value {
+                notificationIds:(NSArray *_Nullable)notificationIds
+                           name:(NSString *)name
+                      timestamp:(NSNumber *)timestamp
+                         weight:(NSNumber *)value {
 
     if (self = [super init]) {
         _session = session;
@@ -57,3 +59,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
@@ -49,7 +49,7 @@
 - (NSDictionary * _Nonnull)jsonRepresentation {
     return @{
         @"session" : OS_SESSION_TO_STRING(self.session),
-        @"notification_ids" : self.notificationIds,
+        @"notification_ids" : OS_NULL_IF_NIL(self.notificationIds),
         @"id" : self.name,
         @"timestamp" : self.timestamp,
         @"weight" : self.weight

--- a/iOS_SDK/OneSignalSDK/Source/OSSessionResult.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSessionResult.h
@@ -33,7 +33,7 @@
 @property (nonatomic, readonly) Session session;
 @property (nonatomic, readonly) NSArray * _Nullable notificationIds;
 
-- (id _Nonnull)init:(Session)session;
-- (id _Nonnull)init:(Session)session withNotificationIds:(NSArray * _Nullable)notificationIds;
+- (instancetype)init:(Session)session;
+- (instancetype)init:(Session)session withNotificationIds:(NSArray * _Nullable)notificationIds;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSSessionResult.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSessionResult.m
@@ -31,15 +31,19 @@
 
 @implementation OSSessionResult
 
-- (id)init:(Session)session {
-    _session = session;
-    _notificationIds = nil;
+- (instancetype)init:(Session)session {
+    if (self = [super init]) {
+        _session = session;
+        _notificationIds = nil;
+    }
     return self;
 }
 
-- (id)init:(Session)session withNotificationIds:(NSArray *)notificationIds {
-    _session = session;
-    _notificationIds = notificationIds;
+- (instancetype)init:(Session)session withNotificationIds:(NSArray *)notificationIds {
+    if (self = [super init]) {
+        _session = session;
+        _notificationIds = notificationIds;
+    }
     return self;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUniqueOutcomeNotification.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUniqueOutcomeNotification.h
@@ -25,12 +25,12 @@
  THE SOFTWARE.
  */
 
-@interface OSUniqueOutcomeNotification : NSObject
+@interface OSUniqueOutcomeNotification : NSObject <NSCoding>
 
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *notificationId;
 @property (nonatomic, readonly) NSNumber *timestamp; // seconds
 
-- (id)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp;
+- (instancetype)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUniqueOutcomeNotification.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUniqueOutcomeNotification.h
@@ -25,6 +25,8 @@
  THE SOFTWARE.
  */
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OSUniqueOutcomeNotification : NSObject <NSCoding>
 
 @property (nonatomic, readonly) NSString *name;
@@ -34,3 +36,5 @@
 - (instancetype)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSUniqueOutcomeNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUniqueOutcomeNotification.m
@@ -30,24 +30,24 @@
 
 @implementation OSUniqueOutcomeNotification
 
-- (id)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp {
+- (instancetype)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp {
     _name = name;
     _notificationId = notificationId;
     _timestamp = timestamp;
     return self;
 }
 
-- (void)encodeWithCoder:(NSCoder *)encoder {
-    [encoder encodeObject:_name forKey:@"name"];
-    [encoder encodeObject:_notificationId forKey:@"notificationId"];
-    [encoder encodeInteger:[_timestamp integerValue] forKey:@"timestamp"];
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeObject:_name forKey:@"name"];
+    [coder encodeObject:_notificationId forKey:@"notificationId"];
+    [coder encodeInteger:[_timestamp integerValue] forKey:@"timestamp"];
 }
 
-- (id)initWithCoder:(NSCoder *)decoder {
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
     if (self = [super init]) {
-        _name = [decoder decodeObjectForKey:@"name"];
-        _notificationId = [decoder decodeObjectForKey:@"notificationId"];
-        _timestamp = [NSNumber numberWithLong:[decoder decodeIntegerForKey:@"timestamp"]];
+        _name = [coder decodeObjectForKey:@"name"];
+        _notificationId = [coder decodeObjectForKey:@"notificationId"];
+        _timestamp = [NSNumber numberWithLong:[coder decodeIntegerForKey:@"timestamp"]];
     }
     return self;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -34,6 +34,8 @@
 #define API_VERSION @"api/v1/"
 #define SERVER_URL @"https://onesignal.com/"
 
+#define OS_NULL_IF_NIL(object) object ?: NSNull.null
+
 // NSUserDefaults parameter names
 #define EMAIL_AUTH_CODE @"GT_EMAIL_AUTH_CODE"
 #define SUBSCRIPTION_SETTING @"ONESIGNAL_SUBSCRIPTION_LAST"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.h
@@ -28,6 +28,8 @@
 #import "OneSignal.h"
 #import "OneSignalSessionManager.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OneSignalOutcomeEventsController : NSObject
 
 @property (strong, nonatomic, nonnull) OneSignalSessionManager *osSessionManager;
@@ -36,20 +38,22 @@
 
 - (void)clearOutcomes;
 
-- (void)sendOutcomeEvent:(NSString * _Nonnull)name
-                   appId:(NSString * _Nonnull)appId
-              deviceType:(NSNumber * _Nonnull)deviceType
+- (void)sendOutcomeEvent:(NSString *)name
+                   appId:(NSString *)appId
+              deviceType:(NSNumber *)deviceType
             successBlock:(OSSendOutcomeSuccess _Nullable)success;
 
-- (void)sendUniqueOutcomeEvent:(NSString * _Nonnull)name
-                         appId:(NSString * _Nonnull)appId
-                    deviceType:(NSNumber * _Nonnull)deviceType
+- (void)sendUniqueOutcomeEvent:(NSString *)name
+                         appId:(NSString *)appId
+                    deviceType:(NSNumber *)deviceType
                   successBlock:(OSSendOutcomeSuccess _Nullable)success;
 
-- (void)sendOutcomeEventWithValue:(NSString * _Nonnull)name
+- (void)sendOutcomeEventWithValue:(NSString *)name
                             value:(NSNumber * _Nullable)weight
-                            appId:(NSString * _Nonnull)appId
-                       deviceType:(NSNumber * _Nonnull)deviceType
+                            appId:(NSString *)appId
+                       deviceType:(NSNumber *)deviceType
                      successBlock:(OSSendOutcomeSuccess _Nullable)success;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.m
@@ -37,6 +37,8 @@
 #import "OneSignalCommonDefines.h"
 #import "OSOutcomeEventsDefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation OneSignalOutcomeEventsController
 
 // Keeps track of unique outcome events sent for UNATTRIBUTED sessions on a per session level
@@ -45,7 +47,7 @@ NSMutableSet *unattributedUniqueOutcomeEventsSentSet;
 // Keeps track of unique outcome events sent for ATTRIBUTED sessions on a per notification level
 NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotificationIdsSentArray;
 
-- (instancetype _Nonnull)init:(OneSignalSessionManager * _Nonnull)sessionManager {
+- (instancetype _Nonnull)init:(OneSignalSessionManager *)sessionManager {
     if (self = [super init]) {
         self.osSessionManager = sessionManager;
         [self initUniqueOutcomeEventsFromCache];
@@ -91,9 +93,9 @@ NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotif
 /*
  Create an OSOutcomeEvent and send an outcome request using measure 'endpoint'
  */
-- (void)sendOutcomeEvent:(NSString * _Nonnull)name
-                   appId:(NSString * _Nonnull)appId
-              deviceType:(NSNumber * _Nonnull)deviceType
+- (void)sendOutcomeEvent:(NSString *)name
+                   appId:(NSString *)appId
+              deviceType:(NSNumber *)deviceType
             successBlock:(OSSendOutcomeSuccess _Nullable)success {
 
     NSTimeInterval timestamp = [[NSDate date] timeIntervalSince1970];
@@ -118,9 +120,9 @@ NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotif
     2. UNATTRIBUTED: Unique outcome events are stored per session level
                      Cache is cleaned on every new session in onSessionEnding callback
  */
-- (void)sendUniqueOutcomeEvent:(NSString * _Nonnull)name
-                   appId:(NSString * _Nonnull)appId
-              deviceType:(NSNumber * _Nonnull)deviceType
+- (void)sendUniqueOutcomeEvent:(NSString *)name
+                   appId:(NSString *)appId
+              deviceType:(NSNumber *)deviceType
             successBlock:(OSSendOutcomeSuccess _Nullable)success {
 
     NSTimeInterval timestamp = [[NSDate date] timeIntervalSince1970];
@@ -176,10 +178,10 @@ NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotif
 /*
  Create an OSOutcomeEvent with a value and send an outcome request using measure 'endpoint'
  */
-- (void)sendOutcomeEventWithValue:(NSString * _Nonnull)name
+- (void)sendOutcomeEventWithValue:(NSString *)name
                    value:(NSNumber * _Nullable)weight
-                   appId:(NSString * _Nonnull)appId
-              deviceType:(NSNumber * _Nonnull)deviceType
+                   appId:(NSString *)appId
+              deviceType:(NSNumber *)deviceType
             successBlock:(OSSendOutcomeSuccess _Nullable)success {
     
     OSSessionResult *sessionResult = [self.osSessionManager getSessionResult];
@@ -199,8 +201,8 @@ NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotif
  Handle the success and failure of the request
  */
 - (void)sendOutcomeEventRequest:(NSString *)appId
-                     deviceType:(NSNumber * _Nonnull)deviceType
-                        outcome:(OSOutcomeEvent * _Nonnull)outcome
+                     deviceType:(NSNumber *)deviceType
+                        outcome:(OSOutcomeEvent *)outcome
                    successBlock:(OSSendOutcomeSuccess _Nullable)success {
 
     OneSignalRequest *request;
@@ -279,3 +281,5 @@ NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotif
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSessionManager.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSessionManager.h
@@ -27,28 +27,32 @@
 
 #import "OSSessionResult.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol SessionStatusDelegate <NSObject>
 
-+ (void)onSessionEnding:(OSSessionResult * _Nonnull)sessionResult;
++ (void)onSessionEnding:(OSSessionResult *)sessionResult;
 
 @end
 
 @interface OneSignalSessionManager : NSObject
 
-@property (nonatomic) id<SessionStatusDelegate> _Nonnull delegate;
+@property (nonatomic) id<SessionStatusDelegate> delegate;
 
 @property (nonatomic) Session session;
 @property (strong, nonatomic, nullable) NSString *directNotificationId;
 @property (strong, nonatomic, nullable) NSArray *indirectNotificationIds;
 
-- (instancetype _Nonnull)init:(Class<SessionStatusDelegate> _Nonnull)delegate;
+- (instancetype _Nonnull)init:(Class<SessionStatusDelegate>)delegate;
 
 - (Session)getSession;
 - (NSArray * _Nullable)getNotificationIds;
-- (OSSessionResult * _Nonnull)getSessionResult;
+- (OSSessionResult *)getSessionResult;
 - (void)initSessionFromCache;
 - (void)restartSessionIfNeeded;
-- (void)onDirectSessionFromNotificationOpen:(NSString * _Nonnull)directNotificationId;
+- (void)onDirectSessionFromNotificationOpen:(NSString *)directNotificationId;
 - (void)attemptSessionUpgrade;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSessionManager.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSessionManager.m
@@ -33,6 +33,8 @@
 #import "OneSignalCommonDefines.h"
 #import "OneSignalSessionManager.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation OneSignalSessionManager
 
 - (instancetype _Nonnull)init:(Class<SessionStatusDelegate>)delegate {
@@ -113,7 +115,7 @@
     return self.session;
 }
 
-- (NSArray *)getNotificationIds {
+- (NSArray *_Nullable)getNotificationIds {
     if (self.session == DIRECT)
         return [NSArray arrayWithObject:self.directNotificationId];
 
@@ -224,3 +226,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -149,9 +149,9 @@
     request.parameters = @{
        @"app_id" : appId,
        @"device_type" : deviceType,
-       @"identifier" : email ?: [NSNull null],
-       @"email_auth_hash" : emailAuthHash ?: [NSNull null],
-       @"device_player_id" : playerId ?: [NSNull null]
+       @"identifier" : OS_NULL_IF_NIL(email),
+       @"email_auth_hash" : OS_NULL_IF_NIL(emailAuthHash),
+       @"device_player_id" : OS_NULL_IF_NIL(playerId)
     };
     
     request.method = POST;
@@ -167,8 +167,8 @@
     let request = [OSRequestLogoutEmail new];
     
     request.parameters = @{
-       @"parent_player_id" : emailPlayerId ?: [NSNull null],
-       @"email_auth_hash" : emailAuthHash ?: [NSNull null],
+       @"parent_player_id" : OS_NULL_IF_NIL(emailPlayerId),
+       @"email_auth_hash" : OS_NULL_IF_NIL(emailAuthHash),
        @"app_id" : appId
     };
     
@@ -206,7 +206,7 @@
 + (instancetype)withUserId:(NSString *)userId emailAuthToken:(NSString *)emailAuthToken appId:(NSString *)appId withPurchases:(NSArray *)purchases {
     let request = [OSRequestSendPurchases new];
     
-    request.parameters = @{@"app_id" : appId, @"purchases" : purchases, @"email_auth_hash" : emailAuthToken ?: [NSNull null]};
+    request.parameters = @{@"app_id" : appId, @"purchases" : purchases, @"email_auth_hash" : OS_NULL_IF_NIL(emailAuthToken)};
     request.method = POST;
     request.path = [NSString stringWithFormat:@"players/%@/on_purchase", userId];
     
@@ -218,7 +218,7 @@
 + (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId wasOpened:(BOOL)opened messageId:(NSString *)messageId withDeviceType:(nonnull NSNumber *)deviceType{
     let request = [OSRequestSubmitNotificationOpened new];
     
-    request.parameters = @{@"player_id" : userId ?: [NSNull null], @"app_id" : appId ?: [NSNull null], @"opened" : @(opened), @"device_type": deviceType};
+    request.parameters = @{@"player_id" : OS_NULL_IF_NIL(userId), @"app_id" : OS_NULL_IF_NIL(appId), @"opened" : @(opened), @"device_type": deviceType};
     request.method = PUT;
     request.path = [NSString stringWithFormat:@"notifications/%@", messageId];
     


### PR DESCRIPTION
# Some various improvements:
- Fixes an issue with Outcomes where we attempted to insert a value into a dictionary that was explicitly marked as nullable, this can result in crashes
- Adds a new common define (`OS_NULL_IF_NUL()`) to make this cleaner
- We had several classes where we apparently added methods to conform to the `NSCoding` protocol, but we never actually marked the classes as conforming to this protocol for some reason
- Fixes a bug where the `OSSessionResult` class' initializers didn't actually initialize
- Changes a few cases where initializers were marked to return `id`, it is preferable to return `instancetype` in Objective-C to avoid unnecessary casting and give the compiler better information to work with

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/567)
<!-- Reviewable:end -->
