### PR TITLE
Custom base url

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -459,6 +459,9 @@ extern NSString * const kOSSettingsKeyProvidesAppNotificationSettings;
 // ======= OneSignal Class Interface =========
 @interface OneSignal : NSObject
 
++ (NSString*) OS_API_SERVER_URL;
++ (void) updateApiServerURL:(NSString*)baseUrl;
+
 extern NSString* const ONESIGNAL_VERSION;
 
 typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -140,10 +140,12 @@ NSString* const kOSSettingsKeyProvidesAppNotificationSettings = @"kOSSettingsKey
 
 NSString* _baseUrl = @"https://api.onesignal.com/";
 + (NSString*) OS_API_SERVER_URL{
+    [self onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"One Signal BASE_URL: %@", _baseUrl]];
     return _baseUrl;
 }
 + (void)updateApiServerURL:(NSString *)baseUrl {
-    if(baseUrl != nil && baseUrl != NULL) _baseUrl = baseUrl;
+    if(baseUrl != nil && ![baseUrl isKindOfClass:[NSNull class]])
+        _baseUrl = baseUrl;
 }
 
 NSString* const ONESIGNAL_VERSION = @"021503";
@@ -523,7 +525,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId {
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
-                               baseUrl: NULL
+                               baseUrl: nil
             handleNotificationReceived:NULL
               handleNotificationAction:NULL
                               settings:@{
@@ -553,7 +555,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
    handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback {
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
-                               baseUrl: NULL
+                               baseUrl: nil
             handleNotificationReceived:NULL
               handleNotificationAction:actionCallback
                               settings:@{
@@ -587,7 +589,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
                    settings:(NSDictionary*)settings {
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
-                                baseUrl: NULL
+                                baseUrl: nil
             handleNotificationReceived:NULL
               handleNotificationAction:actionCallback
                               settings:settings];
@@ -614,7 +616,7 @@ handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback
                   settings:(NSDictionary*)settings {
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
-                               baseUrl: NULL
+                               baseUrl: nil
             handleNotificationReceived:NULL
               handleNotificationAction:actionCallback
                               settings:settings];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -138,6 +138,14 @@ NSString* const kOSSettingsKeyProvidesAppNotificationSettings = @"kOSSettingsKey
 
 @implementation OneSignal
 
+NSString* _baseUrl = @"https://api.onesignal.com/";
++ (NSString*) OS_API_SERVER_URL{
+    return _baseUrl;
+}
++ (void)updateApiServerURL:(NSString *)baseUrl {
+    if(baseUrl != nil && baseUrl != NULL) _baseUrl = baseUrl;
+}
+
 NSString* const ONESIGNAL_VERSION = @"021503";
 static NSString* mSDKType = @"native";
 static BOOL coldStartFromTapOnNotification = NO;
@@ -515,6 +523,21 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId {
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
+                               baseUrl: NULL
+            handleNotificationReceived:NULL
+              handleNotificationAction:NULL
+                              settings:@{
+                                  kOSSettingsKeyAutoPrompt :@YES,
+                                  kOSSettingsKeyInAppAlerts : @YES,
+                                  kOSSettingsKeyInAppLaunchURL : @YES,
+                                  kOSSSettingsKeyPromptBeforeOpeningPushURL : @NO
+                              }];
+}
+
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId baseUrl:(NSString*)baseUrl {
+    return [self initWithLaunchOptions:launchOptions
+                                 appId:appId
+                               baseUrl:baseUrl
             handleNotificationReceived:NULL
               handleNotificationAction:NULL
                               settings:@{
@@ -528,9 +551,26 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions
                        appId:(NSString*)appId
    handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback {
-    
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
+                               baseUrl: NULL
+            handleNotificationReceived:NULL
+              handleNotificationAction:actionCallback
+                              settings:@{
+                                  kOSSettingsKeyAutoPrompt : @YES,
+                                  kOSSettingsKeyInAppAlerts : @YES,
+                                  kOSSettingsKeyInAppLaunchURL : @YES,
+                                  kOSSSettingsKeyPromptBeforeOpeningPushURL : @NO
+                              }];
+}
+
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions
+                       appId:(NSString*)appId
+                        baseUrl:(NSString*)baseUrl
+   handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback {
+    return [self initWithLaunchOptions:launchOptions
+                                 appId:appId
+                                baseUrl:baseUrl
             handleNotificationReceived:NULL
               handleNotificationAction:actionCallback
                               settings:@{
@@ -545,9 +585,36 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
                       appId:(NSString*)appId
    handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback
                    settings:(NSDictionary*)settings {
-    
     return [self initWithLaunchOptions:launchOptions
                                  appId:appId
+                                baseUrl: NULL
+            handleNotificationReceived:NULL
+              handleNotificationAction:actionCallback
+                              settings:settings];
+}
+
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions
+                      appId:(NSString*)appId
+                    baseUrl:(NSString*)baseUrl
+   handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback
+                   settings:(NSDictionary*)settings {
+    return [self initWithLaunchOptions:launchOptions
+                                 appId:appId
+                                baseUrl:baseUrl
+            handleNotificationReceived:NULL
+              handleNotificationAction:actionCallback
+                              settings:settings];
+}
+
+
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions
+                     appId:(NSString*)appId
+handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback
+  handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback
+                  settings:(NSDictionary*)settings {
+    return [self initWithLaunchOptions:launchOptions
+                                 appId:appId
+                               baseUrl: NULL
             handleNotificationReceived:NULL
               handleNotificationAction:actionCallback
                               settings:settings];
@@ -557,10 +624,11 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 //        Ensure a 2nd call can be made later with the appId from the developer's code.
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions
                       appId:(NSString*)appId
+                    baseUrl:(NSString*)baseUrl
  handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback
    handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback
                    settings:(NSDictionary*)settings {
-    
+    [OneSignal updateApiServerURL:baseUrl];
     [self onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Called init with app ID: %@", appId]];
     [[OSMigrationController new] migrate];
     [OneSignalHelper setNotificationActionBlock:actionCallback];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -33,7 +33,7 @@
 // Networking
 #define OS_API_VERSION @"1"
 #define OS_API_ACCEPT_HEADER @"application/vnd.onesignal.v" OS_API_VERSION @"+json"
-#define OS_API_SERVER_URL @"https://api.onesignal.com/"
+//#define OS_API_SERVER_URL @"https://api.onesignal.com/"
 
 #define OS_IAM_WEBVIEW_BASE_URL @"https://onesignal.com/"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
@@ -56,7 +56,7 @@
 
 -(NSMutableURLRequest *)urlRequest {
     //build URL
-    let urlString = [OS_API_SERVER_URL stringByAppendingString:self.path];
+    let urlString = [OneSignal.OS_API_SERVER_URL stringByAppendingString:self.path];
     
     let request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -36,6 +36,7 @@
 #import "OSFocusInfluenceParam.h"
 #import "OneSignalClientOverrider.h"
 #import "UnitTestCommonMethods.h"
+#import "OneSignal.h"
 
 @interface RequestTests : XCTestCase
 
@@ -101,7 +102,7 @@ NSString *urlStringForRequest(OneSignalRequest *request) {
 }
 
 NSString *correctUrlWithPath(NSString *path) {
-    return [OS_API_SERVER_URL stringByAppendingString:path];
+    return [OneSignal.OS_API_SERVER_URL stringByAppendingString:path];
 }
 
 // only works for dictionaries with values that are strings, numbers, or sub-dictionaries/arrays of strings and numbers

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -56,7 +56,7 @@
 #import "OneSignalLifecycleObserver.h"
 
 NSString * serverUrlWithPath(NSString *path) {
-    return [OS_API_SERVER_URL stringByAppendingString:path];
+    return [OneSignal.OS_API_SERVER_URL stringByAppendingString:path];
 }
 
 @interface OneSignal ()


### PR DESCRIPTION
This is a feature request to allow developers to opt in to use a proxy server as OneSignal api base url. It happen that OneSignal domains are blocked in some countries and by some ISPs… so I think this could be a good way to allow devs to use OneSignal.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/742)
<!-- Reviewable:end -->

