### PR TITLE
Feature/implement notification opened handler

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -61,7 +61,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
         [alert show];
     };
-
     id notificationReceiverBlock = ^(OSNotificationGenerationJob *notifJob) {
         NSLog(@"Will Receive Notification - %@", notifJob.notificationId);
         [notifJob complete];
@@ -107,10 +106,10 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     return YES;
 }
 
-#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"77e32082-ea27-42e3-a898-c72e141824ef"
+#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"0ba9731b-33bd-43f4-8b59-61172e27447d"
 
 + (NSString*)getOneSignalAppId {
-    NSString* newAppId = @"77e32082-ea27-42e3-a898-c72e141824ef";
+    NSString* newAppId = @"0ba9731b-33bd-43f4-8b59-61172e27447d";
     NSString* onesignalAppId = [[NSUserDefaults standardUserDefaults] objectForKey:ONESIGNAL_APP_ID_KEY_FOR_TESTING];
 
     if (![newAppId isEqualToString:onesignalAppId]) {

--- a/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/NotificationService.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/NotificationService.m
@@ -19,7 +19,7 @@
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:[NSOperationQueue new] usingBlock:^(NSNotification * _Nonnull note) {
         NSLog(@"Memory warning received");
     }];
-   */
+    */
     
     NSLog(@"######## Start NotificationService!");
 
@@ -43,7 +43,6 @@
     
     
 //    [NSThread sleepForTimeInterval:25.0f];
-    
     self.contentHandler(self.bestAttemptContent);
     
 //    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 25 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -177,6 +177,30 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @end
 
+/* OneSignal OSNotificationGenerationJob used in notificationWillShowInForegroundHandler. The display type for the notification can be changed before it is presented.*/
+@interface OSNotificationGenerationJob : NSObject
+
+/* Display method of the notification */
+@property(nonatomic) OSNotificationDisplayType displayType;
+
+/* Additional key value properties set within the payload */
+@property(readonly)NSDictionary *additionalData;
+
+/* The Notification ID */
+@property(readonly)NSString *notificationId;
+
+/* The message title */
+@property(readonly)NSString *title;
+
+/* The message body */
+@property(readonly)NSString *body;
+
+// Method controlling completion from the notificationWillShowInForegroundHandler
+// If 'complete' is not called within 25 seconds of receiving the OSNotificationGenerationJob in notificationWillShowInForegroundHandler then 'complete' will be automatically fired.
+- (void)complete;
+@end
+
+
 @interface OSNotificationOpenedResult : NSObject
 
 @property(readonly)OSNotification* notification;
@@ -208,6 +232,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 - (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
 @end
 
+typedef void (^OSNotificationDisplayTypeResponse)(OSNotificationDisplayType displayType);
 /* OneSignal Session Types */
 typedef NS_ENUM(NSUInteger, Session) {
     DIRECT,
@@ -339,7 +364,7 @@ typedef void (^OSFailureBlock)(NSError* error);
 typedef void (^OSIdsAvailableBlock)(NSString* userId, NSString* pushToken);
 
 /*Block for handling the reception of a remote notification */
-typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification* notification);
+typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotificationGenerationJob* notification);
 
 /*Block for handling a user reaction to a notification*/
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * result);
@@ -417,9 +442,9 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (void)registerForProvisionalAuthorization:(void(^)(BOOL accepted))completionHandler;
 
 // - Blocks
-+ (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock)delegate;
-+ (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock)delegate;
-+ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)delegate;
++ (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock)block;
++ (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock)block;
++ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)block;
 
 // - Logging
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1936,7 +1936,7 @@ static NSString *_lastnonActiveMessageId;
             type = OSNotificationActionTypeActionTaken;
 
         // Call Action Block
-        [OneSignal handleNotificationOpened:messageDict foreground:foreground isActive:isActive actionType:type displayType:OneSignal.notificationDisplayType];
+        [OneSignal handleNotificationOpened:messageDict foreground:foreground isActive:isActive actionType:type displayType:self.notificationDisplayType];
     }
 }
 
@@ -2165,7 +2165,7 @@ static NSString *_lastnonActiveMessageId;
     [OneSignal updateDeviceToken:parsedDeviceToken];
 }
     
-+ (BOOL)remoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
++ (BOOL)receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     var startedBackgroundJob = false;
     
     NSDictionary* richData = nil;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -202,9 +202,8 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
     // the max number of UNNotificationCategory ID's the SDK will register
     #define MAX_CATEGORIES_SIZE 128
 
-    // Defines how long the SDK will wait for OSNotificationDisplayTypeDelegate to execute
-    // the callback to set the display type for a given notification
-    #define CUSTOM_DISPLAY_TYPE_TIMEOUT 25.0
+    // Defines how long the SDK will wait for a OSNotificationGenerationJob's complete method to execute
+#define CUSTOM_DISPLAY_TYPE_TIMEOUT 25.0
 #else
     // Test defines for API Client
     #define REATTEMPT_DELAY 0.004
@@ -218,9 +217,8 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
     // the max number of UNNotificationCategory ID's the SDK will register
     #define MAX_CATEGORIES_SIZE 5
 
-    // Defines how long the SDK will wait for OSNotificationDisplayTypeDelegate to execute
-    // the callback to set the display type for a given notification
-    #define CUSTOM_DISPLAY_TYPE_TIMEOUT 0.05
+    // Unit testing value for how long the SDK will wait for a OSNotificationGenerationJob's complete method to execute
+#define CUSTOM_DISPLAY_TYPE_TIMEOUT 0.05
 #endif
 
 // A max timeout for a request, which might include multiple reattempts

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -41,9 +41,9 @@
 + (NSMutableDictionary*) formatApsPayloadIntoStandard:(NSDictionary*)remoteUserInfo identifier:(NSString*)identifier;
 + (void)lastMessageReceived:(NSDictionary*)message;
 
-+(void)setNotificationOpenedBlock:(OSNotificationOpenedBlock)block;
-+(void)setNotificationWillShowInForegroundBlock:(OSNotificationWillShowInForegroundBlock)block;
-
++ (void)setNotificationOpenedBlock:(OSNotificationOpenedBlock)block;
++ (void)setNotificationWillShowInForegroundBlock:(OSNotificationWillShowInForegroundBlock)block;
++ (void)handleWillShowInForegroundHandlerForPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion;
 + (void)handleNotificationReceived:(OSNotificationDisplayType)displayType;
 + (void)handleNotificationReceived:(OSNotificationDisplayType)displayType fromBackground:(BOOL)background;
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -272,7 +272,10 @@ NSTimer *_timeoutTimer;
 
 - (void)complete {
     [_timeoutTimer invalidate];
-    _completion(self.displayType);
+    if (_completion) {
+        _completion(self.displayType);
+        _completion = nil;
+    }
 }
 
 - (void)startTimeoutTimer {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -185,7 +185,6 @@
         if (_silentNotification ||
             (_isAppInFocus && OneSignal.notificationDisplayType == OSNotificationDisplayTypeSilent))
             _shown = false;
-        
     }
     return self;
 }
@@ -241,6 +240,54 @@
     NSError *err;
     NSData *jsonData = [NSJSONSerialization  dataWithJSONObject:obj options:0 error:&err];
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+@end
+
+@implementation OSNotificationGenerationJob
+@synthesize displayType = _displayType, notificationId = _notificationId, title = _title, body = _body;
+
+OSNotificationPayload *_payload;
+OSNotificationDisplayTypeResponse _completion;
+NSTimer *_timeoutTimer;
+- (id)initWithPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
+    self = [super init];
+    if (self) {
+        _payload = payload;
+        
+        _displayType = displayType;
+        
+        _body = _payload.body;
+        
+        _title = _payload.title;
+        
+        _notificationId = _payload.notificationID;
+        
+        _completion = completion;
+        
+        _timeoutTimer = [NSTimer timerWithTimeInterval:CUSTOM_DISPLAY_TYPE_TIMEOUT target:self selector:@selector(timeoutTimerFired:) userInfo:_notificationId repeats:false];
+    }
+    return self;
+}
+
+- (void)complete {
+    [_timeoutTimer invalidate];
+    _completion(self.displayType);
+}
+
+- (void)startTimeoutTimer {
+    [[NSRunLoop currentRunLoop] addTimer:_timeoutTimer forMode:NSRunLoopCommonModes];
+}
+
+- (void)timeoutTimerFired:(NSTimer *)timer {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE
+    message:[NSString stringWithFormat:@"NotificationGenerationJob timedout. Complete was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
+    [self complete];
+}
+
+- (void)dealloc {
+    if (_timeoutTimer)
+        [_timeoutTimer invalidate];
 }
 
 @end
@@ -401,6 +448,15 @@ OneSignalWebView *webVC;
     return userInfo;
 }
 
++ (void)handleWillShowInForegroundHandlerForPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
+    let notifJob = [[OSNotificationGenerationJob alloc] initWithPayload:payload displayType:displayType completion:completion];
+    if (notificationWillShowInForegroundHandler) {
+        [notifJob startTimeoutTimer];
+        notificationWillShowInForegroundHandler(notifJob);
+    } else {
+        completion(displayType);
+    }
+}
 
 // Prevent the OSNotification blocks from firing if we receive a Non-OneSignal remote push
 + (BOOL)isOneSignalPayload:(NSDictionary *)payload {
@@ -416,10 +472,9 @@ OneSignalWebView *webVC;
     let payload = [OSNotificationPayload parseWithApns:lastMessageReceived];
     if ([self handleIAMPreview:payload])
         return;
-    
+
     // The payload is a valid OneSignal notification payload and is not a preview
     // Proceed and treat as a normal OneSignal notification
-    let notification = [[OSNotification alloc] initWithPayload:payload displayType:displayType];
 
     // Prevent duplicate calls to same receive event
     if ([payload.notificationID isEqualToString:lastMessageID])
@@ -428,9 +483,6 @@ OneSignalWebView *webVC;
 
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE
                      message:[NSString stringWithFormat:@"handleNotificationReceived lastMessageID: %@ displayType: %lu",lastMessageID, (unsigned long)displayType]];
-
-    if (notificationWillShowInForegroundHandler)
-       notificationWillShowInForegroundHandler(notification);
 }
 
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -504,7 +504,7 @@ OneSignalWebView *webVC;
     
     [OneSignalTrackFirebaseAnalytics trackOpenEvent:result];
     
-    if (!notificationOpenedHandler)
+    if (!notificationOpenedHandler || displayType == OSNotificationDisplayTypeSilent)
         return;
     notificationOpenedHandler(result);
 }

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -43,7 +43,7 @@
 + (void) updateNotificationTypes:(int)notificationTypes;
 + (NSString*) appId;
 + (void)notificationReceived:(NSDictionary*)messageDict foreground:(BOOL)foreground isActive:(BOOL)isActive wasOpened:(BOOL)opened;
-+ (BOOL) remoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
++ (BOOL) receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 + (void) processLocalActionBasedNotification:(UILocalNotification*) notification identifier:(NSString*)identifier;
 + (void) onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString*) message;
 @end
@@ -82,7 +82,7 @@ static NSArray* delegateSubclasses = nil;
     // Need to keep this one for iOS 10 for content-available notifiations when the app is not in focus
     //   iOS 10 doesn't fire a selector on UNUserNotificationCenter in this cases most likely becuase
     //   UNNotificationServiceExtension (mutable-content) and UNNotificationContentExtension (with category) replaced it.
-    injectToProperClass(@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:),
+    injectToProperClass(@selector(oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:),
                         @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:), delegateSubclasses, newClass, delegateClass);
     
     [OneSignalAppDelegate sizzlePreiOS10MethodsPhase1];
@@ -174,7 +174,7 @@ static NSArray* delegateSubclasses = nil;
 }
 
 
-// Fallback method - Normally this would not fire as oneSignalRemoteSilentNotification below will fire instead. Was needed for iOS 6 support in the past.
+// Fallback method - Normally this would not fire as oneSignalReceiveRemoteNotification below will fire instead. Was needed for iOS 6 support in the past.
 - (void)oneSignalReceivedRemoteNotification:(UIApplication*)application userInfo:(NSDictionary*)userInfo {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalReceivedRemoteNotification:userInfo:"];
 
@@ -192,21 +192,21 @@ static NSArray* delegateSubclasses = nil;
 // NOTE: completionHandler must only be called once!
 //          iOS 10 - This crashes the app if it is called twice! Crash will happen when the app is resumed.
 //          iOS 9  - Does not have this issue.
-- (void) oneSignalRemoteSilentNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:"];
+- (void) oneSignalReceiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:"];
     
-    BOOL callExistingSelector = [self respondsToSelector:@selector(oneSignalRemoteSilentNotification:UserInfo:fetchCompletionHandler:)];
+    BOOL callExistingSelector = [self respondsToSelector:@selector(oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:)];
     BOOL startedBackgroundJob = false;
     
     if ([OneSignal appId]) {
         if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
             [OneSignal notificationReceived:userInfo foreground:YES isActive:YES wasOpened:NO];
         else
-            startedBackgroundJob = [OneSignal remoteSilentNotification:application UserInfo:userInfo completionHandler:callExistingSelector ? nil : completionHandler];
+            startedBackgroundJob = [OneSignal receiveRemoteNotification:application UserInfo:userInfo completionHandler:callExistingSelector ? nil : completionHandler];
     }
     
     if (callExistingSelector) {
-        [self oneSignalRemoteSilentNotification:application UserInfo:userInfo fetchCompletionHandler:completionHandler];
+        [self oneSignalReceiveRemoteNotification:application UserInfo:userInfo fetchCompletionHandler:completionHandler];
         return;
     }
     

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -195,10 +195,9 @@ void finishProcessingNotification(UNNotification *notification,
         default: break;
     }
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Notification display type: %lu", (unsigned long)displayType]];
-    let notShown = displayType == OSNotificationDisplayTypeSilent && notification.request.content.body != nil;
     
     if ([OneSignal appId])
-        [OneSignal notificationReceived:notification.request.content.userInfo foreground:YES isActive:YES wasOpened:notShown];
+        [OneSignal notificationReceived:notification.request.content.userInfo foreground:YES isActive:YES wasOpened:NO];
 
     
     // Call orginal selector if one was set.

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
@@ -54,10 +54,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OSInAppMessageTestHelper : NSObject
 + (OSInAppMessage *)testMessageWithTriggersJson:(NSArray<NSDictionary *> *)triggers;
 + (OSInAppMessage *)testMessage;
++ (OSInAppMessage *)testMessagePreview;
 + (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers;
 + (NSDictionary *)testRegistrationJsonWithMessages:(NSArray<NSDictionary *> *)messages;
 + (NSDictionary *)testMessageJsonWithTriggerPropertyName:(NSString *)property withId:(NSString *)triggerId withOperator:(OSTriggerOperatorType)type withValue:(id)value;
 + (NSDictionary*)testInAppMessageGetContainsWithHTML:(NSString *)html;
++ (NSDictionary *)testMessagePreviewJson;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
@@ -82,6 +82,23 @@ int messageIdIncrementer = 0;
     };
 }
 
++ (NSDictionary *)testMessagePreviewJson {
+    return @{
+        @"aps" : @{
+            @"alert" : @"Tap to see In-App Message preview",
+            @"mutable-content" : @1,
+            @"sound" : @"default"
+        },
+        @"custom": @{
+            @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+            @"a": @{
+                @"os_in_app_message_preview_id" : @"c0e8dcb2-d966-4fdc-b345-36bbc00fe76a"
+            }
+        },
+        @"triggers" : @[]
+    };
+}
+
 + (OSInAppMessage *)testMessageWithTriggersJson:(NSArray *)triggers {
     let messageJson = (NSMutableDictionary *)[self.testMessageJson mutableCopy];
     
@@ -94,6 +111,14 @@ int messageIdIncrementer = 0;
 
 + (OSInAppMessage *)testMessage {
     let messageJson = self.testMessageJson;
+    
+    let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
+    
+    return [OSInAppMessage instanceWithData:data];
+}
+
++ (OSInAppMessage *)testMessagePreview {
+    let messageJson = self.testMessagePreviewJson;
     
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -108,12 +108,12 @@ static XCTestCase* _currentXCTestCase;
  Universal init helper that sets appId & launchOptions to default values and
     accepts params to set notificationWillShowInForegroundHandler & notificationOpenedHandler
  */
-+ (void)initOneSignalWithHandlers:(OSNotificationWillShowInForegroundBlock)notificationWillShowInForegroundDelegate
-        notificationOpenedHandler:(OSNotificationOpenedBlock)notificationOpenedDelegate {
++ (void)initOneSignalWithHandlers:(OSNotificationWillShowInForegroundBlock)notificationWillShowInForegroundBlock
+        notificationOpenedHandler:(OSNotificationOpenedBlock)notificationOpenedBlock {
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-[OneSignal setLaunchOptions:@{}];
-    [OneSignal setNotificationWillShowInForegroundHandler:notificationWillShowInForegroundDelegate];
-    [OneSignal setNotificationOpenedHandler:notificationOpenedDelegate];
+    [OneSignal setLaunchOptions:@{}];
+    [OneSignal setNotificationWillShowInForegroundHandler:notificationWillShowInForegroundBlock];
+    [OneSignal setNotificationOpenedHandler:notificationOpenedBlock];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2080,6 +2080,20 @@ didReceiveRemoteNotification:userInfo
     }];
 }
 
+// If the OSNotificationGenerationJob's complete method is fired by the willShowInForegroundHandler block after the job has timed out, the complete method should not result in the completion handler being called
+- (void)testCompleteAfterTimeoutInNotificationForegroundHandler {
+    [self fireWillPresentNotificationInForegroundHandlerWithForegroundBlock:^(OSNotificationGenerationJob *notifJob) {
+        notifJob.displayType = OSNotificationDisplayTypeSilent;
+        XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Always fail"];
+        XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:2.0];
+        if (result != XCTWaiterResultTimedOut) {
+            XCTFail(@"Somehow the expectation didn't timeout");
+        }
+        //WE ARE CALLING COMPLETE AFTER THE TIMEOUT. THIS MEANS THE NOTIFICATIONJOB'S TIMER SHOULD FIRE AND THE SECOND CALL TO COMPLETE SHOULD NOT RESULT IN THE COMPLETION HANDLER BEING CALLED A SECOND TIME.
+        [notifJob complete];
+    }];
+}
+
 
 - (void)testWillShowInForegroundHandlerNotFiredForIAM {
     __block var option = (UNNotificationPresentationOptions)7;


### PR DESCRIPTION
1. This PR fixes the implementation fo the Notification Opened Handler when the display type of a notification is changed in the `notificationWillShowInForegroundHandler`
2. It also renames our swizzled version of `receiveRemoteNotification` in our UIApplicationDelegate category from `oneSignalRemoteSilentNotification` to `oneSignalReceiveRemoteNotification` since the notification is not necessarily silent. 
3. In `UNUserNotificationCenter+OneSignal.m` when calling `notificationReceived` we always set `wasOpened` to no. This is called when the app is in the foreground before the notification has been presented to the user. There was previously a case where we set this opened flag to YES for a silent notification that had a non nil content body. This causes issues when overriding the display type of a notification to silent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/703)
<!-- Reviewable:end -->
