### PR TITLE
Fixed dynamic target for Carthage

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -1194,7 +1194,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh ${SRCROOT}/build_fat_framework.sh\n";
+			shellScript = "/bin/sh ${SRCROOT}/build_dynamic_framework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1452,6 +1452,7 @@
 					"$(ARCHS_STANDARD)",
 					armv7s,
 					x86_64h,
+					x86_64,
 				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1488,17 +1489,12 @@
 				);
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64h";
 			};
 			name = Release;
 		};
 		CA2951B72167F4120064227A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					x86_64h,
-				);
 				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
@@ -1512,17 +1508,12 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = OneSignal;
 				SKIP_INSTALL = NO;
-				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64h";
 			};
 			name = Release;
 		};
 		CA2951B82167F4120064227A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					x86_64h,
-				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -1581,7 +1572,6 @@
 		CA2951BA2167F4120064227A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4ZR3G6ZK9T;
 				ONESIGNAL_DESTINATION_PATH = "${SRCROOT}/Framework/Dynamic";
@@ -1595,7 +1585,6 @@
 		CA2951C12167F9860064227A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4ZR3G6ZK9T;
 				ONESIGNAL_DESTINATION_PATH = "${SRCROOT}/Framework";
@@ -1614,6 +1603,7 @@
 					"$(ARCHS_STANDARD)",
 					armv7s,
 					x86_64h,
+					x86_64,
 				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1650,17 +1640,12 @@
 				);
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64h";
 			};
 			name = Debug;
 		};
 		CA2951C32167FB950064227A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					x86_64h,
-				);
 				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
@@ -1674,17 +1659,12 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = OneSignal;
 				SKIP_INSTALL = NO;
-				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64h";
 			};
 			name = Debug;
 		};
 		CA2951C42167FB950064227A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					x86_64h,
-				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -1743,7 +1723,6 @@
 		CA2951C62167FB950064227A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4ZR3G6ZK9T;
 				ONESIGNAL_DESTINATION_PATH = "${SRCROOT}/Framework/Dynamic";
@@ -1757,7 +1736,6 @@
 		CA2951C72167FB950064227A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4ZR3G6ZK9T;
 				ONESIGNAL_DESTINATION_PATH = "${SRCROOT}/Framework";

--- a/iOS_SDK/OneSignalSDK/build_dynamic_framework.sh
+++ b/iOS_SDK/OneSignalSDK/build_dynamic_framework.sh
@@ -1,0 +1,76 @@
+# Generates a universal/fat framework that can be used in multiple architectures (x86_64 and arm64) to support both simulator and actual devices.
+# Note: When complete, this build script takes the fat framework and moves it to the {project root}/iOS_SDK/OneSignalSDK/Framework folder
+# 
+# INPUT ENVIRONMENTAL VARIABLES (set in Xcode project settings for our Aggregate targets)
+#     $ONESIGNAL_DESTINATION_PATH: The path where the final fat framework should be copied to
+#            eg: ${SRCROOT}/Framework
+#
+#     $ONESIGNAL_OUTPUT_NAME: The name of the framework produced (ie. {OneSignal}.framework)
+#
+#     $ONESIGNAL_TARGET_NAME: The name of the actual Xcode target that produces the framework
+#
+#     #ONESIGNAL_MACH_O_TYPE: Determines if the project is build as a static or dynamic library
+
+set -e
+set -o pipefail
+
+# Build x86 based framework to support iOS simulator 
+xcodebuild -configuration "${CONFIGURATION}" -project "${PROJECT_NAME}.xcodeproj" -target ${ONESIGNAL_TARGET_NAME} -sdk "iphonesimulator${SDK_VERSION}" "${ACTION}" ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode RUN_CLANG_STATIC_ANALYZER=NO CLANG_ENABLE_MODULE_DEBUGGING=NO BUILD_DIR="${BUILD_DIR}" BUILD_ROOT="${BUILD_ROOT}" SYMROOT="${SYMROOT}" MACH_O_TYPE=${ONESIGNAL_MACH_O_TYPE} -UseModernBuildSystem=NO
+
+# Build arm based framework to support actual iOS devices
+xcodebuild -configuration "${CONFIGURATION}" -project "${PROJECT_NAME}.xcodeproj" -target ${ONESIGNAL_TARGET_NAME} -sdk "iphoneos${SDK_VERSION}" "${ACTION}" ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode RUN_CLANG_STATIC_ANALYZER=NO CLANG_ENABLE_MODULE_DEBUGGING=NO BUILD_DIR="${BUILD_DIR}" BUILD_ROOT="${BUILD_ROOT}" SYMROOT="${SYMROOT}" MACH_O_TYPE=${ONESIGNAL_MACH_O_TYPE} -UseModernBuildSystem=NO
+
+CURRENTCONFIG_DEVICE_DIR=${SYMROOT}/${CONFIGURATION}-iphoneos/${ONESIGNAL_OUTPUT_NAME}.framework
+CURRENTCONFIG_SIMULATOR_DIR=${SYMROOT}/${CONFIGURATION}-iphonesimulator/${ONESIGNAL_OUTPUT_NAME}.framework
+CREATING_UNIVERSAL_DIR=${SYMROOT}/${CONFIGURATION}-universal
+FINAL_FRAMEWORK_LOCATION=${CREATING_UNIVERSAL_DIR}/${ONESIGNAL_OUTPUT_NAME}.framework
+EXECUTABLE_DESTINATION=${FINAL_FRAMEWORK_LOCATION}/${ONESIGNAL_OUTPUT_NAME}
+
+rm -rf "${CREATING_UNIVERSAL_DIR}"
+mkdir "${CREATING_UNIVERSAL_DIR}"
+
+# copy the device framework to the location
+# when we use lipo to merge device/sim frameworks, it only 
+# merges the actual binary. Thus, we need to copy all of the
+# Framework files (such as headers and modulemap)
+cp -a "${CURRENTCONFIG_DEVICE_DIR}" "${FINAL_FRAMEWORK_LOCATION}"
+
+# This file gets replaced by lipo when building the fat/universal binary
+rm "${FINAL_FRAMEWORK_LOCATION}/${ONESIGNAL_OUTPUT_NAME}"
+
+# Combine results
+# use lipo to combine device & simulator binaries into one
+lipo -create -output "${EXECUTABLE_DESTINATION}" "${CURRENTCONFIG_DEVICE_DIR}/${ONESIGNAL_OUTPUT_NAME}" "${CURRENTCONFIG_SIMULATOR_DIR}/${ONESIGNAL_OUTPUT_NAME}"
+
+# Move framework files to the location Versions/A/* and create
+# symlinks at the root of the framework, and Versions/Current
+cd $FINAL_FRAMEWORK_LOCATION
+
+declare -a files=("Headers" "Modules" "${ONESIGNAL_OUTPUT_NAME}")
+
+# Create the Versions folders
+mkdir Versions
+mkdir Versions/A
+mkdir Versions/A/Resources
+
+# Move the framework files/folders
+for name in "${files[@]}"; do
+   mv ${name} Versions/A/${name}
+done
+
+# Create symlinks at the root of the framework
+for name in "${files[@]}"; do
+   ln -s Versions/A/${name} ${name}
+done
+
+# move info.plist into Resources and create appropriate symlinks
+mv Info.plist Versions/A/Resources/Info.plist
+ln -s Versions/A/Resources Resources
+
+# Create a symlink directory for 'Versions/A' called 'Current'
+cd Versions
+ln -s A Current
+
+# Copy the built product to the final destination in {repo}/iOS_SDK/OneSignalSDK/Framework
+rm -rf "${ONESIGNAL_DESTINATION_PATH}/${ONESIGNAL_OUTPUT_NAME}.framework"
+cp -a "${FINAL_FRAMEWORK_LOCATION}" "${ONESIGNAL_DESTINATION_PATH}/${ONESIGNAL_OUTPUT_NAME}.framework"

--- a/iOS_SDK/OneSignalSDK/build_fat_framework.sh
+++ b/iOS_SDK/OneSignalSDK/build_fat_framework.sh
@@ -16,7 +16,7 @@ XCODEBUILD_11_0=/Applications/Xcode11.0.app/Contents/Developer/usr/bin/xcodebuil
 #       However variant=Mac Catalyst needs to be be Xcode 11.0
 $XCODEBUILD_OLDEST_SUPPORTED -configuration ${BUILD_CONFIG} MACH_O_TYPE=${BUILD_TYPE} -sdk "iphonesimulator" ARCHS="x86_64" -project ${BUILD_PROJECT} -scheme ${BUILD_SCHEME} SYMROOT="${DERIVED_DATA_RELATIVE_DIR}/"
 $XCODEBUILD_OLDEST_SUPPORTED -configuration ${BUILD_CONFIG} MACH_O_TYPE=${BUILD_TYPE} -sdk "iphoneos" ARCHS="armv7 armv7s arm64 arm64e i386"  -project ${BUILD_PROJECT} -scheme ${BUILD_SCHEME} SYMROOT="${DERIVED_DATA_RELATIVE_DIR}/"
-$XCODEBUILD_11_0 -configuration ${BUILD_CONFIG} ARCHS="x86_64h" -destination 'platform=macOS,variant=Mac Catalyst' MACH_O_TYPE=${BUILD_TYPE} -project ${BUILD_PROJECT} -scheme ${BUILD_SCHEME} SYMROOT="${DERIVED_DATA_RELATIVE_DIR}/"
+$XCODEBUILD_11_0 -configuration ${BUILD_CONFIG} ARCHS="x86_64h" VALID_ARCHS="x86_64h" -destination 'platform=macOS,variant=Mac Catalyst' MACH_O_TYPE=${BUILD_TYPE} -project ${BUILD_PROJECT} -scheme ${BUILD_SCHEME} SYMROOT="${DERIVED_DATA_RELATIVE_DIR}/"
 
 USER=$(id -un)
 DERIVED_DATA_ONESIGNAL_DIR="${WORKING_DIR}/${DERIVED_DATA_RELATIVE_DIR}"
@@ -73,11 +73,16 @@ ln -s Versions/A/Resources Resources
 cd Versions
 ln -s A Current
 
+RELEASE_OUTPUT_FRAMEWORK_DIR="${WORKING_DIR}/Framework/OneSignal.framework"
+
 # Copy the built product to the final destination in {repo}/iOS_SDK/OneSignalSDK/Framework
 rm -rf "${WORKING_DIR}/Framework/OneSignal.framework"
 cp -a "${FINAL_FRAMEWORK}" "${WORKING_DIR}/Framework/OneSignal.framework"
 
+echo "Listing frameworks of final framework"
+file "${RELEASE_OUTPUT_FRAMEWORK_DIR}/Versions/A/OneSignal"
+
 echo "Opening final release framework in Finder:${WORKING_DIR}/Framework/OneSignal.framework"
-open ${WORKING_DIR}/Framework
+open "${WORKING_DIR}/Framework"
 
 echo "Done"


### PR DESCRIPTION
* Removed VALID_ARCHS for all targets in Xcode. Only ARCHS should be set.
* Removed all overrides per target. Going forward only set ARCHS on the root "OneSignal" project.
* Added `build_dynamic_framework.sh`
   - Contains are before we made large changes for Catalyst
   - Note, this means Catalyst may not be supported for Carthage
* build_fat_framework.sh
  - Added VALID_ARCHS=x86_64h as a special case for build Catalyst
  - Added `file` output so we can verify the fat framework contains everything.
* This PR also fixes the issue with the "OneSignalDevApp" not building unless you manually removed the `x86_64h` architecture.
* Resolves #566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/576)
<!-- Reviewable:end -->
