### PR TITLE
Fix way of saving redisplayMessages on UserDefaults

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.h
@@ -34,7 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OSInAppMessage : NSObject <OSJSONDecodable, OSJSONEncodable>
+@interface OSInAppMessage : NSObject <NSCoding, OSJSONDecodable, OSJSONEncodable>
 
 @property (strong, nonatomic, nonnull) NSString *messageId;
 @property (strong, nonatomic, nonnull) NSDictionary<NSString *, NSDictionary <NSString *, NSString *> *> *variants;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.m
@@ -101,7 +101,7 @@
         message.displayStats = [OSInAppMessageDisplayStats instanceWithJson:json[@"redisplay"]];
     else
         message.displayStats = [[OSInAppMessageDisplayStats alloc] init];
-    
+
     if (json[@"triggers"] && [json[@"triggers"] isKindOfClass:[NSArray class]]) {
         let triggers = [NSMutableArray new];
         
@@ -195,6 +195,7 @@
     [encoder encodeObject:_messageId forKey:@"messageId"];
     [encoder encodeObject:_variants forKey:@"variants"];
     [encoder encodeObject:_triggers forKey:@"triggers"];
+    [encoder encodeObject:_displayStats forKey:@"displayStats"];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder {
@@ -202,6 +203,7 @@
         _messageId = [decoder decodeObjectForKey:@"messageId"];
         _variants = [decoder decodeObjectForKey:@"variants"];
         _triggers = [decoder decodeObjectForKey:@"triggers"];
+        _displayStats = [decoder decodeObjectForKey:@"displayStats"];
     }
     return self;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.h
@@ -28,7 +28,7 @@
 #import "OneSignal.h"
 #import "OSJSONHandling.h"
 
-@interface OSInAppMessageDisplayStats : NSObject <OSJSONDecodable, OSJSONEncodable>
+@interface OSInAppMessageDisplayStats : NSObject <NSCoding, OSJSONDecodable, OSJSONEncodable>
 
 //Last IAM display time in seconds
 @property (nonatomic, readwrite) double lastDisplayTime;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
@@ -88,6 +88,15 @@
     return displayStats;
 }
 
+-(NSDictionary *)jsonRepresentation {
+    let json = [NSMutableDictionary new];
+
+    json[@"limit"] = @(_displayLimit);
+    json[@"delay"] = @(_displayDelay);
+
+    return json;
+}
+
 - (BOOL)isDelayTimeSatisfied:(NSTimeInterval)date {
     if (_lastDisplayTime < 0) {
         return true;
@@ -113,13 +122,21 @@
     return [NSString stringWithFormat:@"OSInAppMessageDisplayStats:  redisplayEnabled: %@ \nlastDisplayTime: %f  \ndisplayDelay: %f \ndisplayQuantity: %ld \ndisplayLimit: %ld", self.redisplayEnabled ? @"YES" : @"NO", self.lastDisplayTime, self.displayDelay, (long)self.displayQuantity, (long)self.displayLimit];
 }
 
-- (NSDictionary * _Nonnull)jsonRepresentation {
-    let json = [NSMutableDictionary new];
-    
-    json[@"limit"] = @(self.displayLimit);
-    json[@"delay"] = @(self.displayDelay);
-    
-    return json;
+- (void)encodeWithCoder:(NSCoder *)encoder {
+    [encoder encodeInteger:_displayLimit forKey:@"displayLimit"];
+    [encoder encodeInteger:_displayQuantity forKey:@"displayQuantity"];
+    [encoder encodeDouble:_displayDelay forKey:@"displayDelay"];
+    [encoder encodeDouble:_lastDisplayTime forKey:@"lastDisplayTime"];
+}
+
+- (id)initWithCoder:(NSCoder *)decoder {
+    if (self = [super init]) {
+        _displayLimit = [decoder decodeIntegerForKey:@"displayLimit"];
+        _displayQuantity = [decoder decodeIntegerForKey:@"displayQuantity"];
+        _displayDelay = [decoder decodeDoubleForKey:@"displayDelay"];
+        _lastDisplayTime = [decoder decodeDoubleForKey:@"lastDisplayTime"];
+    }
+    return self;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -130,7 +130,8 @@ static BOOL _isInAppMessagingPaused = false;
         
         // Get all cached IAM data from NSUserDefaults for shown, impressions, and clicks
         self.seenInAppMessages = [[NSMutableSet alloc] initWithSet:[standardUserDefaults getSavedSetForKey:OS_IAM_SEEN_SET_KEY defaultValue:nil]];
-        self.redisplayedInAppMessages = [[NSMutableDictionary alloc] initWithDictionary:[standardUserDefaults getSavedDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:[NSMutableDictionary new]]];
+        self.redisplayedInAppMessages = [[NSMutableDictionary alloc] initWithDictionary:[standardUserDefaults getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:[NSMutableDictionary new]]];
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"init redisplayedInAppMessages with: %@", [_redisplayedInAppMessages description]]];
         self.clickedClickIds = [[NSMutableSet alloc] initWithSet:[standardUserDefaults getSavedSetForKey:OS_IAM_CLICKED_SET_KEY defaultValue:nil]];
         self.impressionedInAppMessages = [[NSMutableSet alloc] initWithSet:[standardUserDefaults getSavedSetForKey:OS_IAM_IMPRESSIONED_SET_KEY defaultValue:nil]];
 
@@ -330,8 +331,11 @@ static BOOL _isInAppMessagingPaused = false;
     
     BOOL messageDismissed = [_seenInAppMessages containsObject:message.messageId];
     let redisplayMessageSavedData = [_redisplayedInAppMessages objectForKey:message.messageId];
-    
-    if (messageDismissed && redisplayMessageSavedData != nil) {
+
+    NSLog(@"Redisplay dismissed: %@ and data: %@", messageDismissed ? @"YES" : @"NO", redisplayMessageSavedData.jsonRepresentation.description);
+
+    if (messageDismissed && redisplayMessageSavedData) {
+        NSLog(@"Redisplay IAM: %@", message.jsonRepresentation.description);
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"setDataForRedisplay with message: %@", message]];
         message.displayStats.displayQuantity = redisplayMessageSavedData.displayStats.displayQuantity;
         message.displayStats.lastDisplayTime = redisplayMessageSavedData.displayStats.lastDisplayTime;
@@ -469,8 +473,8 @@ static BOOL _isInAppMessagingPaused = false;
     // Update the data to enable future re displays
     // Avoid calling the userdefault data again
     [_redisplayedInAppMessages setObject:message forKey:message.messageId];
-    
-    [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:self.redisplayedInAppMessages];
+
+    [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:_redisplayedInAppMessages];
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"persistInAppMessageForRedisplay: %@ \nredisplayedInAppMessages: %@", [message description], [_redisplayedInAppMessages description]]];
 }
 


### PR DESCRIPTION
   * Custom objects need to use NSKeyedArchiver and implement NSCoding
   * Fix implementation on OSInAppMessageDisplayStats and OSInAppMessage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/634)
<!-- Reviewable:end -->
