### PR TITLE
Fixed iOS params issue related to the second init for wrappers

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -66,6 +66,13 @@
 
 + (NSDate *)sessionLaunchTime;
 
+// Indicates if the app provides its own custom Notification customization settings UI
+// To enable this, set kOSSettingsKeyProvidesAppNotificationSettings to true in init.
++ (BOOL)providesAppNotificationSettings;
+
+@property (class, readonly) BOOL didCallDownloadParameters;
+@property (class, readonly) BOOL downloadedParameters;
+
 @property (class) NSObject<OneSignalNotificationSettings>* osNotificationSettings;
 @property (class) OSPermissionState* currentPermissionState;
 
@@ -74,10 +81,6 @@
 @property (class) AppEntryAction appEntryState;
 @property (class) OneSignalSessionManager* sessionManager;
 @property (class) OneSignalOutcomeEventsController* outcomeEventsController;
-
-// Indicates if the app provides its own custom Notification customization settings UI
-// To enable this, set kOSSettingsKeyProvidesAppNotificationSettings to true in init.
-+ (BOOL)providesAppNotificationSettings;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -39,6 +39,10 @@
 
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request
                                          withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
+    // Set default log level of NSE to VERBOSE so we get all logs from NSE logic
+    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_NONE];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"NSE request received, setting OneSignal log level to VERBOSE and beginning to processing request!"];
+    
     if (!replacementContent)
         replacementContent = [request.content mutableCopy];
     
@@ -50,6 +54,7 @@
     // Track receieved
     [OneSignalTrackFirebaseAnalytics trackReceivedEvent:payload];
     
+    // Get and check the received notification id
     let receivedNotificationId = payload.notificationID;
     if (receivedNotificationId && ![receivedNotificationId isEqualToString:@""]) {
         // Track confirmed delivery

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -41,7 +41,7 @@
                                          withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
     // Set default log level of NSE to VERBOSE so we get all logs from NSE logic
     [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_NONE];
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"NSE request received, setting OneSignal log level to VERBOSE and beginning to processing request!"];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"NSE request received, setting OneSignal log level to VERBOSE!"];
     
     if (!replacementContent)
         replacementContent = [request.content mutableCopy];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -75,7 +75,7 @@
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Receieve receipts disabled"];
         return;
     }
-    
+
     let request = [OSRequestReceiveReceipts withPlayerId:playerId notificationId:notificationId appId:appId];
     [OneSignalClient.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
         if (success)


### PR DESCRIPTION
* On first init call the app id is null form some wrappers
* Now every time init is called we try to download the params if the `didCallDownloadParams` false

Current status is waiting on a customer to see if this fix resolves their issues regarding `Confirmed  Deliveries`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/594)
<!-- Reviewable:end -->
