### PR TITLE
Improving file type detection for attachments

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/xcshareddata/xcschemes/OneSignalDevApp.xcscheme
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/xcshareddata/xcschemes/OneSignalDevApp.xcscheme
@@ -26,10 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -46,12 +43,23 @@
             isEnabled = "YES">
          </AdditionalOption>
       </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "911E2CB91E398AB3003112A4"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:../OneSignalSDK/OneSignal.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.h
@@ -31,6 +31,6 @@
 
 - (NSString *)valueFromQueryParameter:(NSString *)parameter;
 
-- (NSString*)supportedFileExtension;
+- (NSString *)supportedFileExtensionFromQueryItems;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.h
@@ -31,4 +31,6 @@
 
 - (NSString *)valueFromQueryParameter:(NSString *)parameter;
 
+- (NSString*)supportedFileExtension;
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
@@ -26,6 +26,7 @@
  */
 
 #import "NSURL+OneSignal.h"
+#import "OneSignalCommonDefines.h"
 
 @implementation NSURL (OneSignal)
 - (NSString *)valueFromQueryParameter:(NSString *)parameter {
@@ -37,4 +38,28 @@
     
     return nil;
 }
+
+- (NSString*)supportedFileExtension {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:false];
+    
+    for(int i = (int)components.queryItems.count-1; i > -1; i--) {
+        NSURLQueryItem *item = components.queryItems[i];
+        NSString *value = item.value;
+        NSString *extension = [self findExtensionInParam:value];
+        if (extension)
+            return extension;
+    }
+    return nil;
+}
+
+- (NSString*)findExtensionInParam:(NSString *)parameter {
+    NSArray *paramComponents = [parameter componentsSeparatedByString:@"."];
+    for (int i = (int)paramComponents.count-1; i > -1; i--) {
+        NSString *component = paramComponents[i];
+        if ([ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES containsObject:component])
+            return component;
+    }
+    return nil;
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
@@ -53,8 +53,7 @@
 
 - (NSString*)findExtensionInParam:(NSString *)parameter {
     NSArray *paramComponents = [parameter componentsSeparatedByString:@"."];
-    for (int i = (int)paramComponents.count-1; i > -1; i--) {
-        NSString *component = paramComponents[i];
+    for (NSString *component in [paramComponents reverseObjectEnumerator]) {
         if ([ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES containsObject:component])
             return component;
     }

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
@@ -32,7 +32,7 @@
 - (NSString *)valueFromQueryParameter:(NSString *)parameter {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:false];
     
-    for(NSURLQueryItem *item in components.queryItems)
+    for (NSURLQueryItem *item in components.queryItems)
         if([item.name isEqualToString:parameter])
             return item.value;
     
@@ -42,8 +42,7 @@
 - (NSString*)supportedFileExtension {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:false];
     
-    for(int i = (int)components.queryItems.count-1; i > -1; i--) {
-        NSURLQueryItem *item = components.queryItems[i];
+    for (NSURLQueryItem *item in [components.queryItems reverseObjectEnumerator]) {
         NSString *value = item.value;
         NSString *extension = [self findExtensionInParam:value];
         if (extension)

--- a/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSURL+OneSignal.m
@@ -39,7 +39,7 @@
     return nil;
 }
 
-- (NSString*)supportedFileExtension {
+- (NSString *)supportedFileExtensionFromQueryItems {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:false];
     
     for (NSURLQueryItem *item in [components.queryItems reverseObjectEnumerator]) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -238,4 +238,6 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 // variance and floating-point error.
 #define OS_ROUGHLY_EQUAL(left, right) (fabs(left - right) < 0.03)
 
+#define MAX_NOTIFICATION_MEDIA_SIZE_BYTES 50000000
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -783,7 +783,7 @@ static OneSignal* singleInstance = nil;
  Synchroneously downloads an attachment
  On success returns bundle resource name, otherwise returns nil
 */
-+ (NSString *)downloadMediaAndSaveInBundle:(NSString*)urlString {
++ (NSString *)downloadMediaAndSaveInBundle:(NSString *)urlString {
     
     let url = [NSURL URLWithString:urlString];
      

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -840,7 +840,7 @@ static OneSignal* singleInstance = nil;
         }
         
         if (error) {
-            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error    while attempting to download file with URL: %@", error]];
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error while attempting to download file with URL: %@", error]];
             return nil;
         }
          

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
@@ -50,8 +50,8 @@
     
     if ([url.absoluteString isEqualToString:@"http://domain.com/file"])
         return @"image/png";
-    else if ([url.absoluteString isEqualToString:@"http://domain.com/secondFile"])
-        return nil;
+    else if ([url.path isEqualToString:@"/secondFile"])
+        return @"image/heic";
     else
         return @"image/jpg";
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2136,16 +2136,7 @@ didReceiveRemoteNotification:userInfo
                      }};
 }
 
-- (void)testExtractFileExtensionFromMimeType {
-    //test to make sure the MIME type parsing works correctly
-    //NSURLSessionOverrider returns image/png for this URL
-    id pngFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/file"];
-    
-    let downloadedPngFilename = [self deliverNotificationWithJSON:pngFormat].URL.lastPathComponent;
-    XCTAssertTrue([downloadedPngFilename.supportedFileExtension isEqualToString:@"png"]);
-}
-
-- (void)testExtractFileExtensionFromQueryParameter {
+- (void)testExtractFileExtensionFromFileNameQueryParameter {
     // we allow developers to add ?filename=test.jpg (for example) to attachment URL's in cases where there is no extension & no mime type
     // tests to make sure the SDK correctly extracts the file extension from the `filename` URL query parameter
     // NSURLSessionOverrider returns nil for this URL
@@ -2155,14 +2146,32 @@ didReceiveRemoteNotification:userInfo
     XCTAssertTrue([downloadedJpgFilename.supportedFileExtension isEqualToString:@"jpg"]);
 }
 
-- (void)testFileExtensionPrioritizesURLFileExtension {
-    //tests to make sure that the URL's file extension is prioritized above the MIME type and URL query param
-    //this attachment URL will have a file extension, a MIME type, and a filename query parameter. It should prioritize the URL file extension (gif)
+- (void)testExtractFileExtensionFromMimeType {
+    //test to make sure the MIME type parsing works correctly
+    //NSURLSessionOverrider returns image/png for this URL
+    id pngFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/file"];
+    
+    let downloadedPngFilename = [self deliverNotificationWithJSON:pngFormat].URL.lastPathComponent;
+    XCTAssertTrue([downloadedPngFilename.supportedFileExtension isEqualToString:@"png"]);
+}
+
+- (void)testFileExtensionPrioritizesFileNameParameter {
+    //tests to make sure that the filename query parameter is prioritized above the MIME type and URL extension
+    //this attachment URL will have a file extension, a MIME type, and a filename query parameter. It should prioritize the filename query parameter (png)
     //NSURLSessionOverrider returns image/png for this URL
     id gifFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/file.gif?filename=test.png"];
     
     let downloadedGifFilename = [self deliverNotificationWithJSON:gifFormat].URL.lastPathComponent;
-    XCTAssertTrue([downloadedGifFilename.supportedFileExtension isEqualToString:@"gif"]);
+    XCTAssertTrue([downloadedGifFilename.supportedFileExtension isEqualToString:@"png"]);
+}
+
+- (void)testExtractFileExtensionFromAnyParamter {
+    //test to make sure the fallback of parsing all parameters for a file type works correctly
+    //NSURLSessionOverrider returns an unallowed extension (heic) for this URL to test the fallback
+    id pngFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/secondFile?file=test.png&media=image&type=.fakeextension"];
+    
+    let downloadedPngFilename = [self deliverNotificationWithJSON:pngFormat].URL.lastPathComponent;
+    XCTAssertTrue([downloadedPngFilename.supportedFileExtension isEqualToString:@"png"]);
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2165,7 +2165,7 @@ didReceiveRemoteNotification:userInfo
     XCTAssertTrue([downloadedGifFilename.supportedFileExtension isEqualToString:@"png"]);
 }
 
-- (void)testExtractFileExtensionFromAnyParamter {
+- (void)testExtractFileExtensionFromAnyParameter {
     //test to make sure the fallback of parsing all parameters for a file type works correctly
     //NSURLSessionOverrider returns an unallowed extension (heic) for this URL to test the fallback
     id pngFormat = [self exampleNotificationJSONWithMediaURL:@"http://domain.com/secondFile?file=test.png&media=image&type=.fakeextension"];


### PR DESCRIPTION
`OneSignalHelper.m`
In `downloadMediaAndSaveInBundle`

- We no longer quit before downloading if a valid file extension isn't found.

- Changing the extension source of truth order to:

1. filename query param
2. MIME type
3. url.pathExtension
4. A new fallback of doing a reverse order query param check for any valid extension.

In the `DirectDownloadDelegate`
We now enforce the 50mb size limit on attachments

`UnitTests.m` and `NSURLSessionOverrider.m`
Updated the unit tests for this area to reflect the new order and new fallback

`NSURL+OneSignal` 
has the logic for query param file extension extraction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/670)
<!-- Reviewable:end -->
