### PR TITLE
Expose ephemeral permission case

### DIFF
--- a/iOS_SDK/OneSignalSDK/SwiftPM/Public/Headers/OneSignal/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/SwiftPM/Public/Headers/OneSignal/OneSignal.h
@@ -252,7 +252,10 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
     OSNotificationPermissionAuthorized,
     
     // the application is only authorized to post Provisional notifications (direct to history)
-    OSNotificationPermissionProvisional
+    OSNotificationPermissionProvisional,
+    
+    // the application is authorized to send notifications for 8 hours. Only used by App Clips.
+    OSNotificationPermissionEphemeral
 };
 
 // Permission Classes


### PR DESCRIPTION
Expose ephemeral permission case to Swift Package consumers.

Discussed here: https://github.com/OneSignal/OneSignal-iOS-SDK/issues/775#issuecomment-729033534

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/805)
<!-- Reviewable:end -->

