### PR TITLE
Fix IAM crash on dismiss if AppDelegate window is nil

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -475,11 +475,12 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 /*
- Hide the window and call makeKeyWindow to ensure the IAM will not be shown
- */
+ Hide the top level IAM window
+ After the IAM window is hidden, iOS will automatically promote the main window
+ This also re-shows the keyboard automatically if it had focus in a text input
+*/
 - (void)hideWindow {
     self.window.hidden = true;
-    [UIApplication.sharedApplication.delegate.window makeKeyWindow];
 }
 
 - (void)persistInAppMessageForRedisplay:(OSInAppMessage *)message {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
@@ -83,14 +83,10 @@
 
 + (void)load {
     injectToProperClass(@selector(overrideShowAndImpressMessage:), @selector(showAndImpressMessage:), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
-    injectToProperClass(@selector(overrideHideWindow), @selector(hideWindow), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
 }
 
 - (void)overrideShowAndImpressMessage:(OSInAppMessage *)message {
     [OSMessagingController.sharedInstance messageViewImpressionRequest:message];
-}
-
-- (void)overrideHideWindow {
 }
 
 + (void)dismissCurrentMessage {


### PR DESCRIPTION
* Fixes #638
Ignore the SwiftUI and Scene references noted in the branch name and comment. `nil` issue can happen on non scene projects too.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/644)
<!-- Reviewable:end -->
