### PR TITLE
Clean up views after dismissing webview by swiping down

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.h
@@ -28,7 +28,7 @@
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
 
-@interface OneSignalWebView : UIViewController <WKNavigationDelegate>
+@interface OneSignalWebView : UIViewController <WKNavigationDelegate, UIAdaptivePresentationControllerDelegate>
 
 @property(nonatomic, copy)NSURL *url;
 @property(nonatomic)WKWebView *webView;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
@@ -67,10 +67,7 @@ UIViewController *viewControllerForPresentation;
 
 - (void)dismiss:(id)sender {
     [self.navigationController dismissViewControllerAnimated:true completion:^{
-        // Clear web view
-        [_webView loadHTMLString:@"" baseURL:nil];
-        if (viewControllerForPresentation)
-            [viewControllerForPresentation.view removeFromSuperview];
+        [self clearWebView];
     }];
 }
 
@@ -108,6 +105,7 @@ UIViewController *viewControllerForPresentation;
     if (!navController) {
         navController = [[UINavigationController alloc] initWithRootViewController:self];
         navController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+        navController.presentationController.delegate = self;
     }
     if (!viewControllerForPresentation) {
         viewControllerForPresentation = [[UIViewController alloc] init];
@@ -133,7 +131,15 @@ UIViewController *viewControllerForPresentation;
     @catch(NSException* exception) { }
 }
 
+- (void)clearWebView {
+    [_webView loadHTMLString:@"" baseURL:nil];
+    if (viewControllerForPresentation)
+        [viewControllerForPresentation.view removeFromSuperview];
+}
 
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    [self clearWebView];
+}
 
 @end
 


### PR DESCRIPTION
Current implementation cleans up views only when 'done' button is tapped.
iOS 13 modal presentation style has other ways to dismiss view controllers
than tapping 'done' button, so we need to add cleaning up code to them.

This PR will fix #606

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/617)
<!-- Reviewable:end -->
