### PR TITLE
Fixed fat build since adding scene support

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -655,12 +655,21 @@ static BOOL _isInAppMessagingPaused = false;
     self.window.opaque = true;
     self.window.clipsToBounds = true;
     
-    if (@available(iOS 13.0, *)) {
-        // Required to display if the app is using a Scene
-        // See https://github.com/OneSignal/OneSignal-iOS-SDK/issues/648
-        self.window.windowScene = UIApplication.sharedApplication.keyWindow.windowScene;
-    }
+    [self addKeySceneToWindow:self.window];
+    
     [self.window makeKeyAndVisible];
+}
+
+// Required to display if the app is using a Scene
+// See https://github.com/OneSignal/OneSignal-iOS-SDK/issues/648
+- (void)addKeySceneToWindow:(UIWindow*)window {
+    if (@available(iOS 13.0, *)) {
+        // The below lines can be replace with this single line once Xcode 10 support is dropped
+        // window.windowScene = UIApplication.sharedApplication.keyWindow.windowScene;
+        UIWindow *keyWindow = UIApplication.sharedApplication.keyWindow;
+        id windowScene = [keyWindow performSelector:@selector(windowScene)];
+        [window performSelector:@selector(setWindowScene:) withObject:windowScene];
+    }
 }
 
 #pragma mark OSTriggerControllerDelegate Methods


### PR DESCRIPTION
* Scenes where not introduced until Xcode 11
* Preprocessor was not an option as we need to make a fat binary that is build with Xcode 10
no matter which Xcode version the consumer uses.
This is so the bitcode version works for Xcode 10 and up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/652)
<!-- Reviewable:end -->
