### PR TITLE
Remove notification display type

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -60,9 +60,9 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
         [alert show];
     };
-    id notificationReceiverBlock = ^(OSNotification *notif, OSNotificationDisplayTypeResponse completion) {
+    id notificationReceiverBlock = ^(OSNotification *notif, OSNotificationDisplayResponse completion) {
         NSLog(@"Will Receive Notification - %@", notif.notificationId);
-        completion(OSNotificationDisplayTypeNotification);
+        completion(notif);
     };
     
     // Example block for IAM action click handler

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification+Internal.h
@@ -32,9 +32,9 @@
 
 @interface OSNotification(Internal)
 +(instancetype _Nonnull )parseWithApns:(nonnull NSDictionary *)message;
-- (void)setCompletionBlock:(OSNotificationDisplayTypeResponse _Nonnull)completion;
+- (void)setCompletionBlock:(OSNotificationDisplayResponse _Nonnull)completion;
 - (void)startTimeoutTimer;
-- (OSNotificationDisplayTypeResponse _Nullable)getCompletionBlock;
+- (OSNotificationDisplayResponse _Nullable)getCompletionBlock;
 @end
 
 #endif /* OSNotification_Internal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -35,7 +35,7 @@
 
 @implementation OSNotification
 
- OSNotificationDisplayTypeResponse _completion;
+ OSNotificationDisplayResponse _completion;
  NSTimer *_timeoutTimer;
  
 + (instancetype)parseWithApns:(nonnull NSDictionary*)message {
@@ -243,21 +243,21 @@
 
 #pragma mark willShowInForegroundHandler Methods
 
-- (void)setCompletionBlock:(OSNotificationDisplayTypeResponse)completion {
+- (void)setCompletionBlock:(OSNotificationDisplayResponse)completion {
     _completion = completion;
 }
 
- - (OSNotificationDisplayTypeResponse)getCompletionBlock {
-     OSNotificationDisplayTypeResponse block = ^(OSNotificationDisplayType displayType){
-         [self complete:displayType];
+ - (OSNotificationDisplayResponse)getCompletionBlock {
+     OSNotificationDisplayResponse block = ^(OSNotification *notification){
+         [self complete:notification];
      };
      return block;
  }
 
- - (void)complete:(OSNotificationDisplayType)displayType {
+ - (void)complete:(OSNotification *)notification {
      [_timeoutTimer invalidate];
      if (_completion) {
-         _completion(displayType);
+         _completion(notification);
          _completion = nil;
      }
  }
@@ -269,7 +269,7 @@
  - (void)timeoutTimerFired:(NSTimer *)timer {
      [OneSignal onesignal_Log:ONE_S_LL_ERROR
      message:[NSString stringWithFormat:@"Notification willShowInForeground completion timed out. Completion was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
-     [self complete:OSNotificationDisplayTypeNotification];
+     [self complete:self];
  }
 
  - (void)dealloc {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -54,16 +54,6 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeActionTaken
 };
 
-/* The way a notification was displayed to the user */
-typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
-    
-    /* Notification is silent */
-    OSNotificationDisplayTypeSilent,
-    
-    /* iOS native notification display */
-    OSNotificationDisplayTypeNotification
-};
-
 @interface OSNotificationAction : NSObject
 
 /* The type of the notification action */
@@ -214,7 +204,8 @@ typedef NS_ENUM(NSUInteger, OSNotificationDisplayType) {
 - (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
 @end
 
-typedef void (^OSNotificationDisplayTypeResponse)(OSNotificationDisplayType displayType);
+// Pass in nil means a notification will not display
+typedef void (^OSNotificationDisplayResponse)(OSNotification* _Nullable  notification);
 /* OneSignal Influence Types */
 typedef NS_ENUM(NSUInteger, Session) {
     DIRECT,
@@ -462,7 +453,7 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 #pragma mark Public Handlers
 
 // If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired.
-typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull notification, OSNotificationDisplayTypeResponse _Nonnull completion);
+typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull notification, OSNotificationDisplayResponse _Nonnull completion);
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull result);
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -46,8 +46,7 @@
 + (void)handleNotificationOpened:(NSDictionary*)messageDict
                       foreground:(BOOL)foreground
                         isActive:(BOOL)isActive
-                      actionType:(OSNotificationActionType)actionType
-                     displayType:(OSNotificationDisplayType)displayType;
+                      actionType:(OSNotificationActionType)actionType;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -44,8 +44,8 @@
 
 + (void)setNotificationOpenedBlock:(OSNotificationOpenedBlock)block;
 + (void)setNotificationWillShowInForegroundBlock:(OSNotificationWillShowInForegroundBlock)block;
-+ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType;
++ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion;
++ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID;
 + (BOOL)handleIAMPreview:(OSNotification *)notification;
 
 // - iOS 10

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -326,13 +326,13 @@ OneSignalWebView *webVC;
     return userInfo;
 }
 
-+ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification displayType:(OSNotificationDisplayType)displayType completion:(OSNotificationDisplayTypeResponse)completion {
++ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion {
     [notification setCompletionBlock:completion];
     if (notificationWillShowInForegroundHandler) {
         [notification startTimeoutTimer];
         notificationWillShowInForegroundHandler(notification, [notification getCompletionBlock]);
     } else {
-        completion(displayType);
+        completion(notification);
     }
 }
 
@@ -343,7 +343,7 @@ OneSignalWebView *webVC;
     return payload[@"custom"][@"i"] || payload[@"os_data"][@"i"];
 }
 
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID displayType:(OSNotificationDisplayType)displayType {
++ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID {
     if (![self isOneSignalPayload:lastMessageReceived])
         return;
     
@@ -358,7 +358,7 @@ OneSignalWebView *webVC;
     
     [OneSignalTrackFirebaseAnalytics trackOpenEvent:result];
     
-    if (!notificationOpenedHandler || displayType == OSNotificationDisplayTypeSilent)
+    if (!notificationOpenedHandler)
         return;
     notificationOpenedHandler(result);
 }


### PR DESCRIPTION
This PR removes `OSNotificationDisplayType` and has the `willShowInForegroundHandler` completion block take an optional `OSNotification` instead of a display type. This allows us to not need a major release to support modifying the notification content from the App itself (not the NSE) if Apple allows us to do so in the future.

`OSNotificationDisplayTypeResponse` is replaced by `OSNotificationDisplayResponse` which takes an optional OSNotification instead of an OSNotificationDisplayType. If an app wants to make a notification silent it will pass nil to the completion handler. If it wants to display the notification it will pass the notification in the completion handler.

`typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull notification, OSNotificationDisplayResponse _Nonnull completion);`

`typedef void (^OSNotificationDisplayResponse)(OSNotification* _Nullable  notification);`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/749)
<!-- Reviewable:end -->
