### PR TITLE
Check for prompts before entering logic

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -539,7 +539,8 @@ static BOOL _isInAppMessagingPaused = false;
     if (action.clickUrl)
         [self handleMessageActionWithURL:action];
     
-    [self handlePromptActions:action.promptActions];
+    if (action.promptActions && action.promptActions.count > 0)
+        [self handlePromptActions:action.promptActions];
 
     if (self.actionClickBlock)
         self.actionClickBlock(action);


### PR DESCRIPTION
   * We want to avoid evaluateMessageDisplayQueue being call if no prompts are available

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/665)
<!-- Reviewable:end -->
