### PR TITLE
Add Settings option to denied location prompt

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageLocationPrompt.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageLocationPrompt.m
@@ -30,7 +30,7 @@
 
 @interface OneSignal ()
 
-+ (void)promptLocation:(void (^)(PromptActionResult result))completionHandler;
++ (void)promptLocationFallbackToSettings:(BOOL)fallback completionHandler:(void (^)(PromptActionResult result))completionHandler;
 
 @end
 
@@ -46,7 +46,7 @@
 }
 
 - (void)handlePrompt:(void (^)(PromptActionResult result))completionHandler {
-    [OneSignal promptLocation:completionHandler];
+    [OneSignal promptLocationFallbackToSettings:true completionHandler:completionHandler];
 }
 
 - (NSString *)description {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -556,7 +556,7 @@ static OneSignalOutcomeEventsController* _outcomeEventsController;
     _outcomeEventsController = [[OneSignalOutcomeEventsController alloc] init:self.sessionManager];
     
     if (appId && mShareLocation)
-       [OneSignalLocation getLocation:false withCompletionHandler:nil];
+       [OneSignalLocation getLocation:false fallbackToSettings:false withCompletionHandler:nil];
     
     /*
      * No need to call the handleNotificationOpened:userInfo as it will be called from one of the following selectors
@@ -1394,15 +1394,15 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void)promptLocation {
-    [self promptLocation:nil];
+    [self promptLocationFallbackToSettings:false completionHandler:nil];
 }
 
-+ (void)promptLocation:(void (^)(PromptActionResult result))completionHandler {
++ (void)promptLocationFallbackToSettings:(BOOL)fallback completionHandler:(void (^)(PromptActionResult result))completionHandler {
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"promptLocation"])
         return;
     
-    [OneSignalLocation getLocation:true withCompletionHandler:completionHandler];
+    [OneSignalLocation getLocation:true fallbackToSettings:fallback withCompletionHandler:completionHandler];
 }
 
 + (BOOL)isLocationShared {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
@@ -25,11 +25,12 @@
  * THE SOFTWARE.
  */
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "OneSignalCommonDefines.h"
+
 #ifndef OneSignalLocation_h
 #define OneSignalLocation_h
-
-#import <Foundation/Foundation.h>
-#import "OneSignalCommonDefines.h"
 
 typedef struct os_location_coordinate {
     double latitude;
@@ -42,13 +43,13 @@ typedef struct os_last_location {
     double horizontalAccuracy;
 } os_last_location;
 
-@interface OneSignalLocation : NSObject
+@interface OneSignalLocation : NSObject <UIAlertViewDelegate>
 
 + (OneSignalLocation*) sharedInstance;
 + (bool)started;
-+ (void)internalGetLocation:(bool)prompt;
++ (void)internalGetLocation:(bool)prompt fallbackToSettings:(BOOL)fallback;
 - (void)locationManager:(id)manager didUpdateLocations:(NSArray *)locations;
-+ (void)getLocation:(bool)prompt withCompletionHandler:(void (^)(PromptActionResult result))completionHandler;
++ (void)getLocation:(bool)prompt fallbackToSettings:(BOOL)fallback withCompletionHandler:(void (^)(PromptActionResult result))completionHandler;
 + (void)sendLocation;
 + (os_last_location*)lastLocation;
 + (void)clearLastLocation;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -50,10 +50,12 @@ NSTimer* sendLocationTimer = nil;
 os_last_location *lastLocation;
 bool initialLocationSent = false;
 UIBackgroundTaskIdentifier fcTask;
+const int alertSettingsTag = 199;
 
 static id locationManager = nil;
 static bool started = false;
 static bool hasDelayed = false;
+static bool fallbackToSettings = false;
 
 // CoreLocation must be statically linked for geotagging to work on iOS 6 and possibly 7.
 // plist NSLocationUsageDescription (iOS 6 & 7) and NSLocationWhenInUseUsageDescription (iOS 8+) keys also required.
@@ -104,18 +106,18 @@ static OneSignalLocation* singleInstance = nil;
     }
 }
 
-+ (void)getLocation:(bool)prompt withCompletionHandler:(void (^)(PromptActionResult result))completionHandler {
++ (void)getLocation:(bool)prompt fallbackToSettings:(BOOL)fallback withCompletionHandler:(void (^)(PromptActionResult result))completionHandler {
     if (completionHandler)
         [OneSignalLocation.locationListeners addObject:completionHandler];
 
     if (hasDelayed)
-        [OneSignalLocation internalGetLocation:prompt];
+        [OneSignalLocation internalGetLocation:prompt fallbackToSettings:fallback];
     else {
         // Delay required for locationServicesEnabled and authorizationStatus return the correct values when CoreLocation is not statically linked.
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 2.0 * NSEC_PER_SEC);
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
             hasDelayed = true;
-            [OneSignalLocation internalGetLocation:prompt];
+            [OneSignalLocation internalGetLocation:prompt fallbackToSettings:fallback];
         });
     }
     // Listen to app going to and from background
@@ -193,16 +195,29 @@ static OneSignalLocation* singleInstance = nil;
     [self sendAndClearLocationListener:denied ? PERMISSION_DENIED : PERMISSION_GRANTED];
 }
 
-+ (void)internalGetLocation:(bool)prompt {
++ (void)internalGetLocation:(bool)prompt fallbackToSettings:(BOOL)fallback {
+    fallbackToSettings = fallback;
+    id clLocationManagerClass = NSClassFromString(@"CLLocationManager");
+    
+    // On the application init we are always calling this method
+    // If location permissions was not asked "started" will never be true
     if ([self started]) {
-        [self sendCurrentAuthStatusToListeners];
+        // We evaluate the following cases after permissions were asked (denied or given)
+        CLAuthorizationStatus permissionStatus = [clLocationManagerClass performSelector:@selector(authorizationStatus)];
+        // Fallback to settings alert view when the following condition are true:
+        //   - On a prompt flow
+        //   - Fallback to settings is enabled
+        //   - Permission were denied
+        if (prompt && fallback && permissionStatus == kCLAuthorizationStatusDenied)
+            [self showLocationSettingsAlertView];
+        else
+            [self sendCurrentAuthStatusToListeners];
         return;
     }
     
-    id clLocationManagerClass = NSClassFromString(@"CLLocationManager");
-    
     // Check for location in plist
     if (![clLocationManagerClass performSelector:@selector(locationServicesEnabled)]) {
+        onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManager locationServices Disabled.");
         [self sendAndClearLocationListener:ERROR];
         return;
     }
@@ -249,11 +264,30 @@ static OneSignalLocation* singleInstance = nil;
     started = true;
 }
 
++ (void)showLocationSettingsAlertView {
+    onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManager permissionStatus kCLAuthorizationStatusDenied fallaback to settings");
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Location Not Available" message:@"You have previously denied sharing your device location. Please go to settings to enable." delegate:singleInstance cancelButtonTitle:@"Cancel" otherButtonTitles:@"Open Settings", nil];
+    alertView.tag = alertSettingsTag;
+    [alertView show];
+}
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
+   if (alertView.tag == alertSettingsTag) {
+       if (buttonIndex == 1) {
+           onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManage open settings option click");
+           [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+       }
+       [OneSignalLocation sendAndClearLocationListener:false];
+       return;
+   }
+}
+
 #pragma mark CLLocationManagerDelegate
 
 - (void)locationManager:(id)manager didUpdateLocations:(NSArray *)locations {
     // return if the user has not granted privacy permissions or location shared is false
-    if ([OneSignal requiresUserPrivacyConsent] || ![OneSignal isLocationShared]) {
+    if (([OneSignal requiresUserPrivacyConsent] || ![OneSignal isLocationShared]) && !fallbackToSettings) {
+        onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManagerDelegate clear Location listener due to permissions denied or location shared not available");
         [OneSignalLocation sendAndClearLocationListener:PERMISSION_DENIED];
         return;
     }

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.m
@@ -99,7 +99,7 @@ NSArray *locations;
     calledRequestAlwaysAuthorization = false;
     calledRequestWhenInUseAuthorization = false;
     
-    [OneSignalLocation internalGetLocation:true];
+    [OneSignalLocation internalGetLocation:true fallbackToSettings:false];
 }
 
 + (int)overrideAuthorizationStatus {


### PR DESCRIPTION
   * Whenever the user clicks on never ask again option and denies the permission,
         we will show the reason why we need it and the option to open settings and change the location permission

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/663)
<!-- Reviewable:end -->
