### PR TITLE
Add json representation

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
@@ -27,6 +27,8 @@
 
 #import <Foundation/Foundation.h>
 #import "OneSignal.h"
+#import "OneSignalHelper.h"
+#import "OneSignalCommonDefines.h"
 
 @implementation OSDeviceState
 
@@ -54,6 +56,22 @@
         _emailAddress = [[state emailSubscriptionStatus] emailAddress];
     }
     return self;
+}
+
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation {
+    let json = [NSMutableDictionary new];
+
+    json[@"hasNotificationPermission"] = @(_hasNotificationPermission);
+    json[@"isPushDisabled"] = @(_isPushDisabled);
+    json[@"isSubscribed"] = @(_isSubscribed);
+    json[@"userId"] = _userId;
+    json[@"pushToken"] = _pushToken;
+    json[@"emailUserId"] = _emailUserId;
+    json[@"emailAddress"] = _emailAddress;
+    json[@"notificationPermissionStatus"] = @(_notificationPermissionStatus);
+
+    return json;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -379,6 +379,9 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 
 - (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state;
 
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
 @end
 
 typedef void (^OSWebOpenURLResultBlock)(BOOL shouldOpen);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -158,6 +158,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
 - (NSString* _Nonnull)stringify;
 
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
 @end;
 
 @interface OSInAppMessageOutcome : NSObject

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -179,7 +179,14 @@
 }
 
 - (NSString*)stringify {
-    
+    NSError * err;
+    NSDictionary *jsonDictionary = [self jsonRepresentation];
+    NSData * jsonData = [NSJSONSerialization  dataWithJSONObject:jsonDictionary options:0 error:&err];
+    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation {
     NSError * jsonError = nil;
     NSData *objectData = [[self.notification stringify] dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *notifDict = [NSJSONSerialization JSONObjectWithData:objectData
@@ -194,10 +201,7 @@
     if(self.action.type)
         [obj[@"action"] setObject:@(self.action.type) forKeyedSubscript: @"type"];
     
-    //Convert obj into a serialized
-    NSError * err;
-    NSData * jsonData = [NSJSONSerialization  dataWithJSONObject:obj options:0 error:&err];
-    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    return obj;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2640,4 +2640,21 @@ didReceiveRemoteNotification:userInfo
     deviceModel = [OneSignalHelper getDeviceVariant];
     XCTAssertEqualObjects(@"iPhone9,3", deviceModel);
 }
+
+- (void)testDeviceStateJson {
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    [OneSignal setEmail:@"test@gmail.com"];
+    [UnitTestCommonMethods runBackgroundThreads];
+    let deviceState = [[OSDeviceState alloc] initWithSubscriptionState:[OneSignal getPermissionSubscriptionState]];
+    let json = [deviceState jsonRepresentation];
+    XCTAssertEqualObjects(json[@"hasNotificationPermission"], @1);
+    XCTAssertEqualObjects(json[@"isPushDisabled"], @0);
+    XCTAssertEqualObjects(json[@"isSubscribed"], @1);
+    XCTAssertEqualObjects(json[@"userId"], @"1234");
+    XCTAssertEqualObjects(json[@"pushToken"], @"0000000000000000000000000000000000000000000000000000000000000000");
+    XCTAssertEqualObjects(json[@"emailUserId"], @"1234");
+    XCTAssertEqualObjects(json[@"emailAddress"], @"test@gmail.com");
+    XCTAssertEqualObjects(json[@"notificationPermissionStatus"], @2);
+}
+
 @end


### PR DESCRIPTION
This PR adds a `jsonRepresentation` public method to OSDeviceState and OSNotificationOpenedResult to make them more easily used from wrappers

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/747)
<!-- Reviewable:end -->

