### PR TITLE
Add Click Action handler for outcomes

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalOutcomeEventsController.m
@@ -84,8 +84,6 @@ NSMutableSet *unattributedUniqueOutcomeEventsSentSet;
         else
             [self sendOutcomeEvent:name appId:appId deviceType:deviceType successBlock:nil];
     }
-    // Requests are sent or cached at this point
-    [_sessionManager onDirectInfluenceFromIAMClickFinished];
 }
 
 - (void)sendUniqueOutcomeEvent:(NSString * _Nonnull)name


### PR DESCRIPTION
   * If the user sends and outcome from the click action handler callback, that outcome should be DIRECT influenced by IAM
   * DIRECT influences by IAM can be from click action handler or click action outcome

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/660)
<!-- Reviewable:end -->
