### PR TITLE
Fixing IAM Preview

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1951,6 +1951,9 @@ static NSString *_lastnonActiveMessageId;
 
         // Call Action Block
         [OneSignal handleNotificationOpened:messageDict foreground:foreground isActive:isActive actionType:type];
+    } else if (isPreview) {
+        let notification = [OSNotification parseWithApns:messageDict];
+        [OneSignalHelper handleIAMPreview:notification];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1930,10 +1930,7 @@ static NSString *_lastnonActiveMessageId;
     [OneSignalHelper lastMessageReceived:messageDict];
     
     BOOL isPreview = [[OSNotification parseWithApns:messageDict] additionalData][ONESIGNAL_IAM_PREVIEW] != nil;
-    if (isPreview && [OneSignalHelper isIOSVersionLessThan:@"10.0"]) {
-        return;
-    }
-
+    
     if (opened) {
         // Prevent duplicate calls
         let newId = [self checkForProcessedDups:customDict lastMessageId:_lastnonActiveMessageId];
@@ -1951,7 +1948,7 @@ static NSString *_lastnonActiveMessageId;
 
         // Call Action Block
         [OneSignal handleNotificationOpened:messageDict foreground:foreground isActive:isActive actionType:type];
-    } else if (isPreview) {
+    } else if (isPreview && [OneSignalHelper isIOSVersionGreaterThanOrEqual:@"10.0"]) {
         let notification = [OSNotification parseWithApns:messageDict];
         [OneSignalHelper handleIAMPreview:notification];
     }


### PR DESCRIPTION
IAM Previews were not being displayed due to reworking notification received as part of the Major Release. This PR displays previews in OneSignal.m's `notificationReceived`

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/772)
<!-- Reviewable:end -->

