### PR TITLE
Public method renaming

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -41,7 +41,7 @@
     
     self.consentSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal requiresUserPrivacyConsent];
 
-    self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getUserDevice.isSubscribed;
+    self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getDeviceState.isSubscribed;
     
     self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) OneSignal.isLocationShared;
     

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -99,7 +99,7 @@
 		7A674F1B2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A674F1A2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m */; };
 		7A674F1C2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A674F1A2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m */; };
 		7A674F1D2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A674F1A2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m */; };
-		7A676BE524981CEC003957CC /* OSDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDevice.m */; };
+		7A676BE524981CEC003957CC /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
 		7A72EB0E23E252C200B4D50F /* OSInAppMessageDisplayStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A72EB0D23E252C200B4D50F /* OSInAppMessageDisplayStats.m */; };
 		7A72EB0F23E252C700B4D50F /* OSInAppMessageDisplayStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A72EB0D23E252C200B4D50F /* OSInAppMessageDisplayStats.m */; };
 		7A72EB1023E252C700B4D50F /* OSInAppMessageDisplayStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A72EB0D23E252C200B4D50F /* OSInAppMessageDisplayStats.m */; };
@@ -123,8 +123,8 @@
 		7ABAF9D62457D3FF0074DFA0 /* ChannelTrackersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9D52457D3FF0074DFA0 /* ChannelTrackersTests.m */; };
 		7ABAF9D82457DD620074DFA0 /* SessionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9D72457DD620074DFA0 /* SessionManagerTests.m */; };
 		7ABAF9E324606E940074DFA0 /* OutcomeV2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9E224606E940074DFA0 /* OutcomeV2Tests.m */; };
-		7AC8D3A824993A0E0023EDE8 /* OSDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDevice.m */; };
-		7AC8D3A924993A0F0023EDE8 /* OSDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDevice.m */; };
+		7AC8D3A824993A0E0023EDE8 /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
+		7AC8D3A924993A0F0023EDE8 /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
 		7AD172382416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
 		7AD172392416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
 		7AD1723A2416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
@@ -509,7 +509,7 @@
 		7A65D629246627AD007FF196 /* OSInAppMessageViewOverrider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageViewOverrider.m; sourceTree = "<group>"; };
 		7A674F182360D813001F9ACD /* OSBaseFocusTimeProcessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSBaseFocusTimeProcessor.h; sourceTree = "<group>"; };
 		7A674F1A2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSBaseFocusTimeProcessor.m; sourceTree = "<group>"; };
-		7A676BE424981CEC003957CC /* OSDevice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSDevice.m; sourceTree = "<group>"; };
+		7A676BE424981CEC003957CC /* OSDeviceState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSDeviceState.m; sourceTree = "<group>"; };
 		7A72EB0D23E252C200B4D50F /* OSInAppMessageDisplayStats.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageDisplayStats.m; sourceTree = "<group>"; };
 		7A72EB1123E252D400B4D50F /* OSInAppMessageDisplayStats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageDisplayStats.h; sourceTree = "<group>"; };
 		7A880F2923FB45CE0081F5E8 /* OSInAppMessageOutcome.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageOutcome.h; sourceTree = "<group>"; };
@@ -1132,7 +1132,7 @@
 				9129C6BC1E89E7AB009CB6A0 /* OSSubscription.m */,
 				CA810FCF202BA97300A60FED /* OSEmailSubscription.h */,
 				CA810FD0202BA97300A60FED /* OSEmailSubscription.m */,
-				7A676BE424981CEC003957CC /* OSDevice.m */,
+				7A676BE424981CEC003957CC /* OSDeviceState.m */,
 			);
 			name = State;
 			sourceTree = "<group>";
@@ -1586,7 +1586,7 @@
 				91B6EA411E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				7AF986432444C47400C36EAE /* OSNotificationTracker.m in Sources */,
 				4529DF0C1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m in Sources */,
-				7A676BE524981CEC003957CC /* OSDevice.m in Sources */,
+				7A676BE524981CEC003957CC /* OSDeviceState.m in Sources */,
 				7AFE856B2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
 				7A12EBD723060A6F005C4FA5 /* OSSessionManager.m in Sources */,
 				7AD8DDE7234BD3BE00747A8A /* OneSignalUserDefaults.m in Sources */,
@@ -1676,7 +1676,7 @@
 				912412271E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				912412331E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				91B6EA421E85D38F00B5CF01 /* OSObservable.m in Sources */,
-				7AC8D3A924993A0F0023EDE8 /* OSDevice.m in Sources */,
+				7AC8D3A924993A0F0023EDE8 /* OSDeviceState.m in Sources */,
 				CA810FD2202BA97600A60FED /* OSEmailSubscription.m in Sources */,
 				CACBAAA2218A6243000ACAA5 /* OSInAppMessage.m in Sources */,
 				7A674F1C2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */,
@@ -1820,7 +1820,7 @@
 				7A5A818224897693002E07C8 /* MigrationTests.m in Sources */,
 				7AECE5A023675F6300537907 /* OSFocusTimeProcessorFactory.m in Sources */,
 				9129C6C01E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
-				7AC8D3A824993A0E0023EDE8 /* OSDevice.m in Sources */,
+				7AC8D3A824993A0E0023EDE8 /* OSDeviceState.m in Sources */,
 				CA63AFC52022670A00E340FB /* ReattemptRequest.m in Sources */,
 				7AFE856D2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
 				CA8E19082193C76D009DA223 /* OSInAppMessagingHelpers.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
@@ -28,18 +28,18 @@
 #import <Foundation/Foundation.h>
 #import "OneSignal.h"
 
-@implementation OSDevice
+@implementation OSDeviceState
 
 - (id)init {
-    return [[OSDevice alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
+    return [[OSDeviceState alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
 }
 
 - (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state {
     self = [super init];
     if (self) {
-        _notificationEnabled = [[state permissionStatus] reachable];
+        _hasNotificationPermission = [[state permissionStatus] reachable];
         
-        _isUserSubscribed = [[state subscriptionStatus] userSubscriptionSetting];
+        _isPushDisabled = ![[state subscriptionStatus] userSubscriptionSetting];
         
         _isSubscribed = [[state subscriptionStatus] subscribed];
         

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -79,7 +79,7 @@ THE SOFTWARE.
 }
 
 - (void)saveCurrentSDKVersion {
-    let currentVersion = [[OneSignal sdk_version_raw] intValue];
+    let currentVersion = [[OneSignal sdkVersionRaw] intValue];
     [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION withValue:currentVersion];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -460,8 +460,8 @@ extern NSString * const kOSSettingsKeyProvidesAppNotificationSettings;
 extern NSString* const ONESIGNAL_VERSION;
 
 + (NSString*)appId;
-+ (NSString* _Nonnull)sdk_version_raw;
-+ (NSString* _Nonnull)sdk_semantic_version;
++ (NSString* _Nonnull)sdkVersionRaw;
++ (NSString* _Nonnull)sdkSemanticVersion;
 
 + (void)setSubscription:(BOOL)enable;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -383,17 +383,17 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 
 @end
 
-@interface OSDevice : NSObject
+@interface OSDeviceState : NSObject
 /**
  * Get the app's notification permission
  * @return false if the user disabled notifications for the app, otherwise true
  */
-@property (readonly) BOOL notificationEnabled;
+@property (readonly) BOOL hasNotificationPermission;
 /**
  * Get whether the user is subscribed to OneSignal notifications or not
  * @return false if the user is not subscribed to OneSignal notifications, otherwise true
  */
-@property (readonly) BOOL isUserSubscribed;
+@property (readonly) BOOL isPushDisabled;
 /**
  * Get whether the user is subscribed
  * @return true if  isNotificationEnabled,  isUserSubscribed, getUserId and getPushToken are true, otherwise false
@@ -496,7 +496,7 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 + (void)promptForPushNotificationsWithUserResponse:(OSUserResponseBlock)block;
 + (void)promptForPushNotificationsWithUserResponse:(OSUserResponseBlock)block fallbackToSettings:(BOOL)fallback;
 + (void)registerForProvisionalAuthorization:(OSUserResponseBlock)block;
-+ (OSDevice*)getUserDevice;
++ (OSDeviceState*)getDeviceState;
 
 #pragma mark Privacy Consent
 + (void)consentGranted:(BOOL)granted;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -310,8 +310,8 @@ static ObservableEmailSubscriptionStateChangesType* _emailSubscriptionStateChang
     mSubscriptionStatus = [status intValue];
 }
 
-+ (OSDevice *)getUserDevice {
-    return [[OSDevice alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
++ (OSDeviceState *)getDeviceState {
+    return [[OSDeviceState alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
 }
 
 static OSRemoteParamController* _remoteParamController;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -398,11 +398,11 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     return appId;
 }
 
-+ (NSString*)sdk_version_raw {
++ (NSString*)sdkVersionRaw {
 	return ONESIGNAL_VERSION;
 }
 
-+ (NSString*)sdk_semantic_version {
++ (NSString*)sdkSemanticVersion {
 	// examples:
 	// ONESIGNAL_VERSION = @"020402" returns 2.4.2
 	// ONESIGNAL_VERSION = @"001000" returns 0.10.0

--- a/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
@@ -67,7 +67,7 @@
     XCTAssertNil(lastNotificationReceivedAfterMigration);
     
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 - (void)testIndirectNotificationToIndirectInfluenceMigration {
@@ -98,7 +98,7 @@
     XCTAssertEqual(timestamp, indirectInfluence.timestamp);
     
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 - (void)testIndirectInfluenceToIndirectInfluenceMigration {
@@ -126,7 +126,7 @@
     XCTAssertEqual(timestamp, indirectInfluenceAfterMigration.timestamp);
     
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 - (void)testIndirectNotificationToIndirectInfluenceMigration_NotificationServiceExtensionHandler {
@@ -162,7 +162,7 @@
     XCTAssertTrue([indirectInfluenceReceived.channelIdTag isEqualToString:@"notification_id"]);
    
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 - (void)testNoAttributedUniqueOutcomeDataAvailableToMigrate {
@@ -176,7 +176,7 @@
     XCTAssertNil(uniqueOutcomesAfterMigration);
     
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 - (void)testUniqueOutcomeNotificationToCacheUniqueOutcomeMigration {
@@ -205,7 +205,7 @@
     XCTAssertEqual([timestamp intValue], [cachedUniqueOutcome.timestamp intValue]);
     
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 - (void)testCachedUniqueOutcomeToCachedUniqueOutcomeMigration {
@@ -234,7 +234,7 @@
     XCTAssertEqual([timestamp intValue], [cachedUniqueOutcomeAfterMigration.timestamp intValue]);
     
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
+    XCTAssertEqual([[OneSignal sdkVersionRaw] intValue], sdkVersionAfterMigration);
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
@@ -206,12 +206,12 @@
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
-    XCTAssertNil([OneSignal getUserDevice].emailAddress);
+    XCTAssertNil([OneSignal getDeviceState].emailAddress);
 
     [OneSignal setEmail:testEmail];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(testEmail, [OneSignal getUserDevice].emailAddress);
+    XCTAssertEqual(testEmail, [OneSignal getDeviceState].emailAddress);
 }
 
 - (void)testOSDeviceHasEmailId {
@@ -220,54 +220,54 @@
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
-    XCTAssertNil([OneSignal getUserDevice].emailAddress);
+    XCTAssertNil([OneSignal getDeviceState].emailAddress);
 
     [OneSignal setEmail:testEmail];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertNotNil([OneSignal getUserDevice].emailAddress);
+    XCTAssertNotNil([OneSignal getDeviceState].emailAddress);
 }
 
 - (void)testOSDeviceHasUserId {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertNotNil([OneSignal getUserDevice].userId);
+    XCTAssertNotNil([OneSignal getDeviceState].userId);
 }
 
 - (void)testOSDeviceHasPushToken {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertNotNil([OneSignal getUserDevice].pushToken);
+    XCTAssertNotNil([OneSignal getDeviceState].pushToken);
 }
 
 - (void)testOSDeviceSubscribed {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertTrue([OneSignal getUserDevice].isSubscribed);
+    XCTAssertTrue([OneSignal getDeviceState].isSubscribed);
 }
 
 - (void)testOSDeviceUserSubscribed {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertTrue([OneSignal getUserDevice].isUserSubscribed);
+    XCTAssertFalse([OneSignal getDeviceState].isPushDisabled);
 }
 
 - (void)testOSDeviceNotificationReachable {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertTrue([OneSignal getUserDevice].notificationEnabled);
+    XCTAssertTrue([OneSignal getDeviceState].hasNotificationPermission);
 }
 
 - (void)testOSDeviceHasNotificationPermissionStatus {
     [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
-    XCTAssertEqual(OSNotificationPermissionAuthorized, [OneSignal getUserDevice].notificationPermissionStatus);
+    XCTAssertEqual(OSNotificationPermissionAuthorized, [OneSignal getDeviceState].notificationPermissionStatus);
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -202,7 +202,7 @@
 
 - (void)testVersionStringLength {
 	XCTAssertEqual(ONESIGNAL_VERSION.length, 6, @"ONESIGNAL_VERSION length is not 6: length is %lu", (unsigned long)ONESIGNAL_VERSION.length);
-	XCTAssertEqual([OneSignal sdk_version_raw].length, 6, @"OneSignal sdk_version_raw length is not 6: length is %lu", (unsigned long)[OneSignal sdk_version_raw].length);
+	XCTAssertEqual([OneSignal sdkVersionRaw].length, 6, @"OneSignal sdk_version_raw length is not 6: length is %lu", (unsigned long)[OneSignal sdkVersionRaw].length);
 }
 
 - (void)testSymanticVersioning {


### PR DESCRIPTION
This PR renames the following public classes/properties

- `OSDevice` -> `OSDeviceState`
  - `getUserDevice` -> `getDeviceState`
  - `isNotificationEnabled` -> `hasNotificationPermission`
  - `isUserSubscribed` -> `isPushDisabled`. Note the inverted logic
- `sdk_version_raw` -> `sdkVersionRaw`
- `sdk_semantic_version` -> `sdkSemanticVersion`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/736)
<!-- Reviewable:end -->
