### PR TITLE
OneSignal notification buttons not displaying fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -666,26 +666,31 @@ static OneSignal* singleInstance = nil;
     var allCategories = OneSignalNotificationCategoryController.sharedInstance.existingCategories;
     
     let newCategoryIdentifier = [OneSignalNotificationCategoryController.sharedInstance registerNotificationCategoryForNotificationId:payload.notificationID];
-
     let category = [UNNotificationCategory categoryWithIdentifier:newCategoryIdentifier
                                                           actions:finalActionArray
                                                 intentIdentifiers:@[]
                                                           options:UNNotificationCategoryOptionCustomDismissAction];
-    
+
     if (allCategories) {
         let newCategorySet = [NSMutableSet new];
         for(UNNotificationCategory *existingCategory in allCategories) {
             if (![existingCategory.identifier isEqualToString:newCategoryIdentifier])
                 [newCategorySet addObject:existingCategory];
         }
-        
+
         [newCategorySet addObject:category];
         allCategories = newCategorySet;
     }
     else
         allCategories = [[NSMutableSet alloc] initWithArray:@[category]];
+
+    [UNUserNotificationCenter.currentNotificationCenter setNotificationCategories:allCategories];
     
-    [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:allCategories];
+    // List Categories again so iOS refreshes it's internal list.
+    // Required otherwise buttons will not display or won't update.
+    // This is a blackbox assumption, the delay on the main thread this call creates might be giving
+    //   some iOS background thread time to flush to disk.
+    allCategories = OneSignalNotificationCategoryController.sharedInstance.existingCategories;
     
     content.categoryIdentifier = newCategoryIdentifier;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationCategoryController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationCategoryController.m
@@ -98,6 +98,7 @@
     return categoryId;
 }
 
+// Get all existing Notifications Categories in a blocking way
 - (NSMutableSet<UNNotificationCategory*>*)existingCategories {
     __block NSMutableSet* allCategories;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);


### PR DESCRIPTION
* Re-listing notifications categories after registering to force a refresh of them.
   - See comment for more details.
* These are the dynamic per notification buttons set via the dashboard or REST API
* Issue since iOS 12
* Fixes #430

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/597)
<!-- Reviewable:end -->
