### PR TITLE
Fixing webviews not being cleared properly

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
@@ -105,8 +105,9 @@ UIViewController *viewControllerForPresentation;
     if (!navController) {
         navController = [[UINavigationController alloc] initWithRootViewController:self];
         navController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-        navController.presentationController.delegate = self;
     }
+    navController.presentationController.delegate = self;
+
     if (!viewControllerForPresentation) {
         viewControllerForPresentation = [[UIViewController alloc] init];
         [[viewControllerForPresentation view] setBackgroundColor:[UIColor clearColor]];
@@ -122,8 +123,9 @@ UIViewController *viewControllerForPresentation;
     
     UIWindow* mainWindow = [[UIApplication sharedApplication] keyWindow];
     
-    if (!viewControllerForPresentation.view.superview)
+    if (!viewControllerForPresentation.view.superview) {
         [mainWindow addSubview:[viewControllerForPresentation view]];
+    }
     
     @try {
         [viewControllerForPresentation presentViewController:navController animated:YES completion:nil];
@@ -133,11 +135,15 @@ UIViewController *viewControllerForPresentation;
 
 - (void)clearWebView {
     [_webView loadHTMLString:@"" baseURL:nil];
-    if (viewControllerForPresentation)
+    if (viewControllerForPresentation) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"clearing web view"];
         [viewControllerForPresentation.view removeFromSuperview];
+    }
+        
 }
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"presentation controller did dismiss webview"];
     [self clearWebView];
 }
 


### PR DESCRIPTION
Webviews were not being cleared properly if multiple were queued in a row. #606 

In `OneSignalWebView's` `showInApp` method we were attempting to reuse `navController` and `viewControllerForPresentation` when opening webviews in the App. However the `presentationController delegate` lifecycle methods were not being properly called for the second webivew after removing the `viewControllerForPresentation.view` from its superview. 

This was because upon clearing the `navController` its presentationController delegate would get reset, and we only set the delegate if the `navController` was nil. The fix is to always set the `navController.presentationController.delegate = self`



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/718)
<!-- Reviewable:end -->
