### PR TITLE
Fixing potential crash on launch when evaluating duration based IAM triggers

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -146,7 +146,7 @@ static BOOL _isInAppMessagingPaused = false;
         self.currentPromptAction = nil;
         self.isAppInactive = NO;
         // BOOL that controls if in-app messaging is paused or not (false by default)
-        [self setInAppMessagingPaused:false];
+        _isInAppMessagingPaused = false;
     }
     
     return self;


### PR DESCRIPTION
This PR fixes a crash when launching the app with cached IAMs that have a "DURATION SINCE LAST IN-APP" trigger.

The fix makes it so that instead of calling the setter for pausing IAMs we set the ivar directly. This means IAMs are not evaluated in the init of `OSMessagingController`.

When evaluating IAMs that have a "DURATION SINCE LAST IN-APP" trigger we try to access the `OSMessagingController.sharedInstance`, but if the evaluation was triggered from the dispatch_once block of `OSMessagingController.sharedInstance` we deadlock/crash.

We do not need to be evaluating IAMs in `OSMessagingController init` since they are already evaluated on launch in `OneSignal receivedInAppMessagingJSON`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/701)
<!-- Reviewable:end -->
