### PR TITLE
Disable swipe to dismiss for IAM Carousel

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL isPreview;
 @property (nonatomic) BOOL isDisplayedInSession;
 @property (nonatomic) BOOL isTriggerChanged;
+@property (nonatomic) BOOL dragToDismissDisabled;
 @property (nonatomic) NSNumber *height;
 
 - (BOOL)isBanner;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageBridgeEventType) {
 @interface OSInAppMessageBridgeEventRenderingComplete : NSObject <OSJSONDecodable>
 @property (nonatomic) OSInAppMessageDisplayPosition displayLocation;
 @property (nonatomic) NSNumber *height;
+@property (nonatomic) BOOL dragToDismissDisabled;
 @end
 
 @interface OSInAppMessageBridgeEventResize : NSObject <OSJSONDecodable>

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.m
@@ -97,6 +97,10 @@
     if (json[@"pageMetaData"][@"rect"][@"height"])
         instance.height = json[@"pageMetaData"][@"rect"][@"height"];
     
+    if (json[@"dragToDismissDisabled"]) {
+        instance.dragToDismissDisabled = [json[@"dragToDismissDisabled"] boolValue];
+    }
+    
     return instance;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -487,15 +487,16 @@
  Adds the pan recognizer (for swiping up and down) and the tap recognizer (for dismissing)
  */
 - (void)setupGestureRecognizers {
-    // Pan gesture recognizer for swiping
-    let recognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognizerDidMove:)];
     
-    [self.messageView addGestureRecognizer:recognizer];
-    
-    recognizer.maximumNumberOfTouches = 1;
-    recognizer.minimumNumberOfTouches = 1;
-    
-    self.panGestureRecognizer = recognizer;
+    if (!self.message.dragToDismissDisabled) {
+        // Pan gesture recognizer for swiping
+        let recognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognizerDidMove:)];
+        [self.messageView addGestureRecognizer:recognizer];
+        recognizer.maximumNumberOfTouches = 1;
+        recognizer.minimumNumberOfTouches = 1;
+        
+        self.panGestureRecognizer = recognizer;
+    }
     
     // Only center modal and full screen should dismiss on background click
     // Banners will allow interacting with the view behind it still
@@ -632,6 +633,7 @@
             
             self.message.position = event.renderingComplete.displayLocation;
             self.message.height = event.renderingComplete.height;
+            self.message.dragToDismissDisabled = event.renderingComplete.dragToDismissDisabled;
 
             // The page is fully loaded and should now be displayed
             // This is only fired once the javascript on the page sends the "rendering_complete" type event


### PR DESCRIPTION
This PR reads dragToDismissDisabled from the rendering_complete event to conditionally disable swipe to dismiss. Currently this is only true for IAM Carousel

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/780)
<!-- Reviewable:end -->

