### PR TITLE
Removing IDFA usage from OneSignal

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1703,15 +1703,6 @@ static dispatch_queue_t serialQueue;
     mLastNotificationTypes = notificationTypes;
     dataDic[@"notification_types"] = [NSNumber numberWithInt:notificationTypes];
     
-    let ASIdentifierManagerClass = NSClassFromString(@"ASIdentifierManager");
-    if (ASIdentifierManagerClass) {
-        id asIdManager = [ASIdentifierManagerClass valueForKey:@"sharedManager"];
-        if ([[asIdManager valueForKey:@"advertisingTrackingEnabled"] isEqual:[NSNumber numberWithInt:1]])
-            dataDic[@"as_id"] = [[asIdManager valueForKey:@"advertisingIdentifier"] UUIDString];
-        else
-            dataDic[@"as_id"] = @"OptedOut";
-    }
-    
     let CTTelephonyNetworkInfoClass = NSClassFromString(@"CTTelephonyNetworkInfo");
     if (CTTelephonyNetworkInfoClass) {
         id instance = [[CTTelephonyNetworkInfoClass alloc] init];


### PR DESCRIPTION
OneSignal was using IDFA to avoid duplicate users for re-installs, but this is being removed to avoid App store rejections.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/783)
<!-- Reviewable:end -->

