### PR TITLE
Added initDone to prevent double initializations

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCacheCleaner.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCacheCleaner.m
@@ -30,13 +30,13 @@
 #import "OneSignalCommonDefines.h"
 #import "OSUniqueOutcomeNotification.h"
 #import "OneSignalUserDefaults.h"
+#import "OneSignalHelper.h"
 
 @implementation OneSignalCacheCleaner
 
 + (void)cleanCachedUserData {
-    // TODO: Add any other intentional clean up for cached data that might become bulky over time
-    
     [self cleanUniqueOutcomeNotifications];
+    [OneSignalHelper clearCachedMedia];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -40,7 +40,10 @@
 // - Notification Opened
 + (NSMutableDictionary*) formatApsPayloadIntoStandard:(NSDictionary*)remoteUserInfo identifier:(NSString*)identifier;
 + (void)lastMessageReceived:(NSDictionary*)message;
-+ (void)notificationBlocks:(OSHandleNotificationReceivedBlock)receivedBlock :(OSHandleNotificationActionBlock)actionBlock;
+
++(void)setNotificationActionBlock:(OSHandleNotificationActionBlock)block;
++(void)setNotificationReceivedBlock:(OSHandleNotificationReceivedBlock)block;
+
 + (void)handleNotificationReceived:(OSNotificationDisplayType)displayType;
 + (void)handleNotificationReceived:(OSNotificationDisplayType)displayType fromBackground:(BOOL)background;
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -322,9 +322,12 @@ OSHandleNotificationActionBlock handleNotificationAction;
     lastMessageReceived = message;
 }
 
-+ (void)notificationBlocks:(OSHandleNotificationReceivedBlock)receivedBlock :(OSHandleNotificationActionBlock)actionBlock {
-    handleNotificationReceived = receivedBlock;
-    handleNotificationAction = actionBlock;
++(void)setNotificationActionBlock:(OSHandleNotificationActionBlock)block {
+    handleNotificationAction = block;
+}
+
++(void)setNotificationReceivedBlock:(OSHandleNotificationReceivedBlock)block {
+    handleNotificationReceived = block;
 }
 
 + (NSString*)getAppName {
@@ -850,8 +853,12 @@ static OneSignal* singleInstance = nil;
 
 }
 
+// TODO: Add back after testing
 +(void)clearCachedMedia {
     /*
+    if (!NSClassFromString(@"UNUserNotificationCenter"))
+      return;
+     
     NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:@"CACHED_MEDIA"];
     if (cachedFiles) {
         NSArray * paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -283,9 +283,13 @@
 
 @implementation OneSignalHelper
 
+static var lastMessageID = @"";
+static NSString *_lastMessageIdFromAction;
+
 + (void)resetLocals {
     [OneSignalHelper lastMessageReceived:nil];
     _lastMessageIdFromAction = nil;
+    lastMessageID = @"";
 }
 
 UIBackgroundTaskIdentifier mediaBackgroundTask;
@@ -416,7 +420,6 @@ OSHandleNotificationActionBlock handleNotificationAction;
     let notification = [[OSNotification alloc] initWithPayload:payload displayType:displayType];
 
     // Prevent duplicate calls to same receive event
-    static var lastMessageID = @"";
     if ([payload.notificationID isEqualToString:lastMessageID])
         return;
     lastMessageID = payload.notificationID;
@@ -427,8 +430,6 @@ OSHandleNotificationActionBlock handleNotificationAction;
     if (handleNotificationReceived)
        handleNotificationReceived(notification);
 }
-
-static NSString *_lastMessageIdFromAction;
 
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType {
     if (![self isOneSignalPayload:lastMessageReceived])

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.h
@@ -30,7 +30,7 @@
 #import "OneSignal.h"
 
 @interface OneSignalTrackFirebaseAnalytics : NSObject
-+(BOOL)needsRemoteParams;
++(BOOL)libraryExists;
 +(void)init;
 +(void)updateFromDownloadParams:(NSDictionary*)params;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
@@ -36,8 +36,7 @@
 static NSTimeInterval lastOpenedTime = 0;
 static var trackingEnabled = false;
 
-// Only need to download remote params if app includes Firebase analytics
-+ (BOOL)needsRemoteParams {
++ (BOOL)libraryExists {
     return NSClassFromString(@"FIRAnalytics") != nil;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
@@ -36,6 +36,11 @@
 static NSTimeInterval lastOpenedTime = 0;
 static var trackingEnabled = false;
 
++ (void)resetLocals {
+    lastOpenedTime = 0;
+    trackingEnabled = false;
+}
+
 + (BOOL)libraryExists {
     return NSClassFromString(@"FIRAnalytics") != nil;
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationTests.m
@@ -543,7 +543,6 @@
     [RestClientAsserts assertNumberOfMeasureRequests:2];
 }
 
-// TODO: This test is flaky, it fails even on it's own sometimes, on step 5
 - (void)testSendingOutcomeWithValue_inIndirectSession {
     // 1. Open app
     [UnitTestCommonMethods initOneSignalAndThreadWait];

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationTests.m
@@ -676,7 +676,7 @@
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods initOneSignalAndThreadWait];
 
-    // 5. Validate new session is ATTRIBUTED (DIRECT or INDIRECT) and send 2 of the same unique outcomes
+    // 5. Validate new session is INDIRECT and send 2 of the same unique outcomes
     XCTAssertEqual(OneSignal.sessionManager.getSession, INDIRECT);
     [OneSignal sendUniqueOutcome:@"unique"];
     [OneSignal sendUniqueOutcome:@"unique"];
@@ -692,6 +692,8 @@
     // 7. Close the app again, but for a week to clean out all outdated unique outcome notifications
     [UnitTestCommonMethods backgroundApp];
     [NSDateOverrider advanceSystemTimeBy:7 * 1441 * 60];
+    [UnitTestCommonMethods runBackgroundThreads];
+    [UnitTestCommonMethods clearStateForAppRestart:self];
     
     // 8. Receive 3 more notifications
     [UnitTestCommonMethods receiveNotification:@"test_notification_1" wasOpened:NO];
@@ -699,16 +701,16 @@
     [UnitTestCommonMethods receiveNotification:@"test_notification_3" wasOpened:NO];
 
     // 9. Open app again
-    [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods initOneSignalAndThreadWait];
+    [UnitTestCommonMethods foregroundApp];
 
-    // 10. Validate new session is ATTRIBUTED (DIRECT or INDIRECT) and send the same 2 unique outcomes
+    // 10. Validate new session is INDIRECT and send the same 2 unique outcomes
     XCTAssertEqual(OneSignal.sessionManager.getSession, INDIRECT);
     [OneSignal sendUniqueOutcome:@"unique"];
     [OneSignal sendUniqueOutcome:@"unique"];
 
     // 11. Make sure 2 measure requests have been made in total
-    [RestClientAsserts assertMeasureAtIndex:5 payload:@{
+    [RestClientAsserts assertMeasureAtIndex:6 payload:@{
         @"direct" : @(false),
         @"notification_ids" : @[@"test_notification_1", @"test_notification_2", @"test_notification_3"],
         @"id" : @"unique"
@@ -749,21 +751,24 @@
     // 7. Close the app again, but for a week to clean out all outdated unique outcome notifications
     [UnitTestCommonMethods backgroundApp];
     [NSDateOverrider advanceSystemTimeBy:7 * 1441 * 60];
+    [UnitTestCommonMethods runBackgroundThreads];
+    [UnitTestCommonMethods clearStateForAppRestart:self];
     
-    // 8. Receive 1 more notification and open it
-    [UnitTestCommonMethods receiveNotification:@"test_notification_2" wasOpened:YES];
-
-    // 9. Open app again
-    [UnitTestCommonMethods foregroundApp];
+    // 8. Open app again
     [UnitTestCommonMethods initOneSignalAndThreadWait];
+    [UnitTestCommonMethods backgroundApp];
+    
+    // 9. Receive 1 more notification and open it
+    [UnitTestCommonMethods receiveNotification:@"test_notification_2" wasOpened:YES];
+    [UnitTestCommonMethods foregroundApp];
 
-    // 10. Validate new session is ATTRIBUTED (DIRECT or INDIRECT) and send the same 2 unique outcomes
+    // 10. Validate new session is DIRECT and send the same 2 unique outcomes
     XCTAssertEqual(OneSignal.sessionManager.getSession, DIRECT);
     [OneSignal sendUniqueOutcome:@"unique"];
     [OneSignal sendUniqueOutcome:@"unique"];
 
     // 11. Make sure 2 measure requests have been made in total
-    [RestClientAsserts assertMeasureAtIndex:6 payload:@{
+    [RestClientAsserts assertMeasureAtIndex:8 payload:@{
         @"direct" : @(true),
         @"notification_ids" : @[@"test_notification_2"],
         @"id" : @"unique"

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalTrackFirebaseAnalyticsOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalTrackFirebaseAnalyticsOverrider.m
@@ -53,7 +53,7 @@ static BOOL hasFIRAnalytics = false;
     [self reset];
     
     injectStaticSelector([OneSignalTrackFirebaseAnalyticsOverrider class], @selector(overrideLogEventWithName:parameters:), [OneSignalTrackFirebaseAnalytics class], @selector(logEventWithName:parameters:));
-    injectStaticSelector([OneSignalTrackFirebaseAnalyticsOverrider class], @selector(overrideNeedsRemoteParams), [OneSignalTrackFirebaseAnalytics class], @selector(needsRemoteParams));
+    injectStaticSelector([OneSignalTrackFirebaseAnalyticsOverrider class], @selector(overrideNeedsRemoteParams), [OneSignalTrackFirebaseAnalytics class], @selector(libraryExists));
 }
 
 +(void)overrideLogEventWithName:(NSString*)name parameters:(NSDictionary*)params {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -49,6 +49,7 @@
 #import "OneSignalLocation.h"
 #import "NSUserDefaultsOverrider.h"
 #import "OneSignalNotificationServiceExtensionHandler.h"
+#import "OneSignalTrackFirebaseAnalytics.h"
 
 NSString * serverUrlWithPath(NSString *path) {
     return [NSString stringWithFormat:@"%@%@%@", SERVER_URL, API_VERSION, path];
@@ -135,6 +136,7 @@ static XCTestCase* _currentXCTestCase;
     [OneSignal setValue:@0 forKeyPath:@"mSubscriptionStatus"];
     
     [OneSignalTracker performSelector:NSSelectorFromString(@"resetLocals")];
+    [OneSignalTrackFirebaseAnalytics performSelector:NSSelectorFromString(@"resetLocals")];
     
     [NSObjectOverrider reset];
         
@@ -162,6 +164,9 @@ static XCTestCase* _currentXCTestCase;
     if (setupUIApplicationDelegate)
         return;
     
+    // Force swizzle in all methods for tests.
+    OneSignalHelperOverrider.mockIOSVersion = 8;
+    
     // Normally this just loops internally, overwrote _run to work around this.
     UIApplicationMain(0, nil, nil, NSStringFromClass([UnitTestAppDelegate class]));
     
@@ -169,10 +174,6 @@ static XCTestCase* _currentXCTestCase;
     
     // InstallUncaughtExceptionHandler();
     
-    // Force swizzle in all methods for tests.
-    OneSignalHelperOverrider.mockIOSVersion = 8;
-    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase1];
-    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase2];
     OneSignalHelperOverrider.mockIOSVersion = 10;
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1011,7 +1011,7 @@
     // Notification is recieved.
     // The Notification Service Extension runs where the notification received id tracked.
     //   Note: This is normally a separate process but can't emulate that here.
-    UNNotificationResponse *response = [self createNotificationResponseForAnalyticsTests];
+    let response = [self createNotificationResponseForAnalyticsTests];
     [OneSignal didReceiveNotificationExtensionRequest:response.notification.request
                        withMutableNotificationContent:nil];
     
@@ -1027,8 +1027,9 @@
     XCTAssertEqualObjects(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents[0], received_event);
     
     // Trigger a new app session
-    [self backgroundApp];
-    NSDateOverrider.timeOffset = 41;
+    [UnitTestCommonMethods backgroundApp];
+    [UnitTestCommonMethods runBackgroundThreads];
+    [NSDateOverrider advanceSystemTimeBy:41];
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     
@@ -1254,17 +1255,18 @@
     
     [UnitTestCommonMethods runBackgroundThreads];
     
-    id userInfo = @{@"custom": @{
+    let userInfo = @{@"custom": @{
                       @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                       @"a": @{ @"foo": @"bar" }
                   }};
     
-    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
-    id notifCenterDelegate = notifCenter.delegate;
+    let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    let notifCenter = UNUserNotificationCenter.currentNotificationCenter;
+    let notifCenterDelegate = notifCenter.delegate;
     
     // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opend.
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertEqual(openedWasFire, true);
     
     // Part 2 - New paylaod test
@@ -1300,7 +1302,7 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    let notifCenter = UNUserNotificationCenter.currentNotificationCenter;
     let notifCenterDelegate = notifCenter.delegate;
     
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
@@ -1337,7 +1339,6 @@
     XCTAssertFalse([OneSignalClientOverrider hasExecutedRequestOfType:[OSRequestSubmitNotificationOpened class]]);
 }
 
-// TODO: FIx flaky test carry over, only fails when running all tests in this file
 - (void)testReceivedCallbackWithButtonsWithNewFormat {
     let newFormat = @{@"aps": @{@"content_available": @1},
                       @"os_data": @{


### PR DESCRIPTION
* Without this the session and outcomeEvents controllers could be created more than once.
* Removed self check in public init method, not needed since it is static
  - This moved a large nested block a tab back
* Split the notificationBlocks:: selector OneSignalHelper into two selectors
* Corrected outcome cache clearing tests to restart the app
* Other small misc clean up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/569)
<!-- Reviewable:end -->
