### PR TITLE
Fix Direct influence case

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSChannelTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSChannelTracker.m
@@ -79,6 +79,7 @@ THE SOFTWARE.
     _indirectIds = [self lastReceivedIds];
     _influenceType = _indirectIds != nil && _indirectIds.count > 0 ? INDIRECT : UNATTRIBUTED;
     
+    [self cacheState];
     [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSChannelTracker resetAndInitInfluence for: %@ finish with influenceType: %@", [self idTag], OS_INFLUENCE_TYPE_TO_STRING(_influenceType)]];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTracker.m
@@ -89,5 +89,4 @@ THE SOFTWARE.
     [self.dataRepository cacheIAMInfluenceType:self.influenceType];
 }
 
-
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSSessionManager.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSessionManager.m
@@ -93,7 +93,6 @@
     
     OSChannelTracker *inAppMessageTracker = [_trackerFactory iamChannelTracker];
     [inAppMessageTracker saveLastId:messageId];
-    [inAppMessageTracker resetAndInitInfluence];
 }
 
 - (void)onDirectInfluenceFromIAMClick:(NSString *)directIAMId {

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationV2Tests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationV2Tests.m
@@ -654,8 +654,10 @@
     // 2. Receive 2 iam
     [[OneSignal sessionManager] onInAppMessageReceived:@"test_in_app_message_1"];
     [[OneSignal sessionManager] onInAppMessageReceived:@"test_in_app_message_2"];
+    // 3. Dismiss iam
+    [[OneSignal sessionManager] onDirectInfluenceFromIAMClickFinished];
     
-    // 3. Validate IN_APP_MESSAGE influence is INDIRECT and send 2 outcomes
+    // 4. Validate IN_APP_MESSAGE influence is INDIRECT and send 2 outcomes
     let sessionInfluences = [OneSignal.sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -672,7 +674,7 @@
     [OneSignal sendOutcome:@"normal_1"];
     [OneSignal sendOutcome:@"normal_2"];
     
-    // 6. Make sure 2 measure requests were made with correct params
+    // 5. Make sure 2 measure requests were made with correct params
     [RestClientAsserts assertMeasureSourcesAtIndex:2 payload:@{
         @"sources": @{
                 @"indirect": @{
@@ -731,8 +733,10 @@
     // 2. Receive 2 iam
     [[OneSignal sessionManager] onInAppMessageReceived:@"test_in_app_message_1"];
     [[OneSignal sessionManager] onInAppMessageReceived:@"test_in_app_message_2"];
+    // 3. Dismiss iam
+    [[OneSignal sessionManager] onDirectInfluenceFromIAMClickFinished];
     
-    // 3. Validate IN_APP_MESSAGE influence is INDIRECT and send 2 outcomes
+    // 4. Validate IN_APP_MESSAGE influence is INDIRECT and send 2 outcomes
     let sessionInfluences = [OneSignal.sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -751,7 +755,7 @@
     let val2 = [NSNumber numberWithDouble:9.95];
     [OneSignal sendOutcomeWithValue:@"value_2" value:val2];
 
-    // 6. Make sure 2 measure requests were made with correct params
+    // 5. Make sure 2 measure requests were made with correct params
     [RestClientAsserts assertMeasureSourcesAtIndex:2 payload:@{
         @"sources": @{
                 @"indirect": @{

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeTests.m
@@ -185,7 +185,7 @@
         XCTAssertEqual(influence.ids, nil);
     }
     
-    // 4. Rceive 3 notifications
+    // 4. Receive 3 notifications
     [sessionManager onNotificationReceived:testNotificationId];
     [sessionManager onNotificationReceived:testNotificationId];
     [sessionManager onNotificationReceived:testNotificationId];

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeV2Tests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeV2Tests.m
@@ -115,8 +115,10 @@
     // 2. Receive 2 iam
     [sessionManager onInAppMessageReceived:testInAppMessageId];
     [sessionManager onInAppMessageReceived:testGenericId];
+    // 3. Dismiss iam
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     
-    // 3. Make sure IN_APP_MESSAGE influence is INDIRECT and has 3 notifications
+    // 4. Make sure IN_APP_MESSAGE influence is INDIRECT and has 3 notifications
     let sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -140,8 +142,10 @@
     [sessionManager onInAppMessageReceived:testInAppMessageId];
     [sessionManager onInAppMessageReceived:testGenericId];
     [sessionManager onInAppMessageReceived:testInAppMessageId];
+    // 3. Dismiss iam
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     
-    // 3. Make sure IN_APP_MESSAGE influence is INDIRECT and has 3 notifications
+    // 4. Make sure IN_APP_MESSAGE influence is INDIRECT and has 3 notifications
     let sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -195,10 +199,12 @@
         XCTAssertEqual(influence.ids, nil);
     }
     
-    // 4. Rceive 3 notifications
+    // 4. Receive 3 notifications
     [sessionManager onInAppMessageReceived:testInAppMessageId];
+    // 5. Dismiss iam
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     
-    // 5. Make sure IN_APP_MESSAGE influence is INDIRECT and has 1 iam
+    // 6. Make sure IN_APP_MESSAGE influence is INDIRECT and has 1 iam
     sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -219,8 +225,10 @@
     
     // 2. Receive a notification
     [sessionManager onInAppMessageReceived:testInAppMessageId];
+    // 3. Dismiss iam
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     
-    // 3. Make sure IN_APP_MESSAGE influence is INDIRECT and has 1 iam
+    // 4. Make sure IN_APP_MESSAGE influence is INDIRECT and has 1 iam
     NSArray<OSInfluence *> *sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -234,11 +242,13 @@
         }
     }
     
-    // 4. Receive 2 more iams
+    // 5. Receive 2 more iams
     [sessionManager onInAppMessageReceived:testNotificationId];
     [sessionManager onInAppMessageReceived:testGenericId];
-
-    // 5. Make sure IN_APP_MESSAGE influence is INDIRECT and has 3 iams because IAM influence does not depend on session
+    // 6. Dismiss iam
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
+    
+    // 7. Make sure IN_APP_MESSAGE influence is INDIRECT and has 3 iams because IAM influence does not depend on session
     sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -284,8 +294,10 @@
     // 2. Receive 2 notifications
     [sessionManager onInAppMessageReceived:testInAppMessageId];
     [sessionManager onInAppMessageReceived:testGenericId];
-
-    // 3. Make sure IN_APP_MESSAGE influence is INDIRECT and has 2 iam
+    // 4. Dismiss iam
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
+    
+    // 5. Make sure IN_APP_MESSAGE influence is INDIRECT and has 2 iam
     NSArray<OSInfluence *> *sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {
@@ -299,11 +311,11 @@
         }
     }
     
-    // 5. Receive a notification and open it
+    // 6. Receive a notification and open it
     [sessionManager onInAppMessageReceived:testNotificationId];
     [sessionManager onDirectInfluenceFromIAMClick:testNotificationId];
 
-    // 6. Make sure IN_APP_MESSAGE influence is DIRECT and has 1 iam
+    // 7. Make sure IN_APP_MESSAGE influence is DIRECT and has 1 iam
     sessionInfluences = [sessionManager getInfluences];
     for (OSInfluence *influence in sessionInfluences) {
         switch (influence.influenceChannel) {

--- a/iOS_SDK/OneSignalSDK/UnitTests/SessionManagerTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/SessionManagerTests.m
@@ -318,6 +318,7 @@ NSArray<OSInfluence *> *lastInfluencesBySessionEnding;
 
     [sessionManager onNotificationReceived:testGenericId];
     [sessionManager onInAppMessageReceived:testGenericId];
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     
     [sessionManager attemptSessionUpgrade:APP_OPEN];
 
@@ -350,6 +351,7 @@ NSArray<OSInfluence *> *lastInfluencesBySessionEnding;
 
     [sessionManager onNotificationReceived:testGenericId];
     [sessionManager onInAppMessageReceived:testGenericId];
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     [sessionManager onDirectInfluenceFromNotificationOpen:NOTIFICATION_CLICK withNotificationId:testGenericId];
 
     iamInfluence = [[trackerFactory iamChannelTracker] currentSessionInfluence];
@@ -511,6 +513,7 @@ NSArray<OSInfluence *> *lastInfluencesBySessionEnding;
     [self setOutcomesParamsEnabled];
 
     [sessionManager onInAppMessageReceived:testIAMId];
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     [sessionManager onNotificationReceived:testNotificationId];
 
     [sessionManager restartSessionIfNeeded:APP_OPEN];
@@ -528,6 +531,7 @@ NSArray<OSInfluence *> *lastInfluencesBySessionEnding;
     [self setOutcomesParamsEnabled];
 
     [sessionManager onInAppMessageReceived:testIAMId];
+    [sessionManager onDirectInfluenceFromIAMClickFinished];
     [sessionManager onNotificationReceived:testNotificationId];
 
     [sessionManager restartSessionIfNeeded:APP_CLOSE];


### PR DESCRIPTION
   * Reset and cache indirect state to avoid direct being the last cached state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/668)
<!-- Reviewable:end -->
