### PR TITLE
Rename setsubscription to disablePush

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -153,7 +153,7 @@
 
 - (IBAction)subscriptionSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller subscription status: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal setSubscription:(bool) sender.selectedSegmentIndex];
+    [OneSignal disablePush:(bool) !sender.selectedSegmentIndex];
 }
 
 - (IBAction)locationSharedSegmentedControlValueChanged:(UISegmentedControl *)sender {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -406,7 +406,7 @@ extern NSString* const ONESIGNAL_VERSION;
 + (NSString* _Nonnull)sdkVersionRaw;
 + (NSString* _Nonnull)sdkSemanticVersion;
 
-+ (void)setSubscription:(BOOL)enable;
++ (void)disablePush:(BOOL)disable;
 
 + (NSString* _Nonnull)parseNSErrorAsJsonString:(NSError* _Nonnull)error;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1377,20 +1377,20 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL withValue:enable];
 }
 
-+ (void)setSubscription:(BOOL)enable {
++ (void)disablePush:(BOOL)disable {
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"setSubscription:"])
         return;
 
     NSString* value = nil;
-    if (!enable)
+    if (disable)
         value = @"no";
     
     [OneSignalUserDefaults.initStandard saveObjectForKey:OSUD_USER_SUBSCRIPTION_TO withValue:value];
     
     shouldDelaySubscriptionUpdate = true;
     
-    self.currentSubscriptionState.userSubscriptionSetting = enable;
+    self.currentSubscriptionState.userSubscriptionSetting = !disable;
     
     if (appId)
         [OneSignal sendNotificationTypesUpdate];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -266,7 +266,7 @@
     [UnitTestCommonMethods setCurrentNotificationPermission:true];
     
     [OneSignal sendTag:@"key" value:@"value"];
-    [OneSignal setSubscription:true];
+    [OneSignal disablePush:false];
     [OneSignal promptLocation];
     [OneSignal promptForPushNotificationsWithUserResponse:nil];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -284,7 +284,7 @@
     [UnitTestCommonMethods clearStateForAppRestart:self];
     
     [OneSignal sendTag:@"key" value:@"value"];
-    [OneSignal setSubscription:true];
+    [OneSignal disablePush:false];
     [OneSignal promptLocation];
     [OneSignal promptForPushNotificationsWithUserResponse:nil];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -591,7 +591,7 @@
     XCTAssertEqual(observer->last.from.subscribed, false);
     XCTAssertEqual(observer->last.to.subscribed, true);
     
-    [OneSignal setSubscription:false];
+    [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(observer->last.from.subscribed, true);
@@ -614,7 +614,7 @@
     XCTAssertEqualObjects(observer->last.to.userId, @"1234");
     XCTAssertFalse(observer->last.to.subscribed);
     
-    [OneSignal setSubscription:false];
+    [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertTrue(observer->last.from.userSubscriptionSetting);
@@ -635,7 +635,7 @@
     XCTAssertFalse(observer->last.to.subscribed);
     
     // Device should be reported a subscribed now as all conditions are true.
-    [OneSignal setSubscription:true];
+    [OneSignal disablePush:false];
     [UnitTestCommonMethods runBackgroundThreads];
     XCTAssertFalse(observer->last.from.subscribed);
     XCTAssertTrue(observer->last.to.subscribed);
@@ -1759,7 +1759,7 @@ didReceiveRemoteNotification:userInfo
     [NSObjectOverrider runPendingSelectors];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    [OneSignal setSubscription:false];
+    [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Prompt and accept notifications
@@ -1773,7 +1773,7 @@ didReceiveRemoteNotification:userInfo
     
     // Device should be reported a subscribed now as all condiditions are true.
     [OneSignalClientOverrider setShouldExecuteInstantaneously:false];
-    [OneSignal setSubscription:true];
+    [OneSignal disablePush:false];
     
     [OneSignalClientOverrider setShouldExecuteInstantaneously:true];
     XCTAssertFalse(observer->last.to.subscribed);
@@ -1815,7 +1815,7 @@ didReceiveRemoteNotification:userInfo
     XCTAssertNil(observer->last.to.userId);
     XCTAssertFalse(observer->last.to.subscribed);
     
-    [OneSignal setSubscription:true];
+    [OneSignal disablePush:false];
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertFalse(observer->last.from.userSubscriptionSetting);


### PR DESCRIPTION
Renaming setSubscription to disablePush and inverting the logic

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/754)
<!-- Reviewable:end -->

