### PR TITLE
Default `kOSSettingsKeyInAppLaunchURL` to `false`

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -808,7 +808,7 @@ static OneSignal* singleInstance = nil;
 
 + (void)displayWebView:(NSURL*)url {
     // Check if in-app or safari
-    __block BOOL inAppLaunch = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL defaultValue:true];
+    __block BOOL inAppLaunch = [OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL defaultValue:false];
     
     // If the URL contains itunes.apple.com, it's an app store link
     // that should be opened using sharedApplication openURL


### PR DESCRIPTION
`kOSSettingsKeyInAppLaunchURL: false` has been part of the [OneSignal setup guide](https://documentation.onesignal.com/docs/ios-sdk-setup#step-5---add-the-onesignal-initialization-code) for a while.
Changing the default to `false` means we no longer need to include this in the setup instructions.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/752)
<!-- Reviewable:end -->

