### PR TITLE
renaming OSSession to OSInfluenceType

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSChannelTracker.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSChannelTracker.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 @interface OSChannelTracker : NSObject
 
-@property (nonatomic, readwrite) OSSession influenceType;
+@property (nonatomic, readwrite) OSInfluenceType influenceType;
 @property (strong, nonatomic, readwrite, nullable) NSString *directId;
 @property (strong, nonatomic, readwrite, nullable) NSArray *indirectIds;
 @property (strong, nonatomic, readonly, nonnull) OSInfluenceDataRepository *dataRepository;

--- a/iOS_SDK/OneSignalSDK/Source/OSInfluence.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInfluence.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 @interface OSInfluenceBuilder : NSObject
 
 @property (nonatomic) OSInfluenceChannel influenceChannel;
-@property (nonatomic) OSSession influenceType;
+@property (nonatomic) OSInfluenceType influenceType;
 @property (nonatomic, copy) NSArray * _Nullable ids;
 
 @end
@@ -41,7 +41,7 @@ THE SOFTWARE.
 @interface OSInfluence : NSObject
 
 @property (nonatomic, readonly) OSInfluenceChannel influenceChannel;
-@property (nonatomic, readonly) OSSession influenceType;
+@property (nonatomic, readonly) OSInfluenceType influenceType;
 @property (nonatomic, readwrite) NSArray * _Nullable ids;
 
 - (id _Nonnull)initWithBuilder:(OSInfluenceBuilder * _Nonnull)builder;

--- a/iOS_SDK/OneSignalSDK/Source/OSInfluence.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInfluence.m
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
 @implementation OSInfluence
 
-- (id)initWithInfluenceType:(OSSession)influenceType
+- (id)initWithInfluenceType:(OSInfluenceType)influenceType
         forInfluenceChannel:(OSInfluenceChannel)influenceChannel
                     withIds:(NSArray *)ids {
     if (self = [super init]) {

--- a/iOS_SDK/OneSignalSDK/Source/OSInfluenceDataRepository.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInfluenceDataRepository.h
@@ -32,11 +32,11 @@ THE SOFTWARE.
 
 @interface OSInfluenceDataRepository : NSObject
 
-- (void)cacheNotificationInfluenceType:(OSSession) influenceType;
-- (OSSession)notificationCachedInfluenceType;
+- (void)cacheNotificationInfluenceType:(OSInfluenceType) influenceType;
+- (OSInfluenceType)notificationCachedInfluenceType;
 
-- (void)cacheIAMInfluenceType:(OSSession) influenceType;
-- (OSSession)iamCachedInfluenceType;
+- (void)cacheIAMInfluenceType:(OSInfluenceType) influenceType;
+- (OSInfluenceType)iamCachedInfluenceType;
 
 - (void)cacheNotificationOpenId:(NSString * _Nullable)notificationId;
 - (NSString * _Nullable)cachedNotificationOpenId;

--- a/iOS_SDK/OneSignalSDK/Source/OSInfluenceDataRepository.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInfluenceDataRepository.m
@@ -33,20 +33,20 @@ THE SOFTWARE.
 
 @implementation OSInfluenceDataRepository
 
-- (void)cacheNotificationInfluenceType:(OSSession) influenceType {
+- (void)cacheNotificationInfluenceType:(OSInfluenceType) influenceType {
     [OneSignalUserDefaults.initShared saveStringForKey:OSUD_CACHED_NOTIFICATION_INFLUENCE withValue:OS_INFLUENCE_TYPE_TO_STRING(influenceType)];
 }
 
-- (OSSession)notificationCachedInfluenceType {
+- (OSInfluenceType)notificationCachedInfluenceType {
     NSString *sessionString = [OneSignalUserDefaults.initShared getSavedStringForKey:OSUD_CACHED_NOTIFICATION_INFLUENCE defaultValue:OS_INFLUENCE_TYPE_TO_STRING(UNATTRIBUTED)];
     return OS_INFLUENCE_TYPE_FROM_STRING(sessionString);
 }
 
-- (void)cacheIAMInfluenceType:(OSSession) influenceType {
+- (void)cacheIAMInfluenceType:(OSInfluenceType) influenceType {
     [OneSignalUserDefaults.initShared saveStringForKey:OSUD_CACHED_IAM_INFLUENCE withValue:OS_INFLUENCE_TYPE_TO_STRING(influenceType)];
 }
 
-- (OSSession)iamCachedInfluenceType {
+- (OSInfluenceType)iamCachedInfluenceType {
     NSString *sessionString = [OneSignalUserDefaults.initShared getSavedStringForKey:OSUD_CACHED_IAM_INFLUENCE defaultValue:OS_INFLUENCE_TYPE_TO_STRING(UNATTRIBUTED)];
     return OS_INFLUENCE_TYPE_FROM_STRING(sessionString);
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSNotificationTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotificationTracker.m
@@ -66,7 +66,7 @@ THE SOFTWARE.
 }
 
 - (void)initInfluencedTypeFromCache {
-    OSSession influenceType = [self.dataRepository notificationCachedInfluenceType];
+    OSInfluenceType influenceType = [self.dataRepository notificationCachedInfluenceType];
     self.influenceType = influenceType;
 
     if (influenceType == INDIRECT)

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.h
@@ -32,7 +32,7 @@
 
 @interface OSOutcomeEvent () <OSJSONEncodable>
 
-- (id _Nonnull)initWithSession:(OSSession)session
+- (id _Nonnull)initWithSession:(OSInfluenceType)session
                notificationIds:(NSArray * _Nullable)notificationIds
                           name:(NSString * _Nonnull)name
                      timestamp:(NSNumber * _Nonnull)timestamp

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEvent.m
@@ -31,7 +31,7 @@
 
 @implementation OSOutcomeEvent
 
-- (id _Nonnull)initWithSession:(OSSession)influenceType
+- (id _Nonnull)initWithSession:(OSInfluenceType)influenceType
                notificationIds:(NSArray * _Nullable)notificationIds
                           name:(NSString * _Nonnull)name
                      timestamp:(NSNumber * _Nonnull)timestamp
@@ -50,7 +50,7 @@
 - (id)initFromOutcomeEventParams:(OSOutcomeEventParams *)outcomeEventParams {
     if (self = [super init]) {
         OSOutcomeSource *source = outcomeEventParams.outcomeSource;
-        OSSession influenceType = UNATTRIBUTED;
+        OSInfluenceType influenceType = UNATTRIBUTED;
         NSArray *notificationId = nil;
 
         if (source) {

--- a/iOS_SDK/OneSignalSDK/Source/OSSessionManager.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSessionManager.m
@@ -196,7 +196,7 @@
 /*
  Called when the session for the app changes, caches the state, and broadcasts the session that just ended
  */
-- (BOOL)setSessionForChannel:(OSChannelTracker *)channelTracker withInfluenceType:(OSSession)influenceType directId:(NSString *)directId indirectIds:(NSArray *)indirectIds {
+- (BOOL)setSessionForChannel:(OSChannelTracker *)channelTracker withInfluenceType:(OSInfluenceType)influenceType directId:(NSString *)directId indirectIds:(NSArray *)indirectIds {
     if (![self willChangeSessionForChannel:channelTracker withInfluenceType:influenceType directId:directId indirectIds:indirectIds])
         return NO;
     
@@ -226,7 +226,7 @@
     2. Is DIRECT session data different from incoming DIRECT session data?
     3. Is INDIRECT session data different from incoming INDIRECT session data?
  */
-- (BOOL)willChangeSessionForChannel:(OSChannelTracker *)channelTracker withInfluenceType:(OSSession)influenceType directId:(NSString *)directId indirectIds:(NSArray *)indirectIds {
+- (BOOL)willChangeSessionForChannel:(OSChannelTracker *)channelTracker withInfluenceType:(OSInfluenceType)influenceType directId:(NSString *)directId indirectIds:(NSArray *)indirectIds {
     if (channelTracker.influenceType != influenceType)
         return true;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -210,7 +210,7 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 // Pass in nil means a notification will not display
 typedef void (^OSNotificationDisplayResponse)(OSNotification* _Nullable  notification);
 /* OneSignal Influence Types */
-typedef NS_ENUM(NSUInteger, OSSession) {
+typedef NS_ENUM(NSUInteger, OSInfluenceType) {
     DIRECT,
     INDIRECT,
     UNATTRIBUTED,
@@ -225,7 +225,7 @@ typedef NS_ENUM(NSUInteger, OSInfluenceChannel) {
 @interface OSOutcomeEvent : NSObject
 
 // Session enum (DIRECT, INDIRECT, UNATTRIBUTED, or DISABLED) to determine code route and request params
-@property (nonatomic) OSSession session;
+@property (nonatomic) OSInfluenceType session;
 
 // Notification ids for the current session
 @property (strong, nonatomic, nullable) NSArray *notificationIds;
@@ -280,10 +280,6 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 
 @end
 
-@protocol OSPermissionObserver <NSObject>
-- (void)onOSPermissionChanged:(OSPermissionStateChanges* _Nonnull)stateChanges;
-@end
-
 // Subscription Classes
 @interface OSSubscriptionState : NSObject
 
@@ -320,6 +316,10 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 
 @protocol OSEmailSubscriptionObserver <NSObject>
 - (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges* _Nonnull)stateChanges;
+@end
+
+@protocol OSPermissionObserver <NSObject>
+- (void)onOSPermissionChanged:(OSPermissionStateChanges* _Nonnull)stateChanges;
 @end
 
 // Permission+Subscription Classes


### PR DESCRIPTION
This PR changes the OSSession enum to OSInfluenceType

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/804)
<!-- Reviewable:end -->

