### PR TITLE
Always call registerForRemoteNotifications from the main thread

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -947,7 +947,9 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Firing registerForRemoteNotifications"];
     
     waitingForApnsResponse = true;
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
+    [OneSignalHelper dispatch_async_on_main_queue:^{
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+    }];
     
     return true;
 }


### PR DESCRIPTION
This is a fix for an issue showing up in our react-native SDK where the `registerForRemoteNotifications` is happening on a background thread. This causes a UI freeze.
https://github.com/OneSignal/react-native-onesignal/issues/749

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/695)
<!-- Reviewable:end -->
