### PR TITLE
Update API URL to circumvent block in Egypt

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -31,8 +31,8 @@
 #import <Foundation/Foundation.h>
 
 // networking
-#define API_VERSION @"api/v1/"
-#define SERVER_URL @"https://onesignal.com/"
+#define API_VERSION @"v1/"
+#define SERVER_URL @"https://api.onesignal.com/"
 
 // NSUserDefaults parameter names
 #define HAS_PROMPTED_FOR_NOTIFICATIONS @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"


### PR DESCRIPTION
It appears that subdomains of onesignal.com are not blocked by the Egyptian ISP TE Data (also known as WE)

Fixes #554 & #545

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/595)
<!-- Reviewable:end -->
