### PR TITLE
Using alertcontrollers instead of alertviews 

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface OSMessagingController : NSObject <OSInAppMessageViewControllerDelegate, OSTriggerControllerDelegate, OSMessagingControllerDelegate, UIAlertViewDelegate>
+@interface OSMessagingController : NSObject <OSInAppMessageViewControllerDelegate, OSTriggerControllerDelegate, OSMessagingControllerDelegate>
 
 @property (class, readonly) BOOL isInAppMessagingPaused;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -35,6 +35,7 @@
 #import "OSInAppMessageController.h"
 #import "OSInAppMessagePrompt.h"
 #import "OneSignalCommonDefines.h"
+#import "OneSignalDialogController.h"
 
 @interface OneSignal ()
 
@@ -547,18 +548,14 @@ static BOOL _isInAppMessagingPaused = false;
                  promptActions:(NSArray<NSObject<OSInAppMessagePrompt> *> *)promptActions  {
     _currentInAppMessage = inAppMessage;
     _currentPromptActions = promptActions;
-    let messageTitle = @"Location Not Available";
-    let message = @"Looks like this app doesn't have location services configured. Please see OneSignal docs for more information.";
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                    message:message
-                                                   delegate:self
-                                          cancelButtonTitle:nil
-                                          otherButtonTitles:@"OK", nil];
-    [alert show];
-}
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex{
-    [self handlePromptActions:_currentPromptActions withMessage:_currentInAppMessage];
+    
+    let message = NSLocalizedString(@"Looks like this app doesn't have location services configured. Please see OneSignal docs for more information.", @"An alert message indicating that the application is not configured to use have location services.");
+    let title = NSLocalizedString(@"Location Not Available", @"An alert title indicating that the location service is unavailable.");
+    let okAction = NSLocalizedString(@"OK", @"Allows the user to acknowledge and dismiss the alert");
+    [[OneSignalDialogController sharedInstance] presentDialogWithTitle:title withMessage:message withActions:nil cancelTitle:okAction withActionCompletion:^(int tappedActionIndex) {
+        //completion is called on the main thread
+        [self handlePromptActions:_currentPromptActions withMessage:_currentInAppMessage];
+    }];
 }
 
 - (void)messageViewDidSelectAction:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
     /*Notification is silent, or app is in focus but InAppAlertNotifications are disabled*/
     OSNotificationDisplayTypeNone,
     
-    /*Default UIAlertView display*/
+    /*Default UIAlertController display*/
     OSNotificationDisplayTypeInAppAlert,
     
     /*iOS native notification display*/

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -33,7 +33,6 @@
 #import "OneSignalReachability.h"
 #import "OneSignalJailbreakDetection.h"
 #import "OneSignalMobileProvision.h"
-#import "OneSignalAlertViewDelegate.h"
 #import "OneSignalHelper.h"
 #import "UNUserNotificationCenter+OneSignal.h"
 #import "OneSignalSelectorHelpers.h"
@@ -892,7 +891,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
         NSLog(@"%@", [levelString stringByAppendingString:message]);
     
     if (logLevel <= _visualLogLevel) {
-        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:levelString withMessage:message withAction:nil cancelTitle:NSLocalizedString(@"Close", @"Close button") withActionCompletion:nil];
+        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:levelString withMessage:message withActions:nil cancelTitle:NSLocalizedString(@"Close", @"Close button") withActionCompletion:nil];
     }
 }
 
@@ -973,10 +972,10 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
             localizedMessage = NSLocalizedString(@"You currently have notifications turned off for this application. You can open Settings to re-enable them", @"A message explaining that users can open Settings to re-enable push notifications");
         
         
-        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:localizedTitle withMessage:localizedMessage withAction:localizedSettingsActionTitle cancelTitle:localizedCancelActionTitle withActionCompletion:^(BOOL tappedAction) {
+        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:localizedTitle withMessage:localizedMessage withActions:@[localizedSettingsActionTitle] cancelTitle:localizedCancelActionTitle withActionCompletion:^(int tappedActionIndex) {
             
             //completion is called on the main thread
-            if (tappedAction)
+            if (tappedActionIndex > -1)
                 [self presentAppSettings];
         }];
         
@@ -1976,7 +1975,7 @@ static NSString *_lastnonActiveMessageId;
         let inAppAlert = (self.inFocusDisplayType == OSNotificationDisplayTypeInAppAlert);
         // Make sure it is not a silent one do display, if inAppAlerts are enabled
         if (inAppAlert && !isPreview && ![OneSignalHelper isRemoteSilentNotification:messageDict]) {
-            [OneSignalAlertView showInAppAlert:messageDict];
+            [[OneSignalDialogController sharedInstance] presentDialogWithMessageDict:messageDict];
             return;
         }
         

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalAlertViewDelegate.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalAlertViewDelegate.m
@@ -77,10 +77,10 @@
 
 NSDictionary* mMessageDict;
 
-
- //delegateReference exist to keep ARC from cleaning up this object when it goes out of scope.
- //This is becuase UIAlertView delegate is set to weak instead of strong
- 
+/*
+ delegateReference exist to keep ARC from cleaning up this object when it goes out of scope.
+ This is becuase UIAlertView delegate is set to weak instead of strong
+ */
 static NSMutableArray* delegateReference;
 
 - (id)initWithMessageDict:(NSDictionary*)messageDict {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalAlertViewDelegate.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalAlertViewDelegate.m
@@ -73,15 +73,14 @@
 
 @end
 
-
 @implementation OneSignalAlertViewDelegate
 
 NSDictionary* mMessageDict;
 
-/*
- delegateReference exist to keep ARC from cleaning up this object when it goes out of scope.
- This is becuase UIAlertView delegate is set to weak instead of strong
- */
+
+ //delegateReference exist to keep ARC from cleaning up this object when it goes out of scope.
+ //This is becuase UIAlertView delegate is set to weak instead of strong
+ 
 static NSMutableArray* delegateReference;
 
 - (id)initWithMessageDict:(NSDictionary*)messageDict {
@@ -138,3 +137,4 @@ static NSMutableArray* delegateReference;
 }
 
 @end
+

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.h
@@ -29,11 +29,15 @@
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
-typedef void (^OSDialogActionCompletion)(BOOL tappedAction);
+typedef void (^OSDialogActionCompletion)(int tappedActionIndex);
 
 @interface OneSignalDialogController : NSObject <UIAlertViewDelegate>
 + (instancetype _Nonnull)sharedInstance;
-- (void)presentDialogWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withAction:(NSString * _Nullable)actionTitle cancelTitle:(NSString * _Nonnull)cancelTitle withActionCompletion:(OSDialogActionCompletion _Nullable)completion;
+- (void)presentDialogWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActions:(NSArray<NSString *> * _Nullable)actionTitles cancelTitle:(NSString * _Nonnull)cancelTitle withActionCompletion:(OSDialogActionCompletion _Nullable)completion;
+
+- (void)presentDialogWithMessageDict:(NSDictionary *)messageDict;
+
+- (void)clearQueue;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -28,6 +28,7 @@
 #import "OneSignalDialogController.h"
 #import "OneSignalHelper.h"
 #import "OneSignalDialogRequest.h"
+#import "OneSignalAlertViewDelegate.h"
 
 /*
  This class handles displaying all dialogs (alerts) for the SDK
@@ -38,6 +39,16 @@
 @interface OneSignalDialogController ()
 
 @property (strong, nonatomic, nonnull) NSMutableArray <OSDialogRequest *> *queue;
+
+@end
+
+@interface OneSignal ()
+
++ (void)handleNotificationOpened:(NSDictionary*)messageDict
+                      foreground:(BOOL)foreground
+                        isActive:(BOOL)isActive
+                      actionType:(OSNotificationActionType)actionType
+                     displayType:(OSNotificationDisplayType)displayType;
 
 @end
 
@@ -55,11 +66,75 @@
     return sharedInstance;
 }
 
-- (void)presentDialogWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withAction:(NSString * _Nullable)actionTitle cancelTitle:(NSString * _Nonnull)cancelTitle withActionCompletion:(OSDialogActionCompletion _Nullable)completion {
+- (NSArray<NSString *> *)getActionTitlesFromPayload:(OSNotificationPayload *)payload {
+    NSMutableArray<NSString *> *actionTitles = [NSMutableArray<NSString *> new];
+    if (payload.actionButtons) {
+        for (id button in payload.actionButtons) {
+            [actionTitles addObject:button[@"text"]];
+        }
+    }
+    return actionTitles;
+}
+
+- (void)presentDialogWithMessageDict:(NSDictionary *)messageDict {
+    if ([OneSignalHelper isIOSVersionLessThan:@"8.0"]) {
+        [OneSignalAlertView showInAppAlert:messageDict];
+    }
+    let payload = [OSNotificationPayload parseWithApns:messageDict];
+    // Add action buttons to payload
+    NSArray<NSString *> *actionTitles = [self getActionTitlesFromPayload:payload];
+
+    [self presentDialogWithTitle:payload.title withMessage:payload.body withActions:actionTitles cancelTitle:@"Close" withActionCompletion:^(int tappedActionIndex) {
+        OSNotificationActionType actionType = OSNotificationActionTypeOpened;
+        
+        NSDictionary *finalDict = messageDict;
+        
+        if (tappedActionIndex > -1) {
+            
+            actionType = OSNotificationActionTypeActionTaken;
+            
+            NSMutableDictionary* userInfo = [messageDict mutableCopy];
+            
+            // Fixed for iOS 7, which has 'actionbuttons' as a root property of the dict, not in 'os_data'
+            if (messageDict[@"os_data"] && !messageDict[@"actionbuttons"]) {
+                if ([messageDict[@"os_data"][@"buttons"] isKindOfClass:[NSDictionary class]])
+                    userInfo[@"actionSelected"] = messageDict[@"os_data"][@"buttons"][@"o"][tappedActionIndex - 1][@"i"];
+                else
+                    userInfo[@"actionSelected"] = messageDict[@"os_data"][@"buttons"][tappedActionIndex][@"i"];
+            } else if (messageDict[@"buttons"]) {
+                 userInfo[@"actionSelected"] = messageDict[@"buttons"][tappedActionIndex][@"i"];
+            } else {
+                NSMutableDictionary* customDict = userInfo[@"custom"] ? [userInfo[@"custom"] mutableCopy] : [NSMutableDictionary new];
+                NSMutableDictionary* additionalData = customDict[@"a"] ? [[NSMutableDictionary alloc] initWithDictionary:customDict[@"a"]] : [NSMutableDictionary new];
+                
+                if([additionalData[@"actionButtons"] isKindOfClass:[NSArray class]]) {
+                    additionalData[@"actionSelected"] = additionalData[@"actionButtons"][tappedActionIndex - 1][@"id"];
+                } else if([messageDict[@"o"] isKindOfClass:[NSArray class]]) {
+                    additionalData[@"actionSelected"] = messageDict[@"o"][tappedActionIndex][@"i"];
+                } else if ([messageDict[@"actionbuttons"] isKindOfClass:[NSArray class]]) {
+                    additionalData[@"actionSelected"] = messageDict[@"actionbuttons"][tappedActionIndex][@"i"];
+                }
+                
+                customDict[@"a"] = additionalData;
+                userInfo[@"custom"] = customDict;
+            }
+            
+            finalDict = userInfo;
+        }
+        
+        [OneSignal handleNotificationOpened:finalDict foreground:YES isActive:YES actionType:actionType displayType:OSNotificationDisplayTypeInAppAlert];
+    }];
+    
+    // Message received that was displayed (Foreground + InAppAlert is true)
+    // Call received callback
+    [OneSignalHelper handleNotificationReceived:OSNotificationDisplayTypeInAppAlert fromBackground:NO];
+}
+
+- (void)presentDialogWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActions:(NSArray<NSString *> * _Nullable)actionTitles cancelTitle:(NSString * _Nonnull)cancelTitle withActionCompletion:(OSDialogActionCompletion _Nullable)completion {
     
     //ensure this UI code executes on the main thread
     dispatch_async(dispatch_get_main_queue(), ^{
-        let request = [[OSDialogRequest alloc] initWithTitle:title withMessage:message withActionTitle:actionTitle withCancelTitle:cancelTitle withCompletion:completion];
+        let request = [[OSDialogRequest alloc] initWithTitle:title withMessage:message withActionTitles:actionTitles withCancelTitle:cancelTitle withCompletion:completion];
         
         [self.queue addObject:request];
         
@@ -75,8 +150,12 @@
 - (void)displayDialog:(OSDialogRequest * _Nonnull)request {
     //iOS 7
     if ([OneSignalHelper isIOSVersionLessThan:@"8.0"]) {
-        
-        let alertView = [[UIAlertView alloc] initWithTitle:request.title message:request.message delegate:self cancelButtonTitle:request.cancelTitle otherButtonTitles:request.actionTitle, nil];
+        let alertView = [[UIAlertView alloc] initWithTitle:request.title message:request.message delegate:self cancelButtonTitle:request.cancelTitle otherButtonTitles:nil, nil];
+        if (request.actionTitles != nil) {
+            for (NSString *actionTitle in request.actionTitles) {
+                [alertView addButtonWithTitle:actionTitle];
+            }
+        }
         
         [alertView show];
         
@@ -89,19 +168,26 @@
     let controller = [UIAlertController alertControllerWithTitle:request.title message:request.message preferredStyle:UIAlertControllerStyleAlert];
     
     [controller addAction:[UIAlertAction actionWithTitle:request.cancelTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-        [self delayResult:false];
+        [self delayResult:-1];
     }]];
     
-    if (request.actionTitle != nil) {
-        [controller addAction:[UIAlertAction actionWithTitle:request.actionTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            [self delayResult:true];
-        }]];
+    if (request.actionTitles != nil) {
+        for (int i = 0; i < request.actionTitles.count; i++) {
+            NSString *actionTitle = request.actionTitles[i];
+            [controller addAction:[UIAlertAction actionWithTitle:actionTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                [self delayResult:i];
+            }]];
+        }
     }
     
     [rootViewController presentViewController:controller animated:true completion:nil];
 }
 
-- (void)delayResult:(BOOL)result {
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
+    [self delayResult:(int)buttonIndex-1];
+}
+
+- (void)delayResult:(int)result {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         let currentDialog = self.queue.firstObject;
         
@@ -120,8 +206,8 @@
     });
 }
 
-- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex {
-    [self delayResult:buttonIndex > 0];
+- (void)clearQueue {
+    self.queue = [NSMutableArray new];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -79,6 +79,7 @@
 - (void)presentDialogWithMessageDict:(NSDictionary *)messageDict {
     if ([OneSignalHelper isIOSVersionLessThan:@"8.0"]) {
         [OneSignalAlertView showInAppAlert:messageDict];
+        return;
     }
     let payload = [OSNotificationPayload parseWithApns:messageDict];
     // Add action buttons to payload

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogRequest.h
@@ -34,11 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic, nonnull) NSString *title;
 @property (strong, nonatomic, nonnull) NSString *message;
-@property (strong, nonatomic, nullable) NSString *actionTitle;
+@property (strong, nonatomic, nullable) NSArray<NSString *> *actionTitles;
 @property (strong, nonatomic, nonnull) NSString *cancelTitle;
 @property (nonatomic, nullable) OSDialogActionCompletion completion;
 
 - (instancetype _Nonnull)initWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActionTitle:(NSString * _Nullable)actionTitle withCancelTitle:(NSString * _Nonnull)cancelTitle withCompletion:(OSDialogActionCompletion _Nullable)completion;
+
+- (instancetype _Nonnull)initWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActionTitles:(NSArray<NSString *> * _Nullable)actionTitles withCancelTitle:(NSString * _Nonnull)cancelTitle withCompletion:(OSDialogActionCompletion _Nullable)completion;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogRequest.m
@@ -29,13 +29,26 @@
 
 @implementation OSDialogRequest
 
-- (instancetype _Nonnull)initWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActionTitle:(NSString * _Nullable)actionTitle withCancelTitle:(NSString * _Nonnull)cancelTitle withCompletion:(OSDialogActionCompletion _Nullable)completion
-{
+- (instancetype _Nonnull)initWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActionTitle:(NSString * _Nullable)actionTitle withCancelTitle:(NSString * _Nonnull)cancelTitle withCompletion:(OSDialogActionCompletion _Nullable)completion {
+    
     self = [super init];
     if (self) {
         self.title = title;
         self.message = message;
-        self.actionTitle = actionTitle;
+        self.actionTitles = @[actionTitle];
+        self.cancelTitle = cancelTitle;
+        self.completion = completion;
+    }
+    return self;
+}
+
+- (instancetype _Nonnull)initWithTitle:(NSString * _Nonnull)title withMessage:(NSString * _Nonnull)message withActionTitles:(NSArray<NSString *> * _Nullable)actionTitles withCancelTitle:(NSString * _Nonnull)cancelTitle withCompletion:(OSDialogActionCompletion _Nullable)completion {
+    
+    self = [super init];
+    if (self) {
+        self.title = title;
+        self.message = message;
+        self.actionTitles = actionTitles;
         self.cancelTitle = cancelTitle;
         self.completion = completion;
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -943,8 +943,8 @@ static OneSignal* singleInstance = nil;
         let openAction = NSLocalizedString(@"Open", @"Allows the user to open the URL/website");
         let cancelAction = NSLocalizedString(@"Cancel", @"The user won't open the URL/website");
         
-        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:title withMessage:message withAction:openAction cancelTitle:cancelAction withActionCompletion:^(BOOL tappedAction) {
-            openUrlBlock(tappedAction);
+        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:title withMessage:message withActions:@[openAction] cancelTitle:cancelAction withActionCompletion:^(int tappedActionIndex) {
+            openUrlBlock(tappedActionIndex > -1);
         }];
     } else {
         openUrlBlock(true);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
@@ -43,7 +43,7 @@ typedef struct os_last_location {
     double horizontalAccuracy;
 } os_last_location;
 
-@interface OneSignalLocation : NSObject <UIAlertViewDelegate>
+@interface OneSignalLocation : NSObject
 
 + (OneSignalLocation*) sharedInstance;
 + (bool)started;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -33,6 +33,7 @@
 #import "OneSignal.h"
 #import "OneSignalClient.h"
 #import "Requests.h"
+#import "OneSignalDialogController.h"
 
 @interface OneSignal ()
 void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
@@ -209,7 +210,7 @@ static OneSignalLocation* singleInstance = nil;
         //   - Fallback to settings is enabled
         //   - Permission were denied
         if (prompt && fallback && permissionStatus == kCLAuthorizationStatusDenied)
-            [self showLocationSettingsAlertView];
+            [self showLocationSettingsAlertController];
         else
             [self sendCurrentAuthStatusToListeners];
         return;
@@ -264,22 +265,16 @@ static OneSignalLocation* singleInstance = nil;
     started = true;
 }
 
-+ (void)showLocationSettingsAlertView {
++ (void)showLocationSettingsAlertController {
     onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManager permissionStatus kCLAuthorizationStatusDenied fallaback to settings");
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Location Not Available" message:@"You have previously denied sharing your device location. Please go to settings to enable." delegate:singleInstance cancelButtonTitle:@"Cancel" otherButtonTitles:@"Open Settings", nil];
-    alertView.tag = alertSettingsTag;
-    [alertView show];
-}
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
-   if (alertView.tag == alertSettingsTag) {
-       if (buttonIndex == 1) {
-           onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManage open settings option click");
-           [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-       }
-       [OneSignalLocation sendAndClearLocationListener:false];
-       return;
-   }
+    [[OneSignalDialogController sharedInstance] presentDialogWithTitle:@"Location Not Available" withMessage:@"You have previously denied sharing your device location. Please go to settings to enable." withActions:@[@"Open Settings"] cancelTitle:@"Cancel" withActionCompletion:^(int tappedActionIndex) {
+        if (tappedActionIndex > -1) {
+            onesignal_Log(ONE_S_LL_DEBUG, @"CLLocationManage open settings option click");
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+        }
+        [OneSignalLocation sendAndClearLocationListener:false];
+        return;
+    }];
 }
 
 #pragma mark CLLocationManagerDelegate

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalDialogControllerOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalDialogControllerOverrider.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OneSignalDialogControllerOverrider : NSObject
 + (OSDialogRequest *)getCurrentDialog;
++ (void)completeDialog:(int)result;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalDialogControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalDialogControllerOverrider.m
@@ -53,4 +53,11 @@ static OSDialogRequest *currentDialog;
     return currentDialog;
 }
 
++ (void)completeDialog:(int)result {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (currentDialog.completion)
+            currentDialog.completion(result);
+    });
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1185,24 +1185,6 @@
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
 }
-/*
- [OneSignal promptForPushNotificationsWithUserResponse:nil fallbackToSettings:true];
- 
- [UnitTestCommonMethods runBackgroundThreads];
- 
- //assert that the correct dialog was presented
- XCTAssertNotNil([OneSignalDialogControllerOverrider getCurrentDialog]);
- XCTAssertEqualObjects(OneSignalDialogControllerOverrider.getCurrentDialog.title, @"Open Settings");
- 
- //answer 'Open Settings' on the prompt
- OneSignalDialogControllerOverrider.getCurrentDialog.completion(0);
- 
- [UnitTestCommonMethods runBackgroundThreads];
- 
- //make sure the app actually tried to open settings
- XCTAssertNotNil(UIApplicationOverrider.lastOpenedUrl);
- XCTAssertEqualObjects(UIApplicationOverrider.lastOpenedUrl.absoluteString, UIApplicationOpenSettingsURLString);
- */
 
 // Testing iOS 10 - 2.4.0+ button fromat - with os_data aps payload format
 - (void)notificationAlertButtonsDisplayWithFormat:(NSDictionary *)userInfo {


### PR DESCRIPTION
Using the `OneSignalDialogController` to present alertcontrollers instead of alertviews.

Keeping `OneSignalAlertViewDelegate` for iOS 7. This will be removed in the next major release.

Updating `OneSignalDialogControllerOverrider` and in app alert unit tests to use the dialog controller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/683)
<!-- Reviewable:end -->
