### PR TITLE
remove public getPermissionSubscriptionState and move to internal header

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
@@ -27,6 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import "OneSignal.h"
+#import "OneSignalInternal.h"
 #import "OneSignalHelper.h"
 #import "OneSignalCommonDefines.h"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -498,7 +498,6 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 
 #pragma mark Permission, Subscription, and Email Observers
 NS_ASSUME_NONNULL_BEGIN
-+ (OSPermissionSubscriptionState*)getPermissionSubscriptionState;
 
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -83,6 +83,8 @@
 @property (class) OSSessionManager* sessionManager;
 @property (class) OneSignalOutcomeEventsController* outcomeEventsController;
 
++ (OSPermissionSubscriptionState*)getPermissionSubscriptionState;
+
 @end
 
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -44,6 +44,7 @@
 #import "NSUserDefaultsOverrider.h"
 #import "OneSignalCommonDefines.h"
 #import "OneSignalTracker.h"
+#import "OneSignalInternal.h"
 
 @interface OneSignalTracker ()
 + (void)setLastOpenedTime:(NSTimeInterval)lastOpened;

--- a/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/ProvisionalAuthorizationTests.m
@@ -33,15 +33,12 @@
 #import "UNUserNotificationCenter+OneSignal.h"
 #import "OneSignalHelperOverrider.h"
 #import "OneSignalHelper.h"
+#import "OneSignalInternal.h"
 #import "OneSignalCommonDefines.h"
 #import "OneSignalClientOverrider.h"
 
 @interface ProvisionalAuthorizationTests : XCTestCase
 
-@end
-
-@interface OSPermissionState ()
-@property (nonatomic) BOOL provisional;
 @end
 
 @implementation ProvisionalAuthorizationTests


### PR DESCRIPTION
This PR removes the public api for `getPermissionSubscriptionState`

This method interface has been moved to onesignal internal for now. If we want to stop using it internally we can now do so without a breaking change.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/765)
<!-- Reviewable:end -->

