### PR TITLE
Switch to api.onesignal.com for all requests

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -218,7 +218,7 @@
         let message = [NSString stringWithFormat:@"In App Messaging htmlContent.html: %@", data[@"hmtl"]];
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:message];
         
-        let baseUrl = [NSURL URLWithString:SERVER_URL];
+        let baseUrl = [NSURL URLWithString:OS_IAM_WEBVIEW_BASE_URL];
         NSString* htmlContent = data[@"html"];
         [self.messageView loadedHtmlContent:htmlContent withBaseURL:baseUrl];
         

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -31,8 +31,11 @@
 #import <Foundation/Foundation.h>
 
 // Networking
-#define API_VERSION @"api/v1/"
-#define SERVER_URL @"https://onesignal.com/"
+#define OS_API_VERSION @"1"
+#define OS_API_ACCEPT_HEADER @"application/vnd.onesignal.v" OS_API_VERSION @"+json"
+#define OS_API_SERVER_URL @"https://api.onesignal.com/"
+
+#define OS_IAM_WEBVIEW_BASE_URL @"https://onesignal.com/"
 
 // OneSignalUserDefault keys
 // String values start with "OSUD_" to maintain a level of uniqueness from other libs and app code

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
@@ -40,7 +40,6 @@
 @property (strong, nonatomic, nullable) NSDictionary *parameters;
 @property (nonatomic) int reattemptCount;
 @property (nonatomic) BOOL dataRequest; //false for JSON based requests
-@property (strong, nonatomic, nonnull) NSString *requestContentType; //ie. application/json
 -(BOOL)missingAppId; //for requests that don't require an appId parameter, the subclass should override this method and return false
 -(NSMutableURLRequest * _Nonnull )urlRequest;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
@@ -49,7 +49,6 @@
         // However some requests want to load non-JSON data like HTML
         // In those cases, `dataRequest` should be true
         self.dataRequest = false;
-        self.requestContentType = @"application/json";
     }
     
     return self;
@@ -57,15 +56,14 @@
 
 -(NSMutableURLRequest *)urlRequest {
     //build URL
-    let urlString = [[SERVER_URL stringByAppendingString:API_VERSION] stringByAppendingString:self.path];
+    let urlString = [OS_API_SERVER_URL stringByAppendingString:self.path];
     
     let request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
     
     if (!self.dataRequest)
         [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     
-    // usually just application/json
-    [request setValue:self.requestContentType forHTTPHeaderField:@"Accept"];
+    [request setValue:OS_API_ACCEPT_HEADER forHTTPHeaderField:@"Accept"];
     
     let versionString = [NSString stringWithFormat:@"%@%@", HTTP_HEADER_PREFIX_OS_VERSION, ONESIGNAL_VERSION];
     [request setValue:versionString forHTTPHeaderField:HTTP_HEADER_KEY_OS_VERSION];

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -100,7 +100,7 @@ NSString *urlStringForRequest(OneSignalRequest *request) {
 }
 
 NSString *correctUrlWithPath(NSString *path) {
-    return [[SERVER_URL stringByAppendingString:API_VERSION] stringByAppendingString:path];
+    return [OS_API_SERVER_URL stringByAppendingString:path];
 }
 
 // only works for dictionaries with values that are strings, numbers, or sub-dictionaries/arrays of strings and numbers
@@ -397,7 +397,7 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
 
     XCTAssertEqualObjects(request.urlRequest.URL.absoluteString, correctUrlWithPath(iamUrlPath));
     XCTAssertEqualObjects(request.urlRequest.HTTPMethod, @"GET");
-    XCTAssertEqualObjects(request.urlRequest.allHTTPHeaderFields[@"Accept"], @"application/json");
+    XCTAssertEqualObjects(request.urlRequest.allHTTPHeaderFields[@"Accept"], @"application/vnd.onesignal.v1+json");
     XCTAssertFalse(request.dataRequest);
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -52,7 +52,7 @@
 #import "OneSignalTrackFirebaseAnalytics.h"
 
 NSString * serverUrlWithPath(NSString *path) {
-    return [NSString stringWithFormat:@"%@%@%@", SERVER_URL, API_VERSION, path];
+    return [OS_API_SERVER_URL stringByAppendingString:path];
 }
 
 @interface OneSignal ()


### PR DESCRIPTION
* Switching from using onesignal.com directly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/640)
<!-- Reviewable:end -->
