### PR TITLE
Foreground handler with completion block

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -60,9 +60,9 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
         [alert show];
     };
-    id notificationReceiverBlock = ^(OSNotificationGenerationJob *notifJob) {
+    id notificationReceiverBlock = ^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         NSLog(@"Will Receive Notification - %@", notifJob.notificationId);
-        [notifJob complete];
+        completion(OSNotificationDisplayTypeNotification);
     };
     
     // Example block for IAM action click handler

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -60,8 +60,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
         [alert show];
     };
-    id notificationReceiverBlock = ^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
-        NSLog(@"Will Receive Notification - %@", notifJob.notificationId);
+    id notificationReceiverBlock = ^(OSPredisplayNotification *notif, OSNotificationDisplayTypeResponse completion) {
+        NSLog(@"Will Receive Notification - %@", notif.notificationId);
         completion(OSNotificationDisplayTypeNotification);
     };
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -196,8 +196,6 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* The message body */
 @property(readonly, nullable)NSString *body;
 
-// Method controlling completion from the notificationWillShowInForegroundHandler
-// If 'complete' is not called within 25 seconds of receiving the OSNotificationGenerationJob in notificationWillShowInForegroundHandler then 'complete' will be automatically fired.
 @end
 
 @interface OSNotificationOpenedResult : NSObject
@@ -505,6 +503,7 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 
 #pragma mark Public Handlers
 
+// If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired using the displayType of the OSNotificationGenerationJob object.
 typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotificationGenerationJob* notification, OSNotificationDisplayTypeResponse completion);
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * result);
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction* action);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -181,9 +181,6 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* OneSignal OSPredisplayNotification used in notificationWillShowInForegroundHandler. The display type for the notification can be changed before it is presented.*/
 @interface OSPredisplayNotification : NSObject
 
-/* Display method of the notification */
-@property(readonly, nonatomic)OSNotificationDisplayType displayType;
-
 /* Additional key value properties set within the payload */
 @property(readonly, nullable)NSDictionary *additionalData;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -198,7 +198,6 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 // Method controlling completion from the notificationWillShowInForegroundHandler
 // If 'complete' is not called within 25 seconds of receiving the OSNotificationGenerationJob in notificationWillShowInForegroundHandler then 'complete' will be automatically fired.
-- (void)complete;
 @end
 
 @interface OSNotificationOpenedResult : NSObject
@@ -506,7 +505,7 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 
 #pragma mark Public Handlers
 
-typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotificationGenerationJob* notification);
+typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotificationGenerationJob* notification, OSNotificationDisplayTypeResponse completion);
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * result);
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction* action);
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -178,11 +178,11 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @end
 
-/* OneSignal OSNotificationGenerationJob used in notificationWillShowInForegroundHandler. The display type for the notification can be changed before it is presented.*/
-@interface OSNotificationGenerationJob : NSObject
+/* OneSignal OSPredisplayNotification used in notificationWillShowInForegroundHandler. The display type for the notification can be changed before it is presented.*/
+@interface OSPredisplayNotification : NSObject
 
 /* Display method of the notification */
-@property(nonatomic)OSNotificationDisplayType displayType;
+@property(readonly, nonatomic)OSNotificationDisplayType displayType;
 
 /* Additional key value properties set within the payload */
 @property(readonly, nullable)NSDictionary *additionalData;
@@ -503,8 +503,8 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 
 #pragma mark Public Handlers
 
-// If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired using the displayType of the OSNotificationGenerationJob object.
-typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotificationGenerationJob* notification, OSNotificationDisplayTypeResponse completion);
+// If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired using the displayType of the OSPredisplayNotification object.
+typedef void (^OSNotificationWillShowInForegroundBlock)(OSPredisplayNotification* notification, OSNotificationDisplayTypeResponse completion);
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * result);
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction* action);
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -229,7 +229,7 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
     // the max number of UNNotificationCategory ID's the SDK will register
     #define MAX_CATEGORIES_SIZE 128
 
-    // Defines how long the SDK will wait for a OSNotificationGenerationJob's complete method to execute
+    // Defines how long the SDK will wait for a OSPredisplayNotification's complete method to execute
 #define CUSTOM_DISPLAY_TYPE_TIMEOUT 25.0
 #else
     // Test defines for API Client
@@ -245,7 +245,7 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
     #define MAX_CATEGORIES_SIZE 5
 
     // Unit testing value for how long the SDK will wait for a
-    // OSNotificationGenerationJob's complete method to execute
+    // OSPredisplayNotification's complete method to execute
 #define CUSTOM_DISPLAY_TYPE_TIMEOUT 0.05
 #endif
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -249,17 +249,15 @@
 @end
 
 @implementation OSPredisplayNotification
-@synthesize displayType = _displayType, notificationId = _notificationId, title = _title, body = _body;
+@synthesize notificationId = _notificationId, title = _title, body = _body;
 
 OSNotificationPayload *_payload;
 OSNotificationDisplayTypeResponse _completion;
 NSTimer *_timeoutTimer;
-- (id)initWithPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
+- (id)initWithPayload:(OSNotificationPayload *)payload completion:(OSNotificationDisplayTypeResponse)completion {
     self = [super init];
     if (self) {
         _payload = payload;
-        
-        _displayType = displayType;
         
         _body = _payload.body;
         
@@ -296,7 +294,7 @@ NSTimer *_timeoutTimer;
 - (void)timeoutTimerFired:(NSTimer *)timer {
     [OneSignal onesignal_Log:ONE_S_LL_ERROR
     message:[NSString stringWithFormat:@"NotificationGenerationJob timed out. Complete was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
-    [self complete:self.displayType];
+    [self complete:OSNotificationDisplayTypeNotification];
 }
 
 - (void)dealloc {
@@ -463,7 +461,7 @@ OneSignalWebView *webVC;
 }
 
 + (void)handleWillShowInForegroundHandlerForPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
-    let predisplayNotif = [[OSPredisplayNotification alloc] initWithPayload:payload displayType:displayType completion:completion];
+    let predisplayNotif = [[OSPredisplayNotification alloc] initWithPayload:payload completion:completion];
     if (notificationWillShowInForegroundHandler) {
         [predisplayNotif startTimeoutTimer];
         notificationWillShowInForegroundHandler(predisplayNotif, [predisplayNotif getCompletionBlock]);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -274,10 +274,17 @@ NSTimer *_timeoutTimer;
     return self;
 }
 
-- (void)complete {
+- (OSNotificationDisplayTypeResponse)getCompletionBlock {
+    OSNotificationDisplayTypeResponse block = ^(OSNotificationDisplayType displayType){
+        [self complete:displayType];
+    };
+    return block;
+}
+
+- (void)complete:(OSNotificationDisplayType)displayType {
     [_timeoutTimer invalidate];
     if (_completion) {
-        _completion(self.displayType);
+        _completion(displayType);
         _completion = nil;
     }
 }
@@ -289,7 +296,7 @@ NSTimer *_timeoutTimer;
 - (void)timeoutTimerFired:(NSTimer *)timer {
     [OneSignal onesignal_Log:ONE_S_LL_ERROR
     message:[NSString stringWithFormat:@"NotificationGenerationJob timed out. Complete was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
-    [self complete];
+    [self complete:self.displayType];
 }
 
 - (void)dealloc {
@@ -459,7 +466,7 @@ OneSignalWebView *webVC;
     let notifJob = [[OSNotificationGenerationJob alloc] initWithPayload:payload displayType:displayType completion:completion];
     if (notificationWillShowInForegroundHandler) {
         [notifJob startTimeoutTimer];
-        notificationWillShowInForegroundHandler(notifJob);
+        notificationWillShowInForegroundHandler(notifJob, [notifJob getCompletionBlock]);
     } else {
         completion(displayType);
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -248,7 +248,7 @@
 
 @end
 
-@implementation OSNotificationGenerationJob
+@implementation OSPredisplayNotification
 @synthesize displayType = _displayType, notificationId = _notificationId, title = _title, body = _body;
 
 OSNotificationPayload *_payload;
@@ -463,10 +463,10 @@ OneSignalWebView *webVC;
 }
 
 + (void)handleWillShowInForegroundHandlerForPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
-    let notifJob = [[OSNotificationGenerationJob alloc] initWithPayload:payload displayType:displayType completion:completion];
+    let predisplayNotif = [[OSPredisplayNotification alloc] initWithPayload:payload displayType:displayType completion:completion];
     if (notificationWillShowInForegroundHandler) {
-        [notifJob startTimeoutTimer];
-        notificationWillShowInForegroundHandler(notifJob, [notifJob getCompletionBlock]);
+        [predisplayNotif startTimeoutTimer];
+        notificationWillShowInForegroundHandler(predisplayNotif, [predisplayNotif getCompletionBlock]);
     } else {
         completion(displayType);
     }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1004,7 +1004,7 @@
     __block BOOL openedWasFired = false;
     __block BOOL receivedWasFired = false;
 
-    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotificationGenerationJob *job) {
+    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotificationGenerationJob *job, OSNotificationDisplayTypeResponse completion) {
         receivedWasFired = true;
     } notificationOpenedHandler:^(OSNotificationOpenedResult *result) {
         openedWasFired = true;
@@ -1080,7 +1080,7 @@
  */
 - (void)receivedCallbackWithButtonsWithUserInfo:(NSDictionary *)userInfo {
     __block BOOL receivedWasFire = false;
-    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotificationGenerationJob *notifJob) {
+    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         receivedWasFire = true;
         // TODO: Fix this unit test since generation jobs do not have action buttons
         //let actionButons = @[ @{@"id": @"id1", @"text": @"text1"} ];
@@ -1518,7 +1518,7 @@ didReceiveRemoteNotification:userInfo
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateBackground;
     
     __block BOOL receivedWasFire = false;
-    [UnitTestCommonMethods initOneSignalWithHandlers:^(OSNotificationGenerationJob *notifJob) {
+    [UnitTestCommonMethods initOneSignalWithHandlers:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         receivedWasFire = true;
     } notificationOpenedHandler:nil];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -1915,16 +1915,16 @@ didReceiveRemoteNotification:userInfo
 
 // Testing overriding the notification's display type in the willShowInForegroundHandler block
 - (void)testOverrideNotificationDisplayType {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob) {
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         notifJob.displayType = OSNotificationDisplayTypeSilent;
-        [notifJob complete];
+        completion(notifJob.displayType);
     } withNotificationOpenedBlock:nil];
 }
 
 // If the OSNotificationGenerationJob's complete method is not fired by the willShowInForegroundHandler block, the complete method
 // should be called automatically based on the job's timer.
 - (void)testTimeoutOverrideNotificationDisplayType {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob) {
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         notifJob.displayType = OSNotificationDisplayTypeSilent;
         //WE ARE NOT CALLING COMPLETE. THIS MEANS THE NOTIFICATIONJOB'S TIMER SHOULD FIRE
     } withNotificationOpenedBlock:nil];
@@ -1932,7 +1932,7 @@ didReceiveRemoteNotification:userInfo
 
 // If the OSNotificationGenerationJob's complete method is fired by the willShowInForegroundHandler block after the job has timed out, the complete method should not result in the completion handler being called
 - (void)testCompleteAfterTimeoutInNotificationForegroundHandler {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob) {
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         notifJob.displayType = OSNotificationDisplayTypeSilent;
         XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Always fail"];
         XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:2.0];
@@ -1940,7 +1940,7 @@ didReceiveRemoteNotification:userInfo
             XCTFail(@"Somehow the expectation didn't timeout");
         }
         //WE ARE CALLING COMPLETE AFTER THE TIMEOUT. THIS MEANS THE NOTIFICATIONJOB'S TIMER SHOULD FIRE AND THE SECOND CALL TO COMPLETE SHOULD NOT RESULT IN THE COMPLETION HANDLER BEING CALLED A SECOND TIME.
-        [notifJob complete];
+        completion(notifJob.displayType);
     } withNotificationOpenedBlock:nil];
 }
 
@@ -1951,7 +1951,7 @@ didReceiveRemoteNotification:userInfo
     let expectation = [self expectationWithDescription:@"wait_for_timeout"];
     expectation.expectedFulfillmentCount = 1;
 
-    let payload = [self setUpWillShowInForegroundHandlerTestWithBlock:^(OSNotificationGenerationJob *notifJob) {
+    let payload = [self setUpWillShowInForegroundHandlerTestWithBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         handlerCalledCount ++;
     } withDisplayType:OSNotificationDisplayTypeNotification withNotificationOpenedBlock:nil withPayload:[OSInAppMessageTestHelper testMessagePreviewJson]];
     
@@ -1976,9 +1976,9 @@ didReceiveRemoteNotification:userInfo
 
 //Change the notification display type to silent and ensure that the opened handler does not fire
 - (void)testOpenedHandlerNotFiredWhenOverridingDisplayType {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob) {
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
         notifJob.displayType = OSNotificationDisplayTypeSilent;
-        [notifJob complete];
+        completion(notifJob.displayType);
     } withNotificationOpenedBlock:^(OSNotificationOpenedResult * result) {
         XCTFail(@"The notification should not have been considered opened");
     }];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1004,7 +1004,7 @@
     __block BOOL openedWasFired = false;
     __block BOOL receivedWasFired = false;
 
-    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotificationGenerationJob *job, OSNotificationDisplayTypeResponse completion) {
+    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSPredisplayNotification *job, OSNotificationDisplayTypeResponse completion) {
         receivedWasFired = true;
     } notificationOpenedHandler:^(OSNotificationOpenedResult *result) {
         openedWasFired = true;
@@ -1080,7 +1080,7 @@
  */
 - (void)receivedCallbackWithButtonsWithUserInfo:(NSDictionary *)userInfo {
     __block BOOL receivedWasFire = false;
-    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
+    [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
         receivedWasFire = true;
         // TODO: Fix this unit test since generation jobs do not have action buttons
         //let actionButons = @[ @{@"id": @"id1", @"text": @"text1"} ];
@@ -1518,7 +1518,7 @@ didReceiveRemoteNotification:userInfo
     UIApplicationOverrider.currentUIApplicationState = UIApplicationStateBackground;
     
     __block BOOL receivedWasFire = false;
-    [UnitTestCommonMethods initOneSignalWithHandlers:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
+    [UnitTestCommonMethods initOneSignalWithHandlers:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
         receivedWasFire = true;
     } notificationOpenedHandler:nil];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -1874,7 +1874,7 @@ didReceiveRemoteNotification:userInfo
     return payload;
 }
 
-- (void)fireDefaultNotificationWithForeGroundBlock:(OSNotificationWillShowInForegroundBlock)willShowInForegroundBlock withNotificationOpenedBlock:(OSNotificationOpenedBlock)openedBlock {
+- (void)fireDefaultNotificationWithForeGroundBlock:(OSNotificationWillShowInForegroundBlock)willShowInForegroundBlock withNotificationOpenedBlock:(OSNotificationOpenedBlock)openedBlock presentationOption:(UNNotificationPresentationOptions)presentationOption {
     __block var option = (UNNotificationPresentationOptions)7;
     __block var completionCount = 0;
     let expectation = [self expectationWithDescription:@"wait_for_timeout"];
@@ -1909,39 +1909,36 @@ didReceiveRemoteNotification:userInfo
     [self waitForExpectationsWithTimeout:1.0 handler:^(NSError * _Nullable error) {
         //The expectation should not timeout. If it does that means something is wrong with the notifjob's timer.
         XCTAssertEqual(completionCount, 1);
-        XCTAssertEqual(option, 0);
+        XCTAssertEqual(option, presentationOption);
     }];
 }
 
 // Testing overriding the notification's display type in the willShowInForegroundHandler block
 - (void)testOverrideNotificationDisplayType {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
-        notifJob.displayType = OSNotificationDisplayTypeSilent;
-        completion(notifJob.displayType);
-    } withNotificationOpenedBlock:nil];
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
+        completion(OSNotificationDisplayTypeSilent);
+    } withNotificationOpenedBlock:nil presentationOption:(UNNotificationPresentationOptions)0];
 }
 
-// If the OSNotificationGenerationJob's complete method is not fired by the willShowInForegroundHandler block, the complete method
+// If the OSPredisplayNotification's complete method is not fired by the willShowInForegroundHandler block, the complete method
 // should be called automatically based on the job's timer.
 - (void)testTimeoutOverrideNotificationDisplayType {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
-        notifJob.displayType = OSNotificationDisplayTypeSilent;
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
         //WE ARE NOT CALLING COMPLETE. THIS MEANS THE NOTIFICATIONJOB'S TIMER SHOULD FIRE
-    } withNotificationOpenedBlock:nil];
+    } withNotificationOpenedBlock:nil presentationOption:(UNNotificationPresentationOptions)7];
 }
 
-// If the OSNotificationGenerationJob's complete method is fired by the willShowInForegroundHandler block after the job has timed out, the complete method should not result in the completion handler being called
+// If the OSPredisplayNotification's complete method is fired by the willShowInForegroundHandler block after the job has timed out, the complete method should not result in the completion handler being called
 - (void)testCompleteAfterTimeoutInNotificationForegroundHandler {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
-        notifJob.displayType = OSNotificationDisplayTypeSilent;
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
         XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Always fail"];
         XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:2.0];
         if (result != XCTWaiterResultTimedOut) {
             XCTFail(@"Somehow the expectation didn't timeout");
         }
         //WE ARE CALLING COMPLETE AFTER THE TIMEOUT. THIS MEANS THE NOTIFICATIONJOB'S TIMER SHOULD FIRE AND THE SECOND CALL TO COMPLETE SHOULD NOT RESULT IN THE COMPLETION HANDLER BEING CALLED A SECOND TIME.
-        completion(notifJob.displayType);
-    } withNotificationOpenedBlock:nil];
+        completion(OSNotificationDisplayTypeSilent);
+    } withNotificationOpenedBlock:nil presentationOption:(UNNotificationPresentationOptions)7];
 }
 
 - (void)testWillShowInForegroundHandlerNotFiredForIAM {
@@ -1951,7 +1948,7 @@ didReceiveRemoteNotification:userInfo
     let expectation = [self expectationWithDescription:@"wait_for_timeout"];
     expectation.expectedFulfillmentCount = 1;
 
-    let payload = [self setUpWillShowInForegroundHandlerTestWithBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
+    let payload = [self setUpWillShowInForegroundHandlerTestWithBlock:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
         handlerCalledCount ++;
     } withDisplayType:OSNotificationDisplayTypeNotification withNotificationOpenedBlock:nil withPayload:[OSInAppMessageTestHelper testMessagePreviewJson]];
     
@@ -1976,12 +1973,11 @@ didReceiveRemoteNotification:userInfo
 
 //Change the notification display type to silent and ensure that the opened handler does not fire
 - (void)testOpenedHandlerNotFiredWhenOverridingDisplayType {
-    [self fireDefaultNotificationWithForeGroundBlock:^(OSNotificationGenerationJob *notifJob, OSNotificationDisplayTypeResponse completion) {
-        notifJob.displayType = OSNotificationDisplayTypeSilent;
-        completion(notifJob.displayType);
+    [self fireDefaultNotificationWithForeGroundBlock:^(OSPredisplayNotification *notifJob, OSNotificationDisplayTypeResponse completion) {
+        completion(OSNotificationDisplayTypeSilent);
     } withNotificationOpenedBlock:^(OSNotificationOpenedResult * result) {
         XCTFail(@"The notification should not have been considered opened");
-    }];
+    } presentationOption:(UNNotificationPresentationOptions)0];
 }
 
 - (UNNotificationAttachment *)deliverNotificationWithJSON:(id)json {


### PR DESCRIPTION
This PR removes the `complete` method from the `OSNotificationGenerationJob` and instead sends a completion block that takes a `OSNotificationDisplayType` parameter. 

**Questions:** 
1. Should we rename `OSNotificationGenerationJob`?
2. Should the `displayType` property on `OSNotificationGenerationJob` remain mutable?
  Currently a developer can change the `displayType` to silent, but have the block timeout and we will respect the `displayType` change
  We could make `displayType` readonly and not allow developers to change the displayType unless they call the completion block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/737)
<!-- Reviewable:end -->
