### PR TITLE
Adding back notification clearing code

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2065,6 +2065,10 @@ static NSString *_lastnonActiveMessageId;
         return false;
     
     bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;
+    
+    if (fromNotifOpened || wasBadgeSet) {
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+    }
 
     return wasBadgeSet;
 }


### PR DESCRIPTION
The block of code that reset the notification badge count was erroneously removed in the Major Release Branch. This PR adds it back. Note that it used to be more complicated to account for iOS 6 and 7 behavior, but since those versions have been dropped it is simplified.

master version:


```
if ((!(NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_7_1) && fromNotifOpened) || wasBadgeSet) {
        // Clear badges and notifications from this app.
        // Setting to 1 then 0 was needed to clear the notifications on iOS 6 & 7. (Otherwise you can click the notification multiple times.)
        // iOS 8+ auto dismisses the notification you tap on so only clear the badge (and notifications [side-effect]) if it was set.
        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];
        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
}
```

New version


```
if (fromNotifOpened || wasBadgeSet) {
        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
    }
```

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/796)
<!-- Reviewable:end -->

