### PR TITLE
received_receipts_nil_app_and_player_id_handling

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -66,12 +66,17 @@
     let message = [NSString stringWithFormat:@"OneSignal sendReceiveReceiptWithPlayerId playerId:%@ notificationId: %@, appId: %@", playerId, notificationId, appId];
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:message];
 
+    if (!appId) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"appId not available from shared UserDefaults!"];
+        return;
+    }
+    
     if (![self isReceiveReceiptsEnabled]) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Receieve receipts disabled"];
         return;
     }
     
-    OSRequestReceiveReceipts *request = [OSRequestReceiveReceipts withPlayerId:playerId notificationId:notificationId appId:appId];
+    let request = [OSRequestReceiveReceipts withPlayerId:playerId notificationId:notificationId appId:appId];
     [OneSignalClient.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
         if (success)
             success(result);

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -463,7 +463,8 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
 
 + (instancetype _Nonnull)withPlayerId:(NSString *)playerId notificationId:(NSString *)notificationId appId:(NSString *)appId {
     let request = [OSRequestReceiveReceipts new];
-    request.parameters = @{@"app_id" : appId, @"player_id" : playerId};
+    
+    request.parameters = @{@"app_id": appId, @"player_id": playerId ?: [NSNull null]};
     request.method = PUT;
     request.path = [NSString stringWithFormat:@"notifications/%@/report_received", notificationId];
 


### PR DESCRIPTION
* Adding nil to a NSDictionary will crash, so we need to handle this `nil` values.
* If we don't have an app_id don't send, our wrapper around need work requests ensures this is always present.
* Use NSNull to send a JSON null when there isn't a player_id however.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/571)
<!-- Reviewable:end -->
