### PR TITLE
Fix DIRECT IAM influence being cache

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTracker.m
@@ -86,7 +86,10 @@ THE SOFTWARE.
 }
 
 - (void)cacheState {
-    [self.dataRepository cacheIAMInfluenceType:self.influenceType];
+    // We only need to cache INDIRECT and UNATTRIBUTED influence types
+    // DIRECT is downgrade to INDIRECT to avoid inconsistency state
+    // where the app might be close before dismissing current displayed IAM
+    [self.dataRepository cacheIAMInfluenceType:self.influenceType == DIRECT ? INDIRECT : self.influenceType];
 }
 
 @end


### PR DESCRIPTION
   * IAM Direct influence shoudn't be cache because DIRECT Influence will be only while the IAM is being display
   * Instead of caching DIRECT cache INDIRECT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/688)
<!-- Reviewable:end -->
