### PR TITLE
Making scene notification names strings for Xcode 10 compilation

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -60,9 +60,9 @@ static OneSignalLifecycleObserver* _instance = nil;
 + (void)registerLifecycleObserverAsUIScene {
     if (@available(iOS 13.0, *)) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registering for Scene Lifecycle notifications"];
-        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:UISceneDidEnterBackgroundNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:UISceneDidActivateNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(willResignActive) name:UISceneWillDeactivateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didEnterBackground) name:@"UISceneDidEnterBackgroundNotification" object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(didBecomeActive) name:@"UISceneDidActivateNotification" object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:[OneSignalLifecycleObserver sharedInstance] selector:@selector(willResignActive) name:@"UISceneWillDeactivateNotification" object:nil];
     }
 }
 


### PR DESCRIPTION
In Xcode 10 the UIScene lifecycle notification name constants are not defined so the build fails.

The name constants are type aliased to strings so we can just use the string equivalent of the name instead to get it it to compile. This is safe because we are wrapping the registering of these notifications in an if @available iOS 13 check where UIScene is guaranteed to be available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/724)
<!-- Reviewable:end -->
