### PR TITLE
Default auto prompt false

### DIFF
--- a/Examples/ObjectiveCExample/OneSignalDemo/AppDelegate.m
+++ b/Examples/ObjectiveCExample/OneSignalDemo/AppDelegate.m
@@ -90,7 +90,7 @@
     };
     
     // (Optional) - Configuration options for OneSignal settings.
-    id oneSignalSettings = @{kOSSettingsKeyInAppLaunchURL : @NO, kOSSettingsKeyAutoPrompt : @YES};
+    id oneSignalSettings = @{kOSSettingsKeyInAppLaunchURL : @NO};
     
     // (REQUIRED) - Initializes OneSignal
     [OneSignal initWithLaunchOptions:launchOptions];

--- a/Examples/SwiftExample/OneSignalDemo/AppDelegate.swift
+++ b/Examples/SwiftExample/OneSignalDemo/AppDelegate.swift
@@ -96,7 +96,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, OSPermissionObserver, OSS
             }
         }
 
-        let onesignalInitSettings = [kOSSettingsKeyAutoPrompt: false, kOSSettingsKeyInAppLaunchURL: true,]
+        let onesignalInitSettings = [kOSSettingsKeyInAppLaunchURL: true,]
         
         OneSignal.setAppId("3beb3078-e0f1-4629-af17-fde833b9f716")
         OneSignal.initWithLaunchOptions(launchOptions)

--- a/Examples/SwiftExample/OneSignalDemo/ViewController.swift
+++ b/Examples/SwiftExample/OneSignalDemo/ViewController.swift
@@ -144,7 +144,6 @@ class ViewController: UIViewController, OSPermissionObserver, OSSubscriptionObse
         let hasPrompted = status.permissionStatus.hasPrompted
         if hasPrompted == false {
             // Call when you want to prompt the user to accept push notifications.
-            // Only call once and only if you set kOSSettingsKeyAutoPrompt in AppDelegate to false.
             OneSignal.promptForPushNotifications(userResponse: { accepted in
                 if accepted == true {
                     print("User accepted notifications: \(accepted)")

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -76,7 +76,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     // OneSignal Init with app settings, app id, and lauch options
     [OneSignal setAppSettings:@{
-        kOSSettingsKeyAutoPrompt: @false,
         kOSSettingsKeyInAppLaunchURL: @true
     }];
     [OneSignal setAppId:[AppDelegate getOneSignalAppId]];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -385,9 +385,6 @@ typedef void (^OSFailureBlock)(NSError* error);
 typedef void (^OSSendOutcomeSuccess)(OSOutcomeEvent* outcome);
 
 /*Dictionary of keys to pass alongside the init settings*/
-    
-/*Let OneSignal directly prompt for push notifications on init*/
-extern NSString * const kOSSettingsKeyAutoPrompt;
 
 /*Enable In-App display of Launch URLs*/
 extern NSString * const kOSSettingsKeyInAppLaunchURL;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -702,7 +702,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         [self enableInAppLaunchURL:true];
     }
     
-    usesAutoPrompt = YES;
+    usesAutoPrompt = NO;
     if (settings[kOSSettingsKeyAutoPrompt] && [settings[kOSSettingsKeyAutoPrompt] isKindOfClass:[NSNumber class]])
         usesAutoPrompt = [settings[kOSSettingsKeyAutoPrompt] boolValue];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -92,8 +92,6 @@
 static ONE_S_LOG_LEVEL _nsLogLevel = ONE_S_LL_WARN;
 static ONE_S_LOG_LEVEL _visualLogLevel = ONE_S_LL_NONE;
 
-NSString* const kOSSettingsKeyAutoPrompt = @"kOSSettingsKeyAutoPrompt";
-
 /* Enable the default in-app launch urls*/
 NSString* const kOSSettingsKeyInAppLaunchURL = @"kOSSettingsKeyInAppLaunchURL";
 
@@ -702,9 +700,8 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         [self enableInAppLaunchURL:true];
     }
     
+    // Always NO, can be cleaned up in a future commit
     usesAutoPrompt = NO;
-    if (settings[kOSSettingsKeyAutoPrompt] && [settings[kOSSettingsKeyAutoPrompt] isKindOfClass:[NSNumber class]])
-        usesAutoPrompt = [settings[kOSSettingsKeyAutoPrompt] boolValue];
     
     if (settings[kOSSettingsKeyProvidesAppNotificationSettings] && [settings[kOSSettingsKeyProvidesAppNotificationSettings] isKindOfClass:[NSNumber class]] && [OneSignalHelper isIOSVersionGreaterThanOrEqual:@"12.0"])
         providesAppNotificationSettings = [settings[kOSSettingsKeyProvidesAppNotificationSettings] boolValue];

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -95,7 +95,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 }
 
 - (void)testSetAuthenticatedEmail {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     [OneSignal setEmail:@"test@test.com"
@@ -138,7 +137,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 }
 
 - (void)testUnauthenticatedEmail {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     [OneSignal setEmail:@"test@test.com"
@@ -183,7 +181,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 }
 
 - (void)testInvalidEmail {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     let expectation = [self expectationWithDescription:@"email"];
@@ -223,7 +220,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 - (void)testRequiresEmailAuth {
     [OneSignalClientOverrider setRequiresEmailAuth:true];
     
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     let expectation = [self expectationWithDescription:@"email"];
@@ -256,7 +252,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 }
 
 - (void)testDoesNotRequireEmailAuth {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     let expectation = [self expectationWithDescription:@"email"];
@@ -293,7 +288,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 - (void)testSubscriptionState {
     [OneSignalClientOverrider setRequiresEmailAuth:true];
     
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     let unsubscribedSubscriptionStatus = [OneSignal getPermissionSubscriptionState].emailSubscriptionStatus;
@@ -341,7 +335,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     
     [OneSignalClientOverrider setRequiresEmailAuth:true];
     
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     let expectation = [self expectationWithDescription:@"email"];
@@ -434,7 +427,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 }
 
 - (void)testRegistration {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     [OneSignalClientOverrider setRequiresEmailAuth:true];
@@ -470,7 +462,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     let observer = [OSEmailSubscriptionStateTestObserver new];
     [OneSignal addEmailSubscriptionObserver:observer];
     
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     let expectation = [self expectationWithDescription:@"email"];
@@ -492,7 +483,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 }
 
 - (void)testSetExternalIdForEmailPlayer {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     [OneSignal setEmail:@"test@test.com"];

--- a/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
@@ -88,8 +88,7 @@
         
         OSSubscriptionStateTestObserver *subscriptionObserver = [OSSubscriptionStateTestObserver new];
         [OneSignal addSubscriptionObserver:subscriptionObserver];
-        
-        [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
+
         [UnitTestCommonMethods initOneSignal_andThreadWait];
         
         let state = [OneSignal getPermissionSubscriptionState];
@@ -126,7 +125,6 @@
         OSPermissionStateTestObserver* observer = [self setupProvisionalTest];
         [UNUserNotificationCenterOverrider setShouldSetProvisionalAuthorizationStatus:true];
 
-        [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
         [UnitTestCommonMethods initOneSignal_andThreadWait];
         
         [UNUserNotificationCenterOverrider fireLastRequestAuthorizationWithGranted:true];
@@ -165,8 +163,7 @@
 - (void)testProvisionalOverridenByAutoPrompt {
     if (@available(iOS 12, *)) {
         OSPermissionStateTestObserver* observer = [self setupProvisionalTest];
-        
-        [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
+
         [UnitTestCommonMethods initOneSignal_andThreadWait];
         
         //ensure the SDK did not request provisional authorization
@@ -189,7 +186,6 @@
         OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
         [OneSignal addPermissionObserver:observer];
         
-        [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
         [UnitTestCommonMethods initOneSignal_andThreadWait];
         
         //ensure the SDK did not request provisional authorization
@@ -203,7 +199,6 @@
 - (void)testOSDeviceHasEmailAddress {
     NSString *testEmail = @"test@onesignal.com";
     
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
     XCTAssertNil([OneSignal getDeviceState].emailAddress);
@@ -217,7 +212,6 @@
 - (void)testOSDeviceHasEmailId {
     NSString *testEmail = @"test@onesignal.com";
     
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
     XCTAssertNil([OneSignal getDeviceState].emailAddress);
@@ -229,42 +223,36 @@
 }
 
 - (void)testOSDeviceHasUserId {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertNotNil([OneSignal getDeviceState].userId);
 }
 
 - (void)testOSDeviceHasPushToken {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertNotNil([OneSignal getDeviceState].pushToken);
 }
 
 - (void)testOSDeviceSubscribed {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertTrue([OneSignal getDeviceState].isSubscribed);
 }
 
 - (void)testOSDeviceUserSubscribed {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertFalse([OneSignal getDeviceState].isPushDisabled);
 }
 
 - (void)testOSDeviceNotificationReachable {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertTrue([OneSignal getDeviceState].hasNotificationPermission);
 }
 
 - (void)testOSDeviceHasNotificationPermissionStatus {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertEqual(OSNotificationPermissionAuthorized, [OneSignal getDeviceState].notificationPermissionStatus);

--- a/iOS_SDK/OneSignalSDK/UnitTests/RemoteParamsTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RemoteParamsTests.m
@@ -216,7 +216,6 @@
 }
 
 - (void)assertUserConsent {
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
     [OneSignal initWithLaunchOptions:nil];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -384,7 +384,6 @@
     OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
     [OneSignal addPermissionObserver:observer];
 
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     
@@ -394,7 +393,6 @@
     // Restart App
     [UnitTestCommonMethods clearStateForAppRestart:self];
 
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     
     observer = [OSPermissionStateTestObserver new];
@@ -407,7 +405,6 @@
 
 - (void)testPermissionChangeObserverDontLoseFromChanges {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     [self registerForPushNotifications];
@@ -458,7 +455,6 @@
 
 - (void)testPermissionChangeObserverWithNativeiOS10PromptCall {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     
     OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
@@ -514,7 +510,6 @@
 - (void)testDeliverQuietly {
     [OneSignalUNUserNotificationCenter setUseiOS10_2_workaround:false];
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     
     OSPermissionStateTestObserver* observer = [OSPermissionStateTestObserver new];
@@ -564,7 +559,6 @@
 
 - (void)testPermissionAndSubscriptionChangeObserverRemove {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     
     OSPermissionStateTestObserver* permissionObserver = [OSPermissionStateTestObserver new];
@@ -585,7 +579,6 @@
 
 - (void)testSubscriptionChangeObserverBasic {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     
     OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
@@ -715,7 +708,6 @@
 - (void)testNotificationTypesWhenAlreadyAcceptedWithAutoPromptOffOnFristStartPreIos10 {
     OneSignalHelperOverrider.mockIOSVersion = 9;
     [UnitTestCommonMethods setCurrentNotificationPermission:true];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @7);
@@ -724,7 +716,6 @@
 
 - (void)testNeverPromptedStatus {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     
     [UnitTestCommonMethods runBackgroundThreads];
@@ -1756,7 +1747,6 @@ didReceiveRemoteNotification:userInfo
 -(void)testDelayedSubscriptionUpdate {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
 
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
     [OneSignal initWithLaunchOptions:nil];
     
@@ -1810,7 +1800,6 @@ didReceiveRemoteNotification:userInfo
     
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
 
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
     [OneSignal initWithLaunchOptions:nil];
     
@@ -2057,7 +2046,6 @@ didReceiveRemoteNotification:userInfo
     //set up the test so that the user has declined the prompt.
     //we can then call prompt with Settings fallback.
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
     [OneSignal initWithLaunchOptions:nil];
     
@@ -2115,7 +2103,6 @@ didReceiveRemoteNotification:userInfo
     // do not answer the prompt (apns will not respond)
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
 
-    [OneSignal setAppSettings:@{kOSSettingsKeyAutoPrompt: @false}];
     [UnitTestCommonMethods initOneSignal];
     [UnitTestCommonMethods foregroundApp];
     [UnitTestCommonMethods runBackgroundThreads];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -698,6 +698,7 @@
 
 - (void)testPromptedButNeveranswerNotificationPrompt {
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
+    [OneSignal promptForPushNotificationsWithUserResponse:nil];
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
     // Don't make a network call right away
@@ -739,6 +740,7 @@
     [UnitTestCommonMethods setCurrentNotificationPermissionAsUnanswered];
     [self backgroundModesDisabledInXcode];
     [UnitTestCommonMethods initOneSignal];
+    [OneSignal promptForPushNotificationsWithUserResponse:nil];
 
     // Testing network call is not being made from the main thread.
     XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest);


### PR DESCRIPTION
## Dropped kOSSettingsKeyAutoPrompt
This change defaults the logic of `kOSSettingsKeyAutoPrompt` to `false` and drops the public API.
Removed `kOSSettingsKeyAutoPrompt` internally but kept `usesAutoPrompt` in this PR to minimize logic changes.
It can be cleaned up in a future PR where more testing can be done

## Reviewer
Recommend reviewing commit by commit

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/751)
<!-- Reviewable:end -->

