### PR TITLE
Fix IAM push prompt dismissing open settings alert

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -445,7 +445,7 @@
         animationOption = UIViewAnimationOptionCurveEaseIn;
         dismissAnimationDuration = MIN_DISMISSAL_ANIMATION_DURATION;
     }
-    
+
     [UIView animateWithDuration:dismissAnimationDuration delay:0.0f options:animationOption animations:^{
         self.view.backgroundColor = [UIColor clearColor];
         self.view.alpha = 0.0f;
@@ -453,9 +453,7 @@
     } completion:^(BOOL finished) {
         if (!finished)
             return;
-        
-        [self dismissViewControllerAnimated:false completion:nil];
-    
+
         self.didPageRenderingComplete = false;
         [self.delegate messageViewControllerWasDismissed];
     }];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -959,9 +959,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     if (self.currentPermissionState.hasPrompted == true && self.osNotificationSettings.getNotificationTypes == 0 && fallback) {
         //show settings
         
-        if (block)
-            block(false);
-        
         let localizedTitle = NSLocalizedString(@"Open Settings", @"A title saying that the user can open iOS Settings");
         let localizedSettingsActionTitle = NSLocalizedString(@"Open Settings", @"A button allowing the user to open the Settings app");
         let localizedCancelActionTitle = NSLocalizedString(@"Cancel", @"A button allowing the user to close the Settings prompt");
@@ -974,7 +971,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
         
         
         [[OneSignalDialogController sharedInstance] presentDialogWithTitle:localizedTitle withMessage:localizedMessage withActions:@[localizedSettingsActionTitle] cancelTitle:localizedCancelActionTitle withActionCompletion:^(int tappedActionIndex) {
-            
+            if (block)
+                block(false);
             //completion is called on the main thread
             if (tappedActionIndex > -1)
                 [self presentAppSettings];


### PR DESCRIPTION
This PR fixes an IAM push prompt when the user has previously denied push. In this case the "Open Settings" alert would be immediately dismissed. This was caused by an erroneous `dismissViewController` AND the prompt action immediately calling the completion block before the alert had actually been addressed.

To fix this I removed the extra `dismissViewController` and moved the completion block call when showing the open settings alert into the completion block for the alert

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/795)
<!-- Reviewable:end -->

