### PR TITLE
Fixing lifecycle methods for Scene based Applications

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = OneSignalDevApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
@@ -474,7 +474,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = OneSignalDevApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
@@ -494,6 +494,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
@@ -515,6 +516,7 @@
 				);
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -421,6 +421,9 @@
 		CAE2E5A9215D80070036FD32 /* OSNotificationPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotificationPayload.m */; };
 		CAE2E5AA215D80380036FD32 /* OneSignalNotificationServiceExtensionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F11FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m */; };
 		CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = CA810FCF202BA97300A60FED /* OSEmailSubscription.h */; };
+		DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
+		DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
+		DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -693,6 +696,8 @@
 		CACBAAA7218A6280000ACAA5 /* OSJSONHandling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSJSONHandling.h; sourceTree = "<group>"; };
 		CACBAAA9218A65AE000ACAA5 /* InAppMessagingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InAppMessagingTests.m; sourceTree = "<group>"; };
 		CACBAAAB218A662B000ACAA5 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalLifecycleObserver.m; sourceTree = "<group>"; };
+		DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalLifecycleObserver.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1027,6 +1032,8 @@
 				91C7725D1E7CCE1000D612D0 /* OneSignalInternal.h */,
 				912411F01E73342200E41FD7 /* OneSignal.h */,
 				912411F11E73342200E41FD7 /* OneSignal.m */,
+				DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */,
+				DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */,
 				CAB4112720852E48005A70D1 /* DelayedInitializationParameters.h */,
 				CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */,
 				CA70E3332023D51000019273 /* OneSignalSetEmailParameters.h */,
@@ -1267,6 +1274,7 @@
 				91F58D7A1E7C7D3F0017D24D /* OneSignalNotificationSettings.h in Headers */,
 				CA4742E4218B8FF30020DC8C /* OSTriggerController.h in Headers */,
 				7A1232AA235E17B4002B6CE3 /* OSSessionManager.h in Headers */,
+				DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */,
 				9D1BD9642379F42700A064F7 /* OSInfluenceDataDefines.h in Headers */,
 				7A674F192360D813001F9ACD /* OSBaseFocusTimeProcessor.h in Headers */,
 				CA8E19052193C76D009DA223 /* OSInAppMessagingHelpers.h in Headers */,
@@ -1541,6 +1549,7 @@
 				912412121E73342200E41FD7 /* OneSignalAlertViewDelegate.m in Sources */,
 				CA36A42D208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
 				912412421E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
+				DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				7A880F2B23FB45FB0081F5E8 /* OSInAppMessageOutcome.m in Sources */,
 				9124123A1E73342200E41FD7 /* OneSignalWebView.m in Sources */,
 				9D3300F523145AF3000F0A83 /* OneSignalViewHelper.m in Sources */,
@@ -1630,6 +1639,7 @@
 				0338566B1FBBD2270002F7C1 /* OSNotificationPayload.m in Sources */,
 				9DDFEEF323189C0E00EAE0BB /* OneSignalViewHelper.m in Sources */,
 				7A880F2C23FB45FB0081F5E8 /* OSInAppMessageOutcome.m in Sources */,
+				DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				912412431E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				CA47439F2190FEA80020DC8C /* OSTrigger.m in Sources */,
 				9124123B1E73342200E41FD7 /* OneSignalWebView.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -424,6 +424,8 @@
 		DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */; };
+		DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
+		DE5EFECA24D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -698,6 +700,8 @@
 		CACBAAAB218A662B000ACAA5 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalLifecycleObserver.m; sourceTree = "<group>"; };
 		DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalLifecycleObserver.h; sourceTree = "<group>"; };
+		DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageViewControllerOverrider.m; sourceTree = "<group>"; };
+		DE5EFECB24D8DC0E0032632D /* OSInAppMessageViewControllerOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageViewControllerOverrider.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -836,6 +840,8 @@
 				CAAE0DFC2195216900A57402 /* OneSignalOverrider.m */,
 				9D348538233D2DCF00EB81C9 /* OneSignalLocationOverrider.h */,
 				9D348539233D2E3600EB81C9 /* OneSignalLocationOverrider.m */,
+				DE5EFECB24D8DC0E0032632D /* OSInAppMessageViewControllerOverrider.h */,
+				DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */,
 			);
 			path = Shadows;
 			sourceTree = "<group>";
@@ -1732,6 +1738,7 @@
 				CAABF34D205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */,
 				912412301E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				91F58D851E7C88230017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
+				DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				CA8E190B2194FE0B009DA223 /* OSMessagingControllerOverrider.m in Sources */,
@@ -1806,6 +1813,7 @@
 				7AFE856D2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
 				CA8E19082193C76D009DA223 /* OSInAppMessagingHelpers.m in Sources */,
 				4529DEE11FA82AB300CEAB1D /* NSBundleOverrider.m in Sources */,
+				DE5EFECA24D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m in Sources */,
 				7AF986602447C13C00C36EAE /* OSInfluenceDataRepository.m in Sources */,
 				912412441E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				03866CC12378A67B0009C1D8 /* RestClientAsserts.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -425,7 +425,11 @@
 		DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */; };
 		DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
+		DE20425E24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */; };
+		DE20425F24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */; };
+		DE20426024E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */; };
 		DE5EFECA24D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */; };
+		DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -700,6 +704,8 @@
 		CACBAAAB218A662B000ACAA5 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalLifecycleObserver.m; sourceTree = "<group>"; };
 		DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalLifecycleObserver.h; sourceTree = "<group>"; };
+		DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIApplication+OneSignal.h"; sourceTree = "<group>"; };
+		DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+OneSignal.m"; sourceTree = "<group>"; };
 		DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageViewControllerOverrider.m; sourceTree = "<group>"; };
 		DE5EFECB24D8DC0E0032632D /* OSInAppMessageViewControllerOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageViewControllerOverrider.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1104,6 +1110,8 @@
 				CA1A6E6820DC2E31001C41B9 /* OneSignalDialogController.m */,
 				CA1A6E6D20DC2E73001C41B9 /* OneSignalDialogRequest.h */,
 				CA1A6E6E20DC2E73001C41B9 /* OneSignalDialogRequest.m */,
+				DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */,
+				DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1320,6 +1328,7 @@
 				9124123D1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.h in Headers */,
 				7AF9865324451F3900C36EAE /* OSFocusCallParams.h in Headers */,
 				CAB269D921B0B6F000F8A43C /* OSInAppMessageAction.h in Headers */,
+				DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */,
 				7AECE59C23675F5700537907 /* OSFocusTimeProcessorFactory.h in Headers */,
 				7AECE59A23674ADC00537907 /* OSUnattributedFocusTimeProcessor.h in Headers */,
 				CA63AFC22022670A00E340FB /* ReattemptRequest.h in Headers */,
@@ -1588,6 +1597,7 @@
 				CA63AFC32022670A00E340FB /* ReattemptRequest.m in Sources */,
 				912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				CACBAAA4218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */,
+				DE20425E24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
 				CA7FC8A021927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				7AECE59623674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				1AF75EAE1E8567FD0097B315 /* NSString+OneSignal.m in Sources */,
@@ -1678,6 +1688,7 @@
 				CA7FC8A121927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				9D1BD965237A08A400A064F7 /* OneSignalUserDefaults.m in Sources */,
+				DE20425F24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
 				7AF9863C2444C43900C36EAE /* OSInAppMessageTracker.m in Sources */,
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
 				9129C6BF1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
@@ -1762,6 +1773,7 @@
 				912412341E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				7AF98694244A567B00C36EAE /* OSOutcomeEventsCache.m in Sources */,
 				03866CBD2378A33B0009C1D8 /* OutcomeIntegrationTests.m in Sources */,
+				DE20426024E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
 				CA36F35B21C33A2500300C77 /* OSInAppMessageController.m in Sources */,
 				9124122C1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				03389F691FB548A0006537F0 /* OneSignalTrackFirebaseAnalyticsOverrider.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -224,7 +224,7 @@ static BOOL _isInAppMessagingPaused = false;
         if (self.isInAppMessageShowing)
             return;
         // Return early if the app is not active
-        if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
+        if (![UIApplication applicationIsActive]) {
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Pause IAMs display due to app inactivity"];
             _isAppInactive = YES;
             return;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -81,6 +81,8 @@
 #import "OSInAppMessageAction.h"
 #import "OSInAppMessage.h"
 
+#import "OneSignalLifecycleObserver.h"
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
 
@@ -622,6 +624,8 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     
     if ([OneSignalTrackFirebaseAnalytics libraryExists])
         [OneSignalTrackFirebaseAnalytics init];
+    
+    [OneSignalLifecycleObserver registerLifecycleObserver];
     
     return self;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -27,6 +27,7 @@
 
 #import "OneSignal.h"
 #import "OneSignalWebView.h"
+#import "UIApplication+OneSignal.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.h
@@ -1,0 +1,14 @@
+//
+//  OneSignalLifecycleObserver.h
+//  OneSignal
+//
+//  Created by Elliot Mawby on 7/30/20.
+//  Copyright © 2020 Hiptic. All rights reserved.
+//
+
+@interface OneSignalLifecycleObserver: NSObject
+
++ (OneSignalLifecycleObserver*) sharedInstance;
++ (void)registerLifecycleObserver;
++ (void)removeObserver;
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.h
@@ -28,5 +28,4 @@ THE SOFTWARE.
 + (OneSignalLifecycleObserver*) sharedInstance;
 + (void)registerLifecycleObserver;
 + (void)removeObserver;
-+ (BOOL)isAppUsingUIScene;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #import "OneSignalTracker.h"
 #import "OneSignalLocation.h"
 #import "OSMessagingController.h"
+#import "UIApplication+OneSignal.h"
 
 @implementation OneSignalLifecycleObserver
 
@@ -47,16 +48,9 @@ static OneSignalLifecycleObserver* _instance = nil;
     return _instance;
 }
 
-+ (BOOL)isAppUsingUIScene {
-    if (@available(iOS 13.0, *)) {
-        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationSceneManifest"] != nil;
-    }
-    return NO;
-}
-
 + (void)registerLifecycleObserver {
     // Replacing swizzled lifecycle selectors with notification center observers for scene based Apps
-    if ([self isAppUsingUIScene]) {
+    if ([UIApplication isAppUsingUIScene]) {
         [self registerLifecycleObserverAsUIScene];
     } else {
         [self registerLifecycleObserverAsUIApplication];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -1,10 +1,29 @@
-//
-//  OneSignalLifecycleObserver.m
-//  OneSignal
-//
-//  Created by Elliot Mawby on 7/30/20.
-//  Copyright © 2020 Hiptic. All rights reserved.
-//
+/**
+Modified MIT License
+
+Copyright 2020 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 
 #import <Foundation/Foundation.h>
 #import "OneSignalLifecycleObserver.h"
@@ -28,18 +47,32 @@ static OneSignalLifecycleObserver* _instance = nil;
     return _instance;
 }
 
++ (BOOL)isAppUsingUIScene {
+    if (@available(iOS 13.0, *)) {
+        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationSceneManifest"] != nil;
+    }
+    return NO;
+}
+
 + (void)registerLifecycleObserver {
     // Replacing swizzled lifecycle selectors with notification center observers for scene based Apps
-    if (@available(iOS 13.0, *)) {
-        NSDictionary *sceneManifest = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationSceneManifest"];
-        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registering for Scene Lifecycle notifications"];
-        if (sceneManifest) {
-            [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:UISceneDidEnterBackgroundNotification object:nil];
-            [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:UISceneDidActivateNotification object:nil];
-            [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(willResignActive) name:UISceneWillDeactivateNotification object:nil];
-            return;
-        }
+    if ([self isAppUsingUIScene]) {
+        [self registerLifecycleObserverAsUIScene];
+    } else {
+        [self registerLifecycleObserverAsUIApplication];
     }
+}
+
++ (void)registerLifecycleObserverAsUIScene {
+    if (@available(iOS 13.0, *)) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registering for Scene Lifecycle notifications"];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:UISceneDidEnterBackgroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:UISceneDidActivateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(willResignActive) name:UISceneWillDeactivateNotification object:nil];
+    }
+}
+
++ (void)registerLifecycleObserverAsUIApplication {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registering for Application Lifecycle notifications"];
     [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -1,0 +1,102 @@
+//
+//  OneSignalLifecycleObserver.m
+//  OneSignal
+//
+//  Created by Elliot Mawby on 7/30/20.
+//  Copyright © 2020 Hiptic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "OneSignalLifecycleObserver.h"
+#import "OneSignal.h"
+#import "OneSignalCommonDefines.h"
+#import "OneSignalTracker.h"
+#import "OneSignalLocation.h"
+#import "OSMessagingController.h"
+
+@implementation OneSignalLifecycleObserver
+
+static OneSignalLifecycleObserver* _instance = nil;
+
++(OneSignalLifecycleObserver*) sharedInstance {
+    @synchronized( _instance ) {
+        if( !_instance ) {
+            _instance = [[OneSignalLifecycleObserver alloc] init];
+        }
+    }
+    
+    return _instance;
+}
+
++ (void)registerLifecycleObserver {
+    // Replace swizzled lifecycle selectors with notification center observers for scene based Apps
+    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(applicationWillResignActive) name:UIApplicationWillResignActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(applicationDidEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    
+    
+    if (@available(iOS 13.0, *)) {
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(sceneDidEnterBackground) name:UISceneDidEnterBackgroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(sceneDidBecomeActive) name:UISceneDidActivateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(sceneWillResignActive) name:UISceneWillDeactivateNotification object:nil];
+    }
+}
+
++ (void)removeObserver {
+    [[NSNotificationCenter defaultCenter] removeObserver:[OneSignalLifecycleObserver sharedInstance]];
+}
+
+- (void)sceneDidBecomeActive {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm sceneDidBecomeActive"];
+    
+    if ([OneSignal app_id]) {
+        [OneSignalTracker onFocus:NO];
+        [OneSignalLocation onFocus:YES];
+        [[OSMessagingController sharedInstance] onApplicationDidBecomeActive];
+    }
+}
+     
+- (void)applicationDidBecomeActive {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm applicationDidBecomeActive"];
+    
+    if ([OneSignal app_id]) {
+        [OneSignalTracker onFocus:NO];
+        [OneSignalLocation onFocus:YES];
+        [[OSMessagingController sharedInstance] onApplicationDidBecomeActive];
+    }
+}
+
+- (void)sceneWillResignActive {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm sceneWillResignActive"];
+    
+    if ([OneSignal app_id])
+            [OneSignalTracker onFocus:YES];
+}
+
+- (void)applicationWillResignActive {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm applicationWillResignActive"];
+    
+    if ([OneSignal app_id])
+            [OneSignalTracker onFocus:YES];
+}
+
+- (void)sceneDidEnterBackground {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm sceneDidEnterBackground"];
+    
+    if ([OneSignal app_id])
+        [OneSignalLocation onFocus:NO];
+}
+
+- (void)applicationDidEnterBackground {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm applicationDidEnterBackground"];
+    
+    if ([OneSignal app_id])
+        [OneSignalLocation onFocus:NO];
+}
+
+- (void)dealloc {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"lifecycle observer deallocated"];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -29,35 +29,29 @@ static OneSignalLifecycleObserver* _instance = nil;
 }
 
 + (void)registerLifecycleObserver {
-    // Replace swizzled lifecycle selectors with notification center observers for scene based Apps
-    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(applicationWillResignActive) name:UIApplicationWillResignActiveNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(applicationDidEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
-    
-    
+    // Replacing swizzled lifecycle selectors with notification center observers for scene based Apps
     if (@available(iOS 13.0, *)) {
-        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(sceneDidEnterBackground) name:UISceneDidEnterBackgroundNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(sceneDidBecomeActive) name:UISceneDidActivateNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(sceneWillResignActive) name:UISceneWillDeactivateNotification object:nil];
+        NSDictionary *sceneManifest = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationSceneManifest"];
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registering for Scene Lifecycle notifications"];
+        if (sceneManifest) {
+            [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:UISceneDidEnterBackgroundNotification object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:UISceneDidActivateNotification object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(willResignActive) name:UISceneWillDeactivateNotification object:nil];
+            return;
+        }
     }
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registering for Application Lifecycle notifications"];
+    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(willResignActive) name:UIApplicationWillResignActiveNotification object:nil];
 }
 
 + (void)removeObserver {
     [[NSNotificationCenter defaultCenter] removeObserver:[OneSignalLifecycleObserver sharedInstance]];
 }
-
-- (void)sceneDidBecomeActive {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm sceneDidBecomeActive"];
-    
-    if ([OneSignal app_id]) {
-        [OneSignalTracker onFocus:NO];
-        [OneSignalLocation onFocus:YES];
-        [[OSMessagingController sharedInstance] onApplicationDidBecomeActive];
-    }
-}
      
-- (void)applicationDidBecomeActive {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm applicationDidBecomeActive"];
+- (void)didBecomeActive {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"application/scene didBecomeActive"];
     
     if ([OneSignal app_id]) {
         [OneSignalTracker onFocus:NO];
@@ -66,29 +60,15 @@ static OneSignalLifecycleObserver* _instance = nil;
     }
 }
 
-- (void)sceneWillResignActive {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm sceneWillResignActive"];
+- (void)willResignActive {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"application/scene willResignActive"];
     
     if ([OneSignal app_id])
-            [OneSignalTracker onFocus:YES];
+        [OneSignalTracker onFocus:YES];
 }
 
-- (void)applicationWillResignActive {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm applicationWillResignActive"];
-    
-    if ([OneSignal app_id])
-            [OneSignalTracker onFocus:YES];
-}
-
-- (void)sceneDidEnterBackground {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm sceneDidEnterBackground"];
-    
-    if ([OneSignal app_id])
-        [OneSignalLocation onFocus:NO];
-}
-
-- (void)applicationDidEnterBackground {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"ecm applicationDidEnterBackground"];
+- (void)didEnterBackground {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"application/scene didEnterBackground"];
     
     if ([OneSignal app_id])
         [OneSignalLocation onFocus:NO];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -40,9 +40,8 @@
 
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request
                                          withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
-    // Set default log level of NSE to VERBOSE so we get all logs from NSE logic
-    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_NONE];
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"NSE request received, setting OneSignal log level to VERBOSE!"];
+
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"NSE request received"];
     
     if (!replacementContent)
         replacementContent = [request.content mutableCopy];

--- a/iOS_SDK/OneSignalSDK/Source/UIApplication+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplication+OneSignal.h
@@ -1,0 +1,32 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2020 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+@interface UIApplication (OneSignal)
++ (BOOL)applicationIsActive;
++ (BOOL)isAppUsingUIScene;
+@end

--- a/iOS_SDK/OneSignalSDK/Source/UIApplication+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplication+OneSignal.m
@@ -1,0 +1,53 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2020 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "UIApplication+OneSignal.h"
+#import "OneSignalCommonDefines.h"
+
+@implementation UIApplication (OneSignal)
+
++ (BOOL)applicationIsActive {
+    if ([self isAppUsingUIScene]) {
+        if (@available(iOS 13.0, *)) {
+            UIWindow *keyWindow = UIApplication.sharedApplication.keyWindow;
+            id windowScene = [keyWindow performSelector:@selector(windowScene)];
+            id session = [windowScene performSelector:@selector(session)];
+            id scene = [session performSelector:@selector(scene)];
+            return [scene performSelector:@selector(activationState)] == 0;
+        }
+    }
+    return [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+}
+
++ (BOOL)isAppUsingUIScene {
+    if (@available(iOS 13.0, *)) {
+        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationSceneManifest"] != nil;
+    }
+    return NO;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -101,16 +101,6 @@ static NSArray* delegateSubclasses = nil;
     
     [OneSignalAppDelegate sizzlePreiOS10MethodsPhase2];
     
-    injectToProperClass(@selector(oneSignalApplicationWillResignActive:),
-                        @selector(applicationWillResignActive:), delegateSubclasses, newClass, delegateClass);
-    
-    // Required for background location
-    injectToProperClass(@selector(oneSignalApplicationDidEnterBackground:),
-                        @selector(applicationDidEnterBackground:), delegateSubclasses, newClass, delegateClass);
-    
-    injectToProperClass(@selector(oneSignalApplicationDidBecomeActive:),
-                        @selector(applicationDidBecomeActive:), delegateSubclasses, newClass, delegateClass);
-    
     // Used to track how long the app has been closed
     injectToProperClass(@selector(oneSignalApplicationWillTerminate:),
                         @selector(applicationWillTerminate:), delegateSubclasses, newClass, delegateClass);
@@ -240,39 +230,6 @@ static NSArray* delegateSubclasses = nil;
     
     if([self respondsToSelector:@selector(oneSignalLocalNotificationOpened:notification:)])
         [self oneSignalLocalNotificationOpened:application notification:notification];
-}
-
-- (void)oneSignalApplicationWillResignActive:(UIApplication*)application {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalApplicationWillResignActive"];
-    
-    if ([OneSignal app_id])
-        [OneSignalTracker onFocus:YES];
-    
-    if ([self respondsToSelector:@selector(oneSignalApplicationWillResignActive:)])
-        [self oneSignalApplicationWillResignActive:application];
-}
-
-- (void) oneSignalApplicationDidEnterBackground:(UIApplication*)application {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalApplicationDidEnterBackground"];
-    
-    if ([OneSignal app_id])
-        [OneSignalLocation onFocus:NO];
-    
-    if ([self respondsToSelector:@selector(oneSignalApplicationDidEnterBackground:)])
-        [self oneSignalApplicationDidEnterBackground:application];
-}
-
-- (void)oneSignalApplicationDidBecomeActive:(UIApplication*)application {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalApplicationDidBecomeActive"];
-    
-    if ([OneSignal app_id]) {
-        [OneSignalTracker onFocus:NO];
-        [OneSignalLocation onFocus:YES];
-        [[OSMessagingController sharedInstance] onApplicationDidBecomeActive];
-    }
-    
-    if ([self respondsToSelector:@selector(oneSignalApplicationDidBecomeActive:)])
-        [self oneSignalApplicationDidBecomeActive:application];
 }
 
 -(void)oneSignalApplicationWillTerminate:(UIApplication *)application {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.h
@@ -24,9 +24,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-@interface OneSignalLifecycleObserver: NSObject
-+ (OneSignalLifecycleObserver*) sharedInstance;
-+ (void)registerLifecycleObserver;
-+ (void)removeObserver;
-+ (BOOL)isAppUsingUIScene;
+
+@interface OSInAppMessageViewControllerOverrider : NSObject
+
 @end
+

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.m
@@ -1,0 +1,46 @@
+/**
+* Modified MIT License
+*
+* Copyright 2020 OneSignal
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* 1. The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* 2. All copies of substantial portions of the Software may only be used in connection
+* with services provided by OneSignal.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#import <Foundation/Foundation.h>
+#import "OSInAppMessageViewControllerOverrider.h"
+#import "OSInAppMessageViewController.h"
+#import "OneSignalSelectorHelpers.h"
+
+@implementation OSInAppMessageViewControllerOverrider
+
++ (void)load {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
+    injectToProperClass(@selector(overrideAnimateAppearance), @selector(animateAppearance), @[], [OSInAppMessageViewControllerOverrider class], [OSInAppMessageViewController class]);
+    #pragma clang diagnostic pop
+}
+
+- (void)overrideAnimateAppearance {
+    
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -28,6 +28,7 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 #import "OneSignal.h"
+#import "UIApplication+OneSignal.h"
 #import "OneSignalNotificationCategoryController.h"
 
 #define TEST_EXTERNAL_USER_ID @"i_am_a_test_external_user_id"

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -40,6 +40,7 @@ NSString * serverUrlWithPath(NSString *path);
 + (void)setCurrentNotificationPermissionAsUnanswered;
 + (void)foregroundApp;
 + (void)backgroundApp;
++ (void)useSceneLifecycle:(BOOL)useSceneLifecycle;
 + (void)initOneSignal;
 + (void)initOneSignalAndThreadWait;
 + (void)runBackgroundThreads;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -222,7 +222,7 @@ static XCTestCase* _currentXCTestCase;
 + (void)foregroundApp {
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateActive;
     
-    if ([OneSignalLifecycleObserver isAppUsingUIScene]) {
+    if ([UIApplication isAppUsingUIScene]) {
         if (@available(iOS 13.0, *)) {
             [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification object:nil];
         }
@@ -233,7 +233,7 @@ static XCTestCase* _currentXCTestCase;
 
 + (void)backgroundApp {
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateBackground;
-    if ([OneSignalLifecycleObserver isAppUsingUIScene]) {
+    if ([UIApplication isAppUsingUIScene]) {
         if (@available(iOS 13.0, *)) {
             [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidEnterBackgroundNotification object:nil];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -136,23 +136,11 @@
 }
 
 - (void)registerForPushNotifications {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [OneSignal registerForPushNotifications];
-    [self backgroundApp];
-}
-
-- (void)backgroundApp {
-    UIApplicationOverrider.currentUIApplicationState = UIApplicationStateBackground;
-    if (@available(iOS 13.0, *)) {
-        NSDictionary *sceneManifest = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationSceneManifest"];
-        if (sceneManifest) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:nil];
-            [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidEnterBackgroundNotification object:nil];
-            return;
-        }
-    }
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
-    
+    #pragma clang diagnostic pop
+    [UnitTestCommonMethods backgroundApp];
 }
                                                                           
 - (UNNotificationResponse*)createBasiciOSNotificationResponse {
@@ -394,7 +382,7 @@
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key"], @"value");
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
     
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     [UnitTestCommonMethods clearStateForAppRestart:self];
     
@@ -600,7 +588,7 @@
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
     [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert + UNAuthorizationOptionSound + UNAuthorizationOptionBadge)
                           completionHandler:^(BOOL granted, NSError* error) {}];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->fireCount, 1);
@@ -633,7 +621,7 @@
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
     [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert + UNAuthorizationOptionSound + UNAuthorizationOptionBadge)
                           completionHandler:^(BOOL granted, NSError* error) {}];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     // Full bug details explained in answerNotifiationPrompt
     [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -655,7 +643,7 @@
     OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
     [OneSignal addPermissionObserver:observer];
     
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     
     //answer the prompt to allow notification
     [UnitTestCommonMethods answerNotificationPrompt:true];
@@ -817,7 +805,7 @@
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         didAccept = accepted;
     }];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(didAccept);
@@ -833,7 +821,7 @@
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         didAccept = accepted;
     }];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(didAccept);
@@ -849,7 +837,7 @@
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         didAccept = accepted;
     }];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(didAccept);
@@ -932,9 +920,12 @@
                             settings:@{kOSSettingsKeyAutoPrompt: @false}];
     
     __block BOOL idsAvailable1Called = false;
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [OneSignal IdsAvailable:^(NSString *userId, NSString *pushToken) {
         idsAvailable1Called = true;
     }];
+    #pragma clang diagnostic pop
     
     [UnitTestCommonMethods runBackgroundThreads];
     
@@ -951,9 +942,12 @@
                             settings:@{kOSSettingsKeyAutoPrompt: @false}];
     
     __block BOOL idsAvailable2Called = false;
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [OneSignal IdsAvailable:^(NSString *userId, NSString *pushToken) {
         idsAvailable2Called = true;
     }];
+    #pragma clang diagnostic pop
     
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertTrue(idsAvailable2Called);
@@ -1444,6 +1438,8 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(localNotif.category, @"__dynamic__");
     XCTAssertEqualObjects(localNotif.userInfo, userInfo);
     
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     let categories = [UIApplication sharedApplication].currentUserNotificationSettings.categories;
     
     XCTAssertEqual(categories.count, 1);
@@ -1452,6 +1448,7 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(category.identifier, @"__dynamic__");
     
     let actions = [category actionsForContext:UIUserNotificationActionContextDefault];
+    #pragma clang diagnostic pop
     XCTAssertEqualObjects(actions[0].identifier, @"id1");
     XCTAssertEqualObjects(actions[0].title, @"text1");
 }
@@ -1460,7 +1457,7 @@ didReceiveRemoteNotification:userInfo
 - (void)testGeneratingLocalNotificationWithButtonsiOS8_osdata_format {
     OneSignalHelperOverrider.mockIOSVersion = 8;
     [UnitTestCommonMethods initOneSignalAndThreadWait];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     
     let userInfo = @{@"aps": @{@"content_available": @1},
                     @"os_data": @{
@@ -1479,7 +1476,7 @@ didReceiveRemoteNotification:userInfo
 - (void)testGeneratingLocalNotificationWithButtonsiOS8 {
     OneSignalHelperOverrider.mockIOSVersion = 8;
     [UnitTestCommonMethods initOneSignalAndThreadWait];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     
     let userInfo = @{@"aps": @{@"content_available": @1},
                     @"m": @"alert body only",
@@ -1709,8 +1706,8 @@ didReceiveRemoteNotification:userInfo
     
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
-    
-    [self backgroundApp];
+
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods setCurrentNotificationPermission:true];
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -1727,7 +1724,7 @@ didReceiveRemoteNotification:userInfo
     [self backgroundModesDisabledInXcode];
     
     [UnitTestCommonMethods initOneSignalAndThreadWait];
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     [UnitTestCommonMethods setCurrentNotificationPermission:true];
     
@@ -1750,15 +1747,15 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods initOneSignalAndThreadWait];
     
     // Don't make an on_session call if only out of the app for 20 secounds
-    [self backgroundApp];
-    NSDateOverrider.timeOffset = 10;
+    [UnitTestCommonMethods backgroundApp];
+    [NSDateOverrider advanceSystemTimeBy:10];
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
     
     // Anything over 30 secounds should count as a session.
-    [self backgroundApp];
-    NSDateOverrider.timeOffset = 41;
+    [UnitTestCommonMethods backgroundApp];
+    [NSDateOverrider advanceSystemTimeBy:41];
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     
@@ -1772,7 +1769,7 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods initOneSignalAndThreadWait];
     
     // 2. Kill the app and wait 31 seconds
-    [self backgroundApp];
+    [UnitTestCommonMethods backgroundApp];
     [UnitTestCommonMethods runBackgroundThreads];
     [UnitTestCommonMethods clearStateForAppRestart:self];
     [NSDateOverrider advanceSystemTimeBy:31];
@@ -2812,8 +2809,11 @@ didReceiveRemoteNotification:userInfo
 }
 
 - (void)testHexStringFromDataWithInvalidValues {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wnonnull"
     XCTAssertNil([NSString hexStringFromData:nil]);
     XCTAssertNil([NSString hexStringFromData:NULL]);
+    #pragma clang diagnostic pop
     XCTAssertNil([NSString hexStringFromData:[NSData new]]);
 }
 


### PR DESCRIPTION
### This development fixes issue #647 

### Previously 
The SDK was swizzling App Delegate lifecycle methods to add behavior for features like

- Session counts
- Session time
- IAM triggers
- Updating push permission status

This behavior was broken for Scene based applications since the following App Delegate methods are not called:

- `applicationDidBecomeActive`
- `applicationWillResignActive`
- `applicationDidEnterBackground`
- `applicationWillEnterForeground`

### Now
The SDK does  not swizzle the App Delegate lifecycle methods and instead listens for equivalent the NSNotificationCenter lifecycle notifications. If it is a scene based App we listen for:
- `UISceneDidEnterBackgroundNotification`
- `UISceneDidActivateNotification`
- `UISceneWillDeactivateNotification`

If it is not a scene based App we listen for:
- `UIApplicationDidEnterBackgroundNotification`
- `UIApplicationDidBecomeActiveNotification`
- `UIApplicationWillResignActiveNotification`

### Dev Project and Unit Test Changes
When doing development I made the development App Scene based, but I did not commit the change since we would not be able to run it on versions less than iOS 13. To make the App scene based:

1. Add the SceneDelegate.h and SceneDelegate.m files
![image](https://user-images.githubusercontent.com/13123372/89240206-4f52ac80-d5b0-11ea-8b53-4d563fcd1c83.png)

2. Update the App's info.plist to include the following entries 
![image](https://user-images.githubusercontent.com/13123372/89240157-27634900-d5b0-11ea-8353-5b924a058ba7.png)

By listening for Notifications instead of Swizzling the App Delegate I needed to change our UnitTests in the following ways

- Change `foregroundApp` and `backgroundApp` in `UnitTestCommonMethods` to post a notification instead of calling the lifecycle method on the appDelegate
- Add a new common method `useSceneLifecycle:(BOOL)sceneLifecycle` that adds the "UIApplicationSceneManifest" key to the mock info.plist dictionary, meaning that we will listen for scene notifications instead of app notifications
- Add an overrider for `OSInAppMessagingViewController` to fix an internalInconsistency crash when running unit tests since the class was listening for lifecycle notifications and updating UI
- Add a new unit test that validates the scene lifecycle observers are working properly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/714)
<!-- Reviewable:end -->
