### PR TITLE
Remove null pushToken check for notification_types

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2192,7 +2192,7 @@ static NSString *_lastnonActiveMessageId;
     
     if (!startedRegister && [self shouldRegisterNow])
         [OneSignal registerUser];
-    else if (self.currentSubscriptionState.pushToken)
+    else
         [self sendNotificationTypesUpdate];
     
     if ([self getUsableDeviceToken])

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -899,16 +899,21 @@
     [self backgroundModesDisabledInXcode];
     
     [UnitTestCommonMethods initOneSignal];
-    // Don't make a network call right away
+    // Testing network call is not being made from the main thread.
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);
     
-    [UnitTestCommonMethods answerNotificationPrompt:false];
+    // Run pending player create call, notification_types should never answnser prompt
     [UnitTestCommonMethods runBackgroundThreads];
-    
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, serverUrlWithPath(@"players"));
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"app_id"], @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"identifier"]);
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @0);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @(ERROR_PUSH_PROMPT_NEVER_ANSWERED));
+    
+    // Ensure we make an PUT call to update to notification_types declined
+    [UnitTestCommonMethods answerNotificationPrompt:false];
+    [UnitTestCommonMethods runBackgroundThreads];
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, serverUrlWithPath(@"players/1234"));
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @(NOTIFICATION_TYPE_NONE));
 }
 
 - (void)testIdsAvailableNotAcceptingNotifications {


### PR DESCRIPTION
* We should always update notification_types so it is the most accurate value.
   - pushToken should not be a factor on if we should update notification_types
   - This logic was here from day one https://github.com/OneSignal/OneSignal-iOS-SDK/blame/85a9351a144c36c9af2206cd3ec80e1abab005c2/iOS_SDK/OneSignalSDK/Source/OneSignal.m#L1636
* Also fixed the testNotAcceptingNotificationsWithoutBackgroundModes flaky test
   - Updated it to account for the new notification_types logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/720)
<!-- Reviewable:end -->
