### PR TITLE
Fixing XCWorkspace

### DIFF
--- a/iOS_SDK/OneSignalSDK.xcworkspace/contents.xcworkspacedata
+++ b/iOS_SDK/OneSignalSDK.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:OneSignalDevApp/OneSignalDevApp.xcodeproj">
+      location = "group:OneSignalDevApp/OneSignalExample.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:OneSignalSDK/OneSignal.xcodeproj">


### PR DESCRIPTION
The workspace was broken because it was referencing the old xcodeproject. This fixes the issue

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/771)
<!-- Reviewable:end -->

