### PR TITLE
Making OSDevice set its state on init

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSDevice.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDevice.m
@@ -30,36 +30,26 @@
 
 @implementation OSDevice
 
-- (BOOL)isNotificationEnabled {
-    return [[[OneSignal getPermissionSubscriptionState] permissionStatus] reachable];
-}
-
-- (BOOL)isUserSubscribed {
-    return [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] userSubscriptionSetting];
-}
-
-- (BOOL)isSubscribed {
-    return [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] subscribed];
-}
-
-- (OSNotificationPermission)getNotificationPermissionStatus {
-    return [[[OneSignal getPermissionSubscriptionState] permissionStatus] status];
-}
-
-- (NSString *)getUserId {
-    return [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] userId];
-}
-
-- (NSString *)getPushToken {
-    return [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] pushToken];
-}
-
-- (NSString *)getEmailUserId {
-    return [[[OneSignal getPermissionSubscriptionState] emailSubscriptionStatus] emailUserId];
-}
-
-- (NSString *)getEmailAddress {
-    return [[[OneSignal getPermissionSubscriptionState] emailSubscriptionStatus] emailAddress];
+- (id)init {
+    self = [super init];
+    if (self) {
+        _notificationEnabled = [[[OneSignal getPermissionSubscriptionState] permissionStatus] reachable];
+        
+        _isUserSubscribed = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] userSubscriptionSetting];
+        
+        _isSubscribed = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] subscribed];
+        
+        _notificationPermissionStatus = [[[OneSignal getPermissionSubscriptionState] permissionStatus] status];
+        
+        _userId = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] userId];
+        
+        _pushToken = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] pushToken];
+        
+        _emailUserId = [[[OneSignal getPermissionSubscriptionState] emailSubscriptionStatus] emailUserId];
+        
+        _emailAddress = [[[OneSignal getPermissionSubscriptionState] emailSubscriptionStatus] emailAddress];
+    }
+    return self;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSDevice.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDevice.m
@@ -31,23 +31,27 @@
 @implementation OSDevice
 
 - (id)init {
+    return [[OSDevice alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
+}
+
+- (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state {
     self = [super init];
     if (self) {
-        _notificationEnabled = [[[OneSignal getPermissionSubscriptionState] permissionStatus] reachable];
+        _notificationEnabled = [[state permissionStatus] reachable];
         
-        _isUserSubscribed = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] userSubscriptionSetting];
+        _isUserSubscribed = [[state subscriptionStatus] userSubscriptionSetting];
         
-        _isSubscribed = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] subscribed];
+        _isSubscribed = [[state subscriptionStatus] subscribed];
         
-        _notificationPermissionStatus = [[[OneSignal getPermissionSubscriptionState] permissionStatus] status];
+        _notificationPermissionStatus = [[state permissionStatus] status];
         
-        _userId = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] userId];
+        _userId = [[state subscriptionStatus] userId];
         
-        _pushToken = [[[OneSignal getPermissionSubscriptionState] subscriptionStatus] pushToken];
+        _pushToken = [[state subscriptionStatus] pushToken];
         
-        _emailUserId = [[[OneSignal getPermissionSubscriptionState] emailSubscriptionStatus] emailUserId];
+        _emailUserId = [[state emailSubscriptionStatus] emailUserId];
         
-        _emailAddress = [[[OneSignal getPermissionSubscriptionState] emailSubscriptionStatus] emailAddress];
+        _emailAddress = [[state emailSubscriptionStatus] emailAddress];
     }
     return self;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -425,6 +425,8 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
  */
 @property (readonly, nullable) NSString* emailAddress;
 
+- (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state;
+
 @end
 
 typedef void (^OSWebOpenURLResultBlock)(BOOL shouldOpen);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -388,42 +388,43 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
  * Get the app's notification permission
  * @return false if the user disabled notifications for the app, otherwise true
  */
-- (BOOL)isNotificationEnabled;
+@property (readonly) BOOL notificationEnabled;
 /**
  * Get whether the user is subscribed to OneSignal notifications or not
  * @return false if the user is not subscribed to OneSignal notifications, otherwise true
  */
-- (BOOL)isUserSubscribed;
+@property (readonly) BOOL isUserSubscribed;
 /**
  * Get whether the user is subscribed
  * @return true if  isNotificationEnabled,  isUserSubscribed, getUserId and getPushToken are true, otherwise false
  */
-- (BOOL)isSubscribed;
+@property (readonly) BOOL isSubscribed;
 /**
  * Get  the user notification permision status
  * @return OSNotificationPermission
 */
-- (OSNotificationPermission)getNotificationPermissionStatus;
+@property (readonly) OSNotificationPermission notificationPermissionStatus;
 /**
  * Get user id from registration (player id)
- * @return user id if user is registered, otherwise false
+ * @return user id if user is registered, otherwise null
  */
-- (NSString*)getUserId;
+@property (readonly, nullable) NSString* userId;
 /**
  * Get apple deice push token
  * @return push token if available, otherwise null
  */
-- (NSString*)getPushToken;
+@property (readonly, nullable) NSString* pushToken;
 /**
  * Get the user email id
  * @return email id if user address was registered, otherwise null
  */
-- (NSString*)getEmailUserId;
+@property (readonly, nullable) NSString* emailUserId;
 /**
  * Get the user email
  * @return email address if set, otherwise null
  */
-- (NSString*)getEmailAddress;
+@property (readonly, nullable) NSString* emailAddress;
+
 @end
 
 typedef void (^OSWebOpenURLResultBlock)(BOOL shouldOpen);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -311,7 +311,7 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
 }
 
 + (OSDevice *)getUserDevice {
-    return [OSDevice new];
+    return [[OSDevice alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
 }
 
 static OSRemoteParamController* _remoteParamController;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -310,11 +310,8 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
     mSubscriptionStatus = [status intValue];
 }
 
-static OSDevice* _userDevice;
 + (OSDevice *)getUserDevice {
-    if (!_userDevice)
-        _userDevice = [OSDevice new];
-    return _userDevice;
+    return [OSDevice new];
 }
 
 static OSRemoteParamController* _remoteParamController;

--- a/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
@@ -206,12 +206,12 @@
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
-    XCTAssertNil([[OneSignal getUserDevice] getEmailAddress]);
+    XCTAssertNil([OneSignal getUserDevice].emailAddress);
 
     [OneSignal setEmail:testEmail];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(testEmail, [[OneSignal getUserDevice] getEmailAddress]);
+    XCTAssertEqual(testEmail, [OneSignal getUserDevice].emailAddress);
 }
 
 - (void)testOSDeviceHasEmailId {
@@ -220,54 +220,54 @@
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
-    XCTAssertNil([[OneSignal getUserDevice] getEmailAddress]);
+    XCTAssertNil([OneSignal getUserDevice].emailAddress);
 
     [OneSignal setEmail:testEmail];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertNotNil([[OneSignal getUserDevice] getEmailAddress]);
+    XCTAssertNotNil([OneSignal getUserDevice].emailAddress);
 }
 
 - (void)testOSDeviceHasUserId {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertNotNil([[OneSignal getUserDevice] getUserId]);
+    XCTAssertNotNil([OneSignal getUserDevice].userId);
 }
 
 - (void)testOSDeviceHasPushToken {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertNotNil([[OneSignal getUserDevice] getPushToken]);
+    XCTAssertNotNil([OneSignal getUserDevice].pushToken);
 }
 
 - (void)testOSDeviceSubscribed {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertTrue([[OneSignal getUserDevice] isSubscribed]);
+    XCTAssertTrue([OneSignal getUserDevice].isSubscribed);
 }
 
 - (void)testOSDeviceUserSubscribed {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertTrue([[OneSignal getUserDevice] isUserSubscribed]);
+    XCTAssertTrue([OneSignal getUserDevice].isUserSubscribed);
 }
 
 - (void)testOSDeviceNotificationReachable {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertTrue([[OneSignal getUserDevice] isNotificationEnabled]);
+    XCTAssertTrue([OneSignal getUserDevice].notificationEnabled);
 }
 
 - (void)testOSDeviceHasNotificationPermissionStatus {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertEqual(OSNotificationPermissionAuthorized, [[OneSignal getUserDevice] getNotificationPermissionStatus]);
+    XCTAssertEqual(OSNotificationPermissionAuthorized, [OneSignal getUserDevice].notificationPermissionStatus);
 }
 
 @end


### PR DESCRIPTION
This PR makes `OSDevice` retain its own state that is set on `init` and never changed, instead of always asking OneSignal for the most up to date user states. 

`getUserDevice` will always return a new instance of `OSDevice`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/734)
<!-- Reviewable:end -->
