### PR TITLE
IAMs now show for apps using Scenes / SwiftUI

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -654,6 +654,12 @@ static BOOL _isInAppMessagingPaused = false;
     self.window.backgroundColor = [UIColor clearColor];
     self.window.opaque = true;
     self.window.clipsToBounds = true;
+    
+    if (@available(iOS 13.0, *)) {
+        // Required to display if the app is using a Scene
+        // See https://github.com/OneSignal/OneSignal-iOS-SDK/issues/648
+        self.window.windowScene = UIApplication.sharedApplication.keyWindow.windowScene;
+    }
     [self.window makeKeyAndVisible];
 }
 


### PR DESCRIPTION
* Before this change any project that updated to use the new UIScene in iOS 13 would result in the IAM not showing.
   - No warning or error was showing either.
* Fixes #648

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/649)
<!-- Reviewable:end -->
