### PR TITLE
Fix confirmed deliveries for sdk upgrades

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -666,14 +666,18 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
         initDone = false;
         let sharedUserDefaults = OneSignalUserDefaults.initShared;
         
-        // Save app_id to both standard and shared NSUserDefaults
         [standardUserDefaults saveStringForKey:NSUD_APP_ID withValue:app_id];
-        [sharedUserDefaults saveStringForKey:NSUD_APP_ID withValue:app_id];
         
         // Remove player_id from both standard and shared NSUserDefaults
         [standardUserDefaults removeValueForKey:USERID];
         [sharedUserDefaults removeValueForKey:USERID];
     }
+    
+    // Always save app_id and player_id as it will not be present on shared if:
+    //   - Updating from an older SDK
+    //   - Updating to an app that didn't have App Groups setup before
+    [OneSignalUserDefaults.initShared saveStringForKey:NSUD_APP_ID withValue:app_id];
+    [OneSignalUserDefaults.initShared saveStringForKey:USERID withValue:self.currentSubscriptionState.userId];
     
     // Invalid app ids reaching here will cause failure
     if (!app_id || ![[NSUUID alloc] initWithUUIDString:app_id]) {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -45,6 +45,7 @@
 #import "OneSignalNotificationSettingsIOS10.h"
 #import "OSPermission.h"
 #import "OSNotificationPayload+Internal.h"
+#import "OneSignalUserDefaults.h"
 
 #import "TestHelperFunctions.h"
 #import "UnitTestAppDelegate.h"
@@ -1817,6 +1818,25 @@ didReceiveRemoteNotification:userInfo
     // Make sure attachments were added.
     XCTAssertEqualObjects(content.attachments[0].identifier, @"id");
     XCTAssertEqualObjects(content.attachments[0].URL.scheme, @"file");
+}
+
+
+- (void)testAddingSharedKeysIfMissing {
+    // 1. Init SDK as normal
+    [UnitTestCommonMethods initOneSignalAndThreadWait];
+    
+    // 2. Remove shared keys to simulate the state of coming from a pre-2.12.1 version
+    [OneSignalUserDefaults.initShared removeValueForKey:NSUD_APP_ID];
+    [OneSignalUserDefaults.initShared removeValueForKey:USERID];
+
+    // 3. Restart app
+    [UnitTestCommonMethods backgroundApp];
+    [UnitTestCommonMethods clearStateForAppRestart:self];
+    [UnitTestCommonMethods initOneSignalAndThreadWait];
+    
+    // 4. Ensure values are present again
+    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:NSUD_APP_ID defaultValue:nil]);
+    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:USERID defaultValue:nil]);
 }
 
 // iOS 10 - Notification Service Extension test - local file


### PR DESCRIPTION
* Fixed confirm deliveries for those who have installed the app on an older SDK and upgrade to this one.
  - Fixed issue where we did not always save shared NSUserDefaults.
  - This also allows those who did not always have App Groups to get the values saved.
* Added test for adding missing shared keys
* NSUserDefaultsOverrider now supports suiteNames

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/579)
<!-- Reviewable:end -->
