### PR TITLE
Fixed some statics not being cleared between tests

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -283,9 +283,13 @@
 
 @implementation OneSignalHelper
 
+static var lastMessageID = @"";
+static NSString *_lastMessageIdFromAction;
+
 + (void)resetLocals {
     [OneSignalHelper lastMessageReceived:nil];
     _lastMessageIdFromAction = nil;
+    lastMessageID = @"";
 }
 
 UIBackgroundTaskIdentifier mediaBackgroundTask;
@@ -416,7 +420,6 @@ OSHandleNotificationActionBlock handleNotificationAction;
     let notification = [[OSNotification alloc] initWithPayload:payload displayType:displayType];
 
     // Prevent duplicate calls to same receive event
-    static var lastMessageID = @"";
     if ([payload.notificationID isEqualToString:lastMessageID])
         return;
     lastMessageID = payload.notificationID;
@@ -427,8 +430,6 @@ OSHandleNotificationActionBlock handleNotificationAction;
     if (handleNotificationReceived)
        handleNotificationReceived(notification);
 }
-
-static NSString *_lastMessageIdFromAction;
 
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType {
     if (![self isOneSignalPayload:lastMessageReceived])

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
@@ -36,6 +36,11 @@
 static NSTimeInterval lastOpenedTime = 0;
 static var trackingEnabled = false;
 
++ (void)resetLocals {
+    lastOpenedTime = 0;
+    trackingEnabled = false;
+}
+
 + (BOOL)libraryExists {
     return NSClassFromString(@"FIRAnalytics") != nil;
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationTests.m
@@ -543,7 +543,6 @@
     [RestClientAsserts assertNumberOfMeasureRequests:2];
 }
 
-// TODO: This test is flaky, it fails even on it's own sometimes, on step 5
 - (void)testSendingOutcomeWithValue_inIndirectSession {
     // 1. Open app
     [UnitTestCommonMethods initOneSignalAndThreadWait];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -49,6 +49,7 @@
 #import "OneSignalLocation.h"
 #import "NSUserDefaultsOverrider.h"
 #import "OneSignalNotificationServiceExtensionHandler.h"
+#import "OneSignalTrackFirebaseAnalytics.h"
 
 NSString * serverUrlWithPath(NSString *path) {
     return [NSString stringWithFormat:@"%@%@%@", SERVER_URL, API_VERSION, path];
@@ -135,6 +136,7 @@ static XCTestCase* _currentXCTestCase;
     [OneSignal setValue:@0 forKeyPath:@"mSubscriptionStatus"];
     
     [OneSignalTracker performSelector:NSSelectorFromString(@"resetLocals")];
+    [OneSignalTrackFirebaseAnalytics performSelector:NSSelectorFromString(@"resetLocals")];
     
     [NSObjectOverrider reset];
         
@@ -162,6 +164,9 @@ static XCTestCase* _currentXCTestCase;
     if (setupUIApplicationDelegate)
         return;
     
+    // Force swizzle in all methods for tests.
+    OneSignalHelperOverrider.mockIOSVersion = 8;
+    
     // Normally this just loops internally, overwrote _run to work around this.
     UIApplicationMain(0, nil, nil, NSStringFromClass([UnitTestAppDelegate class]));
     
@@ -169,10 +174,6 @@ static XCTestCase* _currentXCTestCase;
     
     // InstallUncaughtExceptionHandler();
     
-    // Force swizzle in all methods for tests.
-    OneSignalHelperOverrider.mockIOSVersion = 8;
-    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase1];
-    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase2];
     OneSignalHelperOverrider.mockIOSVersion = 10;
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1011,7 +1011,7 @@
     // Notification is recieved.
     // The Notification Service Extension runs where the notification received id tracked.
     //   Note: This is normally a separate process but can't emulate that here.
-    UNNotificationResponse *response = [self createNotificationResponseForAnalyticsTests];
+    let response = [self createNotificationResponseForAnalyticsTests];
     [OneSignal didReceiveNotificationExtensionRequest:response.notification.request
                        withMutableNotificationContent:nil];
     
@@ -1027,8 +1027,9 @@
     XCTAssertEqualObjects(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents[0], received_event);
     
     // Trigger a new app session
-    [self backgroundApp];
-    NSDateOverrider.timeOffset = 41;
+    [UnitTestCommonMethods backgroundApp];
+    [UnitTestCommonMethods runBackgroundThreads];
+    [NSDateOverrider advanceSystemTimeBy:41];
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     
@@ -1254,17 +1255,18 @@
     
     [UnitTestCommonMethods runBackgroundThreads];
     
-    id userInfo = @{@"custom": @{
+    let userInfo = @{@"custom": @{
                       @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                       @"a": @{ @"foo": @"bar" }
                   }};
     
-    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
-    id notifCenterDelegate = notifCenter.delegate;
+    let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    let notifCenter = UNUserNotificationCenter.currentNotificationCenter;
+    let notifCenterDelegate = notifCenter.delegate;
     
     // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opend.
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertEqual(openedWasFire, true);
     
     // Part 2 - New paylaod test
@@ -1300,7 +1302,7 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    let notifCenter = UNUserNotificationCenter.currentNotificationCenter;
     let notifCenterDelegate = notifCenter.delegate;
     
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
@@ -1337,7 +1339,6 @@
     XCTAssertFalse([OneSignalClientOverrider hasExecutedRequestOfType:[OSRequestSubmitNotificationOpened class]]);
 }
 
-// TODO: FIx flaky test carry over, only fails when running all tests in this file
 - (void)testReceivedCallbackWithButtonsWithNewFormat {
     let newFormat = @{@"aps": @{@"content_available": @1},
                       @"os_data": @{


### PR DESCRIPTION
* OneSignalHelper's lastMessageID is now being cleared correctly.
* OneSignalTrackFirebaseAnalytics statics are now being cleaned up between tests.
* Fixed double swizzling of AppDelegate methods which in some cases created recursion
* Some misc clean up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/570)
<!-- Reviewable:end -->
