### PR TITLE
Change set launch options to init

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -80,7 +80,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         kOSSettingsKeyInAppLaunchURL: @true
     }];
     [OneSignal setAppId:[AppDelegate getOneSignalAppId]];
-    [OneSignal setLaunchOptions:launchOptions];
+    [OneSignal initWithLaunchOptions:launchOptions];
 
     [OneSignal addPermissionObserver:self];
     [OneSignal addSubscriptionObserver:self];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -469,7 +469,7 @@ extern NSString* const ONESIGNAL_VERSION;
 
 #pragma mark Initialization
 + (void)setAppId:(NSString* _Nonnull)newAppId;
-+ (void)setLaunchOptions:(NSDictionary* _Nullable)launchOptions;
++ (void)initWithLaunchOptions:(NSDictionary* _Nullable)launchOptions;
 // TODO: Remove before releasing major release 3.0.0
 + (void)setAppSettings:(NSDictionary* _Nonnull)settings;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -167,9 +167,9 @@ static NSDictionary* appSettings;
 // Make sure launchOptions have been set
 // We need this BOOL because launchOptions can be null so simply null checking
 //  won't validate whether or not launchOptions have been set
-static BOOL hasSetLaunchOptions = false;
+static BOOL hasCalledInitWithLaunchOptions = false;
 // Ensure we only initlize the SDK once even if the public method is called more
-// Called after successfully calling setAppId and setLaunchOptions
+// Called after successfully calling setAppId and initWithLaunchOptions
 static BOOL initDone = false;
 
 //used to ensure registration occurs even if APNS does not respond
@@ -451,7 +451,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     appId = nil;
     launchOptions = false;
     appSettings = nil;
-    hasSetLaunchOptions = false;
+    hasCalledInitWithLaunchOptions = false;
     initDone = false;
     usesAutoPrompt = false;
     requestedProvisionalAuthorization = false;
@@ -502,7 +502,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 }
 
 /*
- 1/2 steps in OneSignal init, relying on setLaunchOptions (usage order does not matter)
+ 1/2 steps in OneSignal init, relying on initWithLaunchOptions (usage order does not matter)
  Sets the app id OneSignal should use in the application
  This is should be set from all OneSignal entry points
  */
@@ -521,8 +521,8 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     appId = newAppId;
 
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"setAppId(id) finished, checking if launchOptions has been set before proceeding...!"];
-    if (!hasSetLaunchOptions) {
-        [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"appId set, but please call setLaunchOptions(launchOptions) to complete OneSignal init!"];
+    if (!hasCalledInitWithLaunchOptions) {
+        [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"appId set, but please call initWithLaunchOptions to complete OneSignal init!"];
         return;
     }
 
@@ -535,13 +535,13 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
  Sets the iOS sepcific app settings
  Method must be called to successfully init OneSignal
  */
-+ (void)setLaunchOptions:(nullable NSDictionary*)newLaunchOptions {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"setLaunchOptions() called with launchOptions: %@!", launchOptions.description]];
++ (void)initWithLaunchOptions:(nullable NSDictionary*)newLaunchOptions {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"initWithLaunchOptions called with launchOptions: %@!", launchOptions.description]];
 
     launchOptions = newLaunchOptions;
-    hasSetLaunchOptions = true;
+    hasCalledInitWithLaunchOptions = true;
 
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"setLaunchOptions(id) finished, checking if appId has been set before proceeding...!"];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"initWithLaunchOptions finished, checking if appId has been set before proceeding...!"];
     if (!appId || appId.length == 0) {
         // Read from .plist if not passed in with this method call
         appId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"OneSignal_APPID"];
@@ -563,7 +563,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         }
     }
 
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"setLaunchOptions(launchOptions) successful and appId is set, initializing OneSignal..."];
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"initWithLaunchOptions successful and appId is set, initializing OneSignal..."];
     [self init];
 }
 
@@ -587,7 +587,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 }
 
 /*
- Called after setAppId and setLaunchOptions, depending on which one is called last (order does not matter)
+ Called after setAppId and initWithLaunchOptions, depending on which one is called last (order does not matter)
  */
 + (void)init {
     [[OSMigrationController new] migrate];
@@ -795,7 +795,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     
     // Try to init again using delayed params (order does not matter)
     [self setAppId:delayedInitParameters.appId];
-    [self setLaunchOptions:delayedInitParameters.launchOptions];
+    [self initWithLaunchOptions:delayedInitParameters.launchOptions];
 
     delayedInitializationForPrivacyConsent = false;
     delayedInitParameters = nil;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -116,7 +116,7 @@ static XCTestCase* _currentXCTestCase;
  */
 + (void)initOneSignal {
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
 }
 
 /*
@@ -126,7 +126,7 @@ static XCTestCase* _currentXCTestCase;
 + (void)initOneSignalWithHandlers:(OSNotificationWillShowInForegroundBlock)notificationWillShowInForegroundBlock
         notificationOpenedHandler:(OSNotificationOpenedBlock)notificationOpenedBlock {
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     [OneSignal setNotificationWillShowInForegroundHandler:notificationWillShowInForegroundBlock];
     [OneSignal setNotificationOpenedHandler:notificationOpenedBlock];
 }
@@ -138,7 +138,7 @@ static XCTestCase* _currentXCTestCase;
              withLaunchOptions:(NSDictionary*)launchOptions withNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock)notificationWillShowInForegroundDelegate
  withNotificationOpenedHandler:(OSNotificationOpenedBlock)notificationOpenedDelegate {
     [OneSignal setAppId:appId];
-    [OneSignal setLaunchOptions:launchOptions];
+    [OneSignal initWithLaunchOptions:launchOptions];
     [OneSignal setNotificationWillShowInForegroundHandler:notificationWillShowInForegroundDelegate];
     [OneSignal setNotificationOpenedHandler:notificationOpenedDelegate];
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1659,7 +1659,7 @@ didReceiveRemoteNotification:userInfo
     [OneSignal setAppId:nil];
     #pragma clang diagnostic pop
 
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     [UnitTestCommonMethods foregroundApp];
     
     // 2. Make sure iOS params did not download, since app id was invalid
@@ -1668,7 +1668,7 @@ didReceiveRemoteNotification:userInfo
 
     // 3. Init with valid app id
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     
     // 4. Make sure iOS params have been downloaded, since app_id is valid
     XCTAssertTrue(OneSignal.didCallDownloadParameters);
@@ -1786,7 +1786,7 @@ didReceiveRemoteNotification:userInfo
 
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     
     OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
     [OneSignal addSubscriptionObserver:observer];
@@ -1854,7 +1854,7 @@ didReceiveRemoteNotification:userInfo
 - (void)assertUserConsent {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     
     //indicates initialization was delayed
     XCTAssertNil(OneSignal.appId);
@@ -1885,7 +1885,7 @@ didReceiveRemoteNotification:userInfo
 
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     
     OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
     [OneSignal addSubscriptionObserver:observer];
@@ -2138,7 +2138,7 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     
     OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
     [OneSignal addPermissionObserver:observer];
@@ -2225,7 +2225,7 @@ didReceiveRemoteNotification:userInfo
  */
 - (void)testHTTPClientTimeout {
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Switches from overriding OneSignalClient to using a
@@ -2671,7 +2671,7 @@ didReceiveRemoteNotification:userInfo
 
 - (void)testNotificationWithButtonsRegistersUniqueCategory {
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
-    [OneSignal setLaunchOptions:nil];
+    [OneSignal initWithLaunchOptions:nil];
     [UnitTestCommonMethods runBackgroundThreads];
 
     let notification = (NSDictionary *)[self exampleNotificationJSONWithMediaURL:@"https://www.onesignal.com"];


### PR DESCRIPTION
This PR changes `setLaunchOptions` to `init:launchOptions` making it more clear how to properly initialize the OneSignal SDK. Additional parameters should not be added to this init unless they are essential for OneSignal functionality and are required on every launch of the App

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/733)
<!-- Reviewable:end -->
