### PR TITLE
WIP - Fix subscribing when Background Modes are off and Direct To History is enabled

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -878,9 +878,11 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     backgroundModesEnabled = (backgroundModes && [backgroundModes containsObject:@"remote-notification"]);
     
     // Only try to register for a pushToken if:
-    //  - The user accepted notifications
+    //  - The user accepted notifications or iOS 12+ provisional notifications are enabled
     //  - "Background Modes" > "Remote Notifications" are enabled in Xcode
-    if (![self.osNotificationSettings getNotificationPermissionState].accepted && !backgroundModesEnabled)
+    let notifPermissionState = [self.osNotificationSettings getNotificationPermissionState];
+    let notificationsEnabled = notifPermissionState.accepted || notifPermissionState.provisional;
+    if (!notificationsEnabled && !backgroundModesEnabled)
         return false;
     
     // Don't attempt to register again if there was a non-recoverable error.
@@ -890,7 +892,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Firing registerForRemoteNotifications"];
     
     waitingForApnsResponse = true;
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
+    [UIApplication.sharedApplication registerForRemoteNotifications];
     
     return true;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS10.m
@@ -72,7 +72,7 @@ static dispatch_queue_t serialQueue;
             UNAuthorizationStatus provisionalStatus = (UNAuthorizationStatus)3;
             
             status.answeredPrompt = settings.authorizationStatus != UNAuthorizationStatusNotDetermined && settings.authorizationStatus != provisionalStatus;
-            status.provisional = (settings.authorizationStatus == 3);
+            status.provisional = (settings.authorizationStatus == 3); // UNAuthorizationStatusProvisional
             status.accepted = settings.authorizationStatus == UNAuthorizationStatusAuthorized && !status.provisional;
             
             status.notificationTypes = (settings.badgeSetting == UNNotificationSettingEnabled ? 1 : 0)


### PR DESCRIPTION
## Issue
If Background Modes are off under Xcode > Capabilities AND iOS "Enable iOS 12 Direct To History" is enabled on the OneSignal dashboard settings the player will be created with the following on the dashboard;"Provisioning Profile Missing Push Permission"

The SDK reports `notification_types` as `80` and no identifier.

Also calling `OneSignal.promptForPushNotificationsWithUserResponse` says that it is disabled when it isn't and won't show a prompt.

## TODO
1. `registerForAPNsToken` needs to check for `notifPermissionState.provisional`.
  * Complete in commit 37a4d6f
1. We need to delay calling `registerForAPNsToken` until the download params completes. 
1. Write unit test reproducing issue

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/591)
<!-- Reviewable:end -->

