### PR TITLE
Combine OSNotification classes

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -60,7 +60,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
         [alert show];
     };
-    id notificationReceiverBlock = ^(OSPredisplayNotification *notif, OSNotificationDisplayTypeResponse completion) {
+    id notificationReceiverBlock = ^(OSNotification *notif, OSNotificationDisplayTypeResponse completion) {
         NSLog(@"Will Receive Notification - %@", notif.notificationId);
         completion(OSNotificationDisplayTypeNotification);
     };

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 
 /* Begin PBXBuildFile section */
 		03217239238278EB004F0E85 /* DelayedSelectors.m in Sources */ = {isa = PBXBuildFile; fileRef = 03217238238278EB004F0E85 /* DelayedSelectors.m */; };
-		0338566B1FBBD2270002F7C1 /* OSNotificationPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotificationPayload.m */; };
+		0338566B1FBBD2270002F7C1 /* OSNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotification.m */; };
 		0338566C1FBBDB150002F7C1 /* OneSignalNotificationServiceExtensionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F11FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m */; };
 		0338566D1FBBDB190002F7C1 /* OneSignalTrackFirebaseAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DF0B1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m */; };
 		03389F691FB548A0006537F0 /* OneSignalTrackFirebaseAnalyticsOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 03389F681FB548A0006537F0 /* OneSignalTrackFirebaseAnalyticsOverrider.m */; };
@@ -73,7 +73,7 @@
 		4529DEF31FA8440A00CEAB1D /* UIAlertViewOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEF21FA8440A00CEAB1D /* UIAlertViewOverrider.m */; };
 		4529DF0C1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DF0B1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m */; };
 		454F94F21FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F11FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m */; };
-		454F94F51FAD2E5A00D74CCF /* OSNotificationPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotificationPayload.m */; };
+		454F94F51FAD2E5A00D74CCF /* OSNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotification.m */; };
 		5B58E4F8237CE7B4009401E0 /* UIDeviceOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B58E4F6237CE7B4009401E0 /* UIDeviceOverrider.m */; };
 		7A123295235DFE3B002B6CE3 /* OutcomeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A123294235DFE3B002B6CE3 /* OutcomeTests.m */; };
 		7A1232A2235E1743002B6CE3 /* OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411F11E73342200E41FD7 /* OneSignal.m */; };
@@ -415,7 +415,7 @@
 		CACBAAAC218A662B000ACAA5 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CACBAAAB218A662B000ACAA5 /* WebKit.framework */; };
 		CACBAAB4218A7113000ACAA5 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CACBAAAB218A662B000ACAA5 /* WebKit.framework */; };
 		CAE2E5A8215D80010036FD32 /* OneSignalTrackFirebaseAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DF0B1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m */; };
-		CAE2E5A9215D80070036FD32 /* OSNotificationPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotificationPayload.m */; };
+		CAE2E5A9215D80070036FD32 /* OSNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F41FAD2E5A00D74CCF /* OSNotification.m */; };
 		CAE2E5AA215D80380036FD32 /* OneSignalNotificationServiceExtensionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 454F94F11FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m */; };
 		CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = CA810FCF202BA97300A60FED /* OSEmailSubscription.h */; };
 		DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
@@ -488,8 +488,8 @@
 		4529DF0B1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalTrackFirebaseAnalytics.m; sourceTree = "<group>"; };
 		454F94F01FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalNotificationServiceExtensionHandler.h; sourceTree = "<group>"; };
 		454F94F11FAD218000D74CCF /* OneSignalNotificationServiceExtensionHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalNotificationServiceExtensionHandler.m; sourceTree = "<group>"; };
-		454F94F41FAD2E5A00D74CCF /* OSNotificationPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSNotificationPayload.m; sourceTree = "<group>"; };
-		454F94F61FAD2EC300D74CCF /* OSNotificationPayload+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OSNotificationPayload+Internal.h"; sourceTree = "<group>"; };
+		454F94F41FAD2E5A00D74CCF /* OSNotification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSNotification.m; sourceTree = "<group>"; };
+		454F94F61FAD2EC300D74CCF /* OSNotification+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OSNotification+Internal.h"; sourceTree = "<group>"; };
 		5B58E4F3237CE7B3009401E0 /* UIDeviceOverrider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIDeviceOverrider.h; sourceTree = "<group>"; };
 		5B58E4F6237CE7B4009401E0 /* UIDeviceOverrider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIDeviceOverrider.m; sourceTree = "<group>"; };
 		7A123294235DFE3B002B6CE3 /* OutcomeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OutcomeTests.m; sourceTree = "<group>"; };
@@ -851,8 +851,8 @@
 		454F94F31FAD263300D74CCF /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				454F94F41FAD2E5A00D74CCF /* OSNotificationPayload.m */,
-				454F94F61FAD2EC300D74CCF /* OSNotificationPayload+Internal.h */,
+				454F94F41FAD2E5A00D74CCF /* OSNotification.m */,
+				454F94F61FAD2EC300D74CCF /* OSNotification+Internal.h */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -1602,7 +1602,7 @@
 				CA7FC8A021927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				7AECE59623674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				1AF75EAE1E8567FD0097B315 /* NSString+OneSignal.m in Sources */,
-				454F94F51FAD2E5A00D74CCF /* OSNotificationPayload.m in Sources */,
+				454F94F51FAD2E5A00D74CCF /* OSNotification.m in Sources */,
 				9129C6BE1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				7AECE59023674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				7ADE379422E8B69C00263048 /* OneSignalOutcomeEventsController.m in Sources */,
@@ -1653,7 +1653,7 @@
 				7AAA60692485D0420004FADE /* OSMigrationController.m in Sources */,
 				7A1232AB235E17B8002B6CE3 /* OneSignalOutcomeEventsController.m in Sources */,
 				CA36A42E208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
-				0338566B1FBBD2270002F7C1 /* OSNotificationPayload.m in Sources */,
+				0338566B1FBBD2270002F7C1 /* OSNotification.m in Sources */,
 				9DDFEEF323189C0E00EAE0BB /* OneSignalViewHelper.m in Sources */,
 				7A880F2C23FB45FB0081F5E8 /* OSInAppMessageOutcome.m in Sources */,
 				DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */,
@@ -1780,7 +1780,7 @@
 				CA810FD3202BA97600A60FED /* OSEmailSubscription.m in Sources */,
 				7ABAF9D62457D3FF0074DFA0 /* ChannelTrackersTests.m in Sources */,
 				CA08FC7B1FE99B13004C445F /* OneSignalRequest.m in Sources */,
-				CAE2E5A9215D80070036FD32 /* OSNotificationPayload.m in Sources */,
+				CAE2E5A9215D80070036FD32 /* OSNotification.m in Sources */,
 				7AF9865A24452A9600C36EAE /* OSInfluence.m in Sources */,
 				4529DED51FA823B900CEAB1D /* TestHelperFunctions.m in Sources */,
 				911E2CBD1E398AB3003112A4 /* UnitTests.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.m
@@ -130,9 +130,9 @@
     return message;
 }
 
-+ (instancetype)instancePreviewFromPayload:(OSNotificationPayload *)payload {
++ (instancetype)instancePreviewFromNotification:(OSNotification *)notification {
     let message = [OSInAppMessage new];
-    message.messageId = [payload additionalData][ONESIGNAL_IAM_PREVIEW];
+    message.messageId = [notification additionalData][ONESIGNAL_IAM_PREVIEW];
     message.isPreview = true;
     return message;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
@@ -88,7 +88,7 @@
     return displayStats;
 }
 
-+ (instancetype)instancePreviewFromPayload:(OSNotificationPayload *)payload {
++ (instancetype)instancePreviewFromNotification:(OSNotification *)notification {
     return [OSInAppMessageDisplayStats new];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageOutcome.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageOutcome.m
@@ -62,7 +62,7 @@
     return outcome;
 }
 
-+ (instancetype _Nullable)instancePreviewFromPayload:(OSNotificationPayload * _Nonnull)payload {
++ (instancetype _Nullable)instancePreviewFromNotification:(OSNotification * _Nonnull)notification {
     return nil;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTag.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageTag.m
@@ -61,7 +61,7 @@
     return tag;
 }
 
-+ (instancetype _Nullable)instancePreviewFromPayload:(OSNotificationPayload * _Nonnull)payload {
++ (instancetype _Nullable)instancePreviewFromNotification:(OSNotification * _Nonnull)notification {
     return nil;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSIndirectInfluence.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSIndirectInfluence.m
@@ -73,7 +73,7 @@
     return indirectInfluence;
 }
 
-+ (instancetype)instancePreviewFromPayload:(OSNotificationPayload *)payload {
++ (instancetype)instancePreviewFromNotification:(OSNotification *)notification {
     return [OSIndirectInfluence new];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSJSONHandling.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSJSONHandling.h
@@ -32,7 +32,7 @@
 + (instancetype _Nullable)instanceWithData:(NSData * _Nonnull)data;
 
 + (instancetype _Nullable)instanceWithJson:(NSDictionary * _Nonnull)json;
-+ (instancetype _Nullable)instancePreviewFromOSNotification:(OSNotification * _Nonnull)notification;
++ (instancetype _Nullable)instancePreviewFromNotification:(OSNotification * _Nonnull)notification;
 @end
 
 @protocol OSJSONEncodable

--- a/iOS_SDK/OneSignalSDK/Source/OSJSONHandling.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSJSONHandling.h
@@ -32,7 +32,7 @@
 + (instancetype _Nullable)instanceWithData:(NSData * _Nonnull)data;
 
 + (instancetype _Nullable)instanceWithJson:(NSDictionary * _Nonnull)json;
-+ (instancetype _Nullable)instancePreviewFromPayload:(OSNotificationPayload * _Nonnull)payload;
++ (instancetype _Nullable)instancePreviewFromOSNotification:(OSNotification * _Nonnull)notification;
 @end
 
 @protocol OSJSONEncodable

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
@@ -27,11 +27,11 @@
 
 #import "OneSignal.h"
 
-#ifndef OSNotificationPayload_Internal_h
-#define OSNotificationPayload_Internal_h
+#ifndef OSNotification_Internal_h
+#define OSNotification_Internal_h
 
-@interface OSNotificationPayload (Internal)
-+(instancetype)parseWithApns:(nonnull NSDictionary*)message;
+@interface OSNotification(Internal)
++(instancetype)parseWithApns:(nonnull NSDictionary *)message;
 @end
 
-#endif /* OSNotificationPayload_Internal_h */
+#endif /* OSNotification_Internal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
@@ -32,6 +32,9 @@
 
 @interface OSNotification(Internal)
 +(instancetype)parseWithApns:(nonnull NSDictionary *)message;
+- (void)setCompletionBlock;
+- (void)startTimeoutTimer;
+- (OSNotificationDisplayTypeResponse)getCompletionBlock;
 @end
 
 #endif /* OSNotification_Internal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
@@ -31,10 +31,10 @@
 #define OSNotification_Internal_h
 
 @interface OSNotification(Internal)
-+(instancetype)parseWithApns:(nonnull NSDictionary *)message;
-- (void)setCompletionBlock;
++(instancetype _Nonnull )parseWithApns:(nonnull NSDictionary *)message;
+- (void)setCompletionBlock:(OSNotificationDisplayTypeResponse _Nonnull)completion;
 - (void)startTimeoutTimer;
-- (OSNotificationDisplayTypeResponse)getCompletionBlock;
+- (OSNotificationDisplayTypeResponse _Nullable)getCompletionBlock;
 @end
 
 #endif /* OSNotification_Internal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -31,6 +31,8 @@
 
 #import "OneSignal.h"
 
+#import "OneSignalCommonDefines.h"
+
 @implementation OSNotification
 /*
  @implementation OSNotification
@@ -62,11 +64,7 @@
 
  */
 
-/*
- 
- @synthesize notificationId = _notificationId, title = _title, body = _body;
 
- OSNotificationPayload *_payload;
  OSNotificationDisplayTypeResponse _completion;
  NSTimer *_timeoutTimer;
  - (id)initWithPayload:(OSNotificationPayload *)payload completion:(OSNotificationDisplayTypeResponse)completion {
@@ -80,12 +78,14 @@
          
          _notificationId = _payload.notificationID;
          
-         _completion = completion;
          
-         _timeoutTimer = [NSTimer timerWithTimeInterval:CUSTOM_DISPLAY_TYPE_TIMEOUT target:self selector:@selector(timeoutTimerFired:) userInfo:_notificationId repeats:false];
      }
      return self;
  }
+
+_completion = completion;
+
+
 
  - (OSNotificationDisplayTypeResponse)getCompletionBlock {
      OSNotificationDisplayTypeResponse block = ^(OSNotificationDisplayType displayType){
@@ -116,9 +116,7 @@
      if (_timeoutTimer)
          [_timeoutTimer invalidate];
  }
-
- @end
- */
+ 
 +(instancetype)parseWithApns:(nonnull NSDictionary*)message {
     if (!message)
         return nil;
@@ -138,6 +136,8 @@
         [self parseOriginalPayload];
     
     [self parseOtherApnsFields];
+    
+    _timeoutTimer = [NSTimer timerWithTimeInterval:CUSTOM_DISPLAY_TYPE_TIMEOUT target:self selector:@selector(timeoutTimerFired:) userInfo:_notificationId repeats:false];
 }
 
 // Original OneSignal payload format.

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -86,14 +86,14 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* Name of Template */
 @property(readonly, nullable)NSString* templateName;
 
-/* True when the key content-available is set to 1 in the aps payload.
+/* True when the key content-available is set to 1 in the apns payload.
    content-available is used to wake your app when the payload is received.
    See Apple's documenation for more details.
   https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application
 */
 @property(readonly)BOOL contentAvailable;
 
-/* True when the key mutable-content is set to 1 in the aps payload.
+/* True when the key mutable-content is set to 1 in the apns payload.
  mutable-content is used to wake your Notification Service Extension to modify a notification.
  See Apple's documenation for more details.
  https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* iOS 10+ : Groups notifications into threads */
 @property(readonly, nullable)NSString *threadId;
 
-/* Parses an APS push payload into a OSNotificationPayload object.
+/* Parses an APNS push payload into a OSNotification object.
    Useful to call from your NotificationServiceExtension when the
       didReceiveNotificationRequest:withContentHandler: method fires. */
 + (instancetype)parseWithApns:(nonnull NSDictionary*)message;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -70,7 +70,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 @property(readonly)OSNotificationActionType type;
 
 /* The ID associated with the button tapped. NULL when the actionType is NotificationTapped */
-@property(readonly, nullable)NSString* actionID;
+@property(readonly, nullable)NSString* actionId;
 
 @end
 
@@ -81,7 +81,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 @property(readonly, nullable)NSString* notificationId;
 
 /* Unique Template Identifier */
-@property(readonly, nullable)NSString* templateID;
+@property(readonly, nullable)NSString* templateId;
 
 /* Name of Template */
 @property(readonly, nullable)NSString* templateName;
@@ -109,8 +109,8 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 @property(readonly, nullable)NSString* category;
 
 /* The badge assigned to the application icon */
-@property(readonly, nullable)NSInteger badge;
-@property(readonly, nullable)NSInteger badgeIncrement;
+@property(readonly)NSInteger badge;
+@property(readonly)NSInteger badgeIncrement;
 
 /* The sound parameter passed to the notification
  By default set to UILocalNotificationDefaultSoundName */
@@ -455,8 +455,8 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 
 #pragma mark Public Handlers
 
-// If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired using the displayType of the OSPredisplayNotification object.
-typedef void (^OSNotificationWillShowInForegroundBlock)(OSPredisplayNotification* notification, OSNotificationDisplayTypeResponse completion);
+// If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired.
+typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification* notification, OSNotificationDisplayTypeResponse completion);
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * result);
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction* action);
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -74,11 +74,11 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 
 @end
 
-/* Notification Payload Received Object */
-@interface OSNotificationPayload : NSObject
+/* OneSignal OSNotification */
+@interface OSNotification : NSObject
 
 /* Unique Message Identifier */
-@property(readonly, nullable)NSString* notificationID;
+@property(readonly, nullable)NSString* notificationId;
 
 /* Unique Template Identifier */
 @property(readonly, nullable)NSString* templateID;
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
  See Apple's documenation for more details.
  https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension
  */
-@property(readonly)BOOL mutableContent;
+@property(readonly, getter=hasMutableContent)BOOL mutableContent;
 
 /*
  Notification category key previously registered to display with.
@@ -109,8 +109,8 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 @property(readonly, nullable)NSString* category;
 
 /* The badge assigned to the application icon */
-@property(readonly)NSInteger badge;
-@property(readonly)NSInteger badgeIncrement;
+@property(readonly, nullable)NSInteger badge;
+@property(readonly, nullable)NSInteger badgeIncrement;
 
 /* The sound parameter passed to the notification
  By default set to UILocalNotificationDefaultSoundName */
@@ -143,55 +143,10 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* Parses an APS push payload into a OSNotificationPayload object.
    Useful to call from your NotificationServiceExtension when the
       didReceiveNotificationRequest:withContentHandler: method fires. */
-
 + (instancetype)parseWithApns:(nonnull NSDictionary*)message;
-
-@end
-
-/* OneSignal OSNotification */
-@interface OSNotification : NSObject
-
-/* Notification Payload */
-@property(readonly, nonnull)OSNotificationPayload* payload;
-
-/* Display method of the notification */
-@property(readonly)OSNotificationDisplayType displayType;
-
-/* Set to true when the user was able to see the notification and reacted to it
- Set to false when app is in focus and in-app alerts are disabled, or the remote notification is silent. */
-@property(readonly, getter=wasShown)BOOL shown;
-
-/* Set to true if the app was in focus when the notification  */
-@property(readonly, getter=wasAppInFocus)BOOL isAppInFocus;
-
-/* Set to true when the received notification is silent
- Silent means there is no alert, sound, or badge payload in the aps dictionary
- requires remote-notification within UIBackgroundModes array of the Info.plist */
-@property(readonly, getter=isSilentNotification)BOOL silentNotification;
-
-/* iOS 10+: Indicates whether or not the received notification has mutableContent : 1 assigned to its payload
- Used for UNNotificationServiceExtension to launch extension. */
-@property(readonly, getter=hasMutableContent)BOOL mutableContent;
 
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
 - (NSString* _Nonnull)stringify;
-
-@end
-
-/* OneSignal OSPredisplayNotification used in notificationWillShowInForegroundHandler. The display type for the notification can be changed before it is presented.*/
-@interface OSPredisplayNotification : NSObject
-
-/* Additional key value properties set within the payload */
-@property(readonly, nullable)NSDictionary *additionalData;
-
-/* The Notification ID */
-@property(readonly, nullable)NSString *notificationId;
-
-/* The message title */
-@property(readonly, nullable)NSString *title;
-
-/* The message body */
-@property(readonly, nullable)NSString *body;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -40,7 +40,7 @@
 #import "NSString+OneSignal.h"
 #import "OneSignalTrackFirebaseAnalytics.h"
 #import "OneSignalNotificationServiceExtensionHandler.h"
-#import "OSNotificationPayload+Internal.h"
+#import "OSNotification+Internal.h"
 #import "OSOutcomeEventsFactory.h"
 #import "OSOutcomeEventsCache.h"
 #import "OneSignalCommonDefines.h"
@@ -1932,7 +1932,7 @@ static NSString *_lastnonActiveMessageId;
     // Should be called first, other methods relay on this global state below.
     [OneSignalHelper lastMessageReceived:messageDict];
     
-    BOOL isPreview = [[OSNotificationPayload parseWithApns:messageDict] additionalData][ONESIGNAL_IAM_PREVIEW] != nil;
+    BOOL isPreview = [[OSNotification parseWithApns:messageDict] additionalData][ONESIGNAL_IAM_PREVIEW] != nil;
     if (isPreview && [OneSignalHelper isIOSVersionLessThan:@"10.0"])
         return;
 
@@ -1975,7 +1975,7 @@ static NSString *_lastnonActiveMessageId;
     }
     //Only call the willShowInForegroundHandler for notifications not preview IAMs
     
-    let osPayload = [OSNotificationPayload parseWithApns:payload];
+    let osPayload = [OSNotification parseWithApns:payload];
     if ([osPayload additionalData][ONESIGNAL_IAM_PREVIEW]) {
         completion(OSNotificationDisplayTypeSilent);
         return;
@@ -1993,8 +1993,8 @@ static NSString *_lastnonActiveMessageId;
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"handleNotificationOpened:foreground:isActive:actionType:displayType:"])
         return;
 
-    OSNotificationPayload *payload = [OSNotificationPayload parseWithApns:messageDict];
-    if ([OneSignalHelper handleIAMPreview:payload])
+    OSNotification *notification = [OSNotification parseWithApns:messageDict];
+    if ([OneSignalHelper handleIAMPreview:notification])
         return;
 
     NSDictionary* customDict = [messageDict objectForKey:@"custom"] ?: [messageDict objectForKey:@"os_data"];
@@ -2175,13 +2175,13 @@ static NSString *_lastnonActiveMessageId;
 
     // Generate local notification for action button and/or attachments.
     if (richData) {
-        let osPayload = [OSNotificationPayload parseWithApns:userInfo];
+        let osNotification = [OSNotification parseWithApns:userInfo];
         
         if ([OneSignalHelper isIOSVersionGreaterThanOrEqual:@"10.0"]) {
             startedBackgroundJob = true;
-            [OneSignalHelper addNotificationRequest:osPayload completionHandler:completionHandler];
+            [OneSignalHelper addNotificationRequest:osNotification completionHandler:completionHandler];
         } else {
-            let notification = [OneSignalHelper prepareUILocalNotification:osPayload];
+            let notification = [OneSignalHelper prepareUILocalNotification:osNotification];
             [[UIApplication sharedApplication] scheduleLocalNotification:notification];
         }
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1975,12 +1975,12 @@ static NSString *_lastnonActiveMessageId;
     }
     //Only call the willShowInForegroundHandler for notifications not preview IAMs
     
-    let osPayload = [OSNotification parseWithApns:payload];
-    if ([osPayload additionalData][ONESIGNAL_IAM_PREVIEW]) {
+    OSNotification *osNotification = [OSNotification parseWithApns:payload];
+    if ([osNotification additionalData][ONESIGNAL_IAM_PREVIEW]) {
         completion(OSNotificationDisplayTypeSilent);
         return;
     }
-    [OneSignalHelper handleWillShowInForegroundHandlerForPayload:osPayload displayType:OSNotificationDisplayTypeNotification completion:completion];
+    [OneSignalHelper handleWillShowInForegroundHandlerForNotification:osNotification displayType:OSNotificationDisplayTypeNotification completion:completion];
 }
 
 + (void)handleNotificationOpened:(NSDictionary*)messageDict

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -65,10 +65,10 @@
     return sharedInstance;
 }
 
-- (NSArray<NSString *> *)getActionTitlesFromPayload:(OSNotificationPayload *)payload {
+- (NSArray<NSString *> *)getActionTitlesFromNotification:(OSNotification *)notification {
     NSMutableArray<NSString *> *actionTitles = [NSMutableArray<NSString *> new];
-    if (payload.actionButtons) {
-        for (id button in payload.actionButtons) {
+    if (notification.actionButtons) {
+        for (id button in notification.actionButtons) {
             [actionTitles addObject:button[@"text"]];
         }
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.h
@@ -30,7 +30,7 @@
 #import "OneSignal.h"
 
 @interface OneSignalExtensionBadgeHandler : NSObject
-+ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotificationPayload:(OSNotificationPayload *)payload withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
++ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotification:(OSNotification *)notification withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
 + (void)updateCachedBadgeValue:(NSInteger)value;
 + (NSInteger)currentCachedBadgeValue;
 + (NSString *)appGroupName;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
@@ -35,20 +35,20 @@
 
 @implementation OneSignalExtensionBadgeHandler
 
-+ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotificationPayload:(OSNotificationPayload *)payload withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent {
++ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotification:(OSNotification *)notification withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent {
     
     //if the user is setting the badge directly instead of incrementing/decrementing,
     //make sure the OneSignal cached value is updated to this value
-    if (!payload.badgeIncrement) {
-        if (payload.badge)
-            [OneSignalExtensionBadgeHandler updateCachedBadgeValue:payload.badge];
+    if (!notification.badgeIncrement) {
+        if (notification.badge)
+            [OneSignalExtensionBadgeHandler updateCachedBadgeValue:notification.badge];
         
         return;
     }
     
     var currentValue = (int)OneSignalExtensionBadgeHandler.currentCachedBadgeValue ?: 0;
     
-    currentValue += (int)payload.badgeIncrement;
+    currentValue += (int)notification.badgeIncrement;
     
     //cannot have negative badge values
     if (currentValue < 0)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalExtensionBadgeHandler.m
@@ -29,7 +29,7 @@
 #import "OneSignalHelper.h"
 #import "OneSignalUserDefaults.h"
 #import "OneSignalCommonDefines.h"
-#import "OSNotificationPayload+Internal.h"
+#import "OSNotification+Internal.h"
 #import "OneSignalExtensionBadgeHandler.h"
 #import "OneSignalTrackFirebaseAnalytics.h"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -44,25 +44,25 @@
 
 + (void)setNotificationOpenedBlock:(OSNotificationOpenedBlock)block;
 + (void)setNotificationWillShowInForegroundBlock:(OSNotificationWillShowInForegroundBlock)block;
-+ (void)handleWillShowInForegroundHandlerForPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion;
++ (void)handleWillShowInForegroundHandlerForPayload:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion;
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType;
-+ (BOOL)handleIAMPreview:(OSNotificationPayload *)payload;
++ (BOOL)handleIAMPreview:(OSNotification *)notification;
 
 // - iOS 10
 + (void)registerAsUNNotificationCenterDelegate;
 + (void)clearCachedMedia;
-+ (UNNotificationRequest*)prepareUNNotificationRequest:(OSNotificationPayload*)payload;
-+ (void)addNotificationRequest:(OSNotificationPayload*)payload completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
++ (UNNotificationRequest*)prepareUNNotificationRequest:(OSNotification*)notification;
++ (void)addNotificationRequest:(OSNotification*)notification completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 
 // - Notifications
 + (BOOL)canGetNotificationTypes;
-+ (UILocalNotification*)prepareUILocalNotification:(OSNotificationPayload*)payload;
++ (UILocalNotification*)prepareUILocalNotification:(OSNotification*)notification;
 + (BOOL)verifyURL:(NSString*)urlString;
 + (BOOL)isRemoteSilentNotification:(NSDictionary*)msg;
 + (BOOL)isInAppPreviewNotification:(NSDictionary*)msg;
 + (NSMutableSet<UNNotificationCategory*>*)existingCategories;
-+ (void)addAttachments:(OSNotificationPayload*)payload toNotificationContent:(UNMutableNotificationContent*)content;
-+ (void)addActionButtons:(OSNotificationPayload*)payload toNotificationContent:(UNMutableNotificationContent*)content;
++ (void)addAttachments:(OSNotification*)notification toNotificationContent:(UNMutableNotificationContent*)content;
++ (void)addActionButtons:(OSNotification*)notification toNotificationContent:(UNMutableNotificationContent*)content;
 + (BOOL)isOneSignalPayload:(NSDictionary *)payload;
 
 // - Networking

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -44,7 +44,7 @@
 
 + (void)setNotificationOpenedBlock:(OSNotificationOpenedBlock)block;
 + (void)setNotificationWillShowInForegroundBlock:(OSNotificationWillShowInForegroundBlock)block;
-+ (void)handleWillShowInForegroundHandlerForPayload:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion;
++ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion;
 + (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType;
 + (BOOL)handleIAMPreview:(OSNotification *)notification;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -323,7 +323,7 @@ OneSignalWebView *webVC;
 }
 
 + (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
-    [notification setCompletionBlock:completion];
+    //[notification setCompletionBlock:completion];
     if (notificationWillShowInForegroundHandler) {
         [notification startTimeoutTimer];
         notificationWillShowInForegroundHandler(notification, [notification getCompletionBlock]);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -323,7 +323,7 @@ OneSignalWebView *webVC;
 }
 
 + (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
-    //[notification setCompletionBlock:completion];
+    [notification setCompletionBlock:completion];
     if (notificationWillShowInForegroundHandler) {
         [notification startTimeoutTimer];
         notificationWillShowInForegroundHandler(notification, [notification getCompletionBlock]);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -31,7 +31,7 @@
 #import <CommonCrypto/CommonDigest.h>
 #import "OneSignalReachability.h"
 #import "OneSignalHelper.h"
-#import "OSNotificationPayload+Internal.h"
+#import "OSNotification+Internal.h"
 #import "OneSignalTrackFirebaseAnalytics.h"
 #import <objc/runtime.h>
 #import "OneSignalInternal.h"
@@ -322,11 +322,11 @@ OneSignalWebView *webVC;
     return userInfo;
 }
 
-+ (void)handleWillShowInForegroundHandlerForPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
-    let predisplayNotif = [[OSPredisplayNotification alloc] initWithPayload:payload completion:completion];
++ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
+    [notification setCompletionBlock:completion];
     if (notificationWillShowInForegroundHandler) {
-        [predisplayNotif startTimeoutTimer];
-        notificationWillShowInForegroundHandler(predisplayNotif, [predisplayNotif getCompletionBlock]);
+        [notification startTimeoutTimer];
+        notificationWillShowInForegroundHandler(notification, [notification getCompletionBlock]);
     } else {
         completion(displayType);
     }
@@ -344,14 +344,13 @@ OneSignalWebView *webVC;
         return;
     
     OSNotificationAction *action = [[OSNotificationAction alloc] initWithActionType:actionType :actionID];
-    OSNotificationPayload *payload = [OSNotificationPayload parseWithApns:lastMessageReceived];
-    OSNotification *notification = [[OSNotification alloc] initWithPayload:payload displayType:displayType];
+    OSNotification *notification = [OSNotification parseWithApns:lastMessageReceived];
     OSNotificationOpenedResult *result = [[OSNotificationOpenedResult alloc] initWithNotification:notification action:action];
     
     // Prevent duplicate calls to same action
-    if ([payload.notificationID isEqualToString:_lastMessageIdFromAction])
+    if ([notification.notificationId isEqualToString:_lastMessageIdFromAction])
         return;
-    _lastMessageIdFromAction = payload.notificationID;
+    _lastMessageIdFromAction = notification.notificationId;
     
     [OneSignalTrackFirebaseAnalytics trackOpenEvent:result];
     
@@ -360,12 +359,12 @@ OneSignalWebView *webVC;
     notificationOpenedHandler(result);
 }
 
-+ (BOOL)handleIAMPreview:(OSNotificationPayload *)payload {
-    NSString *uuid = [payload additionalData][ONESIGNAL_IAM_PREVIEW];
++ (BOOL)handleIAMPreview:(OSNotification *)notification {
+    NSString *uuid = [notification additionalData][ONESIGNAL_IAM_PREVIEW];
     if (uuid) {
 
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"IAM Preview Detected, Begin Handling"];
-        OSInAppMessage *message = [OSInAppMessage instancePreviewFromPayload:payload];
+        OSInAppMessage *message = [OSInAppMessage instancePreviewFromNotification:notification];
         [[OSMessagingController sharedInstance] presentInAppPreviewMessage:message];
         return YES;
     }
@@ -421,14 +420,14 @@ OneSignalWebView *webVC;
 }
 
 // For iOS 9
-+ (UILocalNotification*)createUILocalNotification:(OSNotificationPayload*)payload {
++ (UILocalNotification*)createUILocalNotification:(OSNotification*)osNotification {
     let notification = [UILocalNotification new];
     
     let category = [UIMutableUserNotificationCategory new];
     [category setIdentifier:@"__dynamic__"];
     
     NSMutableArray* actionArray = [NSMutableArray new];
-    for (NSDictionary* button in payload.actionButtons) {
+    for (NSDictionary* button in osNotification.actionButtons) {
         let action = [UIMutableUserNotificationAction new];
         action.title = button[@"text"];
         action.identifier = button[@"id"];
@@ -463,20 +462,20 @@ OneSignalWebView *webVC;
 }
 
 // iOS 9
-+ (UILocalNotification*)prepareUILocalNotification:(OSNotificationPayload*)payload {
-    let notification = [self createUILocalNotification:payload];
++ (UILocalNotification*)prepareUILocalNotification:(OSNotification *)osNotification {
+    let notification = [self createUILocalNotification:osNotification];
     
-    notification.alertTitle = payload.title;
+    notification.alertTitle = osNotification.title;
     
-    notification.alertBody = payload.body;
+    notification.alertBody = osNotification.body;
     
-    notification.userInfo = payload.rawPayload;
+    notification.userInfo = osNotification.rawPayload;
     
-    notification.soundName = payload.sound;
+    notification.soundName = osNotification.sound;
     if (notification.soundName == nil)
         notification.soundName = UILocalNotificationDefaultSoundName;
     
-    notification.applicationIconBadgeNumber = payload.badge;
+    notification.applicationIconBadgeNumber = osNotification.badge;
     
     return notification;
 }
@@ -516,40 +515,40 @@ static OneSignal* singleInstance = nil;
         curNotifCenter.delegate = (id)[self sharedInstance];
 }
 
-+ (UNNotificationRequest*)prepareUNNotificationRequest:(OSNotificationPayload*)payload {
++ (UNNotificationRequest*)prepareUNNotificationRequest:(OSNotification*)notification {
     let content = [UNMutableNotificationContent new];
     
-    [self addActionButtons:payload toNotificationContent:content];
+    [self addActionButtons:notification toNotificationContent:content];
     
-    content.title = payload.title;
-    content.subtitle = payload.subtitle;
-    content.body = payload.body;
+    content.title = notification.title;
+    content.subtitle = notification.subtitle;
+    content.body = notification.body;
     
-    content.userInfo = payload.rawPayload;
+    content.userInfo = notification.rawPayload;
     
-    if (payload.sound)
-        content.sound = [UNNotificationSound soundNamed:payload.sound];
+    if (notification.sound)
+        content.sound = [UNNotificationSound soundNamed:notification.sound];
     else
         content.sound = UNNotificationSound.defaultSound;
     
-    if (payload.badge != 0)
-        content.badge = [NSNumber numberWithInteger:payload.badge];
+    if (notification.badge != 0)
+        content.badge = [NSNumber numberWithInteger:notification.badge];
     
     // Check if media attached    
-    [self addAttachments:payload toNotificationContent:content];
+    [self addAttachments:notification toNotificationContent:content];
     
     let trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:0.25 repeats:NO];
     let identifier = [self randomStringWithLength:16];
     return [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
 }
 
-+ (void)addActionButtons:(OSNotificationPayload*)payload
++ (void)addActionButtons:(OSNotification*)notification
    toNotificationContent:(UNMutableNotificationContent*)content {
-    if (!payload.actionButtons || payload.actionButtons.count == 0)
+    if (!notification.actionButtons || notification.actionButtons.count == 0)
         return;
     
     let actionArray = [NSMutableArray new];
-    for(NSDictionary* button in payload.actionButtons) {
+    for(NSDictionary* button in notification.actionButtons) {
         let action = [UNNotificationAction actionWithIdentifier:button[@"id"]
                                                           title:button[@"text"]
                                                         options:UNNotificationActionOptionForeground];
@@ -565,7 +564,7 @@ static OneSignal* singleInstance = nil;
     // Get a full list of categories so we don't replace any exisiting ones.
     var allCategories = OneSignalNotificationCategoryController.sharedInstance.existingCategories;
     
-    let newCategoryIdentifier = [OneSignalNotificationCategoryController.sharedInstance registerNotificationCategoryForNotificationId:payload.notificationID];
+    let newCategoryIdentifier = [OneSignalNotificationCategoryController.sharedInstance registerNotificationCategoryForNotificationId:notification.notificationId];
     let category = [UNNotificationCategory categoryWithIdentifier:newCategoryIdentifier
                                                           actions:finalActionArray
                                                 intentIdentifiers:@[]
@@ -595,15 +594,15 @@ static OneSignal* singleInstance = nil;
     content.categoryIdentifier = newCategoryIdentifier;
 }
 
-+ (void)addAttachments:(OSNotificationPayload*)payload
++ (void)addAttachments:(OSNotification*)notification
  toNotificationContent:(UNMutableNotificationContent*)content {
-    if (!payload.attachments)
+    if (!notification.attachments)
         return;
     
     let unAttachments = [NSMutableArray new];
     
-    for(NSString* key in payload.attachments) {
-        let URI = [OneSignalHelper trimURLSpacing:[payload.attachments valueForKey:key]];
+    for(NSString* key in notification.attachments) {
+        let URI = [OneSignalHelper trimURLSpacing:[notification.attachments valueForKey:key]];
         
         let nsURL = [NSURL URLWithString:URI];
         
@@ -655,14 +654,14 @@ static OneSignal* singleInstance = nil;
     content.attachments = unAttachments;
 }
 
-+ (void)addNotificationRequest:(OSNotificationPayload*)payload
++ (void)addNotificationRequest:(OSNotification*)notification
              completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     
     // Start background thread to download media so we don't lock the main UI thread.
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [OneSignalHelper beginBackgroundMediaTask];
         
-        let notificationRequest = [OneSignalHelper prepareUNNotificationRequest:payload];
+        let notificationRequest = [OneSignalHelper prepareUNNotificationRequest:notification];
         [[UNUserNotificationCenter currentNotificationCenter]
          addNotificationRequest:notificationRequest
          withCompletionHandler:^(NSError * _Nullable error) {}];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -153,153 +153,15 @@
 @end
 
 @implementation OSNotificationAction
-@synthesize type = _type, actionID = _actionID;
+@synthesize type = _type, actionId = _actionId;
 
 -(id)initWithActionType:(OSNotificationActionType)type :(NSString*)actionID {
     self = [super init];
     if(self) {
         _type = type;
-        _actionID = actionID;
+        _actionId = actionID;
     }
     return self;
-}
-
-@end
-
-@implementation OSNotification
-@synthesize payload = _payload, shown = _shown, isAppInFocus = _isAppInFocus, silentNotification = _silentNotification, displayType = _displayType, mutableContent = _mutableContent;
-
-- (id)initWithPayload:(OSNotificationPayload *)payload displayType:(OSNotificationDisplayType)displayType {
-    self = [super init];
-    if (self) {
-        _payload = payload;
-        
-        _displayType = displayType;
-        
-        _silentNotification = [OneSignalHelper isRemoteSilentNotification:payload.rawPayload];
-        
-        _mutableContent = payload.rawPayload[@"aps"][@"mutable-content"] && [payload.rawPayload[@"aps"][@"mutable-content"] isEqual: @YES];
-        
-        _shown = true;
-        
-        _isAppInFocus = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
-        
-        //If remote silent -> shown = false
-        //If app is active and in-app alerts are not enabled -> shown = false
-        if (_silentNotification ||
-            _isAppInFocus)
-            _shown = false;
-    }
-    return self;
-}
-
-- (NSString*)stringify {
-    let obj = [NSMutableDictionary new];
-    [obj setObject:[NSMutableDictionary new] forKeyedSubscript:@"payload"];
-    
-    if (self.payload.notificationID)
-        [obj[@"payload"] setObject:self.payload.notificationID forKeyedSubscript: @"notificationID"];
-    
-    if (self.payload.sound)
-        [obj[@"payload"] setObject:self.payload.sound forKeyedSubscript: @"sound"];
-    
-    if (self.payload.title)
-        [obj[@"payload"] setObject:self.payload.title forKeyedSubscript: @"title"];
-    
-    if (self.payload.body)
-        [obj[@"payload"] setObject:self.payload.body forKeyedSubscript: @"body"];
-    
-    if (self.payload.subtitle)
-        [obj[@"payload"] setObject:self.payload.subtitle forKeyedSubscript: @"subtitle"];
-    
-    if (self.payload.additionalData)
-        [obj[@"payload"] setObject:self.payload.additionalData forKeyedSubscript: @"additionalData"];
-    
-    if (self.payload.actionButtons)
-        [obj[@"payload"] setObject:self.payload.actionButtons forKeyedSubscript: @"actionButtons"];
-    
-    if (self.payload.rawPayload)
-        [obj[@"payload"] setObject:self.payload.rawPayload forKeyedSubscript: @"rawPayload"];
-    
-    if (self.payload.launchURL)
-        [obj[@"payload"] setObject:self.payload.launchURL forKeyedSubscript: @"launchURL"];
-    
-    if (self.payload.contentAvailable)
-        [obj[@"payload"] setObject:@(self.payload.contentAvailable) forKeyedSubscript: @"contentAvailable"];
-    
-    if (self.payload.badge)
-        [obj[@"payload"] setObject:@(self.payload.badge) forKeyedSubscript: @"badge"];
-    
-    if (self.displayType)
-        [obj setObject:@(self.displayType) forKeyedSubscript: @"displayType"];
-    
-    
-    [obj setObject:@(self.shown) forKeyedSubscript: @"shown"];
-    [obj setObject:@(self.isAppInFocus) forKeyedSubscript: @"isAppInFocus"];
-    
-    if (self.silentNotification)
-        [obj setObject:@(self.silentNotification) forKeyedSubscript: @"silentNotification"];
-    
-    //Convert obj into a serialized
-    NSError *err;
-    NSData *jsonData = [NSJSONSerialization  dataWithJSONObject:obj options:0 error:&err];
-    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-}
-
-@end
-
-@implementation OSPredisplayNotification
-@synthesize notificationId = _notificationId, title = _title, body = _body;
-
-OSNotificationPayload *_payload;
-OSNotificationDisplayTypeResponse _completion;
-NSTimer *_timeoutTimer;
-- (id)initWithPayload:(OSNotificationPayload *)payload completion:(OSNotificationDisplayTypeResponse)completion {
-    self = [super init];
-    if (self) {
-        _payload = payload;
-        
-        _body = _payload.body;
-        
-        _title = _payload.title;
-        
-        _notificationId = _payload.notificationID;
-        
-        _completion = completion;
-        
-        _timeoutTimer = [NSTimer timerWithTimeInterval:CUSTOM_DISPLAY_TYPE_TIMEOUT target:self selector:@selector(timeoutTimerFired:) userInfo:_notificationId repeats:false];
-    }
-    return self;
-}
-
-- (OSNotificationDisplayTypeResponse)getCompletionBlock {
-    OSNotificationDisplayTypeResponse block = ^(OSNotificationDisplayType displayType){
-        [self complete:displayType];
-    };
-    return block;
-}
-
-- (void)complete:(OSNotificationDisplayType)displayType {
-    [_timeoutTimer invalidate];
-    if (_completion) {
-        _completion(displayType);
-        _completion = nil;
-    }
-}
-
-- (void)startTimeoutTimer {
-    [[NSRunLoop currentRunLoop] addTimer:_timeoutTimer forMode:NSRunLoopCommonModes];
-}
-
-- (void)timeoutTimerFired:(NSTimer *)timer {
-    [OneSignal onesignal_Log:ONE_S_LL_ERROR
-    message:[NSString stringWithFormat:@"NotificationGenerationJob timed out. Complete was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
-    [self complete:OSNotificationDisplayTypeNotification];
-}
-
-- (void)dealloc {
-    if (_timeoutTimer)
-        [_timeoutTimer invalidate];
 }
 
 @end
@@ -326,7 +188,7 @@ NSTimer *_timeoutTimer;
     
     NSMutableDictionary* obj = [NSMutableDictionary new];
     NSMutableDictionary* action = [NSMutableDictionary new];
-    [action setObject:self.action.actionID forKeyedSubscript:@"actionID"];
+    [action setObject:self.action.actionId forKeyedSubscript:@"actionID"];
     [obj setObject:action forKeyedSubscript:@"action"];
     [obj setObject:notifDict forKeyedSubscript:@"notification"];
     if(self.action.type)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -30,7 +30,7 @@
 #import "OneSignalHelper.h"
 #import "OSInfluenceDataDefines.h"
 #import "OneSignalTrackFirebaseAnalytics.h"
-#import "OSNotificationPayload+Internal.h"
+#import "OSNotification+Internal.h"
 #import "OSSubscription.h"
 #import "OneSignalInternal.h"
 #import "OneSignalReceiveReceiptsController.h"
@@ -47,25 +47,25 @@
     if (!replacementContent)
         replacementContent = [request.content mutableCopy];
     
-    let payload = [OSNotificationPayload parseWithApns:request.content.userInfo];
+    let notification = [OSNotification parseWithApns:request.content.userInfo];
 
     // Handle badge count
-    [OneSignalExtensionBadgeHandler handleBadgeCountWithNotificationRequest:request withNotificationPayload:payload withMutableNotificationContent:replacementContent];
+    [OneSignalExtensionBadgeHandler handleBadgeCountWithNotificationRequest:request withNotification:notification withMutableNotificationContent:replacementContent];
     
     // Track receieved
-    [OneSignalTrackFirebaseAnalytics trackReceivedEvent:payload];
+    [OneSignalTrackFirebaseAnalytics trackReceivedEvent:notification];
     
     // Get and check the received notification id
-    let receivedNotificationId = payload.notificationID;
+    let receivedNotificationId = notification.notificationId;
     [self onNotificationReceived:receivedNotificationId];
 
     // Action Buttons
     [self addActionButtonsToExtentionRequest:request
-                                 withPayload:payload
+                                 withNotification:notification
               withMutableNotificationContent:replacementContent];
     
     // Media Attachments
-    [OneSignalHelper addAttachments:payload toNotificationContent:replacementContent];
+    [OneSignalHelper addAttachments:notification toNotificationContent:replacementContent];
     
     return replacementContent;
 }
@@ -75,24 +75,24 @@
     if (!replacementContent)
         replacementContent = [request.content mutableCopy];
     
-    let payload = [OSNotificationPayload parseWithApns:request.content.userInfo];
+    let notification = [OSNotification parseWithApns:request.content.userInfo];
     
     [self addActionButtonsToExtentionRequest:request
-                                 withPayload:payload
+                                 withNotification:notification
               withMutableNotificationContent:replacementContent];
     
     return replacementContent;
 }
 
 + (void)addActionButtonsToExtentionRequest:(UNNotificationRequest*)request
-                               withPayload:(OSNotificationPayload*)payload
+                               withNotification:(OSNotification*)notification
             withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
     
     // If the developer already set a category don't replace it with our generated one.
     if (request.content.categoryIdentifier && ![request.content.categoryIdentifier isEqualToString:@""])
         return;
     
-    [OneSignalHelper addActionButtons:payload toNotificationContent:replacementContent];
+    [OneSignalHelper addActionButtons:notification toNotificationContent:replacementContent];
 }
 
 + (void)onNotificationReceived:(NSString *)receivedNotificationId {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.h
@@ -35,6 +35,6 @@
 +(void)updateFromDownloadParams:(NSDictionary*)params;
 
 +(void)trackOpenEvent:(OSNotificationOpenedResult*)results;
-+(void)trackReceivedEvent:(OSNotificationPayload*)notification;
++(void)trackReceivedEvent:(OSNotification*)notification;
 +(void)trackInfluenceOpenEvent;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTrackFirebaseAnalytics.m
@@ -76,17 +76,17 @@ static var trackingEnabled = false;
                             withObject:params];
 }
 
-+ (NSString*)getCampaignNameFromPayload:(OSNotificationPayload*)payload {
-    if (payload.templateName && payload.templateID)
-        return [NSString stringWithFormat:@"%@ - %@", payload.templateName, payload.templateID];
-    if (!payload.title)
++ (NSString*)getCampaignNameFromNotification:(OSNotification *)notification {
+    if (notification.templateName && notification.templateId)
+        return [NSString stringWithFormat:@"%@ - %@", notification.templateName, notification.templateId];
+    if (!notification.title)
         return @"";
     
-    var titleLength = payload.title.length;
+    var titleLength = notification.title.length;
     if (titleLength > 10)
         titleLength = 10;
     
-    return [payload.title substringToIndex:titleLength];
+    return [notification.title substringToIndex:titleLength];
 }
 
 + (void)trackOpenEvent:(OSNotificationOpenedResult*)results {
@@ -99,18 +99,18 @@ static var trackingEnabled = false;
                 parameters:@{
                     @"source": @"OneSignal",
                     @"medium": @"notification",
-                    @"notification_id": results.notification.payload.notificationID,
-                    @"campaign": [self getCampaignNameFromPayload:results.notification.payload]
+                    @"notification_id": results.notification.notificationId,
+                    @"campaign": [self getCampaignNameFromNotification:results.notification]
                 }];
 }
 
-+ (void)trackReceivedEvent:(OSNotificationPayload*)payload {
++ (void)trackReceivedEvent:(OSNotification*)notification {
     if (!trackingEnabled)
         return;
     
-    let campaign = [self getCampaignNameFromPayload:payload];
+    let campaign = [self getCampaignNameFromNotification:notification];
     let sharedUserDefaults = OneSignalUserDefaults.initShared;
-    [sharedUserDefaults saveStringForKey:ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED withValue:payload.notificationID];
+    [sharedUserDefaults saveStringForKey:ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED withValue:notification.notificationId];
     [sharedUserDefaults saveStringForKey:ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED withValue:campaign];
     [sharedUserDefaults saveDoubleForKey:ONESIGNAL_FB_LAST_TIME_RECEIVED withValue:[[NSDate date] timeIntervalSince1970]];
     
@@ -118,7 +118,7 @@ static var trackingEnabled = false;
                 parameters:@{
                     @"source": @"OneSignal",
                     @"medium": @"notification",
-                    @"notification_id": payload.notificationID,
+                    @"notification_id": notification.notificationId,
                     @"campaign": campaign
                 }];
 }

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -29,7 +29,7 @@
 #import <UIKit/UIKit.h>
 
 #import "UIApplicationDelegate+OneSignal.h"
-#import "OSNotificationPayload+Internal.h"
+#import "OSNotification+Internal.h"
 #import "OneSignal.h"
 #import "OneSignalCommonDefines.h"
 #import "OneSignalTracker.h"

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -766,7 +766,7 @@
     [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:nil notificationOpenedHandler:^(OSNotificationOpenedResult *result) {
         XCTAssertNil(result.notification.payload.additionalData);
         XCTAssertEqual(result.action.type, OSNotificationActionTypeOpened);
-        XCTAssertNil(result.action.actionID);
+        XCTAssertNil(result.action.actionId);
         openedWasFire = true;
     }];
     
@@ -912,7 +912,7 @@
     [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:nil notificationOpenedHandler:^(OSNotificationOpenedResult *result) {
         XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
         XCTAssertEqual(result.action.type, OSNotificationActionTypeActionTaken);
-        XCTAssertEqualObjects(result.action.actionID, @"id1");
+        XCTAssertEqualObjects(result.action.actionId, @"id1");
         openedWasFire = true;
     }];
 
@@ -958,7 +958,7 @@
     [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:nil notificationOpenedHandler:^(OSNotificationOpenedResult *result) {
         XCTAssertEqualObjects(result.notification.payload.additionalData[@"actionSelected"], @"id1");
         XCTAssertEqual(result.action.type, OSNotificationActionTypeActionTaken);
-        XCTAssertEqualObjects(result.action.actionID, @"id1");
+        XCTAssertEqualObjects(result.action.actionId, @"id1");
         openedWasFire = true;
     }];
 
@@ -1039,7 +1039,7 @@
     [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:nil notificationOpenedHandler:^(OSNotificationOpenedResult *result) {
         XCTAssertEqualObjects(result.notification.payload.additionalData[@"foo"], @"bar");
         XCTAssertEqual(result.action.type, OSNotificationActionTypeOpened);
-        XCTAssertNil(result.action.actionID);
+        XCTAssertNil(result.action.actionId);
         openedWasFire = true;
     }];
 


### PR DESCRIPTION
This PR combines `OSNotification`, `OSPreDisplayNotification`, and `OSNotificationPayload` into a single class, `OSNotification`

Classes and protocols that were previously using `OSPreDisplayNotification` and `OSNotificationPayload` have been moved to `OSNotification`

The implementation for `OSNotification` and what was `OSPreDisplayNotification` has moved to `OSNotification.m` and some additional OSNotification methods are available internally in `OSNotification+Internal.h`

Additionally the following properties were dropped from `OSNotification` 


* `wasShown`
* `wasAppInFocus`
* `isSilentNotification`
* `displayType`
* `payload`

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/741)
<!-- Reviewable:end -->

