### PR TITLE
Fixing the opened handler not being called while the App is active

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1933,18 +1933,19 @@ static NSString *_lastnonActiveMessageId;
     [OneSignalHelper lastMessageReceived:messageDict];
     
     BOOL isPreview = [[OSNotification parseWithApns:messageDict] additionalData][ONESIGNAL_IAM_PREVIEW] != nil;
-    if (isPreview && [OneSignalHelper isIOSVersionLessThan:@"10.0"])
+    if (isPreview && [OneSignalHelper isIOSVersionLessThan:@"10.0"]) {
         return;
-
-    // Prevent duplicate calls
-    let newId = [self checkForProcessedDups:customDict lastMessageId:_lastnonActiveMessageId];
-    if ([@"dup" isEqualToString:newId])
-        return;
-    if (newId)
-        _lastnonActiveMessageId = newId;
-
-
+    }
+    
     if (opened) {
+        // Prevent duplicate calls
+        let newId = [self checkForProcessedDups:customDict lastMessageId:_lastnonActiveMessageId];
+        if ([@"dup" isEqualToString:newId]) {
+            [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Duplicate notif received. Not calling opened handler."];
+            return;
+        }
+        if (newId)
+            _lastnonActiveMessageId = newId;
         //app was in background / not running and opened due to a tap on a notification or an action check what type
         OSNotificationActionType type = OSNotificationActionTypeOpened;
 

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -171,7 +171,7 @@ static NSArray* delegateSubclasses = nil;
 
     if ([OneSignal appId]) {
         let isActive = [application applicationState] == UIApplicationStateActive;
-        [OneSignal notificationReceived:userInfo foreground:isActive isActive:isActive wasOpened:true];
+        [OneSignal notificationReceived:userInfo foreground:isActive isActive:isActive wasOpened:YES];
     }
     
     if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)])

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1052,6 +1052,8 @@
     let notifCenter = UNUserNotificationCenter.currentNotificationCenter;
     let notifCenterDelegate = notifCenter.delegate;
     
+    UIApplicationOverrider.currentUIApplicationState = UIApplicationStateActive;
+    
     // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
     [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -1083,8 +1085,8 @@
     [UnitTestCommonMethods initOneSignalWithHanders_andThreadWait:^(OSNotification *notif, OSNotificationDisplayResponse completion) {
         receivedWasFire = true;
         // TODO: Fix this unit test since generation jobs do not have action buttons
-        //let actionButons = @[ @{@"id": @"id1", @"text": @"text1"} ];
-        //XCTAssertEqualObjects(notifJob.actionButtons, actionButons);
+        let actionButons = @[ @{@"id": @"id1", @"text": @"text1"} ];
+        XCTAssertEqualObjects(notif.actionButtons, actionButons);
     } notificationOpenedHandler:nil];
     
     let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];


### PR DESCRIPTION
This PR fixes the opened handler not being called when the app is in the foreground. Previously it would be considered a duplicate call to the opened handler even if it had not been called before

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/750)
<!-- Reviewable:end -->

