### PR TITLE
Add migration when application updated but not launched yet

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -54,23 +54,27 @@ THE SOFTWARE.
 - (void)migrateToVersion_02_14_00_AndGreater {
     let influenceVersion = 21400;
     let uniqueCacheOutcomeVersion = 21403;
-    let sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
     if (sdkVersion < influenceVersion) {
-        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSIndirectNotification from version: %d", sdkVersion]];
+        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSIndirectNotification from version: %ld", sdkVersion]];
 
         [NSKeyedUnarchiver setClass:[OSIndirectInfluence class] forClassName:@"OSIndirectNotification"];
         NSArray<OSIndirectInfluence *> * indirectInfluenceData = [[OneSignal influenceDataRepository] lastNotificationsReceivedData];
-        if (indirectInfluenceData)
+        if (indirectInfluenceData) {
+            [NSKeyedArchiver setClassName:@"OSIndirectInfluence" forClass:[OSIndirectInfluence class]];
             [[OneSignal influenceDataRepository] saveNotifications:indirectInfluenceData];
+        }
     }
     
     if (sdkVersion < uniqueCacheOutcomeVersion) {
-        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSUniqueOutcomeNotification from version: %d", sdkVersion]];
+        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSUniqueOutcomeNotification from version: %ld", sdkVersion]];
         
         [NSKeyedUnarchiver setClass:[OSCachedUniqueOutcome class] forClassName:@"OSUniqueOutcomeNotification"];
         NSArray<OSCachedUniqueOutcome *> * attributedCacheUniqueOutcomeEvents = [[OneSignal outcomeEventsCache] getAttributedUniqueOutcomeEventSent];
-        if (attributedCacheUniqueOutcomeEvents)
+        if (attributedCacheUniqueOutcomeEvents) {
+            [NSKeyedArchiver setClassName:@"OSCachedUniqueOutcome" forClass:[OSCachedUniqueOutcome class]];
             [[OneSignal outcomeEventsCache] saveAttributedUniqueOutcomeEventNotificationIds:attributedCacheUniqueOutcomeEvents];
+        }
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2191,7 +2191,7 @@ static NSString *_lastnonActiveMessageId;
         return;
     
     if (!startedRegister && [self shouldRegisterNow])
-        [OneSignal registerUser];
+        [self registerUser];
     else
         [self sendNotificationTypesUpdate];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -35,6 +35,7 @@
 #import "OneSignalInternal.h"
 #import "OneSignalReceiveReceiptsController.h"
 #import "OSSessionManager.h"
+#import "OSMigrationController.h"
 
 @implementation OneSignalNotificationServiceExtensionHandler
 
@@ -99,6 +100,8 @@
     if (receivedNotificationId && ![receivedNotificationId isEqualToString:@""]) {
         // Track confirmed delivery
         [OneSignal.receiveReceiptsController sendReceiveReceiptWithNotificationId:receivedNotificationId];
+        // If update was made without app being initialized/launched before -> migrate
+        [[OSMigrationController new] migrate];
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"NSE request received, sessionManager: %@", [OneSignal sessionManager]]];
         // Save received notification id
         [[OneSignal sessionManager] onNotificationReceived:receivedNotificationId];


### PR DESCRIPTION
  * If the application was upgraded but not launched and then a notification arrives,
    OneSignalNotificationServiceExtensionHandler, onNotificationReceived will fail due to accessing saved
    notifications ids without migration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/722)
<!-- Reviewable:end -->
