### PR TITLE
Fixing notification received when App is Inactive

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2243,15 +2243,14 @@ static NSString *_lastnonActiveMessageId;
         }
     }
     // Method was called due to a tap on a notification - Fire open notification
-    else if (application.applicationState != UIApplicationStateBackground) {
+    else if (application.applicationState == UIApplicationStateActive) {
         [OneSignalHelper lastMessageReceived:userInfo];
         
-        if (application.applicationState == UIApplicationStateActive)
-            [OneSignalHelper handleNotificationReceived:OSNotificationDisplayTypeNotification fromBackground:NO];
-
-        if (![OneSignalHelper isRemoteSilentNotification:userInfo])
-            [OneSignal notificationReceived:userInfo foreground:application.applicationState == UIApplicationStateActive isActive:NO wasOpened:YES];
+        [OneSignalHelper handleNotificationReceived:OSNotificationDisplayTypeNotification fromBackground:NO];
         
+        if (![OneSignalHelper isRemoteSilentNotification:userInfo]) {
+             [OneSignal notificationReceived:userInfo foreground:YES isActive:NO wasOpened:YES];
+        }
         return startedBackgroundJob;
     }
     // content-available notification received in the background - Fire handleNotificationReceived block in app

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -48,10 +48,11 @@ NSString * serverUrlWithPath(NSString *path);
 + (void)beforeEachTest:(XCTestCase *)testCase;
 + (void)clearStateForAppRestart:(XCTestCase *)testCase;
 + (UNNotificationResponse*)createBasiciOSNotificationResponseWithPayload:(NSDictionary*)userInfo;
++ (UNNotification *)createBasiciOSNotificationWithPayload:(NSDictionary *)userInfo;
 + (void)answerNotificationPrompt:(BOOL)accept;
 + (void)setCurrentNotificationPermission:(BOOL)accepted;
 + (void)receiveNotification:(NSString*)notificationId wasOpened:(BOOL)opened;
-+ (void)handleNotificationReceived:(NSString*)notificationId messageDict:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
++ (void)handleNotificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
 + (XCTestCase*)currentXCTestCase;
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -111,18 +111,21 @@ static XCTestCase* _currentXCTestCase;
     // Normal tap on notification
     [notifResponse setValue:@"com.apple.UNNotificationDefaultActionIdentifier" forKeyPath:@"actionIdentifier"];
     
+    [notifResponse setValue:[self createBasiciOSNotificationWithPayload:userInfo] forKeyPath:@"notification"];
+    
+    return notifResponse;
+}
+
++ (UNNotification *)createBasiciOSNotificationWithPayload:(NSDictionary *)userInfo {
     UNNotificationContent *unNotifContent = [UNNotificationContent alloc];
     UNNotification *unNotif = [UNNotification alloc];
     UNNotificationRequest *unNotifRequqest = [UNNotificationRequest alloc];
     // Set as remote push type
     [unNotifRequqest setValue:[UNPushNotificationTrigger alloc] forKey:@"trigger"];
-    
-    [unNotif setValue:unNotifRequqest forKeyPath:@"request"];
-    [notifResponse setValue:unNotif forKeyPath:@"notification"];
-    [unNotifRequqest setValue:unNotifContent forKeyPath:@"content"];
     [unNotifContent setValue:userInfo forKey:@"userInfo"];
-    
-    return notifResponse;
+    [unNotifRequqest setValue:unNotifContent forKeyPath:@"content"];
+    [unNotif setValue:unNotifRequqest forKeyPath:@"request"];
+    return unNotif;
 }
 
 + (void)clearStateForAppRestart:(XCTestCase *)testCase {


### PR DESCRIPTION
When a notification is received when the App is:
1. Open in the foreground
2. Inactive (the notification center or control center is pulled up over the App)

OneSignal was treating the App as being opened from the Background.

This PR fixes the Inactive state by not treating the notification as being opened. The notification received handler still fires.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/719)
<!-- Reviewable:end -->
