### PR TITLE
Fix UserDefault UniqueOutcome decodable clases migration

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		7A880F322404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A880F302404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m */; };
 		7A880F332404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A880F302404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m */; };
 		7A9173A2231971E5007848FA /* OneSignalReceiveReceiptsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A9173A1231971E5007848FA /* OneSignalReceiveReceiptsController.m */; };
+		7A94D8E1249ABF0000E90B40 /* OSUniqueOutcomeNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */; };
 		7AA2848A2406FC6400C25D76 /* OSInAppMessageTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F2D8E2406EFC5007799A9 /* OSInAppMessageTag.m */; };
 		7AA2848B2406FC6500C25D76 /* OSInAppMessageTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F2D8E2406EFC5007799A9 /* OSInAppMessageTag.m */; };
 		7AAA60662485D0310004FADE /* OSMigrationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AAA60652485D0090004FADE /* OSMigrationController.h */; };
@@ -497,6 +498,8 @@
 		7A880F302404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessagePushPrompt.m; sourceTree = "<group>"; };
 		7A9173A1231971E5007848FA /* OneSignalReceiveReceiptsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalReceiveReceiptsController.m; sourceTree = "<group>"; };
 		7A9173A3231971F8007848FA /* OneSignalReceiveReceiptsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalReceiveReceiptsController.h; sourceTree = "<group>"; };
+		7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUniqueOutcomeNotification.m; sourceTree = "<group>"; };
+		7A94D8E2249ABF0C00E90B40 /* OSUniqueOutcomeNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUniqueOutcomeNotification.h; sourceTree = "<group>"; };
 		7AAA60652485D0090004FADE /* OSMigrationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSMigrationController.h; sourceTree = "<group>"; };
 		7AAA60672485D0420004FADE /* OSMigrationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSMigrationController.m; sourceTree = "<group>"; };
 		7ABAF9D02457C3570074DFA0 /* CommonAsserts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommonAsserts.h; sourceTree = "<group>"; };
@@ -831,6 +834,8 @@
 			children = (
 				7A5A8186248990DA002E07C8 /* OSIndirectNotification.h */,
 				7A5A8184248990CD002E07C8 /* OSIndirectNotification.m */,
+				7A94D8E2249ABF0C00E90B40 /* OSUniqueOutcomeNotification.h */,
+				7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1642,6 +1647,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A94D8E1249ABF0000E90B40 /* OSUniqueOutcomeNotification.m in Sources */,
 				7A1232B2235E1BE6002B6CE3 /* OneSignalUserDefaults.m in Sources */,
 				7AF8FDBD2332A5C200A19245 /* OSIndirectInfluence.m in Sources */,
 				7A880F2D23FB45FB0081F5E8 /* OSInAppMessageOutcome.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -390,6 +390,8 @@ static OSSessionManager *_sessionManager;
 
 static OSOutcomeEventsCache *_outcomeEventsCache;
 + (OSOutcomeEventsCache *)outcomeEventsCache {
+    if (!_outcomeEventsCache)
+        _outcomeEventsCache = [[OSOutcomeEventsCache alloc] init];
     return _outcomeEventsCache;
 }
 
@@ -588,8 +590,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     initializationTime = [NSDate date];
     
     // Outcomes init
-    _outcomeEventsCache = [[OSOutcomeEventsCache alloc] init];
-    _outcomeEventFactory = [[OSOutcomeEventsFactory alloc] initWithCache:_outcomeEventsCache];
+    _outcomeEventFactory = [[OSOutcomeEventsFactory alloc] initWithCache:OneSignal.outcomeEventsCache];
     _outcomeEventsController = [[OneSignalOutcomeEventsController alloc] initWithSessionManager:OneSignal.sessionManager outcomeEventsFactory:_outcomeEventFactory];
     
     if (appId && mShareLocation)

--- a/iOS_SDK/OneSignalSDK/UnitTests/Models/OSUniqueOutcomeNotification.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Models/OSUniqueOutcomeNotification.h
@@ -1,0 +1,36 @@
+/**
+ Modified MIT License
+
+ Copyright 2019 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+@interface OSUniqueOutcomeNotification : NSObject
+
+@property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly) NSString *notificationId;
+@property (nonatomic, readonly) NSNumber *timestamp; // seconds
+
+- (id)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp;
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Models/OSUniqueOutcomeNotification.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Models/OSUniqueOutcomeNotification.m
@@ -1,0 +1,71 @@
+/**
+ Modified MIT License
+
+ Copyright 2019 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "OSUniqueOutcomeNotification.h"
+
+@implementation OSUniqueOutcomeNotification
+
+- (id)initWithParamsNotificationId:(NSString *)name notificationId:(NSString *)notificationId timestamp:(NSNumber *)timestamp {
+    _name = name;
+    _notificationId = notificationId;
+    _timestamp = timestamp;
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)encoder {
+    [encoder encodeObject:_name forKey:@"name"];
+    [encoder encodeObject:_notificationId forKey:@"notificationId"];
+    [encoder encodeInteger:[_timestamp integerValue] forKey:@"timestamp"];
+}
+
+- (id)initWithCoder:(NSCoder *)decoder {
+    if (self = [super init]) {
+        _name = [decoder decodeObjectForKey:@"name"];
+        _notificationId = [decoder decodeObjectForKey:@"notificationId"];
+        _timestamp = [NSNumber numberWithLong:[decoder decodeIntegerForKey:@"timestamp"]];
+    }
+    return self;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"Name: %@ Notification Id: %@ Timestamp: %@", _name, _notificationId, _timestamp];
+}
+
+- (BOOL)isEqual:(OSUniqueOutcomeNotification *)other {
+    NSString *key = [NSString stringWithFormat:@"%@_%@", _name, _notificationId];
+    NSString *otherKey = [NSString stringWithFormat:@"%@_%@", other.name, other.notificationId];
+    return [key isEqualToString:otherKey];
+}
+
+- (NSUInteger)hash {
+    return [_notificationId hash];
+}
+
+@end
+
+


### PR DESCRIPTION
  * Add OSUniqueOutcomeNotification migration to OSCachedUniqueOutcome

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/697)
<!-- Reviewable:end -->
