### PR TITLE
Matching iOS and Android state class property names

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -121,7 +121,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 - (void) onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
     NSLog(@"onOSSubscriptionChanged: %@", stateChanges);
     ViewController* mainController = (ViewController*) self.window.rootViewController;
-    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.subscribed;
+    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.isSubscribed;
 }
 
 - (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -118,7 +118,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 - (void) onOSSubscriptionChanged:(OSSubscriptionStateChanges*)stateChanges {
     NSLog(@"onOSSubscriptionChanged: %@", stateChanges);
     ViewController* mainController = (ViewController*) self.window.rootViewController;
-    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.subscribed;
+    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.isSubscribed;
 }
 
 - (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {

--- a/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
@@ -44,7 +44,7 @@
         
         _isPushDisabled = ![[state subscriptionStatus] userSubscriptionSetting];
         
-        _isSubscribed = [[state subscriptionStatus] subscribed];
+        _isSubscribed = [[state subscriptionStatus] isSubscribed];
         
         _notificationPermissionStatus = [[state permissionStatus] status];
         

--- a/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
@@ -55,6 +55,8 @@
         _emailUserId = [[state emailSubscriptionStatus] emailUserId];
         
         _emailAddress = [[state emailSubscriptionStatus] emailAddress];
+        
+        _isEmailSubscribed = [[state emailSubscriptionStatus] isSubscribed];
     }
     return self;
 }
@@ -70,6 +72,7 @@
     json[@"pushToken"] = _pushToken;
     json[@"emailUserId"] = _emailUserId;
     json[@"emailAddress"] = _emailAddress;
+    json[@"isEmailSubscribed"] = @(_isEmailSubscribed);
     json[@"notificationPermissionStatus"] = @(_notificationPermissionStatus);
 
     return json;

--- a/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSDeviceState.m
@@ -42,7 +42,7 @@
     if (self) {
         _hasNotificationPermission = [[state permissionStatus] reachable];
         
-        _isPushDisabled = ![[state subscriptionStatus] userSubscriptionSetting];
+        _isPushDisabled = [[state subscriptionStatus] isPushDisabled];
         
         _isSubscribed = [[state subscriptionStatus] isSubscribed];
         

--- a/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
@@ -48,7 +48,7 @@
     return self;
 }
 
--(BOOL)subscribed {
+-(BOOL)isSubscribed {
     return self.emailUserId != nil;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -45,13 +45,13 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 
 // Redefine OSSubscriptionState
 @interface OSSubscriptionState () {
-@protected BOOL _userSubscriptionSetting;
+@protected BOOL _isPushDisabled;
 @protected NSString* _userId;
 @protected NSString* _pushToken;
 }
 
 // @property (readonly, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (readwrite, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (readwrite, nonatomic) BOOL isPushDisabled; // returns value of disablePush.
 @property (readwrite, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
 @property (readwrite, nonatomic) NSString* pushToken; // AKA Apple Device Token
 @property (nonatomic) ObservableSubscriptionStateType* observable;

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -47,7 +47,7 @@
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
     _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_TO defaultValue:nil];
     _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_TO defaultValue:nil];
-    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_TO];
+    _isPushDisabled = [standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_TO];
     
     return self;
 }
@@ -55,7 +55,7 @@
 - (BOOL)compare:(OSSubscriptionState*)from {
     return ![self.userId ?: @"" isEqualToString:from.userId ?: @""] ||
            ![self.pushToken ?: @"" isEqualToString:from.pushToken ?: @""] ||
-           self.userSubscriptionSetting != from.userSubscriptionSetting ||
+           self.isPushDisabled != from.isPushDisabled ||
            self.accpeted != from.accpeted;
 }
 
@@ -64,14 +64,14 @@
     _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_FROM defaultValue:false];
     _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_FROM defaultValue:nil];
     _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_FROM defaultValue:nil];
-    _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_FROM];
+    _isPushDisabled = [standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_FROM];
     
     return self;
 }
 
 - (void)persistAsFrom {
     NSString* strUserSubscriptionSetting = nil;
-    if (!_userSubscriptionSetting)
+    if (_isPushDisabled)
         strUserSubscriptionSetting = @"no";
     
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
@@ -87,7 +87,7 @@
     if (copy) {
         copy->_userId = [_userId copy];
         copy->_pushToken = [_pushToken copy];
-        copy->_userSubscriptionSetting = _userSubscriptionSetting;
+        copy->_isPushDisabled = _isPushDisabled;
         copy->_accpeted = _accpeted;
     }
     
@@ -116,9 +116,9 @@
     }
 }
 
-- (void)setUserSubscriptionSetting:(BOOL)userSubscriptionSetting {
-    BOOL changed = userSubscriptionSetting != _userSubscriptionSetting;
-    _userSubscriptionSetting = userSubscriptionSetting;
+- (void)setIsPushDisabled:(BOOL)isPushDisabled {
+    BOOL changed = isPushDisabled != _isPushDisabled;
+    _isPushDisabled = isPushDisabled;
     if (self.observable && changed)
         [self.observable notifyChange:self];
 }
@@ -142,20 +142,20 @@
 }
 
 - (BOOL)isSubscribed {
-    return _userId && _pushToken && _userSubscriptionSetting && _accpeted;
+    return _userId && _pushToken && !_isPushDisabled && _accpeted;
 }
 
 - (NSString*)description {
     static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, userSubscriptionSetting: %d, subscribed: %d>";
-    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.userSubscriptionSetting, self.isSubscribed];
+    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.isPushDisabled, self.isSubscribed];
 }
 
 - (NSDictionary*)toDictionary {
     return @{
          @"userId": _userId ?: [NSNull null],
          @"pushToken": _pushToken ?: [NSNull null],
-         @"userSubscriptionSetting": @(_userSubscriptionSetting),
-         @"subscribed": @(self.isSubscribed)
+         @"isPushDisabled": @(_isPushDisabled),
+         @"isSubscribed": @(self.isSubscribed)
      };
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -125,7 +125,7 @@
 
 
 - (void)setAccepted:(BOOL)inAccpeted {
-    BOOL lastSubscribed = self.subscribed;
+    BOOL lastSubscribed = self.isSubscribed;
     
     // checks to see if we should delay the observer update
     // This is to prevent a problem where the observer gets updated
@@ -137,17 +137,17 @@
     }
     
     _accpeted = inAccpeted;
-    if (lastSubscribed != self.subscribed)
+    if (lastSubscribed != self.isSubscribed)
         [self.observable notifyChange:self];
 }
 
-- (BOOL)subscribed {
+- (BOOL)isSubscribed {
     return _userId && _pushToken && _userSubscriptionSetting && _accpeted;
 }
 
 - (NSString*)description {
     static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, userSubscriptionSetting: %d, subscribed: %d>";
-    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.userSubscriptionSetting, self.subscribed];
+    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.userSubscriptionSetting, self.isSubscribed];
 }
 
 - (NSDictionary*)toDictionary {
@@ -155,7 +155,7 @@
          @"userId": _userId ?: [NSNull null],
          @"pushToken": _pushToken ?: [NSNull null],
          @"userSubscriptionSetting": @(_userSubscriptionSetting),
-         @"subscribed": @(self.subscribed)
+         @"subscribed": @(self.isSubscribed)
      };
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -64,7 +64,7 @@
     _accpeted = [standardUserDefaults getSavedBoolForKey:OSUD_PERMISSION_ACCEPTED_FROM defaultValue:false];
     _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_FROM defaultValue:nil];
     _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_FROM defaultValue:nil];
-    _isPushDisabled = [standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_FROM];
+    _isPushDisabled = ![standardUserDefaults getSavedBoolForKey:OSUD_USER_SUBSCRIPTION_FROM defaultValue:NO];
     
     return self;
 }
@@ -146,7 +146,7 @@
 }
 
 - (NSString*)description {
-    static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, userSubscriptionSetting: %d, subscribed: %d>";
+    static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, isPushDisabled: %d, isSubscribed: %d>";
     return [NSString stringWithFormat:format, self.userId, self.pushToken, self.isPushDisabled, self.isSubscribed];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -287,7 +287,7 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 // Subscription Classes
 @interface OSSubscriptionState : NSObject
 
-@property (readonly, nonatomic) BOOL subscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
+@property (readonly, nonatomic) BOOL isSubscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
 @property (readonly, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
 @property (readonly, nonatomic, nullable) NSString* userId;    // AKA OneSignal PlayerId
 @property (readonly, nonatomic, nullable) NSString* pushToken; // AKA Apple Device Token
@@ -298,7 +298,7 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 @interface OSEmailSubscriptionState : NSObject
 @property (readonly, nonatomic, nullable) NSString* emailUserId; // The new Email user ID
 @property (readonly, nonatomic, nullable) NSString *emailAddress;
-@property (readonly, nonatomic) BOOL subscribed;
+@property (readonly, nonatomic) BOOL isSubscribed;
 - (NSDictionary* _Nonnull)toDictionary;
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -374,6 +374,8 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
  */
 @property (readonly, nullable) NSString* emailAddress;
 
+@property (readonly) BOOL isEmailSubscribed;
+
 - (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state;
 
 // Convert the class into a NSDictionary

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -288,7 +288,7 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 @interface OSSubscriptionState : NSObject
 
 @property (readonly, nonatomic) BOOL isSubscribed; // (yes only if userId, pushToken, and setSubscription exists / are true)
-@property (readonly, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
+@property (readonly, nonatomic) BOOL isPushDisabled; // returns value of disablePush.
 @property (readonly, nonatomic, nullable) NSString* userId;    // AKA OneSignal PlayerId
 @property (readonly, nonatomic, nullable) NSString* pushToken; // AKA Apple Device Token
 - (NSDictionary* _Nonnull)toDictionary;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1379,7 +1379,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 
 + (void)disablePush:(BOOL)disable {
     // return if the user has not granted privacy permissions
-    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"setSubscription:"])
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"disablePush:"])
         return;
 
     NSString* value = nil;
@@ -1390,7 +1390,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     
     shouldDelaySubscriptionUpdate = true;
     
-    self.currentSubscriptionState.userSubscriptionSetting = !disable;
+    self.currentSubscriptionState.isPushDisabled = disable;
     
     if (appId)
         [OneSignal sendNotificationTypesUpdate];
@@ -2096,7 +2096,7 @@ static NSString *_lastnonActiveMessageId;
     if (!permissionStatus.provisional && !permissionStatus.answeredPrompt)
         return ERROR_PUSH_PROMPT_NEVER_ANSWERED;
     
-    if (!self.currentSubscriptionState.userSubscriptionSetting)
+    if (self.currentSubscriptionState.isPushDisabled)
         return -2;
 
     return permissionStatus.notificationTypes;

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -296,7 +296,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     XCTAssertNil(unsubscribedSubscriptionStatus.emailAuthCode);
     XCTAssertNil(unsubscribedSubscriptionStatus.emailAddress);
     XCTAssertNil(unsubscribedSubscriptionStatus.emailUserId);
-    XCTAssertFalse(unsubscribedSubscriptionStatus.subscribed);
+    XCTAssertFalse(unsubscribedSubscriptionStatus.isSubscribed);
     
     let expectation = [self expectationWithDescription:@"email"];
     expectation.expectedFulfillmentCount = 2;
@@ -312,7 +312,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     XCTAssertEqual(loggedInSubscriptionStatus.emailUserId, @"1234");
     XCTAssertEqual(loggedInSubscriptionStatus.emailAddress, @"test@test.com");
     XCTAssertEqual(loggedInSubscriptionStatus.emailAuthCode, @"test-hash-token");
-    XCTAssertEqual(loggedInSubscriptionStatus.subscribed, true);
+    XCTAssertEqual(loggedInSubscriptionStatus.isSubscribed, true);
     
     [OneSignal logoutEmailWithSuccess:^{
         [expectation fulfill];
@@ -327,7 +327,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     XCTAssertNil(loggedOutSubscriptionStatus.emailAuthCode);
     XCTAssertNil(loggedOutSubscriptionStatus.emailAddress);
     XCTAssertNil(loggedOutSubscriptionStatus.emailUserId);
-    XCTAssertFalse(loggedOutSubscriptionStatus.subscribed);
+    XCTAssertFalse(loggedOutSubscriptionStatus.isSubscribed);
 }
 
 - (void)testEmailSubscriptionObserver {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -184,7 +184,7 @@
     NSLog(@"CURRENT USER ID: %@", status.subscriptionStatus);
     
     XCTAssertEqual(status.subscriptionStatus.isSubscribed, true);
-    XCTAssertEqual(status.subscriptionStatus.userSubscriptionSetting, true);
+    XCTAssertEqual(status.subscriptionStatus.isPushDisabled, false);
     XCTAssertEqual(status.subscriptionStatus.userId, @"1234");
     XCTAssertEqualObjects(status.subscriptionStatus.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
     
@@ -617,8 +617,8 @@
     [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertTrue(observer->last.from.userSubscriptionSetting);
-    XCTAssertFalse(observer->last.to.userSubscriptionSetting);
+    XCTAssertFalse(observer->last.from.isPushDisabled);
+    XCTAssertTrue(observer->last.to.isPushDisabled);
     // Device registered with OneSignal so now make pushToken available.
     XCTAssertEqualObjects(observer->last.to.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
     
@@ -1818,8 +1818,8 @@ didReceiveRemoteNotification:userInfo
     [OneSignal disablePush:false];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertFalse(observer->last.from.userSubscriptionSetting);
-    XCTAssertFalse(observer->last.to.userSubscriptionSetting);
+    XCTAssertFalse(observer->last.from.isPushDisabled);
+    XCTAssertFalse(observer->last.to.isPushDisabled);
     // Device registered with OneSignal so now make pushToken available.
     XCTAssertNil(observer->last.to.pushToken);
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2646,6 +2646,7 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(json[@"emailUserId"], @"1234");
     XCTAssertEqualObjects(json[@"emailAddress"], @"test@gmail.com");
     XCTAssertEqualObjects(json[@"notificationPermissionStatus"], @2);
+    XCTAssertEqualObjects(json[@"isEmailSubscribed"], @1);
 }
 
 - (void)testNotificationJson {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -438,7 +438,9 @@
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
     [OneSignal addSubscriptionObserver:observer];
-
+    [UnitTestCommonMethods runBackgroundThreads];
+    XCTAssertEqual(observer->last.to.isSubscribed, true);
+    
     // User kills app, turns off notifications, then opnes it agian.
     [UnitTestCommonMethods clearStateForAppRestart:self];
     [UnitTestCommonMethods setCurrentNotificationPermission:false];
@@ -449,7 +451,7 @@
     [OneSignal addSubscriptionObserver:observer];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(observer->last.from.isSubscribed, true);
+
     XCTAssertEqual(observer->last.to.isSubscribed, false);
 }
 
@@ -574,7 +576,8 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertNil(permissionObserver->last);
-    XCTAssertNil(subscriptionObserver->last);
+    XCTAssertTrue([[OneSignal getDeviceState] isSubscribed]);
+    XCTAssertFalse(subscriptionObserver->last.to.isSubscribed);
 }
 
 - (void)testSubscriptionChangeObserverBasic {
@@ -1815,11 +1818,11 @@ didReceiveRemoteNotification:userInfo
     XCTAssertNil(observer->last.to.userId);
     XCTAssertFalse(observer->last.to.isSubscribed);
     
-    [OneSignal disablePush:false];
+    [OneSignal disablePush:true]; //This should not result in a a change in state because we are waiting on privacy
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertFalse(observer->last.from.isPushDisabled);
-    XCTAssertFalse(observer->last.to.isPushDisabled);
+    XCTAssertTrue(observer->last.from.isPushDisabled); //Initial from is that push is disabled
+    XCTAssertFalse(observer->last.to.isPushDisabled); //Default value after adding an observer is that push is not disabled
     // Device registered with OneSignal so now make pushToken available.
     XCTAssertNil(observer->last.to.pushToken);
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -183,13 +183,13 @@
     
     NSLog(@"CURRENT USER ID: %@", status.subscriptionStatus);
     
-    XCTAssertEqual(status.subscriptionStatus.subscribed, true);
+    XCTAssertEqual(status.subscriptionStatus.isSubscribed, true);
     XCTAssertEqual(status.subscriptionStatus.userSubscriptionSetting, true);
     XCTAssertEqual(status.subscriptionStatus.userId, @"1234");
     XCTAssertEqualObjects(status.subscriptionStatus.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
     
     //email has not been set so the email properties should be nil
-    XCTAssertFalse(status.emailSubscriptionStatus.subscribed);
+    XCTAssertFalse(status.emailSubscriptionStatus.isSubscribed);
     XCTAssertNil(status.emailSubscriptionStatus.emailUserId);
     XCTAssertNil(status.emailSubscriptionStatus.emailAddress);
     
@@ -428,8 +428,8 @@
     [OneSignal addSubscriptionObserver:observer];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(observer->last.from.subscribed, false);
-    XCTAssertEqual(observer->last.to.subscribed, true);
+    XCTAssertEqual(observer->last.from.isSubscribed, false);
+    XCTAssertEqual(observer->last.to.isSubscribed, true);
     XCTAssertEqual(observer->fireCount, 1);
 }
 
@@ -449,8 +449,8 @@
     [OneSignal addSubscriptionObserver:observer];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(observer->last.from.subscribed, true);
-    XCTAssertEqual(observer->last.to.subscribed, false);
+    XCTAssertEqual(observer->last.from.isSubscribed, true);
+    XCTAssertEqual(observer->last.to.isSubscribed, false);
 }
 
 - (void)testPermissionChangeObserverWithNativeiOS10PromptCall {
@@ -588,14 +588,14 @@
     [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(observer->last.from.subscribed, false);
-    XCTAssertEqual(observer->last.to.subscribed, true);
+    XCTAssertEqual(observer->last.from.isSubscribed, false);
+    XCTAssertEqual(observer->last.to.isSubscribed, true);
     
     [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(observer->last.from.subscribed, true);
-    XCTAssertEqual(observer->last.to.subscribed, false);
+    XCTAssertEqual(observer->last.from.isSubscribed, true);
+    XCTAssertEqual(observer->last.to.isSubscribed, false);
 }
 
 - (void)testSubscriptionChangeObserverWhenPromptNotShown {
@@ -612,7 +612,7 @@
     
     XCTAssertNil(observer->last.from.userId);
     XCTAssertEqualObjects(observer->last.to.userId, @"1234");
-    XCTAssertFalse(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.to.isSubscribed);
     
     [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -622,8 +622,8 @@
     // Device registered with OneSignal so now make pushToken available.
     XCTAssertEqualObjects(observer->last.to.pushToken, @"0000000000000000000000000000000000000000000000000000000000000000");
     
-    XCTAssertFalse(observer->last.from.subscribed);
-    XCTAssertFalse(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.from.isSubscribed);
+    XCTAssertFalse(observer->last.to.isSubscribed);
     
     // Prompt and accept notifications
     [self registerForPushNotifications];
@@ -631,14 +631,14 @@
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Shouldn't be subscribed yet as we called setSubscription:false before
-    XCTAssertFalse(observer->last.from.subscribed);
-    XCTAssertFalse(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.from.isSubscribed);
+    XCTAssertFalse(observer->last.to.isSubscribed);
     
     // Device should be reported a subscribed now as all conditions are true.
     [OneSignal disablePush:false];
     [UnitTestCommonMethods runBackgroundThreads];
-    XCTAssertFalse(observer->last.from.subscribed);
-    XCTAssertTrue(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.from.isSubscribed);
+    XCTAssertTrue(observer->last.to.isSubscribed);
 }
 
 - (void)testInitAcceptingNotificationsWithoutCapabilitesSet {
@@ -1768,19 +1768,19 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods runBackgroundThreads];
     
     // Shouldn't be subscribed yet as we called setSubscription:false before
-    XCTAssertFalse(observer->last.from.subscribed);
-    XCTAssertFalse(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.from.isSubscribed);
+    XCTAssertFalse(observer->last.to.isSubscribed);
     
     // Device should be reported a subscribed now as all condiditions are true.
     [OneSignalClientOverrider setShouldExecuteInstantaneously:false];
     [OneSignal disablePush:false];
     
     [OneSignalClientOverrider setShouldExecuteInstantaneously:true];
-    XCTAssertFalse(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.to.isSubscribed);
     
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertTrue(observer->last.to.subscribed);
+    XCTAssertTrue(observer->last.to.isSubscribed);
 }
 
 // Checks to make sure that media URL's will not fail the extension-type check if they have query parameters
@@ -1813,7 +1813,7 @@ didReceiveRemoteNotification:userInfo
     
     XCTAssertNil(observer->last.from.userId);
     XCTAssertNil(observer->last.to.userId);
-    XCTAssertFalse(observer->last.to.subscribed);
+    XCTAssertFalse(observer->last.to.isSubscribed);
     
     [OneSignal disablePush:false];
     [UnitTestCommonMethods runBackgroundThreads];


### PR DESCRIPTION
This PR updates iOS native property names for state classes and adds one missing property to device state.

* `OSSubscriptionState`
  * `subscribed` changed to `isSubscribed`
  * `userSubscriptionSetting` changed to `isPushDisabled`. Internal class logic and properties were also changed to accommodate this.
* `OSEmailSubscriptionState`
  * `subscribed` changed to `isSubscribed`
* `OSDeviceState`
  * Added `isEmailSubscribed` to the class

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/779)
<!-- Reviewable:end -->

