### PR TITLE
Fixing redisplaying for dynamic trigger IAMs

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -85,12 +85,12 @@
     return YES;
 }
 
-#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"ONESIGNAL_APP_ID_KEY_FOR_TESTING"
+#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"77e32082-ea27-42e3-a898-c72e141824ef"
 
 + (NSString*)getOneSignalAppId {
     NSString* onesignalAppId = [[NSUserDefaults standardUserDefaults] objectForKey:ONESIGNAL_APP_ID_KEY_FOR_TESTING];
     if (!onesignalAppId)
-        onesignalAppId = @"0ba9731b-33bd-43f4-8b59-61172e27447d";
+        onesignalAppId = @"77e32082-ea27-42e3-a898-c72e141824ef";
 
     return onesignalAppId;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OSDynamicTriggerControllerDelegate <NSObject>
 
-- (void)dynamicTriggerFired;
+- (void)dynamicTriggerFired:(NSString *triggerId);
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.h
@@ -32,7 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OSDynamicTriggerControllerDelegate <NSObject>
 
-- (void)dynamicTriggerFired:(NSString *triggerId);
+- (void)dynamicTriggerFired:(NSString *)triggerId;
+// Alerts the observer that a trigger evaluated to true
+- (void)dynamicTriggerCompleted:(NSString *)triggerId;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OSDynamicTriggerControllerDelegate <NSObject>
 
-- (void)dynamicTriggerFired:(NSString *)triggerId;
+- (void)dynamicTriggerFired;
 // Alerts the observer that a trigger evaluated to true
 - (void)dynamicTriggerCompleted:(NSString *)triggerId;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
@@ -147,7 +147,7 @@
 
         [self.scheduledMessages removeObject:trigger.triggerId];
 
-        [self.delegate dynamicTriggerFired];
+        [self.delegate dynamicTriggerFired:trigger.triggerId];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
@@ -79,6 +79,7 @@
         if ([trigger.kind isEqualToString:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME]) {
             let currentDuration = fabs([[OneSignal sessionLaunchTime] timeIntervalSinceNow]);
             if ([self evaluateTimeInterval:requiredTimeValue withCurrentValue:currentDuration forOperator:trigger.operatorType]) {
+                [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"session time trigger completed: %@", trigger.triggerId]];
                 [self.delegate dynamicTriggerCompleted:trigger.triggerId];
                 return true;
             }
@@ -91,9 +92,10 @@
 
             let timestampSinceLastMessage = fabs([self.timeSinceLastMessage timeIntervalSinceNow]);
 
-            if ([self evaluateTimeInterval:requiredTimeValue withCurrentValue:timestampSinceLastMessage forOperator:trigger.operatorType])
+            if ([self evaluateTimeInterval:requiredTimeValue withCurrentValue:timestampSinceLastMessage forOperator:trigger.operatorType]) {
+                [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"time since last inapp trigger completed: %@", trigger.triggerId]];
                 return true;
-
+            }
             offset = requiredTimeValue - timestampSinceLastMessage;
         }
 
@@ -107,9 +109,10 @@
                                           selector:@selector(timerFiredForMessage:)
                                           userInfo:@{@"trigger" : trigger}
                                            repeats:false];
-        if (timer)
+        if (timer) {
+            [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"timer added for triggerId: %@, messageId: %@", trigger.triggerId, messageId]];
             [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
-
+        }
         [self.scheduledMessages addObject:trigger.triggerId];
     }
     return false;

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
@@ -104,7 +104,7 @@
             return false;
 
         // If we reach this point, it means we need to return false and set up a timer for a future time
-        let timer = [NSTimer timerWithTimeInterval:offset
+        NSTimer *timer = [NSTimer timerWithTimeInterval:offset
                                             target:self
                                           selector:@selector(timerFiredForMessage:)
                                           userInfo:@{@"trigger" : trigger}
@@ -113,6 +113,7 @@
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"timer added for triggerId: %@, messageId: %@", trigger.triggerId, messageId]];
             [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
         }
+
         [self.scheduledMessages addObject:trigger.triggerId];
     }
     return false;

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
@@ -81,6 +81,7 @@
             if ([self evaluateTimeInterval:requiredTimeValue withCurrentValue:currentDuration forOperator:trigger.operatorType]) {
                 [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"session time trigger completed: %@", trigger.triggerId]];
                 [self.delegate dynamicTriggerCompleted:trigger.triggerId];
+                //[self.delegate dynamicTriggerFired:trigger.triggerId];
                 return true;
             }
             offset = requiredTimeValue - currentDuration;
@@ -149,7 +150,7 @@
 
         [self.scheduledMessages removeObject:trigger.triggerId];
 
-        [self.delegate dynamicTriggerFired:trigger.triggerId];
+        [self.delegate dynamicTriggerFired];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDynamicTriggerController.m
@@ -58,7 +58,6 @@
 }
 
 - (BOOL)dynamicTriggerShouldFire:(OSTrigger *)trigger withMessageId:(NSString *)messageId {
-    
     if (!trigger.value)
         return false;
 
@@ -79,10 +78,10 @@
         // Check what type of trigger it is
         if ([trigger.kind isEqualToString:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME]) {
             let currentDuration = fabs([[OneSignal sessionLaunchTime] timeIntervalSinceNow]);
-
-            if ([self evaluateTimeInterval:requiredTimeValue withCurrentValue:currentDuration forOperator:trigger.operatorType])
+            if ([self evaluateTimeInterval:requiredTimeValue withCurrentValue:currentDuration forOperator:trigger.operatorType]) {
+                [self.delegate dynamicTriggerCompleted:trigger.triggerId];
                 return true;
-
+            }
             offset = requiredTimeValue - currentDuration;
         } else if ([trigger.kind isEqualToString:OS_DYNAMIC_TRIGGER_KIND_MIN_TIME_SINCE]) {
 
@@ -113,7 +112,6 @@
 
         [self.scheduledMessages addObject:trigger.triggerId];
     }
-    
     return false;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
@@ -133,6 +133,7 @@
     [encoder encodeInteger:_displayQuantity forKey:@"displayQuantity"];
     [encoder encodeDouble:_displayDelay forKey:@"displayDelay"];
     [encoder encodeDouble:_lastDisplayTime forKey:@"lastDisplayTime"];
+    [encoder encodeBool:_redisplayEnabled forKey:@"redisplayEnabled"];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder {
@@ -141,6 +142,7 @@
         _displayQuantity = [decoder decodeIntegerForKey:@"displayQuantity"];
         _displayDelay = [decoder decodeDoubleForKey:@"displayDelay"];
         _lastDisplayTime = [decoder decodeDoubleForKey:@"lastDisplayTime"];
+        _redisplayEnabled = [decoder decodeBoolForKey:@"redisplayEnabled"];
     }
     return self;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageDisplayStats.m
@@ -111,7 +111,9 @@
 }
 
 - (BOOL)shouldDisplayAgain {
-    return _displayQuantity < _displayLimit;
+    BOOL result = _displayQuantity < _displayLimit;
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"In app message shouldDisplayAgain: %hhu", result]];
+    return result;
 }
 
 - (void)incrementDisplayQuantity {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -697,8 +697,18 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
+- (void)makeRedisplayMessagesAvailableWithTriggers:(NSArray<NSString *> *)triggerIds {
+    for (OSInAppMessage *message in self.messages) {
+        if ([self.redisplayedInAppMessages objectForKey:message.messageId]
+            && [_triggerController hasSharedTriggers:message newTriggersKeys:triggerIds]) {
+            message.isTriggerChanged = YES;
+        }
+    }
+}
+
 #pragma mark OSTriggerControllerDelegate Methods
-- (void)triggerConditionChanged {
+- (void)triggerConditionChanged:(NSString *)triggerId {
+    [self makeRedisplayMessagesAvailableWithTriggers:@[triggerId]];
     // We should re-evaluate all in-app messages
     [self evaluateMessages];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -493,8 +493,11 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)persistInAppMessageForRedisplay:(OSInAppMessage *)message {
     // If the IAM doesn't have the re display prop or is a preview IAM there is no need to save it
-    if (![message.displayStats isRedisplayEnabled] || message.isPreview)
-      return;
+    if (![message.displayStats isRedisplayEnabled] || message.isPreview) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"not persisting %@",message.displayStats]];
+        return;
+    }
+
 
     let displayTimeSeconds = self.dateGenerator();
     message.displayStats.lastDisplayTime = displayTimeSeconds;
@@ -714,14 +717,10 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 #pragma mark OSTriggerControllerDelegate Methods
-- (void)triggerConditionChanged:(NSString *)triggerId {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"trigger condition changed for triggerId: %@", triggerId]];
-    [self makeRedisplayMessagesAvailableWithTriggers:@[triggerId]];
-    [self triggerConditionChanged];
-}
 
 - (void)triggerConditionChanged {
     // We should re-evaluate all in-app messages
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Trigger condition changed"];
     [self evaluateMessages];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -715,6 +715,7 @@ static BOOL _isInAppMessagingPaused = false;
 
 #pragma mark OSTriggerControllerDelegate Methods
 - (void)triggerConditionChanged:(NSString *)triggerId {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"trigger condition changed for triggerId: %@", triggerId]];
     [self makeRedisplayMessagesAvailableWithTriggers:@[triggerId]];
     [self triggerConditionChanged];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  The message should be shown (assuming no other triggers are false for that message)
  It is also called when the app changes trigger values
  */
-- (void)triggerConditionChanged;
+- (void)triggerConditionChanged:(NSString *)triggerId;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
@@ -38,8 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
  The message should be shown (assuming no other triggers are false for that message)
  It is also called when the app changes trigger values
  */
+- (void)triggerConditionChanged;
 - (void)triggerConditionChanged:(NSString *)triggerId;
-
+- (void)dynamicTriggerCompleted:(NSString *)triggerId;
 @end
 
 @interface OSTriggerController : NSObject <OSDynamicTriggerControllerDelegate>

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
  It is also called when the app changes trigger values
  */
 - (void)triggerConditionChanged;
-- (void)triggerConditionChanged:(NSString *)triggerId;
 - (void)dynamicTriggerCompleted:(NSString *)triggerId;
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
@@ -85,7 +85,7 @@
     for (NSString *triggerKey in newTriggersKeys) {
         for (NSArray <OSTrigger *> *andConditions in message.triggers) {
             for (OSTrigger *trigger in andConditions) {
-                if ([triggerKey isEqual:trigger.property]) {
+                if ([triggerKey isEqual:trigger.property] || [triggerKey isEqualToString:trigger.triggerId]) {
                     // At least one trigger has changed
                     return YES;
                 }
@@ -259,8 +259,8 @@
     return false;
 }
 
-- (void)dynamicTriggerFired {
-    [self.delegate triggerConditionChanged];
+- (void)dynamicTriggerFired:(NSString *)triggerId {
+    [self.delegate triggerConditionChanged:triggerId];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
@@ -261,8 +261,8 @@
     return false;
 }
 
-- (void)dynamicTriggerFired:(NSString *)triggerId {
-    [self.delegate triggerConditionChanged:triggerId];
+- (void)dynamicTriggerFired {
+    [self.delegate triggerConditionChanged];
 }
 
 - (void)dynamicTriggerCompleted:(NSString *)triggerId {

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
@@ -85,6 +85,8 @@
     for (NSString *triggerKey in newTriggersKeys) {
         for (NSArray <OSTrigger *> *andConditions in message.triggers) {
             for (OSTrigger *trigger in andConditions) {
+                // Dynamic triggers depends on triggerId
+                // Common triggers changed by user depends on property
                 if ([triggerKey isEqual:trigger.property] || [triggerKey isEqualToString:trigger.triggerId]) {
                     // At least one trigger has changed
                     return YES;
@@ -261,6 +263,10 @@
 
 - (void)dynamicTriggerFired:(NSString *)triggerId {
     [self.delegate triggerConditionChanged:triggerId];
+}
+
+- (void)dynamicTriggerCompleted:(NSString *)triggerId {
+    [self.delegate dynamicTriggerCompleted:triggerId];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1712,6 +1712,7 @@ static dispatch_queue_t serialQueue;
     }
     
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Calling OneSignal create/on_session"];
+    sessionLaunchTime = [NSDate date];
     
     
     if (mShareLocation && [OneSignalLocation lastLocation]) {
@@ -2801,7 +2802,6 @@ static NSString *_lastnonActiveMessageId;
 + (void)onSessionEnding:(NSArray<OSInfluence *> *)lastInfluences {
     if (_outcomeEventsController)
         [_outcomeEventsController clearOutcomes];
-    
     [OneSignalTracker onSessionEnded:lastInfluences];
 }
 
@@ -2850,7 +2850,6 @@ static NSString *_lastnonActiveMessageId;
     injectToProperClass(@selector(onesignalSetApplicationIconBadgeNumber:), @selector(setApplicationIconBadgeNumber:), @[], [OneSignalAppDelegate class], [UIApplication class]);
     
     [self setupUNUserNotificationCenterDelegate];
-
     sessionLaunchTime = [NSDate date];
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingTests.m
@@ -541,7 +541,7 @@ NSInteger const DELAY = 60;
     
     XCTAssertFalse(triggered);
     XCTAssertTrue(NSTimerOverrider.hasScheduledTimer);
-    XCTAssertTrue(fabs(NSTimerOverrider.mostRecentTimerInterval - 30.0f) < 0.1f);
+    XCTAssertTrue(fabs(NSTimerOverrider.mostRecentTimerInterval - 30.0f) < 1.1f);
 }
 
 


### PR DESCRIPTION
This PR allows IAMs with only dynamic triggers to be redisplayed by setting `message.isTriggerChanged = YES;` when the trigger fires. Additionally `evaluateMessages` now evaluates message triggers before setting redisplay data

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/745)
<!-- Reviewable:end -->

