### PR TITLE
Fix for subscribe issue, on cold start always unsubscribed

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -29,9 +29,9 @@
 // This project exisits to make testing OneSignal SDK changes.
 
 #import "AppDelegate.h"
+#import "ViewController.h"
 
 @implementation AppDelegate
-
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     
@@ -63,8 +63,6 @@
                              action.closesMessage];
         [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:message];
     };
-
-    [OneSignal setSubscription:true];
 
     // Example setter for IAM action click handler using OneSignal public method
     [OneSignal setInAppMessageClickHandler:inAppMessagingActionClickBlock];
@@ -105,19 +103,18 @@
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (void) onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
-    NSLog(@"onOSSubscriptionChanged: %@", stateChanges);
-    NSLog(@"HERE");
-}
-
 - (void) onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
     NSLog(@"onOSPermissionChanged: %@", stateChanges);
-    NSLog(@"HERE");
 }
 
--(void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {
+- (void) onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
+    NSLog(@"onOSSubscriptionChanged: %@", stateChanges);
+    ViewController* mainController = (ViewController*) self.window.rootViewController;
+    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.subscribed;
+}
+
+- (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {
     NSLog(@"onOSEmailSubscriptionChanged: %@", stateChanges);
-    
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Base.lproj/Main.storyboard
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina5_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,14 +19,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" delaysContentTouches="NO" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="Dse-f7-S3F">
-                                <rect key="frame" x="0.0" y="20" width="375" height="800"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" delaysContentTouches="NO" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="Dse-f7-S3F">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="820"/>
                                 <subviews>
                                     <view autoresizesSubviews="NO" clipsSubviews="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="6dV-2z-2jJ">
                                         <rect key="frame" x="0.0" y="-40" width="375" height="850"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kp7-Oh-BQ1" userLabel="Update App Id">
-                                                <rect key="frame" x="138" y="177" width="99" height="30"/>
+                                                <rect key="frame" x="138" y="184" width="99" height="30"/>
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Update App Id"/>
@@ -37,86 +35,104 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H3K-GA-smE">
-                                                <rect key="frame" x="151.66666666666666" y="215" width="72" height="30"/>
+                                                <rect key="frame" x="151.66666666666666" y="222" width="72" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Send Tags"/>
                                                 <connections>
                                                     <action selector="sendTagButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bug-x1-TIR"/>
                                                 </connections>
                                             </button>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cWh-Hu-7CP">
-                                                <rect key="frame" x="46.666666666666657" y="437" width="132" height="30"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subscription:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wT0-PD-6z7">
+                                                <rect key="frame" x="102" y="267" width="171" height="21"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="Gjd-Jn-5nw"/>
-                                                    <constraint firstAttribute="width" constant="132" id="JPj-Bi-2sh"/>
+                                                    <constraint firstAttribute="width" constant="171" id="1Hc-Sp-iz1"/>
                                                 </constraints>
-                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="gZI-5K-94s">
+                                                <rect key="frame" x="90" y="301" width="195" height="32"/>
+                                                <segments>
+                                                    <segment title="Unsubscribe"/>
+                                                    <segment title="Subscribe"/>
+                                                </segments>
+                                                <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="selectedSegmentTintColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <connections>
+                                                    <action selector="subscriptionSegmentedControlValueChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="ZlI-Tm-gk6"/>
+                                                </connections>
+                                            </segmentedControl>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cWh-Hu-7CP">
+                                                <rect key="frame" x="45.666666666666657" y="506" width="132" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="Hyo-HG-Thf"/>
+                                                    <constraint firstAttribute="width" constant="132" id="ber-g2-7Nf"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Consent Status:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j3e-42-uww">
                                                 <rect key="frame" x="112.66666666666669" y="65" width="150" height="20"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="150" id="WYp-C4-HKj"/>
+                                                    <constraint firstAttribute="width" constant="150" id="daY-4q-YV2"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="05S-ud-V2e">
-                                                <rect key="frame" x="98" y="93" width="179" height="29"/>
+                                                <rect key="frame" x="93" y="93" width="189" height="32"/>
                                                 <segments>
                                                     <segment title="Not Granted"/>
                                                     <segment title="Granted"/>
                                                 </segments>
                                                 <color key="tintColor" red="1" green="0.13671011566193114" blue="0.017019837433124962" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="selectedSegmentTintColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <connections>
                                                     <action selector="consentSegmentedControlValueChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="oL2-15-pJ0"/>
                                                 </connections>
                                             </segmentedControl>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In App Messaging:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Whm-aD-RCM">
-                                                <rect key="frame" x="102" y="281" width="171" height="20"/>
+                                                <rect key="frame" x="102" y="350" width="171" height="20"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="171" id="sXk-LT-ecu"/>
+                                                    <constraint firstAttribute="width" constant="171" id="GlJ-IC-RVW"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Outcomes:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ecj-vJ-K60">
-                                                <rect key="frame" x="102" y="523" width="171" height="22"/>
+                                                <rect key="frame" x="101" y="592" width="171" height="22"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="22" id="bR3-lY-DLH"/>
-                                                    <constraint firstAttribute="width" constant="171" id="g2v-kX-gEe"/>
+                                                    <constraint firstAttribute="height" constant="22" id="SOz-xd-ZHj"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="saG-x9-o6U">
-                                                <rect key="frame" x="132" y="318" width="111" height="29"/>
+                                                <rect key="frame" x="126" y="384" width="121" height="32"/>
                                                 <segments>
                                                     <segment title="Pause"/>
                                                     <segment title="Enable"/>
                                                 </segments>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="selectedSegmentTintColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <connections>
                                                     <action selector="inAppMessagingSegmentedControlValueChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="QUP-tp-uvZ"/>
                                                 </connections>
                                             </segmentedControl>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ykz-Wq-cb5">
-                                                <rect key="frame" x="46.666666666666657" y="361" width="134" height="30"/>
+                                                <rect key="frame" x="45.666666666666657" y="430" width="134" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="SHA-bV-TaJ"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="XJ5-CT-d92"/>
-                                                    <constraint firstAttribute="width" constant="134" id="jyp-cY-zkc"/>
+                                                    <constraint firstAttribute="height" constant="30" id="bcm-8l-dBS"/>
                                                 </constraints>
-                                                <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="79P-xw-1Q5">
-                                                <rect key="frame" x="147" y="399" width="81" height="30"/>
+                                                <rect key="frame" x="146" y="468" width="81" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Add Trigger"/>
                                                 <connections>
@@ -124,35 +140,25 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="G56-cW-rWo">
-                                                <rect key="frame" x="195.66666666666663" y="361" width="133" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="wqN-3C-Dyq"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
+                                                <rect key="frame" x="194.66666666666669" y="428" width="132.66666666666669" height="32"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="fill" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="OneSignal App Id" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="TVC-yc-aRa">
-                                                <rect key="frame" x="14.666666666666657" y="139" width="346" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="346" id="e0v-aD-g31"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
+                                                <rect key="frame" x="14.666666666666657" y="142" width="345.66666666666674" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bmb-ib-r40">
-                                                <rect key="frame" x="46.666666666666657" y="485" width="132" height="30"/>
+                                                <rect key="frame" x="45.666666666666657" y="554" width="132" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="132" id="3Xq-vi-qN5"/>
-                                                    <constraint firstAttribute="height" constant="30" id="APV-Hl-r5G"/>
+                                                    <constraint firstAttribute="height" constant="30" id="UJK-GU-nj5"/>
                                                 </constraints>
-                                                <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="idh-ud-yeY">
-                                                <rect key="frame" x="195.66666666666663" y="485" width="133" height="30"/>
+                                                <rect key="frame" x="194.66666666666669" y="554" width="132.66666666666669" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Get Trigger Value"/>
                                                 <connections>
@@ -160,20 +166,16 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="310" translatesAutoresizingMaskIntoConstraints="NO" id="7au-a5-gty">
-                                                <rect key="frame" x="46.666666666666657" y="555" width="282" height="28"/>
+                                                <rect key="frame" x="45.666666666666657" y="614" width="281.66666666666674" height="28"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="28" id="4X2-d1-LW8"/>
+                                                    <constraint firstAttribute="height" constant="28" id="glR-uc-YQQ"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A38-En-69W">
-                                                <rect key="frame" x="195.66666666666663" y="437" width="133" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="A7v-h4-L7l"/>
-                                                    <constraint firstAttribute="width" constant="133" id="HMN-lK-tEV"/>
-                                                </constraints>
+                                                <rect key="frame" x="194.66666666666669" y="506" width="132.66666666666669" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Remove Trigger"/>
                                                 <connections>
@@ -181,56 +183,33 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Xj9-lX-hR2">
-                                                <rect key="frame" x="46.666666666666657" y="553" width="134" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="30" id="Hpi-3Y-JXi"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="LRA-b5-j8K"/>
-                                                    <constraint firstAttribute="height" constant="30" id="mhD-6A-hqy"/>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="134" id="mmF-6h-CkS"/>
-                                                    <constraint firstAttribute="width" constant="134" id="tek-RQ-Uw8"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
+                                                <rect key="frame" x="45.666666666666657" y="622" width="134" height="30"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="knZ-rP-bRU">
-                                                <rect key="frame" x="188.66666666666666" y="553" width="132.99999999999997" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="cr5-cx-XcR"/>
-                                                    <constraint firstAttribute="width" constant="133" id="hJb-qf-ACq"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
+                                                <rect key="frame" x="187.66666666666666" y="620" width="132.99999999999997" height="32"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Whw-1A-6W0">
-                                                <rect key="frame" x="46.666666666666657" y="645" width="132" height="30"/>
+                                                <rect key="frame" x="45.666666666666657" y="704" width="132" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="132" id="3AL-CV-xOh"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="c3f-6R-YHU"/>
-                                                    <constraint firstAttribute="width" constant="132" id="iGb-HB-Cen"/>
-                                                    <constraint firstAttribute="height" constant="30" id="u7C-Vg-e6B"/>
+                                                    <constraint firstAttribute="height" constant="30" id="QCe-y1-azO"/>
                                                 </constraints>
-                                                <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9Tw-qJ-FVq">
-                                                <rect key="frame" x="46.666666666666657" y="683" width="132" height="30"/>
+                                                <rect key="frame" x="45.666666666666657" y="742" width="132" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="132" id="Gg3-t7-DGu"/>
-                                                    <constraint firstAttribute="height" constant="30" id="swY-Wc-sXV"/>
+                                                    <constraint firstAttribute="height" constant="30" id="8XX-vc-sES"/>
                                                 </constraints>
-                                                <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zQ9-CS-si6">
-                                                <rect key="frame" x="194.66666666666663" y="683" width="153" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="153" id="0aq-Pz-1Nz"/>
-                                                    <constraint firstAttribute="height" constant="30" id="Zir-3E-7qh"/>
-                                                </constraints>
+                                                <rect key="frame" x="193.66666666666663" y="742" width="153" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Send unique Outcome"/>
                                                 <connections>
@@ -238,14 +217,8 @@
                                                     <action selector="sendUniqueOutcomeEvent:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7hu-Fe-chY"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f4C-he-vQl">
-                                                <rect key="frame" x="194.66666666666663" y="645" width="133" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="5gI-q4-2ku"/>
-                                                    <constraint firstAttribute="width" constant="133" id="efK-zq-e7M"/>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="133" id="s5U-2u-wa4"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="xDn-C0-eFd"/>
-                                                </constraints>
+                                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f4C-he-vQl">
+                                                <rect key="frame" x="193.66666666666663" y="704" width="133" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Send Outcome"/>
                                                 <connections>
@@ -254,11 +227,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="De4-AJ-nrw">
-                                                <rect key="frame" x="97.666666666666686" y="599" width="180" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="180" id="FSO-Vf-yRd"/>
-                                                    <constraint firstAttribute="height" constant="30" id="jMN-Sf-exb"/>
-                                                </constraints>
+                                                <rect key="frame" x="96.666666666666671" y="658" width="179.66666666666663" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Send Outcome With Value"/>
                                                 <connections>
@@ -267,7 +236,7 @@
                                                 </connections>
                                             </button>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="XKn-G6-r2q">
-                                                <rect key="frame" x="16" y="729" width="343" height="105"/>
+                                                <rect key="frame" x="15" y="788" width="343" height="105"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -275,78 +244,95 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="G56-cW-rWo" firstAttribute="trailing" secondItem="A38-En-69W" secondAttribute="trailing" id="070-rr-He7"/>
-                                            <constraint firstItem="Xj9-lX-hR2" firstAttribute="leading" secondItem="bmb-ib-r40" secondAttribute="leading" id="0Uc-6n-dEo"/>
-                                            <constraint firstAttribute="trailing" secondItem="XKn-G6-r2q" secondAttribute="trailing" constant="16" id="0gW-Wt-C2R"/>
-                                            <constraint firstItem="j3e-42-uww" firstAttribute="centerX" secondItem="05S-ud-V2e" secondAttribute="centerX" id="1Sf-7c-jOe"/>
-                                            <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="centerX" secondItem="H3K-GA-smE" secondAttribute="centerX" id="4Jj-Nt-cIZ"/>
-                                            <constraint firstItem="Xj9-lX-hR2" firstAttribute="top" secondItem="Ecj-vJ-K60" secondAttribute="bottom" constant="8" id="5ue-Y3-W13"/>
-                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="top" secondItem="De4-AJ-nrw" secondAttribute="bottom" constant="16" id="78l-TJ-jAI"/>
-                                            <constraint firstItem="G56-cW-rWo" firstAttribute="leading" secondItem="Ykz-Wq-cb5" secondAttribute="trailing" constant="15" id="7t7-sb-wUv"/>
-                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="top" secondItem="A38-En-69W" secondAttribute="top" id="7tD-ol-9tR"/>
-                                            <constraint firstItem="bmb-ib-r40" firstAttribute="top" secondItem="cWh-Hu-7CP" secondAttribute="bottom" constant="18" id="ANy-V5-B7Z"/>
-                                            <constraint firstAttribute="bottom" secondItem="7au-a5-gty" secondAttribute="bottom" constant="267" id="AhF-dz-Y7U"/>
-                                            <constraint firstItem="De4-AJ-nrw" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="B6L-lH-eba"/>
-                                            <constraint firstItem="bmb-ib-r40" firstAttribute="leading" secondItem="7au-a5-gty" secondAttribute="leading" id="Ejf-Uw-KwU"/>
-                                            <constraint firstAttribute="height" constant="850" id="Fuw-EV-7Vv"/>
-                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="top" secondItem="f4C-he-vQl" secondAttribute="top" id="Gon-zA-vro"/>
-                                            <constraint firstItem="9Tw-qJ-FVq" firstAttribute="top" secondItem="Whw-1A-6W0" secondAttribute="bottom" constant="8" id="H5z-rW-LkL"/>
-                                            <constraint firstItem="f4C-he-vQl" firstAttribute="leading" secondItem="Whw-1A-6W0" secondAttribute="trailing" constant="16" id="Hql-bE-rmS"/>
-                                            <constraint firstItem="saG-x9-o6U" firstAttribute="top" secondItem="Whm-aD-RCM" secondAttribute="bottom" constant="17" id="IF7-Jc-Gom"/>
-                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="leading" secondItem="Xj9-lX-hR2" secondAttribute="leading" id="IHo-98-DQf"/>
-                                            <constraint firstItem="G56-cW-rWo" firstAttribute="top" secondItem="saG-x9-o6U" secondAttribute="bottom" constant="15" id="L60-Gp-Sh0"/>
-                                            <constraint firstItem="j3e-42-uww" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="NsN-kb-Xt9"/>
-                                            <constraint firstAttribute="bottom" secondItem="XKn-G6-r2q" secondAttribute="bottom" constant="16" id="OVj-AQ-aXl"/>
-                                            <constraint firstItem="H3K-GA-smE" firstAttribute="centerX" secondItem="Whm-aD-RCM" secondAttribute="centerX" id="OuE-Pj-ufv"/>
-                                            <constraint firstItem="saG-x9-o6U" firstAttribute="centerX" secondItem="79P-xw-1Q5" secondAttribute="centerX" id="RFT-gh-vAq"/>
-                                            <constraint firstItem="05S-ud-V2e" firstAttribute="centerX" secondItem="TVC-yc-aRa" secondAttribute="centerX" id="SR4-ZQ-RpQ"/>
-                                            <constraint firstItem="H3K-GA-smE" firstAttribute="top" secondItem="Kp7-Oh-BQ1" secondAttribute="bottom" constant="8" symbolic="YES" id="TXk-Ob-0qX"/>
-                                            <constraint firstItem="Ecj-vJ-K60" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="UyB-It-oBR"/>
-                                            <constraint firstItem="knZ-rP-bRU" firstAttribute="top" secondItem="Ecj-vJ-K60" secondAttribute="bottom" constant="8" id="XDD-mf-U89"/>
-                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="top" secondItem="79P-xw-1Q5" secondAttribute="bottom" constant="8" symbolic="YES" id="Ygg-Hc-MZx"/>
-                                            <constraint firstItem="A38-En-69W" firstAttribute="leading" secondItem="idh-ud-yeY" secondAttribute="leading" id="Yy4-R7-xry"/>
-                                            <constraint firstItem="idh-ud-yeY" firstAttribute="trailing" secondItem="7au-a5-gty" secondAttribute="trailing" id="aF6-wx-sGU"/>
-                                            <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="top" secondItem="TVC-yc-aRa" secondAttribute="bottom" constant="8" symbolic="YES" id="bT0-tf-1dH"/>
-                                            <constraint firstItem="Whm-aD-RCM" firstAttribute="top" secondItem="H3K-GA-smE" secondAttribute="bottom" constant="36" id="eOm-rv-EiF"/>
-                                            <constraint firstItem="05S-ud-V2e" firstAttribute="top" secondItem="j3e-42-uww" secondAttribute="bottom" constant="8" symbolic="YES" id="fX5-fB-2Se"/>
-                                            <constraint firstItem="G56-cW-rWo" firstAttribute="leading" secondItem="A38-En-69W" secondAttribute="leading" id="gj1-1e-Dhq"/>
-                                            <constraint firstItem="zQ9-CS-si6" firstAttribute="top" secondItem="f4C-he-vQl" secondAttribute="bottom" constant="8" id="h4j-br-9Ly"/>
-                                            <constraint firstItem="79P-xw-1Q5" firstAttribute="top" secondItem="G56-cW-rWo" secondAttribute="bottom" constant="8" symbolic="YES" id="hJ2-y7-dfE"/>
-                                            <constraint firstItem="j3e-42-uww" firstAttribute="top" secondItem="6dV-2z-2jJ" secondAttribute="top" constant="65" id="hQ9-Dj-FqC"/>
-                                            <constraint firstItem="Ecj-vJ-K60" firstAttribute="top" secondItem="bmb-ib-r40" secondAttribute="bottom" constant="8" id="jED-DA-A1V"/>
-                                            <constraint firstItem="Whm-aD-RCM" firstAttribute="centerX" secondItem="saG-x9-o6U" secondAttribute="centerX" id="kGu-1B-hbp"/>
-                                            <constraint firstItem="De4-AJ-nrw" firstAttribute="top" secondItem="7au-a5-gty" secondAttribute="bottom" constant="16" id="kip-tl-kro"/>
-                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="top" secondItem="05S-ud-V2e" secondAttribute="bottom" constant="18" id="l8e-uh-Cw6"/>
-                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="leading" secondItem="bmb-ib-r40" secondAttribute="leading" id="m3M-qg-za6"/>
-                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="leading" secondItem="cWh-Hu-7CP" secondAttribute="leading" id="p3n-gr-JVq"/>
-                                            <constraint firstItem="A38-En-69W" firstAttribute="trailing" secondItem="idh-ud-yeY" secondAttribute="trailing" id="qs4-S5-ShT"/>
-                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="centerX" secondItem="Kp7-Oh-BQ1" secondAttribute="centerX" id="svc-Bs-wLI"/>
-                                            <constraint firstItem="knZ-rP-bRU" firstAttribute="leading" secondItem="Xj9-lX-hR2" secondAttribute="trailing" constant="8" id="tmK-EA-cPj"/>
-                                            <constraint firstItem="XKn-G6-r2q" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="16" id="txs-yp-cN8"/>
-                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="baseline" secondItem="G56-cW-rWo" secondAttribute="baseline" id="uFl-n6-FHV"/>
-                                            <constraint firstItem="79P-xw-1Q5" firstAttribute="centerX" secondItem="7au-a5-gty" secondAttribute="centerX" id="uUQ-Ei-Obj"/>
-                                            <constraint firstItem="bmb-ib-r40" firstAttribute="top" secondItem="idh-ud-yeY" secondAttribute="top" id="uXp-8a-IM6"/>
-                                            <constraint firstItem="zQ9-CS-si6" firstAttribute="leading" secondItem="9Tw-qJ-FVq" secondAttribute="trailing" constant="16" id="wzk-s7-e12"/>
-                                            <constraint firstItem="9Tw-qJ-FVq" firstAttribute="leading" secondItem="Xj9-lX-hR2" secondAttribute="leading" id="xV6-HX-svn"/>
-                                            <constraint firstItem="XKn-G6-r2q" firstAttribute="top" secondItem="9Tw-qJ-FVq" secondAttribute="bottom" constant="16" id="zi3-oK-8U1"/>
+                                            <constraint firstItem="wT0-PD-6z7" firstAttribute="centerX" secondItem="gZI-5K-94s" secondAttribute="centerX" id="0ZT-nK-mcp"/>
+                                            <constraint firstItem="7au-a5-gty" firstAttribute="top" secondItem="Ecj-vJ-K60" secondAttribute="bottom" id="1UR-cM-krV"/>
+                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="trailing" secondItem="Xj9-lX-hR2" secondAttribute="trailing" id="1YU-5z-VFv"/>
+                                            <constraint firstItem="saG-x9-o6U" firstAttribute="centerX" secondItem="79P-xw-1Q5" secondAttribute="centerX" id="3TW-dg-dyJ"/>
+                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="45.666666666666657" id="3YQ-a2-ECj"/>
+                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="top" secondItem="De4-AJ-nrw" secondAttribute="bottom" constant="16" id="5Lb-po-dWK"/>
+                                            <constraint firstItem="De4-AJ-nrw" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="96.666666666666671" id="5kd-tw-qnK"/>
+                                            <constraint firstAttribute="trailing" secondItem="knZ-rP-bRU" secondAttribute="trailing" constant="54.333333333333371" id="7H0-aQ-Ozl"/>
+                                            <constraint firstItem="knZ-rP-bRU" firstAttribute="leading" secondItem="Xj9-lX-hR2" secondAttribute="trailing" constant="7.9999999999999716" id="7li-jl-GST"/>
+                                            <constraint firstItem="A38-En-69W" firstAttribute="trailing" secondItem="idh-ud-yeY" secondAttribute="trailing" id="8US-vs-Fni"/>
+                                            <constraint firstItem="bmb-ib-r40" firstAttribute="top" secondItem="idh-ud-yeY" secondAttribute="top" id="9yE-lu-NwI"/>
+                                            <constraint firstItem="XKn-G6-r2q" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="15" id="9zr-SP-RFT"/>
+                                            <constraint firstItem="7au-a5-gty" firstAttribute="centerX" secondItem="De4-AJ-nrw" secondAttribute="centerX" id="A1Q-jf-N8b"/>
+                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="leading" secondItem="9Tw-qJ-FVq" secondAttribute="leading" id="ADA-RS-6uk"/>
+                                            <constraint firstItem="05S-ud-V2e" firstAttribute="top" secondItem="j3e-42-uww" secondAttribute="bottom" constant="8" id="BEp-Rs-HmE"/>
+                                            <constraint firstItem="Whm-aD-RCM" firstAttribute="top" secondItem="gZI-5K-94s" secondAttribute="bottom" constant="18" id="BNZ-2J-Txt"/>
+                                            <constraint firstItem="bmb-ib-r40" firstAttribute="trailing" secondItem="Whw-1A-6W0" secondAttribute="trailing" id="CD1-eI-6bV"/>
+                                            <constraint firstItem="Xj9-lX-hR2" firstAttribute="top" secondItem="Ecj-vJ-K60" secondAttribute="bottom" constant="8" id="EMG-NT-GpX"/>
+                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="top" secondItem="A38-En-69W" secondAttribute="top" id="ET2-Bx-oB2"/>
+                                            <constraint firstItem="9Tw-qJ-FVq" firstAttribute="top" secondItem="zQ9-CS-si6" secondAttribute="top" id="EcY-3v-m2g"/>
+                                            <constraint firstItem="wT0-PD-6z7" firstAttribute="leading" secondItem="Whm-aD-RCM" secondAttribute="leading" id="GCU-dL-7XC"/>
+                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="centerX" secondItem="Kp7-Oh-BQ1" secondAttribute="centerX" id="HCs-OD-mS2"/>
+                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="top" secondItem="79P-xw-1Q5" secondAttribute="bottom" constant="8" id="J9u-B8-6mh"/>
+                                            <constraint firstItem="Whm-aD-RCM" firstAttribute="centerX" secondItem="saG-x9-o6U" secondAttribute="centerX" constant="1" id="JPd-DJ-qbM"/>
+                                            <constraint firstItem="G56-cW-rWo" firstAttribute="top" secondItem="saG-x9-o6U" secondAttribute="bottom" constant="13" id="K2O-zM-oxs"/>
+                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="leading" secondItem="cWh-Hu-7CP" secondAttribute="leading" id="M9e-TJ-BPe"/>
+                                            <constraint firstItem="De4-AJ-nrw" firstAttribute="top" secondItem="7au-a5-gty" secondAttribute="bottom" constant="16" id="NIi-eF-Hyo"/>
+                                            <constraint firstItem="Ecj-vJ-K60" firstAttribute="centerX" secondItem="7au-a5-gty" secondAttribute="centerX" id="PGm-wr-BGa"/>
+                                            <constraint firstItem="knZ-rP-bRU" firstAttribute="top" secondItem="Ecj-vJ-K60" secondAttribute="bottom" constant="6" id="PZB-FI-0cY"/>
+                                            <constraint firstItem="j3e-42-uww" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="Psf-g8-2Id"/>
+                                            <constraint firstItem="G56-cW-rWo" firstAttribute="trailing" secondItem="A38-En-69W" secondAttribute="trailing" id="QEO-49-idg"/>
+                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="leading" secondItem="bmb-ib-r40" secondAttribute="leading" id="Qzi-IH-IFZ"/>
+                                            <constraint firstItem="bmb-ib-r40" firstAttribute="leading" secondItem="7au-a5-gty" secondAttribute="leading" id="RfW-Jb-aPz"/>
+                                            <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="top" secondItem="TVC-yc-aRa" secondAttribute="bottom" constant="8" id="RtD-xS-8z3"/>
+                                            <constraint firstItem="j3e-42-uww" firstAttribute="top" secondItem="6dV-2z-2jJ" secondAttribute="top" constant="65" id="UGh-ZC-RhX"/>
+                                            <constraint firstItem="Whm-aD-RCM" firstAttribute="leading" secondItem="Ecj-vJ-K60" secondAttribute="leading" constant="1" id="VOK-ev-RTV"/>
+                                            <constraint firstItem="A38-En-69W" firstAttribute="leading" secondItem="cWh-Hu-7CP" secondAttribute="trailing" constant="17" id="YRg-Pi-R8I"/>
+                                            <constraint firstItem="idh-ud-yeY" firstAttribute="trailing" secondItem="7au-a5-gty" secondAttribute="trailing" id="YVg-AS-esS"/>
+                                            <constraint firstItem="cWh-Hu-7CP" firstAttribute="trailing" secondItem="bmb-ib-r40" secondAttribute="trailing" id="Zi0-Ak-z1H"/>
+                                            <constraint firstItem="05S-ud-V2e" firstAttribute="centerX" secondItem="TVC-yc-aRa" secondAttribute="centerX" id="Zpc-U6-A5y"/>
+                                            <constraint firstItem="H3K-GA-smE" firstAttribute="top" secondItem="Kp7-Oh-BQ1" secondAttribute="bottom" constant="8" id="aSG-2M-dTc"/>
+                                            <constraint firstItem="saG-x9-o6U" firstAttribute="top" secondItem="Whm-aD-RCM" secondAttribute="bottom" constant="14" id="adb-5Q-raZ"/>
+                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="top" secondItem="05S-ud-V2e" secondAttribute="bottom" constant="18" id="bgg-xw-XwK"/>
+                                            <constraint firstItem="Xj9-lX-hR2" firstAttribute="bottom" secondItem="knZ-rP-bRU" secondAttribute="bottom" id="eA6-KM-ozQ"/>
+                                            <constraint firstItem="f4C-he-vQl" firstAttribute="leading" secondItem="zQ9-CS-si6" secondAttribute="leading" id="ea4-dn-VE9"/>
+                                            <constraint firstItem="XKn-G6-r2q" firstAttribute="top" secondItem="9Tw-qJ-FVq" secondAttribute="bottom" constant="16" id="eaR-Fk-W8s"/>
+                                            <constraint firstItem="f4C-he-vQl" firstAttribute="leading" secondItem="Whw-1A-6W0" secondAttribute="trailing" constant="15.999999999999972" id="f8S-xT-jpb"/>
+                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="trailing" secondItem="9Tw-qJ-FVq" secondAttribute="trailing" id="fOR-cE-Zaa"/>
+                                            <constraint firstItem="Whm-aD-RCM" firstAttribute="trailing" secondItem="Ecj-vJ-K60" secondAttribute="trailing" constant="1" id="gic-WK-yi1"/>
+                                            <constraint firstItem="A38-En-69W" firstAttribute="leading" secondItem="idh-ud-yeY" secondAttribute="leading" id="hOo-6r-9uP"/>
+                                            <constraint firstAttribute="bottom" secondItem="XKn-G6-r2q" secondAttribute="bottom" constant="-43" id="hve-rj-VQa"/>
+                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="top" secondItem="saG-x9-o6U" secondAttribute="bottom" constant="15" id="hyN-FW-j9s"/>
+                                            <constraint firstItem="G56-cW-rWo" firstAttribute="leading" secondItem="Ykz-Wq-cb5" secondAttribute="trailing" constant="15" id="kU4-K4-ayv"/>
+                                            <constraint firstItem="Whw-1A-6W0" firstAttribute="top" secondItem="f4C-he-vQl" secondAttribute="top" id="kxu-9G-k5h"/>
+                                            <constraint firstItem="wT0-PD-6z7" firstAttribute="centerX" secondItem="H3K-GA-smE" secondAttribute="centerX" id="lAd-KI-FY8"/>
+                                            <constraint firstItem="Ykz-Wq-cb5" firstAttribute="bottom" secondItem="G56-cW-rWo" secondAttribute="bottom" id="lSM-5c-DxS"/>
+                                            <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="centerX" secondItem="H3K-GA-smE" secondAttribute="centerX" id="mRt-AJ-OBk"/>
+                                            <constraint firstItem="Xj9-lX-hR2" firstAttribute="leading" secondItem="Whw-1A-6W0" secondAttribute="leading" id="n0X-eM-041"/>
+                                            <constraint firstItem="De4-AJ-nrw" firstAttribute="centerX" secondItem="XKn-G6-r2q" secondAttribute="centerX" id="oiz-Zf-GBx"/>
+                                            <constraint firstItem="wT0-PD-6z7" firstAttribute="top" secondItem="H3K-GA-smE" secondAttribute="bottom" constant="15" id="ojL-ev-kNn"/>
+                                            <constraint firstItem="idh-ud-yeY" firstAttribute="centerX" secondItem="f4C-he-vQl" secondAttribute="centerX" id="os8-By-I6y"/>
+                                            <constraint firstItem="79P-xw-1Q5" firstAttribute="top" secondItem="G56-cW-rWo" secondAttribute="bottom" constant="8" id="osU-b6-I30"/>
+                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="14.666666666666657" id="ouH-Wx-AAD"/>
+                                            <constraint firstItem="De4-AJ-nrw" firstAttribute="top" secondItem="Xj9-lX-hR2" secondAttribute="bottom" constant="6" id="pCd-xW-9UB"/>
+                                            <constraint firstItem="j3e-42-uww" firstAttribute="centerX" secondItem="05S-ud-V2e" secondAttribute="centerX" id="pbJ-aN-4Fd"/>
+                                            <constraint firstAttribute="height" constant="850" id="qKR-2z-UgG"/>
+                                            <constraint firstItem="gZI-5K-94s" firstAttribute="top" secondItem="wT0-PD-6z7" secondAttribute="bottom" constant="13" id="teY-sG-FWL"/>
+                                            <constraint firstItem="Ecj-vJ-K60" firstAttribute="top" secondItem="bmb-ib-r40" secondAttribute="bottom" constant="8" id="uFL-iF-4YC"/>
+                                            <constraint firstItem="9Tw-qJ-FVq" firstAttribute="top" secondItem="Whw-1A-6W0" secondAttribute="bottom" constant="8" id="vNh-Vd-Dk8"/>
+                                            <constraint firstItem="bmb-ib-r40" firstAttribute="top" secondItem="cWh-Hu-7CP" secondAttribute="bottom" constant="18" id="w2d-na-OzR"/>
+                                            <constraint firstItem="G56-cW-rWo" firstAttribute="leading" secondItem="A38-En-69W" secondAttribute="leading" id="xmz-74-IFS"/>
+                                            <constraint firstItem="7au-a5-gty" firstAttribute="leading" secondItem="Xj9-lX-hR2" secondAttribute="leading" id="yYP-WY-7HX"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="6dV-2z-2jJ" secondAttribute="bottom" constant="-10" id="N2e-Pl-ggS"/>
-                                    <constraint firstAttribute="trailing" secondItem="6dV-2z-2jJ" secondAttribute="trailing" id="VnM-4p-tkT"/>
-                                    <constraint firstItem="6dV-2z-2jJ" firstAttribute="leading" secondItem="Dse-f7-S3F" secondAttribute="leading" id="hWg-Ts-CVk"/>
-                                    <constraint firstItem="6dV-2z-2jJ" firstAttribute="centerX" secondItem="Dse-f7-S3F" secondAttribute="centerX" id="ipt-Pq-Res"/>
-                                    <constraint firstItem="6dV-2z-2jJ" firstAttribute="top" secondItem="Dse-f7-S3F" secondAttribute="top" constant="-40" id="nM2-Av-aYu"/>
+                                    <constraint firstAttribute="trailing" secondItem="6dV-2z-2jJ" secondAttribute="trailing" id="Zy3-DG-kdf"/>
+                                    <constraint firstItem="6dV-2z-2jJ" firstAttribute="centerX" secondItem="Dse-f7-S3F" secondAttribute="centerX" id="b4l-hR-Ol3"/>
+                                    <constraint firstItem="6dV-2z-2jJ" firstAttribute="leading" secondItem="Dse-f7-S3F" secondAttribute="leading" id="eNr-T4-cUD"/>
+                                    <constraint firstItem="6dV-2z-2jJ" firstAttribute="top" secondItem="Dse-f7-S3F" secondAttribute="top" constant="-40" id="rPm-Iz-hMT"/>
                                 </constraints>
                             </scrollView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="Dse-f7-S3F" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="1Vv-PU-aCG"/>
-                            <constraint firstAttribute="bottom" secondItem="Dse-f7-S3F" secondAttribute="bottom" id="Tt4-yj-0PO"/>
-                            <constraint firstItem="Dse-f7-S3F" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="jvL-tQ-1sf"/>
-                            <constraint firstAttribute="trailing" secondItem="Dse-f7-S3F" secondAttribute="trailing" id="lmW-LL-as8"/>
+                            <constraint firstItem="Dse-f7-S3F" firstAttribute="bottom" secondItem="8bC-Xf-vdC" secondAttribute="bottomMargin" id="XTf-LI-mS8"/>
+                            <constraint firstItem="Dse-f7-S3F" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="-16" id="cgT-OY-WA7"/>
+                            <constraint firstItem="Dse-f7-S3F" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="qZf-dP-dih"/>
+                            <constraint firstItem="Dse-f7-S3F" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="topMargin" id="vVv-aA-zel"/>
                         </constraints>
                     </view>
                     <size key="freeformSize" width="375" height="820"/>
@@ -365,6 +351,7 @@
                         <outlet property="outcomeValueName" destination="Xj9-lX-hR2" id="Dhu-Pd-sBU"/>
                         <outlet property="removeTriggerKey" destination="cWh-Hu-7CP" id="j0S-4T-AXs"/>
                         <outlet property="result" destination="XKn-G6-r2q" id="bPC-p9-k4N"/>
+                        <outlet property="subscriptionSegmentedControl" destination="gZI-5K-94s" id="CCF-Qh-9Xg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.h
@@ -33,5 +33,23 @@
 
 @interface ViewController : UIViewController <OSInAppMessageDelegate>
 
+    @property (weak, nonatomic) IBOutlet UITextField *appIdTextField;
+    @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
+    @property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;
+    @property (weak, nonatomic) IBOutlet UISegmentedControl *subscriptionSegmentedControl;
+    @property (weak, nonatomic) IBOutlet UISegmentedControl *inAppMessagingSegmentedControl;
+    @property (weak, nonatomic) IBOutlet UITextField *addTriggerKey;
+    @property (weak, nonatomic) IBOutlet UITextField *addTriggerValue;
+    @property (weak, nonatomic) IBOutlet UIButton *addTriggerButton;
+    @property (weak, nonatomic) IBOutlet UITextField *removeTriggerKey;
+    @property (weak, nonatomic) IBOutlet UITextField *getTriggerKey;
+    @property (weak, nonatomic) IBOutlet UILabel *infoLabel;
+    @property (weak, nonatomic) IBOutlet UITextField *externalIdTextField;
+    @property (weak, nonatomic) IBOutlet UITextField *outcomeName;
+    @property (weak, nonatomic) IBOutlet UITextField *outcomeValueName;
+    @property (weak, nonatomic) IBOutlet UITextField *outcomeValue;
+    @property (weak, nonatomic) IBOutlet UITextField *outcomeUniqueName;
+    @property (weak, nonatomic) IBOutlet UITextView *result;
+
 @end
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -31,27 +31,6 @@
 #import "ViewController.h"
 #import "AppDelegate.h"
 
-
-@interface ViewController ()
-@property (weak, nonatomic) IBOutlet UITextField *appIdTextField;
-@property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
-@property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;
-@property (weak, nonatomic) IBOutlet UISegmentedControl *inAppMessagingSegmentedControl;
-@property (weak, nonatomic) IBOutlet UITextField *addTriggerKey;
-@property (weak, nonatomic) IBOutlet UITextField *addTriggerValue;
-@property (weak, nonatomic) IBOutlet UIButton *addTriggerButton;
-@property (weak, nonatomic) IBOutlet UITextField *removeTriggerKey;
-@property (weak, nonatomic) IBOutlet UITextField *getTriggerKey;
-@property (weak, nonatomic) IBOutlet UILabel *infoLabel;
-@property (weak, nonatomic) IBOutlet UITextField *externalIdTextField;
-@property (weak, nonatomic) IBOutlet UITextField *outcomeName;
-@property (weak, nonatomic) IBOutlet UITextField *outcomeValueName;
-@property (weak, nonatomic) IBOutlet UITextField *outcomeValue;
-@property (weak, nonatomic) IBOutlet UITextField *outcomeUniqueName;
-@property (weak, nonatomic) IBOutlet UITextView *result;
-
-@end
-
 @implementation ViewController
 
 - (void)viewDidLoad {
@@ -60,9 +39,11 @@
     
     self.activityIndicatorView.hidden = true;
     
-    self.consentSegmentedControl.selectedSegmentIndex = (NSInteger)![OneSignal requiresUserPrivacyConsent];
+    self.consentSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal requiresUserPrivacyConsent];
 
-    self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger)![OneSignal isInAppMessagingPaused];
+    self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getPermissionSubscriptionState.subscriptionStatus.subscribed;
+    
+    self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal isInAppMessagingPaused];
 
     self.appIdTextField.text = [AppDelegate getOneSignalAppId];
 
@@ -102,9 +83,8 @@
 }
 
 - (IBAction)sendTagButton:(id)sender {
-    //[self promptForNotificationsWithNativeiOS10Code];
-    
-    //[OneSignal registerForPushNotifications];
+//    [self promptForNotificationsWithNativeiOS10Code];
+//    [OneSignal registerForPushNotifications];
     
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         NSLog(@"NEW SDK 2.5.0 METHDO: promptForPushNotificationsWithUserResponse: %d", accepted);
@@ -146,13 +126,18 @@
 }
 
 - (IBAction)consentSegmentedControlValueChanged:(UISegmentedControl *)sender {
-    NSLog(@"View controller consent granted: %i", (int)sender.selectedSegmentIndex);
-    [OneSignal consentGranted:(bool)sender.selectedSegmentIndex];
+    NSLog(@"View controller consent granted: %i", (int) sender.selectedSegmentIndex);
+    [OneSignal consentGranted:(bool) sender.selectedSegmentIndex];
+}
+
+- (IBAction)subscriptionSegmentedControlValueChanged:(UISegmentedControl *)sender {
+    NSLog(@"View controller subscription status: %i", (int) sender.selectedSegmentIndex);
+    [OneSignal setSubscription:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {
-    NSLog(@"View controller in app messaging paused: %i", (int)sender.selectedSegmentIndex);
-    [OneSignal pauseInAppMessages:(bool)sender.selectedSegmentIndex];
+    NSLog(@"View controller in app messaging paused: %i", (int) !sender.selectedSegmentIndex);
+    [OneSignal pauseInAppMessages:(bool) !sender.selectedSegmentIndex];
 }
 
 -(void)handleMessageAction:(NSString *)actionId {

--- a/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
@@ -61,7 +61,7 @@ static let DELAY_TIME = 30;
 }
 
 - (NSString*)unsentActiveTimeUserDefaultsKey {
-    return UNSENT_ACTIVE_TIME_ATTRIBUTED;
+    return OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED;
 }
 
 - (void)sendOnFocusCall:(OSFocusCallParams *)params {

--- a/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
@@ -40,10 +40,10 @@
 
 - (instancetype)init {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _emailAddress = [standardUserDefaults getSavedStringForKey:EMAIL_ADDRESS defaultValue:nil];
-    _requiresEmailAuth = [standardUserDefaults getSavedBoolForKey:REQUIRE_EMAIL_AUTH defaultValue:false];
-    _emailAuthCode = [standardUserDefaults getSavedStringForKey:EMAIL_AUTH_CODE defaultValue:nil];
-    _emailUserId = [standardUserDefaults getSavedStringForKey:EMAIL_USERID defaultValue:nil];
+    _emailAddress = [standardUserDefaults getSavedStringForKey:OSUD_EMAIL_ADDRESS defaultValue:nil];
+    _requiresEmailAuth = [standardUserDefaults getSavedBoolForKey:OSUD_REQUIRE_EMAIL_AUTH defaultValue:false];
+    _emailAuthCode = [standardUserDefaults getSavedStringForKey:OSUD_EMAIL_AUTH_CODE defaultValue:nil];
+    _emailUserId = [standardUserDefaults getSavedStringForKey:OSUD_EMAIL_PLAYER_ID defaultValue:nil];
     
     return self;
 }
@@ -54,10 +54,10 @@
 
 - (void)persist {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    [standardUserDefaults saveStringForKey:EMAIL_ADDRESS withValue:_emailAddress];
-    [standardUserDefaults saveBoolForKey:REQUIRE_EMAIL_AUTH withValue:_requiresEmailAuth];
-    [standardUserDefaults saveStringForKey:EMAIL_AUTH_CODE withValue:_emailAuthCode];
-    [standardUserDefaults saveStringForKey:EMAIL_USERID withValue:_emailUserId];
+    [standardUserDefaults saveStringForKey:OSUD_EMAIL_ADDRESS withValue:_emailAddress];
+    [standardUserDefaults saveBoolForKey:OSUD_REQUIRE_EMAIL_AUTH withValue:_requiresEmailAuth];
+    [standardUserDefaults saveStringForKey:OSUD_EMAIL_AUTH_CODE withValue:_emailAuthCode];
+    [standardUserDefaults saveStringForKey:OSUD_EMAIL_PLAYER_ID withValue:_emailUserId];
 }
 
 - (NSString *)description {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -34,8 +34,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OSMessagingController : NSObject <OSInAppMessageViewControllerDelegate, OSTriggerControllerDelegate>
-  
-@property (nonatomic) BOOL isInAppMessagingPaused;
+
+@property (class, readonly) BOOL isInAppMessagingPaused;
 
 // Tracks when an IAM is showing or not, useful for deciding to show or hide an IAM
 // Toggled in two places dismissing/displaying

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -180,7 +180,7 @@ static BOOL _isInAppMessagingPaused = false;
 - (void)displayMessage:(OSInAppMessage *)message {
     // Check if the app disabled IAMs for this device before showing an IAM
     if (_isInAppMessagingPaused) {
-        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app messages will not show while pasued"];
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app messages will not show while paused"];
         return;
     }
     
@@ -199,7 +199,6 @@ static BOOL _isInAppMessagingPaused = false;
  Request should only be made for IAMs that are not previews and have not been impressioned yet
  */
 - (void)messageViewImpressionRequest:(OSInAppMessage *)message {
-    
     // Make sure no tracking is performed for previewed IAMs
     // If the messageId exists in cached impressionedInAppMessages return early so the impression is not tracked again
     if (message.isPreview || [self.impressionedInAppMessages containsObject:message.messageId])

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEventsDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEventsDefines.h
@@ -29,14 +29,14 @@
 #define OSOutcomeEventsDefines_h
 
 // Outcome param keys
-static NSString * const OUTCOMES_PARAM = @"outcomes";
-static NSString * const DIRECT_PARAM = @"direct";
-static NSString * const INDIRECT_PARAM = @"indirect";
-static NSString * const UNATTRIBUTED_PARAM = @"unattributed";
-static NSString * const ENABLED_PARAM = @"enabled";
-static NSString * const NOTIFICATION_ATTRIBUTION_PARAM = @"notification_attribution";
-static NSString * const MINUTES_SINCE_DISPLAYED_PARAM = @"minutes_since_displayed";
-static NSString * const LIMIT_PARAM = @"limit";
+static NSString* const OUTCOMES_PARAM = @"outcomes";
+static NSString* const DIRECT_PARAM = @"direct";
+static NSString* const INDIRECT_PARAM = @"indirect";
+static NSString* const UNATTRIBUTED_PARAM = @"unattributed";
+static NSString* const ENABLED_PARAM = @"enabled";
+static NSString* const NOTIFICATION_ATTRIBUTION_PARAM = @"notification_attribution";
+static NSString* const MINUTES_SINCE_DISPLAYED_PARAM = @"minutes_since_displayed";
+static NSString* const LIMIT_PARAM = @"limit";
 
 // Outcome default param values
 static int DEFAULT_INDIRECT_NOTIFICATION_LIMIT = 10;

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomesUtils.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomesUtils.m
@@ -41,27 +41,27 @@
 
 // Number of notifications allowed in an INDIRECT session
 + (NSInteger)getIndirectNotificationLimit {
-    return [OneSignalUserDefaults.initShared getSavedIntegerForKey:NOTIFICATION_LIMIT defaultValue:DEFAULT_INDIRECT_NOTIFICATION_LIMIT];
+    return [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_NOTIFICATION_LIMIT defaultValue:DEFAULT_INDIRECT_NOTIFICATION_LIMIT];
 }
 
 // Time in minutes to keep track of notifications in an INDIRECT session
 + (NSInteger)getIndirectAttributionWindow {
-    return [OneSignalUserDefaults.initShared getSavedIntegerForKey:NOTIFICATION_ATTRIBUTION_WINDOW defaultValue:DEFAULT_INDIRECT_ATTRIBUTION_WINDOW];
+    return [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_NOTIFICATION_ATTRIBUTION_WINDOW defaultValue:DEFAULT_INDIRECT_ATTRIBUTION_WINDOW];
 }
 
 // Flag for DIRECT session enabled
 + (BOOL)isDirectSessionEnabled {
-    return [OneSignalUserDefaults.initShared getSavedBoolForKey:DIRECT_SESSION_ENABLED defaultValue:NO];
+    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_DIRECT_SESSION_ENABLED defaultValue:NO];
 }
 
 // Flag for INDIRECT session enabled
 + (BOOL)isIndirectSessionEnabled {
-    return [OneSignalUserDefaults.initShared getSavedBoolForKey:INDIRECT_SESSION_ENABLED defaultValue:NO];
+    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_INDIRECT_SESSION_ENABLED defaultValue:NO];
 }
 
 // Flag for UNATTRIBUTED session enabled
 + (BOOL)isUnattributedSessionEnabled {
-    return [OneSignalUserDefaults.initShared getSavedBoolForKey:UNATTRIBUTED_SESSION_ENABLED defaultValue:NO];
+    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_UNATTRIBUTED_SESSION_ENABLED defaultValue:NO];
 }
 
 /*
@@ -77,9 +77,9 @@
         NSDictionary *unattributed = [outcomes objectForKey:UNATTRIBUTED_PARAM];
         
         // Save all of the outcome enabled flags
-        [self saveOutcomeEnabledFlag:DIRECT_SESSION_ENABLED dictionary:direct];
-        [self saveOutcomeEnabledFlag:INDIRECT_SESSION_ENABLED dictionary:indirect];
-        [self saveOutcomeEnabledFlag:UNATTRIBUTED_SESSION_ENABLED dictionary:unattributed];
+        [self saveOutcomeEnabledFlag:OSUD_DIRECT_SESSION_ENABLED dictionary:direct];
+        [self saveOutcomeEnabledFlag:OSUD_INDIRECT_SESSION_ENABLED dictionary:indirect];
+        [self saveOutcomeEnabledFlag:OSUD_UNATTRIBUTED_SESSION_ENABLED dictionary:unattributed];
         
         // Validate and save the INDIRECT notification limit and attribution window
         if (indirect) {
@@ -91,8 +91,8 @@
                 int minutesLimitValue = minutesLimit ? [minutesLimit intValue] : DEFAULT_INDIRECT_ATTRIBUTION_WINDOW;
                 int notificationLimitValue = notificationLimit ? [notificationLimit intValue] : DEFAULT_INDIRECT_NOTIFICATION_LIMIT;
                 
-                [OneSignalUserDefaults.initShared saveIntegerForKey:NOTIFICATION_LIMIT withValue:notificationLimitValue];
-                [OneSignalUserDefaults.initShared saveIntegerForKey:NOTIFICATION_ATTRIBUTION_WINDOW withValue:minutesLimitValue];
+                [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_NOTIFICATION_LIMIT withValue:notificationLimitValue];
+                [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_NOTIFICATION_ATTRIBUTION_WINDOW withValue:minutesLimitValue];
             }
         }
     }
@@ -112,38 +112,38 @@
 }
 
 + (Session)getCachedSession {
-    NSString *sessionString = [OneSignalUserDefaults.initShared getSavedStringForKey:CACHED_SESSION defaultValue:OS_SESSION_TO_STRING(UNATTRIBUTED)];
+    NSString *sessionString = [OneSignalUserDefaults.initShared getSavedStringForKey:OSUD_CACHED_SESSION defaultValue:OS_SESSION_TO_STRING(UNATTRIBUTED)];
     return OS_SESSION_FROM_STRING(sessionString);
 }
 
 + (void)saveSession:(Session)session {
-    [OneSignalUserDefaults.initShared saveStringForKey:CACHED_SESSION withValue:OS_SESSION_TO_STRING(session)];
+    [OneSignalUserDefaults.initShared saveStringForKey:OSUD_CACHED_SESSION withValue:OS_SESSION_TO_STRING(session)];
 }
 
 + (NSString *)getCachedDirectNotificationId {
-    return [OneSignalUserDefaults.initShared getSavedStringForKey:CACHED_DIRECT_NOTIFICATION_ID defaultValue:nil];
+    return [OneSignalUserDefaults.initShared getSavedStringForKey:OSUD_CACHED_DIRECT_NOTIFICATION_ID defaultValue:nil];
 }
 
 + (void)saveDirectNotificationId:(NSString *)notificationId {
-    [OneSignalUserDefaults.initShared saveStringForKey:CACHED_DIRECT_NOTIFICATION_ID withValue:notificationId];
+    [OneSignalUserDefaults.initShared saveStringForKey:OSUD_CACHED_DIRECT_NOTIFICATION_ID withValue:notificationId];
 }
 
 + (NSArray *)getCachedIndirectNotificationIds {
-    NSArray *indirectNotifications = [OneSignalUserDefaults.initShared getSavedObjectForKey:CACHED_INDIRECT_NOTIFICATION_IDS defaultValue:nil];
+    NSArray *indirectNotifications = [OneSignalUserDefaults.initShared getSavedObjectForKey:OSUD_CACHED_INDIRECT_NOTIFICATION_IDS defaultValue:nil];
     return indirectNotifications;
 }
 
 + (void)saveIndirectNotificationIds:(NSArray *)indirectNotifications {
-    [OneSignalUserDefaults.initShared saveObjectForKey:CACHED_INDIRECT_NOTIFICATION_IDS withValue:indirectNotifications];
+    [OneSignalUserDefaults.initShared saveObjectForKey:OSUD_CACHED_INDIRECT_NOTIFICATION_IDS withValue:indirectNotifications];
 }
 
 + (NSArray *)getCachedReceivedNotifications {
-    NSArray *notifications = [OneSignalUserDefaults.initShared getSavedCodeableDataForKey:CACHED_RECEIVED_NOTIFICATION_IDS defaultValue:nil];
+    NSArray *notifications = [OneSignalUserDefaults.initShared getSavedCodeableDataForKey:OSUD_CACHED_RECEIVED_NOTIFICATION_IDS defaultValue:nil];
     return notifications;
 }
 
 + (void)saveReceivedNotifications:(NSArray *)notifications {
-    [OneSignalUserDefaults.initShared saveCodeableDataForKey:CACHED_RECEIVED_NOTIFICATION_IDS withValue:notifications];
+    [OneSignalUserDefaults.initShared saveCodeableDataForKey:OSUD_CACHED_RECEIVED_NOTIFICATION_IDS withValue:notifications];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -46,10 +46,10 @@
 
 - (instancetype)initAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _hasPrompted = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST defaultValue:false];
-    _answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST defaultValue:false];
-    _accepted  = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST defaultValue:false];
-    _provisional = [standardUserDefaults getSavedBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST defaultValue:false];
+    _hasPrompted = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_FROM defaultValue:false];
+    _answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_FROM defaultValue:false];
+    _accepted  = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_FROM defaultValue:false];
+    _provisional = [standardUserDefaults getSavedBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION_FROM defaultValue:false];
     _providesAppNotificationSettings = [standardUserDefaults getSavedBoolForKey:OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS defaultValue:false];
     
     return self;
@@ -57,10 +57,10 @@
 
 - (void)persistAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    [standardUserDefaults saveBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST withValue:_hasPrompted];
-    [standardUserDefaults saveBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST withValue:_answeredPrompt];
-    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST withValue:_accepted];
-    [standardUserDefaults saveBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST withValue:_provisional];
+    [standardUserDefaults saveBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_FROM withValue:_hasPrompted];
+    [standardUserDefaults saveBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_FROM withValue:_answeredPrompt];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED_FROM withValue:_accepted];
+    [standardUserDefaults saveBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION_FROM withValue:_provisional];
     [standardUserDefaults saveBoolForKey:OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS withValue:_providesAppNotificationSettings];
 }
 
@@ -80,9 +80,6 @@
 }
 
 - (void)setHasPrompted:(BOOL)inHasPrompted {
-    if (_hasPrompted != inHasPrompted)
-        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS withValue:true];
-    
     BOOL last = self.hasPrompted;
     _hasPrompted = inHasPrompted;
     if (last != self.hasPrompted)
@@ -101,9 +98,6 @@
 }
 
 - (void)setProvisional:(BOOL)provisional {
-    if (_provisional != provisional)
-        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION withValue:provisional];
-    
     BOOL previous = _provisional;
     _provisional = provisional;
     

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -47,10 +47,10 @@
 - (instancetype)initAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
     _hasPrompted = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST defaultValue:false];
-    _answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ANSWERED_PROMPT defaultValue:false];
-    _accepted  = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED defaultValue:false];
-    _provisional = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_PROVISIONAL_STATUS defaultValue:false];
-    _providesAppNotificationSettings = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_PROVIDES_NOTIFICATION_SETTINGS defaultValue:false];
+    _answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST defaultValue:false];
+    _accepted  = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST defaultValue:false];
+    _provisional = [standardUserDefaults getSavedBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST defaultValue:false];
+    _providesAppNotificationSettings = [standardUserDefaults getSavedBoolForKey:OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS defaultValue:false];
     
     return self;
 }
@@ -58,10 +58,10 @@
 - (void)persistAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
     [standardUserDefaults saveBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST withValue:_hasPrompted];
-    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ANSWERED_PROMPT withValue:_answeredPrompt];
-    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED withValue:_accepted];
-    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_PROVISIONAL_STATUS withValue:_provisional];
-    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_PROVIDES_NOTIFICATION_SETTINGS withValue:_providesAppNotificationSettings];
+    [standardUserDefaults saveBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST withValue:_answeredPrompt];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST withValue:_accepted];
+    [standardUserDefaults saveBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST withValue:_provisional];
+    [standardUserDefaults saveBoolForKey:OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS withValue:_providesAppNotificationSettings];
 }
 
 
@@ -96,13 +96,13 @@
     return _hasPrompted;
 }
 
--(BOOL)reachable {
+- (BOOL)reachable {
     return self.provisional || self.accepted;
 }
 
 - (void)setProvisional:(BOOL)provisional {
     if (_provisional != provisional)
-        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_PROVISIONAL_AUTHORIZATION withValue:provisional];
+        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_PROVISIONAL_PUSH_AUTHORIZATION withValue:provisional];
     
     BOOL previous = _provisional;
     _provisional = provisional;
@@ -186,7 +186,6 @@
 
 @end
 
-
 @implementation OSPermissionChangedInternalObserver
 
 - (void)onChanged:(OSPermissionState*)state {
@@ -208,6 +207,7 @@
 @end
 
 @implementation OSPermissionStateChanges
+
 - (NSString*)description {
     static NSString* format = @"<OSSubscriptionStateChanges:\nfrom: %@,\nto:   %@\n>";
     return [NSString stringWithFormat:format, _from, _to];

--- a/iOS_SDK/OneSignalSDK/Source/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPermission.m
@@ -46,22 +46,22 @@
 
 - (instancetype)initAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _hasPrompted = [standardUserDefaults getSavedBoolForKey:PERMISSION_HAS_PROMPTED defaultValue:false];
-    _answeredPrompt = [standardUserDefaults getSavedBoolForKey:PERMISSION_ANSWERED_PROMPT defaultValue:false];
-    _accepted  = [standardUserDefaults getSavedBoolForKey:PERMISSION_ACCEPTED defaultValue:false];
-    _provisional = [standardUserDefaults getSavedBoolForKey:PERMISSION_PROVISIONAL_STATUS defaultValue:false];
-    _providesAppNotificationSettings = [standardUserDefaults getSavedBoolForKey:PERMISSION_PROVIDES_NOTIFICATION_SETTINGS defaultValue:false];
+    _hasPrompted = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST defaultValue:false];
+    _answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ANSWERED_PROMPT defaultValue:false];
+    _accepted  = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED defaultValue:false];
+    _provisional = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_PROVISIONAL_STATUS defaultValue:false];
+    _providesAppNotificationSettings = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_PROVIDES_NOTIFICATION_SETTINGS defaultValue:false];
     
     return self;
 }
 
 - (void)persistAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    [standardUserDefaults saveBoolForKey:PERMISSION_HAS_PROMPTED withValue:_hasPrompted];
-    [standardUserDefaults saveBoolForKey:PERMISSION_ANSWERED_PROMPT withValue:_answeredPrompt];
-    [standardUserDefaults saveBoolForKey:PERMISSION_ACCEPTED withValue:_accepted];
-    [standardUserDefaults saveBoolForKey:PERMISSION_PROVISIONAL_STATUS withValue:_provisional];
-    [standardUserDefaults saveBoolForKey:PERMISSION_PROVIDES_NOTIFICATION_SETTINGS withValue:_providesAppNotificationSettings];
+    [standardUserDefaults saveBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST withValue:_hasPrompted];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ANSWERED_PROMPT withValue:_answeredPrompt];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED withValue:_accepted];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_PROVISIONAL_STATUS withValue:_provisional];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_PROVIDES_NOTIFICATION_SETTINGS withValue:_providesAppNotificationSettings];
 }
 
 
@@ -81,7 +81,7 @@
 
 - (void)setHasPrompted:(BOOL)inHasPrompted {
     if (_hasPrompted != inHasPrompted)
-        [OneSignalUserDefaults.initStandard saveBoolForKey:HAS_PROMPTED_FOR_NOTIFICATIONS withValue:true];
+        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS withValue:true];
     
     BOOL last = self.hasPrompted;
     _hasPrompted = inHasPrompted;
@@ -102,7 +102,7 @@
 
 - (void)setProvisional:(BOOL)provisional {
     if (_provisional != provisional)
-        [OneSignalUserDefaults.initStandard saveBoolForKey:PROVISIONAL_AUTHORIZATION withValue:provisional];
+        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_PROVISIONAL_AUTHORIZATION withValue:provisional];
     
     BOOL previous = _provisional;
     _provisional = provisional;

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -45,9 +45,9 @@
     _accpeted = permission;
     
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID defaultValue:nil];
-    _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN defaultValue:nil];
-    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION];
+    _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_TO defaultValue:nil];
+    _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_TO defaultValue:nil];
+    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_TO];
     
     return self;
 }
@@ -61,10 +61,10 @@
 
 - (instancetype)initAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST defaultValue:false];
-    _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_LAST defaultValue:nil];
-    _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_LAST defaultValue:nil];
-    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_LAST];
+    _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_FROM defaultValue:false];
+    _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_FROM defaultValue:nil];
+    _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_FROM defaultValue:nil];
+    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_FROM];
     
     return self;
 }
@@ -75,10 +75,10 @@
         strUserSubscriptionSetting = @"no";
     
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST withValue:_accpeted];
-    [standardUserDefaults saveStringForKey:OSUD_PLAYER_ID_LAST withValue:_userId];
-    [standardUserDefaults saveObjectForKey:OSUD_PUSH_TOKEN_LAST withValue:_pushToken];
-    [standardUserDefaults saveObjectForKey:OSUD_USER_SUBSCRIPTION_LAST withValue:strUserSubscriptionSetting];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED_FROM withValue:_accpeted];
+    [standardUserDefaults saveStringForKey:OSUD_PLAYER_ID_FROM withValue:_userId];
+    [standardUserDefaults saveObjectForKey:OSUD_PUSH_TOKEN_FROM withValue:_pushToken];
+    [standardUserDefaults saveObjectForKey:OSUD_USER_SUBSCRIPTION_FROM withValue:strUserSubscriptionSetting];
 }
 
 - (instancetype)copyWithZone:(NSZone*)zone {
@@ -109,7 +109,7 @@
     BOOL changed = ![[NSString stringWithString:pushToken] isEqualToString:_pushToken];
     _pushToken = pushToken;
     if (changed) {
-        [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PUSH_TOKEN withValue:_pushToken];
+        [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PUSH_TOKEN_TO withValue:_pushToken];
         
         if (self.observable)
             [self.observable notifyChange:self];

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -45,9 +45,9 @@
     _accpeted = permission;
     
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _userId = [standardUserDefaults getSavedStringForKey:USERID defaultValue:nil];
-    _pushToken = [standardUserDefaults getSavedStringForKey:DEVICE_TOKEN defaultValue:nil];
-    _userSubscriptionSetting = [standardUserDefaults getSavedObjectForKey:SUBSCRIPTION defaultValue:nil] == nil;
+    _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID defaultValue:nil];
+    _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN defaultValue:nil];
+    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION];
     
     return self;
 }
@@ -61,10 +61,10 @@
 
 - (instancetype)initAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _accpeted = [standardUserDefaults getSavedBoolForKey:ACCEPTED_PERMISSION defaultValue:false];
-    _userId = [standardUserDefaults getSavedStringForKey:USERID_LAST defaultValue:nil];
-    _pushToken = [standardUserDefaults getSavedStringForKey:PUSH_TOKEN defaultValue:nil];
-    _userSubscriptionSetting = [standardUserDefaults getSavedObjectForKey:SUBSCRIPTION_SETTING defaultValue:nil] == nil;
+    _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_ACCEPTED_PERMISSION defaultValue:false];
+    _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_LAST defaultValue:nil];
+    _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_LAST defaultValue:nil];
+    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_LAST];
     
     return self;
 }
@@ -75,10 +75,10 @@
         strUserSubscriptionSetting = @"no";
     
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    [standardUserDefaults saveBoolForKey:ACCEPTED_PERMISSION withValue:_accpeted];
-    [standardUserDefaults saveStringForKey:USERID_LAST withValue:_userId];
-    [standardUserDefaults saveObjectForKey:PUSH_TOKEN withValue:_pushToken];
-    [standardUserDefaults saveObjectForKey:SUBSCRIPTION_SETTING withValue:strUserSubscriptionSetting];
+    [standardUserDefaults saveBoolForKey:OSUD_ACCEPTED_PERMISSION withValue:_accpeted];
+    [standardUserDefaults saveStringForKey:OSUD_PLAYER_ID_LAST withValue:_userId];
+    [standardUserDefaults saveObjectForKey:OSUD_PUSH_TOKEN_LAST withValue:_pushToken];
+    [standardUserDefaults saveObjectForKey:OSUD_USER_SUBSCRIPTION_LAST withValue:strUserSubscriptionSetting];
 }
 
 - (instancetype)copyWithZone:(NSZone*)zone {
@@ -109,7 +109,7 @@
     BOOL changed = ![[NSString stringWithString:pushToken] isEqualToString:_pushToken];
     _pushToken = pushToken;
     if (changed) {
-        [OneSignalUserDefaults.initStandard saveStringForKey:DEVICE_TOKEN withValue:_pushToken];
+        [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PUSH_TOKEN withValue:_pushToken];
         
         if (self.observable)
             [self.observable notifyChange:self];

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -61,7 +61,7 @@
 
 - (instancetype)initAsFrom {
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_ACCEPTED_PERMISSION defaultValue:false];
+    _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST defaultValue:false];
     _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_LAST defaultValue:nil];
     _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_LAST defaultValue:nil];
     _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_LAST];
@@ -75,7 +75,7 @@
         strUserSubscriptionSetting = @"no";
     
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    [standardUserDefaults saveBoolForKey:OSUD_ACCEPTED_PERMISSION withValue:_accpeted];
+    [standardUserDefaults saveBoolForKey:OSUD_PERMISSION_ACCEPTED_LAST withValue:_accpeted];
     [standardUserDefaults saveStringForKey:OSUD_PLAYER_ID_LAST withValue:_userId];
     [standardUserDefaults saveObjectForKey:OSUD_PUSH_TOKEN_LAST withValue:_pushToken];
     [standardUserDefaults saveObjectForKey:OSUD_USER_SUBSCRIPTION_LAST withValue:strUserSubscriptionSetting];

--- a/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
@@ -60,7 +60,7 @@ static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 60;
 }
 
 - (NSString*)unsentActiveTimeUserDefaultsKey {
-    return UNSENT_ACTIVE_TIME;
+    return OSUD_UNSENT_ACTIVE_TIME;
 }
 
 - (void)sendOnFocusCall:(OSFocusCallParams *)params {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -564,17 +564,17 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
     // Check if disabled in-app launch url if passed a NO
     if (settings[kOSSettingsKeyInAppLaunchURL] && [settings[kOSSettingsKeyInAppLaunchURL] isKindOfClass:[NSNumber class]])
         [self enableInAppLaunchURL:[settings[kOSSettingsKeyInAppLaunchURL] boolValue]];
-    else if (![standardUserDefaults keyExists:OSUD_INAPP_LAUNCH_URL]) {
+    else if (![standardUserDefaults keyExists:OSUD_NOTIFICATION_OPEN_LAUNCH_URL]) {
         // Only need to default to true if the app doesn't already have this setting saved in NSUserDefaults
         [self enableInAppLaunchURL:true];
     }
     
     if (settings[kOSSSettingsKeyPromptBeforeOpeningPushURL] && [settings[kOSSSettingsKeyPromptBeforeOpeningPushURL] isKindOfClass:[NSNumber class]]) {
         promptBeforeOpeningPushURLs = [settings[kOSSSettingsKeyPromptBeforeOpeningPushURL] boolValue];
-        [standardUserDefaults saveBoolForKey:OSUD_PROMPT_BEFORE_OPENING_PUSH_URL withValue:promptBeforeOpeningPushURLs];
+        [standardUserDefaults saveBoolForKey:OSUD_PROMPT_BEFORE_NOTIFICATION_LAUNCH_URL_OPENS withValue:promptBeforeOpeningPushURLs];
     }
     else
-        promptBeforeOpeningPushURLs = [standardUserDefaults getSavedBoolForKey:OSUD_PROMPT_BEFORE_OPENING_PUSH_URL defaultValue:false];
+        promptBeforeOpeningPushURLs = [standardUserDefaults getSavedBoolForKey:OSUD_PROMPT_BEFORE_NOTIFICATION_LAUNCH_URL_OPENS defaultValue:false];
     
     usesAutoPrompt = YES;
     if (settings[kOSSettingsKeyAutoPrompt] && [settings[kOSSettingsKeyAutoPrompt] isKindOfClass:[NSNumber class]])
@@ -685,15 +685,15 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
         [standardUserDefaults saveStringForKey:OSUD_APP_ID withValue:app_id];
         
         // Remove player_id from both standard and shared NSUserDefaults
-        [standardUserDefaults removeValueForKey:OSUD_PLAYER_ID];
-        [sharedUserDefaults removeValueForKey:OSUD_PLAYER_ID];
+        [standardUserDefaults removeValueForKey:OSUD_PLAYER_ID_TO];
+        [sharedUserDefaults removeValueForKey:OSUD_PLAYER_ID_TO];
     }
     
     // Always save app_id and player_id as it will not be present on shared if:
     //   - Updating from an older SDK
     //   - Updating to an app that didn't have App Groups setup before
     [OneSignalUserDefaults.initShared saveStringForKey:OSUD_APP_ID withValue:app_id];
-    [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID withValue:self.currentSubscriptionState.userId];
+    [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID_TO withValue:self.currentSubscriptionState.userId];
     
     // Invalid app ids reaching here will cause failure
     if (!app_id || ![[NSUUID alloc] initWithUUIDString:app_id]) {
@@ -1357,7 +1357,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void)enableInAppLaunchURL:(BOOL)enable {
-    [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_INAPP_LAUNCH_URL withValue:enable];
+    [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL withValue:enable];
 }
 
 + (void)setSubscription:(BOOL)enable {
@@ -1369,7 +1369,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     if (!enable)
         value = @"no";
     
-    [OneSignalUserDefaults.initStandard saveObjectForKey:OSUD_USER_SUBSCRIPTION withValue:value];
+    [OneSignalUserDefaults.initStandard saveObjectForKey:OSUD_USER_SUBSCRIPTION_TO withValue:value];
     
     shouldDelaySubscriptionUpdate = true;
     
@@ -1703,8 +1703,8 @@ static dispatch_queue_t serialQueue;
             }
             
             // Save player_id to both standard and shared NSUserDefaults
-            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PLAYER_ID withValue:self.currentSubscriptionState.userId];
-            [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID withValue:self.currentSubscriptionState.userId];
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PLAYER_ID_TO withValue:self.currentSubscriptionState.userId];
+            [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID_TO withValue:self.currentSubscriptionState.userId];
             
             if (nowProcessingCallbacks) {
                 for (OSPendingCallbacks *callbackSet in nowProcessingCallbacks) {
@@ -2095,7 +2095,7 @@ static NSString *_lastnonActiveMessageId;
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"updateNotificationTypes called: %d", notificationTypes]];
     
     if ([OneSignalHelper isIOSVersionLessThan:@"10.0"])
-        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED withValue:true];
+        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_TO withValue:true];
     
     BOOL startedRegister = [self registerForAPNsToken];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -559,22 +559,22 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
     if ([OneSignalHelper isIOSVersionGreaterThanOrEqual:@"8.0"])
         registeredWithApple = self.currentPermissionState.accepted;
     else
-        registeredWithApple = self.currentSubscriptionState.pushToken || [standardUserDefaults getSavedBoolForKey:REGISTERED_WITH_APPLE defaultValue:false];
+        registeredWithApple = self.currentSubscriptionState.pushToken || [standardUserDefaults getSavedBoolForKey:OSUD_REGISTERED_WITH_APPLE defaultValue:false];
     
     // Check if disabled in-app launch url if passed a NO
     if (settings[kOSSettingsKeyInAppLaunchURL] && [settings[kOSSettingsKeyInAppLaunchURL] isKindOfClass:[NSNumber class]])
         [self enableInAppLaunchURL:[settings[kOSSettingsKeyInAppLaunchURL] boolValue]];
-    else if (![standardUserDefaults keyExists:INAPP_LAUNCH_URL]) {
+    else if (![standardUserDefaults keyExists:OSUD_INAPP_LAUNCH_URL]) {
         // Only need to default to true if the app doesn't already have this setting saved in NSUserDefaults
         [self enableInAppLaunchURL:true];
     }
     
     if (settings[kOSSSettingsKeyPromptBeforeOpeningPushURL] && [settings[kOSSSettingsKeyPromptBeforeOpeningPushURL] isKindOfClass:[NSNumber class]]) {
         promptBeforeOpeningPushURLs = [settings[kOSSSettingsKeyPromptBeforeOpeningPushURL] boolValue];
-        [standardUserDefaults saveBoolForKey:PROMPT_BEFORE_OPENING_PUSH_URL withValue:promptBeforeOpeningPushURLs];
+        [standardUserDefaults saveBoolForKey:OSUD_PROMPT_BEFORE_OPENING_PUSH_URL withValue:promptBeforeOpeningPushURLs];
     }
     else
-        promptBeforeOpeningPushURLs = [standardUserDefaults getSavedBoolForKey:PROMPT_BEFORE_OPENING_PUSH_URL defaultValue:false];
+        promptBeforeOpeningPushURLs = [standardUserDefaults getSavedBoolForKey:OSUD_PROMPT_BEFORE_OPENING_PUSH_URL defaultValue:false];
     
     usesAutoPrompt = YES;
     if (settings[kOSSettingsKeyAutoPrompt] && [settings[kOSSettingsKeyAutoPrompt] isKindOfClass:[NSNumber class]])
@@ -655,7 +655,7 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
     }
 
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
-    let prevAppId = [standardUserDefaults getSavedStringForKey:NSUD_APP_ID defaultValue:nil];
+    let prevAppId = [standardUserDefaults getSavedStringForKey:OSUD_APP_ID defaultValue:nil];
     if (appId) {
         app_id = appId;
     } else {
@@ -682,18 +682,18 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
         _didCallDownloadParameters = false;
         let sharedUserDefaults = OneSignalUserDefaults.initShared;
         
-        [standardUserDefaults saveStringForKey:NSUD_APP_ID withValue:app_id];
+        [standardUserDefaults saveStringForKey:OSUD_APP_ID withValue:app_id];
         
         // Remove player_id from both standard and shared NSUserDefaults
-        [standardUserDefaults removeValueForKey:USERID];
-        [sharedUserDefaults removeValueForKey:USERID];
+        [standardUserDefaults removeValueForKey:OSUD_PLAYER_ID];
+        [sharedUserDefaults removeValueForKey:OSUD_PLAYER_ID];
     }
     
     // Always save app_id and player_id as it will not be present on shared if:
     //   - Updating from an older SDK
     //   - Updating to an app that didn't have App Groups setup before
-    [OneSignalUserDefaults.initShared saveStringForKey:NSUD_APP_ID withValue:app_id];
-    [OneSignalUserDefaults.initShared saveStringForKey:USERID withValue:self.currentSubscriptionState.userId];
+    [OneSignalUserDefaults.initShared saveStringForKey:OSUD_APP_ID withValue:app_id];
+    [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID withValue:self.currentSubscriptionState.userId];
     
     // Invalid app ids reaching here will cause failure
     if (!app_id || ![[NSUUID alloc] initWithUUIDString:app_id]) {
@@ -711,7 +711,7 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
     
-    BOOL usesProvisional = [OneSignalUserDefaults.initStandard getSavedBoolForKey:USES_PROVISIONAL_AUTHORIZATION defaultValue:false];
+    BOOL usesProvisional = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_USES_PROVISIONAL_AUTHORIZATION defaultValue:false];
     
     // if iOS parameters for this app have never downloaded, this method
     // should return
@@ -794,13 +794,13 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
         }
 
         if (!usesAutoPrompt && result[IOS_USES_PROVISIONAL_AUTHORIZATION] != (id)[NSNull null]) {
-            [OneSignalUserDefaults.initStandard saveBoolForKey:USES_PROVISIONAL_AUTHORIZATION withValue:[result[IOS_USES_PROVISIONAL_AUTHORIZATION] boolValue]];
+            [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_USES_PROVISIONAL_AUTHORIZATION withValue:[result[IOS_USES_PROVISIONAL_AUTHORIZATION] boolValue]];
             
             [self checkProvisionalAuthorizationStatus];
         }
 
         if (result[IOS_RECEIVE_RECEIPTS_ENABLE] != (id)[NSNull null])
-            [OneSignalUserDefaults.initShared saveBoolForKey:ONESIGNAL_ENABLE_RECEIVE_RECEIPTS withValue:[result[IOS_RECEIVE_RECEIPTS_ENABLE] boolValue]];
+            [OneSignalUserDefaults.initShared saveBoolForKey:OSUD_ENABLE_RECEIVE_RECEIPTS withValue:[result[IOS_RECEIVE_RECEIPTS_ENABLE] boolValue]];
 
         [OSOutcomesUtils saveOutcomeParamsForApp:result];
         [OneSignalTrackFirebaseAnalytics updateFromDownloadParams:result];
@@ -1357,7 +1357,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void)enableInAppLaunchURL:(BOOL)enable {
-    [OneSignalUserDefaults.initStandard saveBoolForKey:INAPP_LAUNCH_URL withValue:enable];
+    [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_INAPP_LAUNCH_URL withValue:enable];
 }
 
 + (void)setSubscription:(BOOL)enable {
@@ -1365,7 +1365,11 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"setSubscription:"])
         return;
 
-    [OneSignalUserDefaults.initStandard saveBoolForKey:SUBSCRIPTION withValue:enable];
+    NSString* value = nil;
+    if (!enable)
+        value = @"no";
+    
+    [OneSignalUserDefaults.initStandard saveObjectForKey:OSUD_USER_SUBSCRIPTION withValue:value];
     
     shouldDelaySubscriptionUpdate = true;
     
@@ -1498,7 +1502,7 @@ static BOOL isOnSessionSuccessfulForCurrentState = false;
         return false;
     
     NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
-    NSTimeInterval lastTimeClosed = [OneSignalUserDefaults.initStandard getSavedDoubleForKey:USER_LAST_CLOSED_TIME defaultValue:0];
+    NSTimeInterval lastTimeClosed = [OneSignalUserDefaults.initStandard getSavedDoubleForKey:OSUD_USER_LAST_CLOSED_TIME defaultValue:0];
 
     if (lastTimeClosed == 0) {
         onesignal_Log(ONE_S_LL_DEBUG, @"shouldRegisterNow: lastTimeClosed: default.");
@@ -1685,7 +1689,7 @@ static dispatch_queue_t serialQueue;
             }
             
             self.currentEmailSubscriptionState.emailUserId = results[@"email"][@"id"];
-            [OneSignalUserDefaults.initStandard saveStringForKey:EMAIL_USERID withValue:self.currentEmailSubscriptionState.emailUserId];
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_PLAYER_ID withValue:self.currentEmailSubscriptionState.emailUserId];
         }
         
         //update push player id
@@ -1699,8 +1703,8 @@ static dispatch_queue_t serialQueue;
             }
             
             // Save player_id to both standard and shared NSUserDefaults
-            [OneSignalUserDefaults.initStandard saveStringForKey:USERID withValue:self.currentSubscriptionState.userId];
-            [OneSignalUserDefaults.initShared saveStringForKey:USERID withValue:self.currentSubscriptionState.userId];
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PLAYER_ID withValue:self.currentSubscriptionState.userId];
+            [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID withValue:self.currentSubscriptionState.userId];
             
             if (nowProcessingCallbacks) {
                 for (OSPendingCallbacks *callbackSet in nowProcessingCallbacks) {
@@ -2009,7 +2013,7 @@ static NSString *_lastnonActiveMessageId;
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
     //(DUPLICATE Fix): Make sure we do not upload a notification opened twice for the same messageId
     //Keep track of the Id for the last message sent
-    NSString* lastMessageId = [standardUserDefaults getSavedStringForKey:LAST_MESSAGE_OPENED defaultValue:nil];
+    NSString* lastMessageId = [standardUserDefaults getSavedStringForKey:OSUD_LAST_MESSAGE_OPENED defaultValue:nil];
     //Only submit request if messageId not nil and: (lastMessage is nil or not equal to current one)
     if(messageId && (!lastMessageId || ![lastMessageId isEqualToString:messageId])) {
         [OneSignalClient.sharedClient executeRequest:[OSRequestSubmitNotificationOpened withUserId:self.currentSubscriptionState.userId
@@ -2019,7 +2023,7 @@ static NSString *_lastnonActiveMessageId;
                                                                                     withDeviceType:[NSNumber numberWithInt:DEVICE_TYPE_PUSH]]
                                            onSuccess:nil
                                            onFailure:nil];
-        [standardUserDefaults saveStringForKey:LAST_MESSAGE_OPENED withValue:messageId];
+        [standardUserDefaults saveStringForKey:OSUD_LAST_MESSAGE_OPENED withValue:messageId];
     }
 }
     
@@ -2091,7 +2095,7 @@ static NSString *_lastnonActiveMessageId;
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"updateNotificationTypes called: %d", notificationTypes]];
     
     if ([OneSignalHelper isIOSVersionLessThan:@"10.0"])
-        [OneSignalUserDefaults.initStandard saveBoolForKey:NOTIFICATION_PROMPT_ANSWERED withValue:true];
+        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_NOTIFICATION_PROMPT_ANSWERED withValue:true];
     
     BOOL startedRegister = [self registerForAPNsToken];
     
@@ -2374,7 +2378,7 @@ static NSString *_lastnonActiveMessageId;
     
     [OneSignalClient.sharedClient executeRequest:[OSRequestLogoutEmail withAppId: self.app_id emailPlayerId:self.currentEmailSubscriptionState.emailUserId devicePlayerId:self.currentSubscriptionState.userId emailAuthHash:self.currentEmailSubscriptionState.emailAuthCode] onSuccess:^(NSDictionary *result) {
         
-        [OneSignalUserDefaults.initStandard removeValueForKey:EMAIL_USERID];
+        [OneSignalUserDefaults.initStandard removeValueForKey:OSUD_EMAIL_PLAYER_ID];
         
         self.currentEmailSubscriptionState.emailAddress = nil;
         self.currentEmailSubscriptionState.emailAuthCode = nil;
@@ -2536,11 +2540,11 @@ static NSString *_lastnonActiveMessageId;
 }
 
 + (NSString *)existingExternalUserId {
-    return [NSUserDefaults.standardUserDefaults stringForKey:EXTERNAL_USER_ID] ?: @"";
+    return [NSUserDefaults.standardUserDefaults stringForKey:OSUD_EXTERNAL_USER_ID] ?: @"";
 }
 
 + (void)successfullySentExternalUserId:(NSString *)externalId {
-    [NSUserDefaults.standardUserDefaults setObject:externalId forKey:EXTERNAL_USER_ID];
+    [NSUserDefaults.standardUserDefaults setObject:externalId forKey:OSUD_EXTERNAL_USER_ID];
     [NSUserDefaults.standardUserDefaults synchronize];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -711,7 +711,7 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
     
-    BOOL usesProvisional = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_USES_PROVISIONAL_AUTHORIZATION defaultValue:false];
+    BOOL usesProvisional = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION defaultValue:false];
     
     // if iOS parameters for this app have never downloaded, this method
     // should return
@@ -794,13 +794,13 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
         }
 
         if (!usesAutoPrompt && result[IOS_USES_PROVISIONAL_AUTHORIZATION] != (id)[NSNull null]) {
-            [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_USES_PROVISIONAL_AUTHORIZATION withValue:[result[IOS_USES_PROVISIONAL_AUTHORIZATION] boolValue]];
+            [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION withValue:[result[IOS_USES_PROVISIONAL_AUTHORIZATION] boolValue]];
             
             [self checkProvisionalAuthorizationStatus];
         }
 
         if (result[IOS_RECEIVE_RECEIPTS_ENABLE] != (id)[NSNull null])
-            [OneSignalUserDefaults.initShared saveBoolForKey:OSUD_ENABLE_RECEIVE_RECEIPTS withValue:[result[IOS_RECEIVE_RECEIPTS_ENABLE] boolValue]];
+            [OneSignalUserDefaults.initShared saveBoolForKey:OSUD_RECEIVE_RECEIPTS_ENABLED withValue:[result[IOS_RECEIVE_RECEIPTS_ENABLE] boolValue]];
 
         [OSOutcomesUtils saveOutcomeParamsForApp:result];
         [OneSignalTrackFirebaseAnalytics updateFromDownloadParams:result];
@@ -1502,7 +1502,7 @@ static BOOL isOnSessionSuccessfulForCurrentState = false;
         return false;
     
     NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
-    NSTimeInterval lastTimeClosed = [OneSignalUserDefaults.initStandard getSavedDoubleForKey:OSUD_USER_LAST_CLOSED_TIME defaultValue:0];
+    NSTimeInterval lastTimeClosed = [OneSignalUserDefaults.initStandard getSavedDoubleForKey:OSUD_APP_LAST_CLOSED_TIME defaultValue:0];
 
     if (lastTimeClosed == 0) {
         onesignal_Log(ONE_S_LL_DEBUG, @"shouldRegisterNow: lastTimeClosed: default.");
@@ -2095,7 +2095,7 @@ static NSString *_lastnonActiveMessageId;
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"updateNotificationTypes called: %d", notificationTypes]];
     
     if ([OneSignalHelper isIOSVersionLessThan:@"10.0"])
-        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_NOTIFICATION_PROMPT_ANSWERED withValue:true];
+        [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED withValue:true];
     
     BOOL startedRegister = [self registerForAPNsToken];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCacheCleaner.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCacheCleaner.m
@@ -43,7 +43,7 @@
  Iterate through all stored cached OSUniqueOutcomeNotification and clean any items over 7 days old
  */
 + (void)cleanUniqueOutcomeNotifications {
-    NSArray *uniqueOutcomeNotifications = [OneSignalUserDefaults.initShared getSavedCodeableDataForKey:CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT defaultValue:nil];
+    NSArray *uniqueOutcomeNotifications = [OneSignalUserDefaults.initShared getSavedCodeableDataForKey:OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT defaultValue:nil];
     
     NSTimeInterval timeInSeconds = [[NSDate date] timeIntervalSince1970];
     NSMutableArray *finalNotifications = [NSMutableArray new];
@@ -55,7 +55,7 @@
             [finalNotifications addObject:notif];
     }
     
-    [OneSignalUserDefaults.initShared saveCodeableDataForKey:CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT withValue:finalNotifications];
+    [OneSignalUserDefaults.initShared saveCodeableDataForKey:OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT withValue:finalNotifications];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -35,60 +35,62 @@
 #define SERVER_URL @"https://onesignal.com/"
 
 // OneSignalUserDefault keys
-// String values start with "OSUD_" to maintain a level of uniqueness fropm other apps
-// Key names match the string keys associated, for consistency
+// String values start with "OSUD_" to maintain a level of uniqueness from other libs and app code
+// Key names should be identical to the string values to prevent confusion
 // TODO: Refactored variable names, but not strings since UserDefaults might need a migration
 // Comments next to the NSUserDefault keys are the planned string value and key names
-// "?" in line ending comment means uncertainty in naming the string value of the associated key and keeping as is for now
-// TODO: Key names fixed, but string values need fixing
-// App Id
-#define OSUD_APP_ID                                                         @"GT_APP_ID"                                                        // OSUD_APP_ID
-// External Id
-#define OSUD_EXTERNAL_USER_ID                                               @"OS_EXTERNAL_USER_ID"                                              // OSUD_EXTERNAL_USER_ID
+// "?" in comment line ending comment means uncertainty in naming the string value of the associated key and keeping as is for now
+// "$" in comment line ending comment means the key name has not been changed
+// "*" in comment line ending comment means the string value has not been changed
+// App
+#define OSUD_APP_ID                                                         @"GT_APP_ID"                                                        // * OSUD_APP_ID
+#define OSUD_PERMISSION_ACCEPTED                                            @"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"                             // * OSUD_PERMISSION_ACCEPTED
+#define OSUD_PERMISSION_ACCEPTED_LAST                                       @"ONESIGNAL_PERMISSION_ACCEPTED_LAST"                               // * OSUD_PERMISSION_ACCEPTED_LAST
+#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS                                 @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"                                // * OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS
+#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST                            @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"                           // * OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST
+#define OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED                               @"OS_NOTIFICATION_PROMPT_ANSWERED"                                  // * OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED
+#define OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST                          @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"                             // * OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST
+#define OSUD_PROVISIONAL_PUSH_AUTHORIZATION                                 @"ONESIGNAL_PROVISIONAL_AUTHORIZATION"                              // * OSUD_PROVISIONAL_PUSH_AUTHORIZATION
+#define OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST                            @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"                         // * OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST
+#define OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION                            @"ONESIGNAL_USES_PROVISIONAL_PUSH_AUTHORIZATION"                    // * OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION
+// Player
+#define OSUD_EXTERNAL_USER_ID                                               @"OS_EXTERNAL_USER_ID"                                              // * OSUD_EXTERNAL_USER_ID
+#define OSUD_PLAYER_ID                                                      @"GT_PLAYER_ID"                                                     // * OSUD_PLAYER_ID
+#define OSUD_PLAYER_ID_LAST                                                 @"GT_PLAYER_ID_LAST"                                                // * OSUD_PLAYER_ID_LAST
+#define OSUD_PUSH_TOKEN                                                     @"GT_DEVICE_TOKEN"                                                  // * OSUD_PUSH_TOKEN
+#define OSUD_PUSH_TOKEN_LAST                                                @"GT_DEVICE_TOKEN_LAST"                                             // * OSUD_PUSH_TOKEN_LAST
+#define OSUD_USER_SUBSCRIPTION                                              @"ONESIGNAL_SUBSCRIPTION"                                           // * OSUD_USER_SUBSCRIPTION
+#define OSUD_USER_SUBSCRIPTION_LAST                                         @"ONESIGNAL_SUBSCRIPTION_SETTING"                                   // * OSUD_USER_SUBSCRIPTION_LAST
 // Email
-#define OSUD_REQUIRE_EMAIL_AUTH                                             @"GT_REQUIRE_EMAIL_AUTH"                                            // OSUD_REQUIRE_EMAIL_AUTH
-#define OSUD_EMAIL_AUTH_CODE                                                @"GT_EMAIL_AUTH_CODE"                                               // OSUD_EMAIL_AUTH_CODE
-#define OSUD_EMAIL_PLAYER_ID                                                @"GT_EMAIL_PLAYER_ID"                                               // OSUD_EMAIL_PLAYER_ID
-#define OSUD_EMAIL_ADDRESS                                                  @"EMAIL_ADDRESS"                                                    // OSUD_EMAIL_ADDRESS
+#define OSUD_EMAIL_ADDRESS                                                  @"EMAIL_ADDRESS"                                                    // * OSUD_EMAIL_ADDRESS
+#define OSUD_EMAIL_PLAYER_ID                                                @"GT_EMAIL_PLAYER_ID"                                               // * OSUD_EMAIL_PLAYER_ID
+#define OSUD_REQUIRE_EMAIL_AUTH                                             @"GT_REQUIRE_EMAIL_AUTH"                                            // * OSUD_REQUIRE_EMAIL_AUTH
+#define OSUD_EMAIL_AUTH_CODE                                                @"GT_EMAIL_AUTH_CODE"                                               // * OSUD_EMAIL_AUTH_CODE
 // Receive Receipts
-#define OSUD_ENABLE_RECEIVE_RECEIPTS                                        @"OS_ENABLE_RECEIVE_RECEIPTS"                                       // OSUD_ENABLE_RECEIVE_RECEIPTS
+#define OSUD_RECEIVE_RECEIPTS_ENABLED                                       @"OS_ENABLE_RECEIVE_RECEIPTS"                                       // * OSUD_RECEIVE_RECEIPTS_ENABLED
 // Outcomes
-#define OSUD_NOTIFICATION_LIMIT                                             @"NOTIFICATION_LIMIT"                                               // OSUD_NOTIFICATION_LIMIT
-#define OSUD_NOTIFICATION_ATTRIBUTION_WINDOW                                @"NOTIFICATION_ATTRIBUTION_WINDOW"                                  // OSUD_NOTIFICATION_ATTRIBUTION_WINDOW
-#define OSUD_DIRECT_SESSION_ENABLED                                         @"DIRECT_SESSION_ENABLED"                                           // OSUD_DIRECT_SESSION_ENABLED
-#define OSUD_INDIRECT_SESSION_ENABLED                                       @"INDIRECT_SESSION_ENABLED"                                         // OSUD_INDIRECT_SESSION_ENABLED
-#define OSUD_UNATTRIBUTED_SESSION_ENABLED                                   @"UNATTRIBUTED_SESSION_ENABLED"                                     // OSUD_UNATTRIBUTED_SESSION_ENABLED
-#define OSUD_CACHED_SESSION                                                 @"CACHED_SESSION"                                                   // OSUD_CACHED_SESSION
-#define OSUD_CACHED_DIRECT_NOTIFICATION_ID                                  @"CACHED_DIRECT_NOTIFICATION_ID"                                    // OSUD_CACHED_DIRECT_NOTIFICATION_ID
-#define OSUD_CACHED_INDIRECT_NOTIFICATION_IDS                               @"CACHED_INDIRECT_NOTIFICATION_IDS"                                 // OSUD_CACHED_INDIRECT_NOTIFICATION_IDS
-#define OSUD_CACHED_RECEIVED_NOTIFICATION_IDS                               @"CACHED_RECEIVED_NOTIFICATION_IDS"                                 // OSUD_CACHED_RECEIVED_NOTIFICATION_IDS
-#define OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT                 @"CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT"                   // OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT
-#define OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT   @"CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT"     // OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT
+#define OSUD_NOTIFICATION_LIMIT                                             @"NOTIFICATION_LIMIT"                                               // * OSUD_NOTIFICATION_LIMIT
+#define OSUD_NOTIFICATION_ATTRIBUTION_WINDOW                                @"NOTIFICATION_ATTRIBUTION_WINDOW"                                  // * OSUD_NOTIFICATION_ATTRIBUTION_WINDOW
+#define OSUD_DIRECT_SESSION_ENABLED                                         @"DIRECT_SESSION_ENABLED"                                           // * OSUD_DIRECT_SESSION_ENABLED
+#define OSUD_INDIRECT_SESSION_ENABLED                                       @"INDIRECT_SESSION_ENABLED"                                         // * OSUD_INDIRECT_SESSION_ENABLED
+#define OSUD_UNATTRIBUTED_SESSION_ENABLED                                   @"UNATTRIBUTED_SESSION_ENABLED"                                     // * OSUD_UNATTRIBUTED_SESSION_ENABLED
+#define OSUD_CACHED_SESSION                                                 @"CACHED_SESSION"                                                   // * OSUD_CACHED_SESSION
+#define OSUD_CACHED_DIRECT_NOTIFICATION_ID                                  @"CACHED_DIRECT_NOTIFICATION_ID"                                    // * OSUD_CACHED_DIRECT_NOTIFICATION_ID
+#define OSUD_CACHED_INDIRECT_NOTIFICATION_IDS                               @"CACHED_INDIRECT_NOTIFICATION_IDS"                                 // * OSUD_CACHED_INDIRECT_NOTIFICATION_IDS
+#define OSUD_CACHED_RECEIVED_NOTIFICATION_IDS                               @"CACHED_RECEIVED_NOTIFICATION_IDS"                                 // * OSUD_CACHED_RECEIVED_NOTIFICATION_IDS
+#define OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT                 @"CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT"                   // * OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT
+#define OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT   @"CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT"     // * OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT
+// Time Tracking
+#define OSUD_APP_LAST_CLOSED_TIME                                           @"GT_LAST_CLOSED_TIME"                                              // * OSUD_APP_LAST_CLOSED_TIME
+#define OSUD_UNSENT_ACTIVE_TIME                                             @"GT_UNSENT_ACTIVE_TIME"                                            // * OSUD_UNSENT_ACTIVE_TIME
+#define OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED                                  @"GT_UNSENT_ACTIVE_TIME_ATTRIBUTED"                                 // * OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED
 // Misc (TODO: Organize these with other associated keys)
-#define OSUD_PLAYER_ID                                                      @"GT_PLAYER_ID"                                                     // OSUD_PLAYER_ID
-#define OSUD_PLAYER_ID_LAST                                                 @"GT_PLAYER_ID_LAST"                                                // OSUD_PLAYER_ID_LAST
-#define OSUD_PUSH_TOKEN                                                     @"GT_DEVICE_TOKEN"                                                  // OSUD_DEVICE_TOKEN
-#define OSUD_PUSH_TOKEN_LAST                                                @"GT_DEVICE_TOKEN_LAST"                                             // OSUD_DEVICE_TOKEN_LAST
-#define OSUD_USER_SUBSCRIPTION                                              @"ONESIGNAL_SUBSCRIPTION"                                           // OSUD_USER_SUBSCRIPTION
-#define OSUD_USER_SUBSCRIPTION_LAST                                         @"ONESIGNAL_SUBSCRIPTION_SETTING"                                   // OSUD_USER_SUBSCRIPTION_LAST
-#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS                                 @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"                                // OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS
-#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST                            @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"                           // OSUD_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST
-#define OSUD_PROVISIONAL_AUTHORIZATION                                      @"ONESIGNAL_PROVISIONAL_AUTHORIZATION"                              // OSUD_PROVISIONAL_AUTHORIZATION
-#define OSUD_PERMISSION_PROVISIONAL_STATUS                                  @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"                         // OSUD_PROVISIONAL_AUTHORIZATION_LAST
-#define OSUD_USES_PROVISIONAL_AUTHORIZATION                                 @"ONESIGNAL_USES_PROVISIONAL_PUSH_AUTHORIZATION"                    // OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION
-#define OSUD_REGISTERED_WITH_APPLE                                          @"GT_REGISTERED_WITH_APPLE"                                         // OSUD_REGISTERED_WITH_APPLE
-#define OSUD_INAPP_LAUNCH_URL                                               @"ONESIGNAL_INAPP_LAUNCH_URL"                                       // ? OSUD_INAPP_LAUNCH_URL
-#define OSUD_NOTIFICATION_PROMPT_ANSWERED                                   @"OS_NOTIFICATION_PROMPT_ANSWERED"                                  // OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED
-#define OSUD_LAST_MESSAGE_OPENED                                            @"GT_LAST_MESSAGE_OPENED_"                                          // OSUD_MOST_RECENT_NOTIFICATION_OPENED
-#define OSUD_CACHED_MEDIA                                                   @"CACHED_MEDIA"                                                     // ? OSUD_CACHED_MEDIA
-#define OSUD_ACCEPTED_PERMISSION                                            @"ONESIGNAL_PERMISSION_ACCEPTED_LAST"                               // OSUD_PERMISSION_ACCEPTED_LAST
-#define OSUD_PROMPT_BEFORE_OPENING_PUSH_URL                                 @"PROMPT_BEFORE_OPENING_PUSH_URL"                                   // OSUD_PROMPT_BEFORE_OPENING_PUSH_URL
-#define OSUD_PERMISSION_ANSWERED_PROMPT                                     @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"                             // OSUD_NOTIFICATION_PROMPT_ANSWERED_LAST
-#define OSUD_PERMISSION_ACCEPTED                                            @"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"                             // OSUD_ACCEPTED_NOTIFICATION_LAST
-#define OSUD_PERMISSION_PROVIDES_NOTIFICATION_SETTINGS                      @"OS_APP_PROVIDES_NOTIFICATION_SETTINGS"                            // OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS
-#define OSUD_USER_LAST_CLOSED_TIME                                          @"GT_LAST_CLOSED_TIME"                                              // OSUD_LAST_CLOSED_TIME
-#define OSUD_UNSENT_ACTIVE_TIME                                             @"GT_UNSENT_ACTIVE_TIME"                                            // OSUD_UNSENT_ACTIVE_TIME
-#define OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED                                  @"GT_UNSENT_ACTIVE_TIME_ATTRIBUTED"                                 // OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED
+#define OSUD_REGISTERED_WITH_APPLE                                          @"GT_REGISTERED_WITH_APPLE"                                         // * OSUD_REGISTERED_WITH_APPLE
+#define OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS                             @"OS_APP_PROVIDES_NOTIFICATION_SETTINGS"                            // * OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS
+#define OSUD_LAST_MESSAGE_OPENED                                            @"GT_LAST_MESSAGE_OPENED_"                                          // * OSUD_MOST_RECENT_NOTIFICATION_OPENED
+#define OSUD_PROMPT_BEFORE_OPENING_PUSH_URL                                 @"PROMPT_BEFORE_OPENING_PUSH_URL"                                   // * OSUD_PROMPT_BEFORE_OPENING_PUSH_URL
+#define OSUD_INAPP_LAUNCH_URL                                               @"ONESIGNAL_INAPP_LAUNCH_URL"                                       // * ? OSUD_INAPP_LAUNCH_URL
+#define OSUD_CACHED_MEDIA                                                   @"CACHED_MEDIA"                                                     // * ? OSUD_CACHED_MEDIA
 
 // Deprecated Selectors
 #define DEPRECATED_SELECTORS @[ @"application:didReceiveLocalNotification:", \

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -30,56 +30,70 @@
 
 #import <Foundation/Foundation.h>
 
-// networking
+// Networking
 #define API_VERSION @"api/v1/"
 #define SERVER_URL @"https://onesignal.com/"
 
-// NSUserDefaults parameter names
-#define HAS_PROMPTED_FOR_NOTIFICATIONS @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"
-#define PROVISIONAL_AUTHORIZATION @"ONESIGNAL_PROVISIONAL_AUTHORIZATION"
-#define REGISTERED_WITH_APPLE @"GT_REGISTERED_WITH_APPLE"
-#define INAPP_LAUNCH_URL @"ONESIGNAL_INAPP_LAUNCH_URL"
-#define NOTIFICATION_PROMPT_ANSWERED @"OS_NOTIFICATION_PROMPT_ANSWERED"
-#define LAST_MESSAGE_OPENED @"GT_LAST_MESSAGE_OPENED_"
-#define CACHED_MEDIA @"CACHED_MEDIA"
-#define EMAIL_AUTH_CODE @"GT_EMAIL_AUTH_CODE"
-#define SUBSCRIPTION_SETTING @"ONESIGNAL_SUBSCRIPTION_LAST"
-#define EMAIL_USERID @"GT_EMAIL_PLAYER_ID"
-#define NSUD_APP_ID @"GT_APP_ID"
-#define USERID @"GT_PLAYER_ID"
-#define USERID_LAST @"GT_PLAYER_ID_LAST"
-#define USER_LAST_CLOSED_TIME @"GT_LAST_CLOSED_TIME"
-#define DEVICE_TOKEN @"GT_DEVICE_TOKEN"
-#define UNSENT_ACTIVE_TIME @"GT_UNSENT_ACTIVE_TIME"
-#define UNSENT_ACTIVE_TIME_ATTRIBUTED @"GT_UNSENT_ACTIVE_TIME_ATTRIBUTED"
-#define SUBSCRIPTION @"ONESIGNAL_SUBSCRIPTION"
-#define PUSH_TOKEN @"GT_DEVICE_TOKEN_LAST"
-#define ACCEPTED_PERMISSION @"ONESIGNAL_PERMISSION_ACCEPTED_LAST"
-#define REQUIRE_EMAIL_AUTH @"GT_REQUIRE_EMAIL_AUTH"
-#define EMAIL_ADDRESS @"EMAIL_ADDRESS"
-#define PROMPT_BEFORE_OPENING_PUSH_URL @"PROMPT_BEFORE_OPENING_PUSH_URL"
-#define DEPRECATED_SELECTORS @[@"application:didReceiveLocalNotification:", @"application:handleActionWithIdentifier:forLocalNotification:completionHandler:", @"application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:"]
-#define USES_PROVISIONAL_AUTHORIZATION @"ONESIGNAL_USES_PROVISIONAL_PUSH_AUTHORIZATION"
-#define PERMISSION_HAS_PROMPTED @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"
-#define PERMISSION_ANSWERED_PROMPT @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"
-#define PERMISSION_ACCEPTED @"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"
-#define PERMISSION_PROVISIONAL_STATUS @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"
-#define PERMISSION_PROVIDES_NOTIFICATION_SETTINGS @"OS_APP_PROVIDES_NOTIFICATION_SETTINGS"
-#define EXTERNAL_USER_ID @"OS_EXTERNAL_USER_ID"
+// OneSignalUserDefault keys
+// String values start with "OSUD_" to maintain a level of uniqueness fropm other apps
+// Key names match the string keys associated, for consistency
+// TODO: Refactored variable names, but not strings since UserDefaults might need a migration
+// Comments next to the NSUserDefault keys are the planned string value and key names
+// "?" in line ending comment means uncertainty in naming the string value of the associated key and keeping as is for now
+// TODO: Key names fixed, but string values need fixing
+// App Id
+#define OSUD_APP_ID                                                         @"GT_APP_ID"                                                        // OSUD_APP_ID
+// External Id
+#define OSUD_EXTERNAL_USER_ID                                               @"OS_EXTERNAL_USER_ID"                                              // OSUD_EXTERNAL_USER_ID
+// Email
+#define OSUD_REQUIRE_EMAIL_AUTH                                             @"GT_REQUIRE_EMAIL_AUTH"                                            // OSUD_REQUIRE_EMAIL_AUTH
+#define OSUD_EMAIL_AUTH_CODE                                                @"GT_EMAIL_AUTH_CODE"                                               // OSUD_EMAIL_AUTH_CODE
+#define OSUD_EMAIL_PLAYER_ID                                                @"GT_EMAIL_PLAYER_ID"                                               // OSUD_EMAIL_PLAYER_ID
+#define OSUD_EMAIL_ADDRESS                                                  @"EMAIL_ADDRESS"                                                    // OSUD_EMAIL_ADDRESS
 // Receive Receipts
-#define ONESIGNAL_ENABLE_RECEIVE_RECEIPTS @"OS_ENABLE_RECEIVE_RECEIPTS"
+#define OSUD_ENABLE_RECEIVE_RECEIPTS                                        @"OS_ENABLE_RECEIVE_RECEIPTS"                                       // OSUD_ENABLE_RECEIVE_RECEIPTS
 // Outcomes
-#define NOTIFICATION_LIMIT @"NOTIFICATION_LIMIT"
-#define NOTIFICATION_ATTRIBUTION_WINDOW @"NOTIFICATION_ATTRIBUTION_WINDOW"
-#define DIRECT_SESSION_ENABLED @"DIRECT_SESSION_ENABLED"
-#define INDIRECT_SESSION_ENABLED @"INDIRECT_SESSION_ENABLED"
-#define UNATTRIBUTED_SESSION_ENABLED @"UNATTRIBUTED_SESSION_ENABLED"
-#define CACHED_SESSION @"CACHED_SESSION"
-#define CACHED_DIRECT_NOTIFICATION_ID @"CACHED_DIRECT_NOTIFICATION_ID"
-#define CACHED_INDIRECT_NOTIFICATION_IDS @"CACHED_INDIRECT_NOTIFICATION_IDS"
-#define CACHED_RECEIVED_NOTIFICATION_IDS @"CACHED_RECEIVED_NOTIFICATION_IDS"
-#define CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT @"CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT"
-#define CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT @"CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT"
+#define OSUD_NOTIFICATION_LIMIT                                             @"NOTIFICATION_LIMIT"                                               // OSUD_NOTIFICATION_LIMIT
+#define OSUD_NOTIFICATION_ATTRIBUTION_WINDOW                                @"NOTIFICATION_ATTRIBUTION_WINDOW"                                  // OSUD_NOTIFICATION_ATTRIBUTION_WINDOW
+#define OSUD_DIRECT_SESSION_ENABLED                                         @"DIRECT_SESSION_ENABLED"                                           // OSUD_DIRECT_SESSION_ENABLED
+#define OSUD_INDIRECT_SESSION_ENABLED                                       @"INDIRECT_SESSION_ENABLED"                                         // OSUD_INDIRECT_SESSION_ENABLED
+#define OSUD_UNATTRIBUTED_SESSION_ENABLED                                   @"UNATTRIBUTED_SESSION_ENABLED"                                     // OSUD_UNATTRIBUTED_SESSION_ENABLED
+#define OSUD_CACHED_SESSION                                                 @"CACHED_SESSION"                                                   // OSUD_CACHED_SESSION
+#define OSUD_CACHED_DIRECT_NOTIFICATION_ID                                  @"CACHED_DIRECT_NOTIFICATION_ID"                                    // OSUD_CACHED_DIRECT_NOTIFICATION_ID
+#define OSUD_CACHED_INDIRECT_NOTIFICATION_IDS                               @"CACHED_INDIRECT_NOTIFICATION_IDS"                                 // OSUD_CACHED_INDIRECT_NOTIFICATION_IDS
+#define OSUD_CACHED_RECEIVED_NOTIFICATION_IDS                               @"CACHED_RECEIVED_NOTIFICATION_IDS"                                 // OSUD_CACHED_RECEIVED_NOTIFICATION_IDS
+#define OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT                 @"CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT"                   // OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT
+#define OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT   @"CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT"     // OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT
+// Misc (TODO: Organize these with other associated keys)
+#define OSUD_PLAYER_ID                                                      @"GT_PLAYER_ID"                                                     // OSUD_PLAYER_ID
+#define OSUD_PLAYER_ID_LAST                                                 @"GT_PLAYER_ID_LAST"                                                // OSUD_PLAYER_ID_LAST
+#define OSUD_PUSH_TOKEN                                                     @"GT_DEVICE_TOKEN"                                                  // OSUD_DEVICE_TOKEN
+#define OSUD_PUSH_TOKEN_LAST                                                @"GT_DEVICE_TOKEN_LAST"                                             // OSUD_DEVICE_TOKEN_LAST
+#define OSUD_USER_SUBSCRIPTION                                              @"ONESIGNAL_SUBSCRIPTION"                                           // OSUD_USER_SUBSCRIPTION
+#define OSUD_USER_SUBSCRIPTION_LAST                                         @"ONESIGNAL_SUBSCRIPTION_SETTING"                                   // OSUD_USER_SUBSCRIPTION_LAST
+#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS                                 @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"                                // OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS
+#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST                            @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"                           // OSUD_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST
+#define OSUD_PROVISIONAL_AUTHORIZATION                                      @"ONESIGNAL_PROVISIONAL_AUTHORIZATION"                              // OSUD_PROVISIONAL_AUTHORIZATION
+#define OSUD_PERMISSION_PROVISIONAL_STATUS                                  @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"                         // OSUD_PROVISIONAL_AUTHORIZATION_LAST
+#define OSUD_USES_PROVISIONAL_AUTHORIZATION                                 @"ONESIGNAL_USES_PROVISIONAL_PUSH_AUTHORIZATION"                    // OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION
+#define OSUD_REGISTERED_WITH_APPLE                                          @"GT_REGISTERED_WITH_APPLE"                                         // OSUD_REGISTERED_WITH_APPLE
+#define OSUD_INAPP_LAUNCH_URL                                               @"ONESIGNAL_INAPP_LAUNCH_URL"                                       // ? OSUD_INAPP_LAUNCH_URL
+#define OSUD_NOTIFICATION_PROMPT_ANSWERED                                   @"OS_NOTIFICATION_PROMPT_ANSWERED"                                  // OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED
+#define OSUD_LAST_MESSAGE_OPENED                                            @"GT_LAST_MESSAGE_OPENED_"                                          // OSUD_MOST_RECENT_NOTIFICATION_OPENED
+#define OSUD_CACHED_MEDIA                                                   @"CACHED_MEDIA"                                                     // ? OSUD_CACHED_MEDIA
+#define OSUD_ACCEPTED_PERMISSION                                            @"ONESIGNAL_PERMISSION_ACCEPTED_LAST"                               // OSUD_PERMISSION_ACCEPTED_LAST
+#define OSUD_PROMPT_BEFORE_OPENING_PUSH_URL                                 @"PROMPT_BEFORE_OPENING_PUSH_URL"                                   // OSUD_PROMPT_BEFORE_OPENING_PUSH_URL
+#define OSUD_PERMISSION_ANSWERED_PROMPT                                     @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"                             // OSUD_NOTIFICATION_PROMPT_ANSWERED_LAST
+#define OSUD_PERMISSION_ACCEPTED                                            @"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"                             // OSUD_ACCEPTED_NOTIFICATION_LAST
+#define OSUD_PERMISSION_PROVIDES_NOTIFICATION_SETTINGS                      @"OS_APP_PROVIDES_NOTIFICATION_SETTINGS"                            // OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS
+#define OSUD_USER_LAST_CLOSED_TIME                                          @"GT_LAST_CLOSED_TIME"                                              // OSUD_LAST_CLOSED_TIME
+#define OSUD_UNSENT_ACTIVE_TIME                                             @"GT_UNSENT_ACTIVE_TIME"                                            // OSUD_UNSENT_ACTIVE_TIME
+#define OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED                                  @"GT_UNSENT_ACTIVE_TIME_ATTRIBUTED"                                 // OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED
+
+// Deprecated Selectors
+#define DEPRECATED_SELECTORS @[ @"application:didReceiveLocalNotification:", \
+                                @"application:handleActionWithIdentifier:forLocalNotification:completionHandler:", \
+                                @"application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:" ]
 
 // To avoid undefined symbol compiler errors on older versions of Xcode,
 // instead of using UNAuthorizationOptionProvisional directly, we will use

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -37,35 +37,42 @@
 // OneSignalUserDefault keys
 // String values start with "OSUD_" to maintain a level of uniqueness from other libs and app code
 // Key names should be identical to the string values to prevent confusion
+// Add the suffix "_TO" or "_FROM" to any keys with "to" and "from" logic
 // TODO: Refactored variable names, but not strings since UserDefaults might need a migration
 // Comments next to the NSUserDefault keys are the planned string value and key names
 // "?" in comment line ending comment means uncertainty in naming the string value of the associated key and keeping as is for now
-// "$" in comment line ending comment means the key name has not been changed
 // "*" in comment line ending comment means the string value has not been changed
 // App
 #define OSUD_APP_ID                                                         @"GT_APP_ID"                                                        // * OSUD_APP_ID
-#define OSUD_PERMISSION_ACCEPTED                                            @"ONESIGNAL_ACCEPTED_NOTIFICATION_LAST"                             // * OSUD_PERMISSION_ACCEPTED
-#define OSUD_PERMISSION_ACCEPTED_LAST                                       @"ONESIGNAL_PERMISSION_ACCEPTED_LAST"                               // * OSUD_PERMISSION_ACCEPTED_LAST
-#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS                                 @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS"                                // * OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS
-#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST                            @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"                           // * OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_LAST
-#define OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED                               @"OS_NOTIFICATION_PROMPT_ANSWERED"                                  // * OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED
-#define OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST                          @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"                             // * OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_LAST
-#define OSUD_PROVISIONAL_PUSH_AUTHORIZATION                                 @"ONESIGNAL_PROVISIONAL_AUTHORIZATION"                              // * OSUD_PROVISIONAL_PUSH_AUTHORIZATION
-#define OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST                            @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"                         // * OSUD_PROVISIONAL_PUSH_AUTHORIZATION_LAST
+#define OSUD_REGISTERED_WITH_APPLE                                          @"GT_REGISTERED_WITH_APPLE"                                         // * OSUD_REGISTERED_WITH_APPLE
+#define OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS                             @"OS_APP_PROVIDES_NOTIFICATION_SETTINGS"                            // * OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS
+#define OSUD_PROMPT_BEFORE_NOTIFICATION_LAUNCH_URL_OPENS                    @"PROMPT_BEFORE_OPENING_PUSH_URL"                                   // * OSUD_PROMPT_BEFORE_NOTIFICATION_LAUNCH_URL_OPENS
+#define OSUD_PERMISSION_ACCEPTED_TO                                         @"OSUD_PERMISSION_ACCEPTED_TO"                                      // OSUD_PERMISSION_ACCEPTED_TO
+#define OSUD_PERMISSION_ACCEPTED_FROM                                       @"ONESIGNAL_PERMISSION_ACCEPTED_LAST"                               // * OSUD_PERMISSION_ACCEPTED_FROM
+#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_TO                              @"OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_TO"                           // OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_TO
+#define OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_FROM                            @"OS_HAS_PROMPTED_FOR_NOTIFICATIONS_LAST"                           // * OSUD_WAS_PROMPTED_FOR_NOTIFICATIONS_FROM
+#define OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_TO                            @"OS_NOTIFICATION_PROMPT_ANSWERED"                                  // * OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_TO
+#define OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_FROM                          @"OS_NOTIFICATION_PROMPT_ANSWERED_LAST"                             // * OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_FROM
+#define OSUD_PROVISIONAL_PUSH_AUTHORIZATION_TO                              @"OSUD_PROVISIONAL_PUSH_AUTHORIZATION_TO"                           // OSUD_PROVISIONAL_PUSH_AUTHORIZATION_TO
+#define OSUD_PROVISIONAL_PUSH_AUTHORIZATION_FROM                            @"ONESIGNAL_PROVISIONAL_AUTHORIZATION_LAST"                         // * OSUD_PROVISIONAL_PUSH_AUTHORIZATION_FROM
 #define OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION                            @"ONESIGNAL_USES_PROVISIONAL_PUSH_AUTHORIZATION"                    // * OSUD_USES_PROVISIONAL_PUSH_AUTHORIZATION
 // Player
 #define OSUD_EXTERNAL_USER_ID                                               @"OS_EXTERNAL_USER_ID"                                              // * OSUD_EXTERNAL_USER_ID
-#define OSUD_PLAYER_ID                                                      @"GT_PLAYER_ID"                                                     // * OSUD_PLAYER_ID
-#define OSUD_PLAYER_ID_LAST                                                 @"GT_PLAYER_ID_LAST"                                                // * OSUD_PLAYER_ID_LAST
-#define OSUD_PUSH_TOKEN                                                     @"GT_DEVICE_TOKEN"                                                  // * OSUD_PUSH_TOKEN
-#define OSUD_PUSH_TOKEN_LAST                                                @"GT_DEVICE_TOKEN_LAST"                                             // * OSUD_PUSH_TOKEN_LAST
-#define OSUD_USER_SUBSCRIPTION                                              @"ONESIGNAL_SUBSCRIPTION"                                           // * OSUD_USER_SUBSCRIPTION
-#define OSUD_USER_SUBSCRIPTION_LAST                                         @"ONESIGNAL_SUBSCRIPTION_SETTING"                                   // * OSUD_USER_SUBSCRIPTION_LAST
+#define OSUD_PLAYER_ID_TO                                                   @"GT_PLAYER_ID"                                                     // * OSUD_PLAYER_ID_TO
+#define OSUD_PLAYER_ID_FROM                                                 @"GT_PLAYER_ID_LAST"                                                // * OSUD_PLAYER_ID_FROM
+#define OSUD_PUSH_TOKEN_TO                                                  @"GT_DEVICE_TOKEN"                                                  // * OSUD_PUSH_TOKEN_TO
+#define OSUD_PUSH_TOKEN_FROM                                                @"GT_DEVICE_TOKEN_LAST"                                             // * OSUD_PUSH_TOKEN_FROM
+#define OSUD_USER_SUBSCRIPTION_TO                                           @"ONESIGNAL_SUBSCRIPTION"                                           // * OSUD_USER_SUBSCRIPTION_TO
+#define OSUD_USER_SUBSCRIPTION_FROM                                         @"ONESIGNAL_SUBSCRIPTION_SETTING"                                   // * OSUD_USER_SUBSCRIPTION_FROM
 // Email
 #define OSUD_EMAIL_ADDRESS                                                  @"EMAIL_ADDRESS"                                                    // * OSUD_EMAIL_ADDRESS
 #define OSUD_EMAIL_PLAYER_ID                                                @"GT_EMAIL_PLAYER_ID"                                               // * OSUD_EMAIL_PLAYER_ID
 #define OSUD_REQUIRE_EMAIL_AUTH                                             @"GT_REQUIRE_EMAIL_AUTH"                                            // * OSUD_REQUIRE_EMAIL_AUTH
 #define OSUD_EMAIL_AUTH_CODE                                                @"GT_EMAIL_AUTH_CODE"                                               // * OSUD_EMAIL_AUTH_CODE
+// Notification
+#define OSUD_LAST_MESSAGE_OPENED                                            @"GT_LAST_MESSAGE_OPENED_"                                          // * OSUD_MOST_RECENT_NOTIFICATION_OPENED
+#define OSUD_NOTIFICATION_OPEN_LAUNCH_URL                                   @"ONESIGNAL_INAPP_LAUNCH_URL"                                       // * OSUD_NOTIFICATION_OPEN_LAUNCH_URL
+#define OSUD_TEMP_CACHED_NOTIFICATION_MEDIA                                 @"OSUD_TEMP_CACHED_NOTIFICATION_MEDIA"                              // OSUD_TEMP_CACHED_NOTIFICATION_MEDIA
 // Receive Receipts
 #define OSUD_RECEIVE_RECEIPTS_ENABLED                                       @"OS_ENABLE_RECEIVE_RECEIPTS"                                       // * OSUD_RECEIVE_RECEIPTS_ENABLED
 // Outcomes
@@ -84,13 +91,6 @@
 #define OSUD_APP_LAST_CLOSED_TIME                                           @"GT_LAST_CLOSED_TIME"                                              // * OSUD_APP_LAST_CLOSED_TIME
 #define OSUD_UNSENT_ACTIVE_TIME                                             @"GT_UNSENT_ACTIVE_TIME"                                            // * OSUD_UNSENT_ACTIVE_TIME
 #define OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED                                  @"GT_UNSENT_ACTIVE_TIME_ATTRIBUTED"                                 // * OSUD_UNSENT_ACTIVE_TIME_ATTRIBUTED
-// Misc (TODO: Organize these with other associated keys)
-#define OSUD_REGISTERED_WITH_APPLE                                          @"GT_REGISTERED_WITH_APPLE"                                         // * OSUD_REGISTERED_WITH_APPLE
-#define OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS                             @"OS_APP_PROVIDES_NOTIFICATION_SETTINGS"                            // * OSUD_APP_PROVIDES_NOTIFICATION_SETTINGS
-#define OSUD_LAST_MESSAGE_OPENED                                            @"GT_LAST_MESSAGE_OPENED_"                                          // * OSUD_MOST_RECENT_NOTIFICATION_OPENED
-#define OSUD_PROMPT_BEFORE_OPENING_PUSH_URL                                 @"PROMPT_BEFORE_OPENING_PUSH_URL"                                   // * OSUD_PROMPT_BEFORE_OPENING_PUSH_URL
-#define OSUD_INAPP_LAUNCH_URL                                               @"ONESIGNAL_INAPP_LAUNCH_URL"                                       // * ? OSUD_INAPP_LAUNCH_URL
-#define OSUD_CACHED_MEDIA                                                   @"CACHED_MEDIA"                                                     // * ? OSUD_CACHED_MEDIA
 
 // Deprecated Selectors
 #define DEPRECATED_SELECTORS @[ @"application:didReceiveLocalNotification:", \

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -835,7 +835,7 @@ static OneSignal* singleInstance = nil;
         
         let standardUserDefaults = OneSignalUserDefaults.initStandard;
         
-        NSArray* cachedFiles = [standardUserDefaults getSavedObjectForKey:OSUD_CACHED_MEDIA defaultValue:nil];
+        NSArray* cachedFiles = [standardUserDefaults getSavedObjectForKey:OSUD_TEMP_CACHED_NOTIFICATION_MEDIA defaultValue:nil];
         NSMutableArray* appendedCache;
         if (cachedFiles) {
             appendedCache = [[NSMutableArray alloc] initWithArray:cachedFiles];
@@ -844,7 +844,7 @@ static OneSignal* singleInstance = nil;
         else
             appendedCache = [[NSMutableArray alloc] initWithObjects:name, nil];
         
-        [standardUserDefaults saveObjectForKey:OSUD_CACHED_MEDIA withValue:appendedCache];
+        [standardUserDefaults saveObjectForKey:OSUD_TEMP_CACHED_NOTIFICATION_MEDIA withValue:appendedCache];
         return name;
     } @catch (NSException *exception) {
         [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal encountered an exception while downloading file (%@), exception: %@", url, exception.description]];
@@ -855,12 +855,12 @@ static OneSignal* singleInstance = nil;
 }
 
 // TODO: Add back after testing
-+(void)clearCachedMedia {
++ (void)clearCachedMedia {
     /*
     if (!NSClassFromString(@"UNUserNotificationCenter"))
       return;
      
-    NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:OSUD_CACHED_MEDIA];
+    NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:OSUD_TEMP_CACHED_NOTIFICATION_MEDIA];
     if (cachedFiles) {
         NSArray * paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         for (NSString* file in cachedFiles) {
@@ -868,7 +868,7 @@ static OneSignal* singleInstance = nil;
             NSError* error;
             [[NSFileManager defaultManager] removeItemAtPath:filePath error:&error];
         }
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:OSUD_CACHED_MEDIA];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:OSUD_TEMP_CACHED_NOTIFICATION_MEDIA];
     }
      */
 }
@@ -890,7 +890,7 @@ static OneSignal* singleInstance = nil;
 
 + (void) displayWebView:(NSURL*)url {
     // Check if in-app or safari
-    __block BOOL inAppLaunch = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_INAPP_LAUNCH_URL defaultValue:true];
+    __block BOOL inAppLaunch = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL defaultValue:true];
     
     // If the URL contains itunes.apple.com, it's an app store link
     // that should be opened using sharedApplication openURL

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -835,7 +835,7 @@ static OneSignal* singleInstance = nil;
         
         let standardUserDefaults = OneSignalUserDefaults.initStandard;
         
-        NSArray* cachedFiles = [standardUserDefaults getSavedObjectForKey:CACHED_MEDIA defaultValue:nil];
+        NSArray* cachedFiles = [standardUserDefaults getSavedObjectForKey:OSUD_CACHED_MEDIA defaultValue:nil];
         NSMutableArray* appendedCache;
         if (cachedFiles) {
             appendedCache = [[NSMutableArray alloc] initWithArray:cachedFiles];
@@ -844,7 +844,7 @@ static OneSignal* singleInstance = nil;
         else
             appendedCache = [[NSMutableArray alloc] initWithObjects:name, nil];
         
-        [standardUserDefaults saveObjectForKey:CACHED_MEDIA withValue:appendedCache];
+        [standardUserDefaults saveObjectForKey:OSUD_CACHED_MEDIA withValue:appendedCache];
         return name;
     } @catch (NSException *exception) {
         [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal encountered an exception while downloading file (%@), exception: %@", url, exception.description]];
@@ -860,7 +860,7 @@ static OneSignal* singleInstance = nil;
     if (!NSClassFromString(@"UNUserNotificationCenter"))
       return;
      
-    NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:@"CACHED_MEDIA"];
+    NSArray* cachedFiles = [[NSUserDefaults standardUserDefaults] objectForKey:OSUD_CACHED_MEDIA];
     if (cachedFiles) {
         NSArray * paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         for (NSString* file in cachedFiles) {
@@ -868,7 +868,7 @@ static OneSignal* singleInstance = nil;
             NSError* error;
             [[NSFileManager defaultManager] removeItemAtPath:filePath error:&error];
         }
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"CACHED_MEDIA"];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:OSUD_CACHED_MEDIA];
     }
      */
 }
@@ -890,7 +890,7 @@ static OneSignal* singleInstance = nil;
 
 + (void) displayWebView:(NSURL*)url {
     // Check if in-app or safari
-    __block BOOL inAppLaunch = [OneSignalUserDefaults.initStandard getSavedBoolForKey:INAPP_LAUNCH_URL defaultValue:true];
+    __block BOOL inAppLaunch = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_INAPP_LAUNCH_URL defaultValue:true];
     
     // If the URL contains itunes.apple.com, it's an app store link
     // that should be opened using sharedApplication openURL

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -44,9 +44,9 @@
     OSPermissionState* status = OneSignal.currentPermissionState;
     
     // Don't call getNotificationTypes as this will cause currentSubscriptionState to initialize before currentPermissionState
-    status.notificationTypes = [standardUserDefaults getSavedStringForKey:DEVICE_TOKEN defaultValue:nil] == nil ? 0 : 7;
+    status.notificationTypes = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN defaultValue:nil] == nil ? 0 : 7;
     status.accepted = status.notificationTypes > 0;
-    status.answeredPrompt = [standardUserDefaults getSavedBoolForKey:NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
+    status.answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
     status.provisional = false;
     
     completionHandler(status);
@@ -74,7 +74,7 @@
     notificationPromptReponseCallback = completionHandler;
     [[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert];
     [OneSignal setWaitingForApnsResponse:true];
-    [OneSignalUserDefaults.initStandard saveBoolForKey:REGISTERED_WITH_APPLE withValue:true];
+    [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_REGISTERED_WITH_APPLE withValue:true];
 }
 
 #pragma GCC diagnostic pop

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -44,9 +44,9 @@
     OSPermissionState* status = OneSignal.currentPermissionState;
     
     // Don't call getNotificationTypes as this will cause currentSubscriptionState to initialize before currentPermissionState
-    status.notificationTypes = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN defaultValue:nil] == nil ? 0 : 7;
+    status.notificationTypes = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_TO defaultValue:nil] == nil ? 0 : 7;
     status.accepted = status.notificationTypes > 0;
-    status.answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
+    status.answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_TO defaultValue:false];
     status.provisional = false;
     
     completionHandler(status);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS7.m
@@ -46,7 +46,7 @@
     // Don't call getNotificationTypes as this will cause currentSubscriptionState to initialize before currentPermissionState
     status.notificationTypes = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN defaultValue:nil] == nil ? 0 : 7;
     status.accepted = status.notificationTypes > 0;
-    status.answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
+    status.answeredPrompt = [standardUserDefaults getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
     status.provisional = false;
     
     completionHandler(status);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -41,7 +41,7 @@
     
     status.notificationTypes = UIApplication.sharedApplication.currentUserNotificationSettings.types;
     status.accepted = status.notificationTypes > 0;
-    status.answeredPrompt = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
+    status.answeredPrompt = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED_TO defaultValue:false];
     status.provisional = false;
     
     completionHandler(status);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -41,7 +41,7 @@
     
     status.notificationTypes = UIApplication.sharedApplication.currentUserNotificationSettings.types;
     status.accepted = status.notificationTypes > 0;
-    status.answeredPrompt = [OneSignalUserDefaults.initStandard getSavedBoolForKey:NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
+    status.answeredPrompt = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
     status.provisional = false;
     
     completionHandler(status);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationSettingsIOS8.m
@@ -41,7 +41,7 @@
     
     status.notificationTypes = UIApplication.sharedApplication.currentUserNotificationSettings.types;
     status.accepted = status.notificationTypes > 0;
-    status.answeredPrompt = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
+    status.answeredPrompt = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_WAS_NOTIFICATION_PROMPT_ANSWERED defaultValue:false];
     status.provisional = false;
     
     completionHandler(status);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.m
@@ -70,22 +70,22 @@ NSMutableArray<OSUniqueOutcomeNotification *> *attributedUniqueOutcomeEventNotif
 
 // Save the current set of UNATTRIBUTED unique outcome names to NSUserDefaults
 - (NSSet *)getUnattributedUniqueOutcomeEventNames {
-    return [OneSignalUserDefaults.initShared getSavedSetForKey:CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT defaultValue:nil];
+    return [OneSignalUserDefaults.initShared getSavedSetForKey:OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT defaultValue:nil];
 }
 
 // Save the current set of UNATTRIBUTED unique outcome names to NSUserDefaults
 - (void)saveUnattributedUniqueOutcomeEventNames {
-    [OneSignalUserDefaults.initShared saveSetForKey:CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT withValue:unattributedUniqueOutcomeEventsSentSet];
+    [OneSignalUserDefaults.initShared saveSetForKey:OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT withValue:unattributedUniqueOutcomeEventsSentSet];
 }
 
 // Save the current set of ATTRIBUTED unique outcome names and notificationIds to NSUserDefaults
 - (NSArray *)getAttributedUniqueOutcomeEventNotificationIds {
-    return [OneSignalUserDefaults.initShared getSavedCodeableDataForKey:CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT defaultValue:nil];
+    return [OneSignalUserDefaults.initShared getSavedCodeableDataForKey:OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT defaultValue:nil];
 }
 
 // Save the current set of ATTRIBUTED unique outcome names and notificationIds to NSUserDefaults
 - (void)saveAttributedUniqueOutcomeEventNotificationIds {
-    [OneSignalUserDefaults.initShared saveCodeableDataForKey:CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT withValue:attributedUniqueOutcomeEventNotificationIdsSentArray];
+    [OneSignalUserDefaults.initShared saveCodeableDataForKey:OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT withValue:attributedUniqueOutcomeEventNotificationIdsSentArray];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -36,13 +36,13 @@
 @implementation OneSignalReceiveReceiptsController
 
 - (BOOL)isReceiveReceiptsEnabled {
-    return [OneSignalUserDefaults.initShared getSavedBoolForKey:ONESIGNAL_ENABLE_RECEIVE_RECEIPTS defaultValue:NO];
+    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_ENABLE_RECEIVE_RECEIPTS defaultValue:NO];
 }
 
 - (void)sendReceiveReceiptWithNotificationId:(NSString *)notificationId {
     let sharedUserDefaults = OneSignalUserDefaults.initShared;
-    let playerId = [sharedUserDefaults getSavedStringForKey:USERID defaultValue:nil];
-    let appId = [sharedUserDefaults getSavedStringForKey:NSUD_APP_ID defaultValue:nil];
+    let playerId = [sharedUserDefaults getSavedStringForKey:OSUD_PLAYER_ID defaultValue:nil];
+    let appId = [sharedUserDefaults getSavedStringForKey:OSUD_APP_ID defaultValue:nil];
 
     [self sendReceiveReceiptWithPlayerId:playerId
                           notificationId:notificationId

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -41,7 +41,7 @@
 
 - (void)sendReceiveReceiptWithNotificationId:(NSString *)notificationId {
     let sharedUserDefaults = OneSignalUserDefaults.initShared;
-    let playerId = [sharedUserDefaults getSavedStringForKey:OSUD_PLAYER_ID defaultValue:nil];
+    let playerId = [sharedUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_TO defaultValue:nil];
     let appId = [sharedUserDefaults getSavedStringForKey:OSUD_APP_ID defaultValue:nil];
 
     [self sendReceiveReceiptWithPlayerId:playerId

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -36,7 +36,7 @@
 @implementation OneSignalReceiveReceiptsController
 
 - (BOOL)isReceiveReceiptsEnabled {
-    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_ENABLE_RECEIVE_RECEIPTS defaultValue:NO];
+    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_RECEIVE_RECEIPTS_ENABLED defaultValue:NO];
 }
 
 - (void)sendReceiveReceiptWithNotificationId:(NSString *)notificationId {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -199,7 +199,7 @@ static BOOL lastOnFocusWasToBackground = YES;
 
 + (void)updateLastClosedTime {
     let now = [NSDate date].timeIntervalSince1970;
-    [OneSignalUserDefaults.initStandard saveDoubleForKey:USER_LAST_CLOSED_TIME withValue:now];
+    [OneSignalUserDefaults.initStandard saveDoubleForKey:OSUD_USER_LAST_CLOSED_TIME withValue:now];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -199,7 +199,7 @@ static BOOL lastOnFocusWasToBackground = YES;
 
 + (void)updateLastClosedTime {
     let now = [NSDate date].timeIntervalSince1970;
-    [OneSignalUserDefaults.initStandard saveDoubleForKey:OSUD_USER_LAST_CLOSED_TIME withValue:now];
+    [OneSignalUserDefaults.initStandard saveDoubleForKey:OSUD_APP_LAST_CLOSED_TIME withValue:now];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -98,8 +98,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     [UnitTestCommonMethods runBackgroundThreads];
     
     //check to make sure that the push token & auth were saved to NSUserDefaults
-    XCTAssertNotNil([OneSignalUserDefaults.initStandard getSavedStringForKey:EMAIL_USERID defaultValue:nil]);
-    XCTAssertNotNil([OneSignalUserDefaults.initStandard getSavedStringForKey:EMAIL_AUTH_CODE defaultValue:nil]);
+    XCTAssertNotNil([OneSignalUserDefaults.initStandard getSavedStringForKey:OSUD_EMAIL_PLAYER_ID defaultValue:nil]);
+    XCTAssertNotNil([OneSignalUserDefaults.initStandard getSavedStringForKey:OSUD_EMAIL_AUTH_CODE defaultValue:nil]);
     
     //check to make sure the OSRequestCreateDevice HTTP call was made, and was formatted correctly
     XCTAssertTrue([NSStringFromClass([OSRequestUpdateDeviceToken class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -300,9 +300,8 @@
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestInAppMessageClicked class]));
 }
 
-- (void)testDisablingMessagesPreventsDisplay {
+- (void)testDisablingMessages_stillCreatesMessageQueue_butPreventsMessageDisplay {
     let message = [OSInAppMessageTestHelper testMessageJsonWithTriggerPropertyName:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withId:@"test_id1" withOperator:OSTriggerOperatorTypeLessThan withValue:@10.0];
-    
     let registrationResponse = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message]];
     
     // this should prevent message from being shown
@@ -314,8 +313,9 @@
 
     [UnitTestCommonMethods initOneSignalAndThreadWait];
     
-    // no message should have been shown
-    XCTAssertEqual(OSMessagingControllerOverrider.messageDisplayQueue.count, 0);
+    // Make sure no IAM is showing, but the queue has any IAMs
+    XCTAssertFalse(OSMessagingControllerOverrider.isInAppMessageShowing);
+    XCTAssertEqual(OSMessagingControllerOverrider.messageDisplayQueue.count, 1);
 }
 
 /**

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, nonatomic) NSArray<OSInAppMessage *> *messageDisplayQueue;
 
 + (void)reset;
++ (BOOL)isInAppMessageShowing;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
@@ -74,11 +74,15 @@ static NSMutableArray<OSInAppMessage *> *_displayedMessages;
     [_displayedMessages removeAllObjects];
 }
 
-+(NSArray *)messageDisplayQueue {
++ (BOOL)isInAppMessageShowing {
+    return OSMessagingController.sharedInstance.isInAppMessageShowing;
+}
+
++ (NSArray *)messageDisplayQueue {
     return _displayedMessages;
 }
 
-+(void)setMessageDisplayQueue:(NSArray *)displayedMessages {
++ (void)setMessageDisplayQueue:(NSArray *)displayedMessages {
     _displayedMessages = [displayedMessages mutableCopy];
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1853,7 +1853,7 @@ didReceiveRemoteNotification:userInfo
     
     // 2. Remove shared keys to simulate the state of coming from a pre-2.12.1 version
     [OneSignalUserDefaults.initShared removeValueForKey:OSUD_APP_ID];
-    [OneSignalUserDefaults.initShared removeValueForKey:OSUD_PLAYER_ID];
+    [OneSignalUserDefaults.initShared removeValueForKey:OSUD_PLAYER_ID_TO];
 
     // 3. Restart app
     [UnitTestCommonMethods backgroundApp];
@@ -1862,7 +1862,7 @@ didReceiveRemoteNotification:userInfo
     
     // 4. Ensure values are present again
     XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:OSUD_APP_ID defaultValue:nil]);
-    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:OSUD_PLAYER_ID defaultValue:nil]);
+    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:OSUD_PLAYER_ID_TO defaultValue:nil]);
 }
 
 // iOS 10 - Notification Service Extension test - local file

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1852,8 +1852,8 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods initOneSignalAndThreadWait];
     
     // 2. Remove shared keys to simulate the state of coming from a pre-2.12.1 version
-    [OneSignalUserDefaults.initShared removeValueForKey:NSUD_APP_ID];
-    [OneSignalUserDefaults.initShared removeValueForKey:USERID];
+    [OneSignalUserDefaults.initShared removeValueForKey:OSUD_APP_ID];
+    [OneSignalUserDefaults.initShared removeValueForKey:OSUD_PLAYER_ID];
 
     // 3. Restart app
     [UnitTestCommonMethods backgroundApp];
@@ -1861,8 +1861,8 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods initOneSignalAndThreadWait];
     
     // 4. Ensure values are present again
-    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:NSUD_APP_ID defaultValue:nil]);
-    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:USERID defaultValue:nil]);
+    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:OSUD_APP_ID defaultValue:nil]);
+    XCTAssertNotNil([OneSignalUserDefaults.initShared getSavedSetForKey:OSUD_PLAYER_ID defaultValue:nil]);
 }
 
 // iOS 10 - Notification Service Extension test - local file
@@ -2377,7 +2377,7 @@ didReceiveRemoteNotification:userInfo
 
 - (void)testDoesntSendExistingExternalUserIdBeforeRegistration {
     //mimics a previous session where the external user ID was set
-    [NSUserDefaults.standardUserDefaults setObject:TEST_EXTERNAL_USER_ID forKey:EXTERNAL_USER_ID];
+    [NSUserDefaults.standardUserDefaults setObject:TEST_EXTERNAL_USER_ID forKey:OSUD_EXTERNAL_USER_ID];
     [NSUserDefaults.standardUserDefaults synchronize];
 
     [OneSignal setExternalUserId:TEST_EXTERNAL_USER_ID];


### PR DESCRIPTION
* During previous refactoring for USerDefault keys an issue was caused with SUBSCRIPTION key
* Two essential checks (OneSignal.m and OSSubscription.m) were changed and should not have been
* When pausing in app messaging, this only prevented items from being added to the queue, instead of from showing

* Demo app changes
  * Moved all UI property to ViewController.h interface so that the AppDelegate.m has access to them
  * Added a subscribe segment control (like consent and pausing IAM) to demo app, connected subscription observer
  * When subscription changes so does the segment control will also
  * Made segment control selected switches green instead
  * Fixed white text problem due to default in dark mode

* SDK changes
  * Reverted change for the SUBSCRIPTION key to fix the always unsubscribed issue
  * Using keyExists in OSSubscription.m now, replaces getSavedObjectForKey and objectForKey
  * Reverted changes for saving SUBSCRIPTION status in OneSignal.m
  * Moved the check for paused in app messaging so that queue items won't be shown now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/599)
<!-- Reviewable:end -->

![IMG_0007](https://user-images.githubusercontent.com/24537305/72461062-fdb51280-3782-11ea-9ab8-0d7f8d1c7354.png)