### PR TITLE
Public api updates

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -68,7 +68,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     // Example block for IAM action click handler
     id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
         NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
-        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:message];
+        [OneSignal onesignalLog:ONE_S_LL_DEBUG message:message];
     };
 
     // Example setter for IAM action click handler using OneSignal public method

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -65,7 +65,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     // Example block for IAM action click handler
     id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
         NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
-        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:message];
+        [OneSignal onesignalLog:ONE_S_LL_DEBUG message:message];
     };
 
     // Example setter for IAM action click handler using OneSignal public method

--- a/iOS_SDK/OneSignalSDK/Source/OSBaseFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSBaseFocusTimeProcessor.m
@@ -30,6 +30,7 @@
 #import "OSBaseFocusTimeProcessor.h"
 #import "OneSignalUserDefaults.h"
 #import "OneSignalCommonDefines.h"
+#import "OneSignalInternal.h"
 
 // This is an abstract class
 @implementation OSBaseFocusTimeProcessor {

--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -292,7 +292,7 @@
  }
 
  - (void)timeoutTimerFired:(NSTimer *)timer {
-     [OneSignal onesignal_Log:ONE_S_LL_ERROR
+     [OneSignal onesignalLog:ONE_S_LL_ERROR
      message:[NSString stringWithFormat:@"Notification willShowInForeground completion timed out. Completion was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
      [self complete:self];
  }
@@ -300,7 +300,7 @@
  - (void)dealloc {
      if (_timeoutTimer && _completion) {
          [_timeoutTimer invalidate];
-         [OneSignal onesignal_Log:ONE_S_LL_WARN
+         [OneSignal onesignalLog:ONE_S_LL_WARN
                           message:[NSString stringWithFormat:@"Notification: %@ was deallocated before calling completion block.", self.notificationId]];
      }
  }

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationTracker.m
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #import <Foundation/Foundation.h>
 #import "OSInfluence.h"
 #import "OSNotificationTracker.h"
+#import "OneSignalInternal.h"
 
 @interface OSChannelTracker ()
 

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEventsRepository.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEventsRepository.m
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #import <Foundation/Foundation.h>
 #import "OSCachedUniqueOutcome.h"
 #import "OSOutcomeEventsRepository.h"
+#import "OneSignalInternal.h"
 
 #define mustOverride() @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"%s must be overridden in a subclass/category", __PRETTY_FUNCTION__] userInfo:nil]
 #define methodNotImplemented() mustOverride()

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -322,16 +322,6 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 - (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges* _Nonnull)stateChanges;
 @end
 
-// Permission+Subscription Classes
-@interface OSPermissionSubscriptionState : NSObject
-
-@property (readonly, nonnull) OSPermissionState* permissionStatus;
-@property (readonly, nonnull) OSSubscriptionState* subscriptionStatus;
-@property (readonly, nonnull) OSEmailSubscriptionState *emailSubscriptionStatus;
-- (NSDictionary* _Nonnull)toDictionary;
-
-@end
-
 @interface OSDeviceState : NSObject
 /**
  * Get the app's notification permission
@@ -376,8 +366,6 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 
 @property (readonly) BOOL isEmailSubscribed;
 
-- (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state;
-
 // Convert the class into a NSDictionary
 - (NSDictionary *_Nonnull)jsonRepresentation;
 
@@ -416,8 +404,6 @@ extern NSString* const ONESIGNAL_VERSION;
 
 + (void)disablePush:(BOOL)disable;
 
-+ (NSString* _Nonnull)parseNSErrorAsJsonString:(NSError* _Nonnull)error;
-
 // Only used for wrapping SDKs, such as Unity, Cordova, Xamarin, etc.
 + (void)setMSDKType:(NSString* _Nonnull)type;
 
@@ -439,7 +425,7 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 };
 
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
-+ (void)onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
++ (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
 
 #pragma mark Prompt For Push
 typedef void(^OSUserResponseBlock)(BOOL accepted);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -862,6 +862,10 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     onesignal_Log(logLevel, message);
 }
 
++ (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message {
+    onesignal_Log(logLevel, message);
+}
+
 void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     NSString* levelString;
     switch (logLevel) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -26,6 +26,7 @@
  */
 
 #import "OneSignal.h"
+#import "OneSignalInternal.h"
 #import "OneSignalWebView.h"
 #import "UIApplication+OneSignal.h"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -46,11 +46,12 @@
 
 
 // Permission + Subscription - Redefine OSPermissionSubscriptionState
-@interface OSPermissionSubscriptionState ()
+@interface OSPermissionSubscriptionState : NSObject
 
 @property (readwrite) OSPermissionState* permissionStatus;
 @property (readwrite) OSSubscriptionState* subscriptionStatus;
 @property (readwrite) OSEmailSubscriptionState *emailSubscriptionStatus;
+- (NSDictionary* _Nonnull)toDictionary;
 
 @end
 
@@ -71,6 +72,8 @@
 // To enable this, set kOSSettingsKeyProvidesAppNotificationSettings to true in init.
 + (BOOL)providesAppNotificationSettings;
 
++ (NSString* _Nonnull)parseNSErrorAsJsonString:(NSError* _Nonnull)error;
+
 @property (class, readonly) BOOL didCallDownloadParameters;
 @property (class, readonly) BOOL downloadedParameters;
 
@@ -85,7 +88,12 @@
 
 + (OSPermissionSubscriptionState*)getPermissionSubscriptionState;
 
++ (void)onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
+
 @end
 
+@interface OSDeviceState (OSDeviceStateInternal)
+- (instancetype)initWithSubscriptionState:(OSPermissionSubscriptionState *)state;
+@end
 
 #endif /* OneSignalInternal_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #import <Foundation/Foundation.h>
 #import "OneSignalLifecycleObserver.h"
 #import "OneSignal.h"
+#import "OneSignalInternal.h"
 #import "OneSignalCommonDefines.h"
 #import "OneSignalTracker.h"
 #import "OneSignalLocation.h"

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalMobileProvision.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalMobileProvision.m
@@ -11,6 +11,7 @@
 #import "OneSignalMobileProvision.h"
 #import "TargetConditionals.h"
 #import "OneSignal.h"
+#import "OneSignalInternal.h"
 
 @implementation OneSignalMobileProvision
 


### PR DESCRIPTION
This PR makes minor changes to the OneSignal public api

1. `OSPermissionSubscriptionState` has been made private
2. `initWithSubscriptionState` on `OSDeviceState` has been made private
3. parseNSErrorAsJsonString` has been made private
4. `onesignal_Log` has been renamed to `onesignalLog`. `onesignal_Log`  still exists privately

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/800)
<!-- Reviewable:end -->
