### PR TITLE
Added `jsonRepresentation` method to `OSInAppMessageAction` class

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -56,11 +56,7 @@
     
     // Example block for IAM action click handler
     id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
-        NSString *message = [NSString stringWithFormat:@"Click Action Occurred: clickName:%@ clickUrl:%@ firstClick:%i closesMessage:%i",
-                             action.clickName,
-                             action.clickUrl,
-                             action.firstClick,
-                             action.closesMessage];
+        NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
         [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:message];
     };
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.h
@@ -50,12 +50,6 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
 // The unique identifier for this click
 @property (strong, nonatomic, nonnull) NSString *clickId;
 
-// The outcome to send for this action
-@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
-
-// The tags to send for this action
-@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
-
 // The prompt action available
 @property (nonatomic, nullable) NSArray<NSObject<OSInAppMessagePrompt>*> *promptActions;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
     OSInAppMessageActionUrlTypeReplaceContent
 };
 
-@interface OSInAppMessageAction () <OSJSONEncodable, OSJSONDecodable>
+@interface OSInAppMessageAction () <OSJSONDecodable>
 
 // The type of element that was clicked, button or image
 @property (strong, nonatomic, nonnull) NSString *clickType;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
     OSInAppMessageActionUrlTypeReplaceContent
 };
 
-@interface OSInAppMessageAction () <OSJSONDecodable>
+@interface OSInAppMessageAction () <OSJSONEncodable, OSJSONDecodable>
 
 // The type of element that was clicked, button or image
 @property (strong, nonatomic, nonnull) NSString *clickType;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.m
@@ -110,13 +110,15 @@
     return action;
 }
 
-- (NSDictionary *_Nonnull)jsonRepresentation {
-    let json = @{
-        @"click_name": self.clickName ?: [NSNull null],
-        @"click_url": self.clickUrl.absoluteString ?: [NSNull null],
-        @"first_click": @(self.firstClick),
-        @"closes_message": @(self.closesMessage)
-    };
+- (NSDictionary *)jsonRepresentation {
+    let json = [NSMutableDictionary new];
+    
+    json[@"click_name"] = self.clickName;
+    json[@"first_click"] = @(self.firstClick);
+    json[@"closes_message"] = @(self.closesMessage);
+    
+    if (self.clickUrl)
+        json[@"click_url"] = self.clickUrl.absoluteString;
     
     return json;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.m
@@ -119,6 +119,18 @@
     
     if (self.clickUrl)
         json[@"click_url"] = self.clickUrl.absoluteString;
+        
+    if (self.outcomes && self.outcomes.count > 0) {
+        let *jsonOutcomes = [NSMutableArray new];
+        for (OSInAppMessageOutcome *outcome in self.outcomes) {
+            [jsonOutcomes addObject:[outcome jsonRepresentation]];
+        }
+        
+        json[@"outcomes"] = jsonOutcomes;
+    }
+    
+    if (self.tags)
+        json[@"tags"] = [self.tags jsonRepresentation];
     
     return json;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageAction.m
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#import "OneSignalHelper.h"
 #import "OSInAppMessageAction.h"
 #import "OSInAppMessagePushPrompt.h"
 #import "OSInAppMessageLocationPrompt.h"
@@ -107,6 +108,17 @@
     action.promptActions = promptActions;
 
     return action;
+}
+
+- (NSDictionary *_Nonnull)jsonRepresentation {
+    let json = @{
+        @"click_name": self.clickName ?: [NSNull null],
+        @"click_url": self.clickUrl.absoluteString ?: [NSNull null],
+        @"first_click": @(self.firstClick),
+        @"closes_message": @(self.closesMessage)
+    };
+    
+    return json;
 }
 
 - (NSString *)description {

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageOutcome.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageOutcome.h
@@ -32,11 +32,7 @@
 #import "OSJSONHandling.h"
 #import "OneSignal.h"
 
-@interface OSInAppMessageOutcome : NSObject <OSJSONDecodable>
-
-@property (strong, nonatomic, nonnull) NSString *name;
-@property (strong, nonatomic, nonnull) NSNumber *weight;
-@property (nonatomic) BOOL unique;
+@interface OSInAppMessageOutcome () <OSJSONDecodable>
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageOutcome.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageOutcome.m
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#import "OneSignalHelper.h"
 #import "OSInAppMessageOutcome.h"
 
 @implementation OSInAppMessageOutcome
@@ -63,6 +64,16 @@
 
 + (instancetype _Nullable)instancePreviewFromPayload:(OSNotificationPayload * _Nonnull)payload {
     return nil;
+}
+
+- (NSDictionary *)jsonRepresentation {
+    let json = [NSMutableDictionary new];
+    
+    json[@"name"] = self.name;
+    json[@"weight"] = self.weight;
+    json[@"unique"] = @(self.unique);
+
+    return json;
 }
 
 - (NSString *)description {

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTag.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTag.h
@@ -32,10 +32,7 @@
 #import "OSJSONHandling.h"
 #import "OneSignal.h"
 
-@interface OSInAppMessageTag : NSObject <OSJSONEncodable, OSJSONDecodable>
-
-@property (strong, nonatomic, nullable) NSDictionary *tagsToAdd;
-@property (strong, nonatomic, nullable) NSArray *tagsToRemove;
+@interface OSInAppMessageTag () <OSJSONEncodable, OSJSONDecodable>
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -189,6 +189,27 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @end;
 
+@interface OSInAppMessageOutcome : NSObject
+
+@property (strong, nonatomic, nonnull) NSString *name;
+@property (strong, nonatomic, nonnull) NSNumber *weight;
+@property (nonatomic) BOOL unique;
+
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
+@end
+
+@interface OSInAppMessageTag : NSObject
+
+@property (strong, nonatomic, nullable) NSDictionary *tagsToAdd;
+@property (strong, nonatomic, nullable) NSArray *tagsToRemove;
+
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
+@end
+
 @interface OSInAppMessageAction : NSObject
 
 // The action name attached to the IAM action
@@ -202,6 +223,12 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 // Whether or not the click action dismisses the message
 @property (nonatomic) BOOL closesMessage;
+
+// The outcome to send for this action
+@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
+
+// The tags to send for this action
+@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
 
 // Convert the class into a NSDictionary
 - (NSDictionary *_Nonnull)jsonRepresentation;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -191,19 +191,19 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @interface OSInAppMessageAction : NSObject
 
-/* The action name attached to the IAM action */
+// The action name attached to the IAM action
 @property (strong, nonatomic, nullable) NSString *clickName;
 
-/* The URL (if any) that should be opened when the action occurs */
+// The URL (if any) that should be opened when the action occurs
 @property (strong, nonatomic, nullable) NSURL *clickUrl;
 
-/* Whether or not the click action is first click on the IAM */
+// Whether or not the click action is first click on the IAM
 @property (nonatomic) BOOL firstClick;
 
-/* Whether or not the click action dismisses the message */
+// Whether or not the click action dismisses the message
 @property (nonatomic) BOOL closesMessage;
 
-// Convert the object into a NSDictionary
+// Convert the class into a NSDictionary
 - (NSDictionary *_Nonnull)jsonRepresentation;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -203,6 +203,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* Whether or not the click action dismisses the message */
 @property (nonatomic) BOOL closesMessage;
 
+// Convert the object into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
 @end
 
 @protocol OSInAppMessageDelegate <NSObject>

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -1123,7 +1123,7 @@
     XCTAssertFalse(OneSignalClientOverrider.lastHTTPRequestType);
 }
 
-- (void)testIAMClickedLaunchesTagSendPIRequest {
+- (void)testIAMClickedLaunchesTagSendAPIRequest {
     let message = [OSInAppMessageTestHelper testMessageJsonWithTriggerPropertyName:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withId:@"test_id1" withOperator:OSTriggerOperatorTypeLessThan withValue:@10.0];
     let registrationResponse = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message]];
     


### PR DESCRIPTION
* `OSJSONEncodable` now opens up possibility to have the `jsonRepresentation` method
  * Modified how we construct the json for the `OSInAppMessageAction` class
* Fixed demo app example IAM click block and now print out the constructed json rep

Major difference noticed between Android click event and iOS... Below is a screenshot showing the Android payload when tags or outcomes are included in the click action
![Screen Shot 2020-06-30 at 11 52 02 AM](https://user-images.githubusercontent.com/24537305/86148526-bae4be00-bac8-11ea-8128-b0290e1329c0.png)

Now iOS payload example witch shows consistency between both SDKs
Example 1:
![Screen Shot 2020-06-30 at 1 39 23 PM](https://user-images.githubusercontent.com/24537305/86161638-89c1b900-badb-11ea-91ed-211a85a1cfda.png)
Example 2:
![Screen Shot 2020-06-30 at 2 17 29 PM](https://user-images.githubusercontent.com/24537305/86162224-795e0e00-badc-11ea-8925-ce1633e6178a.png)
Example 3:
![Screen Shot 2020-06-30 at 2 17 37 PM](https://user-images.githubusercontent.com/24537305/86162230-7b27d180-badc-11ea-870d-97f3152c3dfc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/704)
<!-- Reviewable:end -->
