### PR TITLE
Always send external id auth

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -123,6 +123,9 @@
 		7ABAF9D62457D3FF0074DFA0 /* ChannelTrackersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9D52457D3FF0074DFA0 /* ChannelTrackersTests.m */; };
 		7ABAF9D82457DD620074DFA0 /* SessionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9D72457DD620074DFA0 /* SessionManagerTests.m */; };
 		7ABAF9E324606E940074DFA0 /* OutcomeV2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9E224606E940074DFA0 /* OutcomeV2Tests.m */; };
+		7AC0D2182576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */; };
+		7AC0D2192576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */; };
+		7AC0D21A2576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */; };
 		7AC8D3A824993A0E0023EDE8 /* OSDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDevice.m */; };
 		7AC8D3A924993A0F0023EDE8 /* OSDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDevice.m */; };
 		7AD172382416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
@@ -531,6 +534,8 @@
 		7ABAF9D52457D3FF0074DFA0 /* ChannelTrackersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ChannelTrackersTests.m; sourceTree = "<group>"; };
 		7ABAF9D72457DD620074DFA0 /* SessionManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SessionManagerTests.m; sourceTree = "<group>"; };
 		7ABAF9E224606E940074DFA0 /* OutcomeV2Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OutcomeV2Tests.m; sourceTree = "<group>"; };
+		7AC0D2162576940100E29448 /* OneSignalSetExternalIdParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalSetExternalIdParameters.h; sourceTree = "<group>"; };
+		7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalSetExternalIdParameters.m; sourceTree = "<group>"; };
 		7AD172362416D52D00A78B19 /* OSInAppMessageLocationPrompt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageLocationPrompt.h; sourceTree = "<group>"; };
 		7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageLocationPrompt.m; sourceTree = "<group>"; };
 		7AD8DDE6234BD3BE00747A8A /* OneSignalUserDefaults.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalUserDefaults.m; sourceTree = "<group>"; };
@@ -1050,6 +1055,8 @@
 				CAB4112820852E48005A70D1 /* DelayedInitializationParameters.m */,
 				CA70E3332023D51000019273 /* OneSignalSetEmailParameters.h */,
 				CA70E3342023D51000019273 /* OneSignalSetEmailParameters.m */,
+				7AC0D2162576940100E29448 /* OneSignalSetExternalIdParameters.h */,
+				7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */,
 				9D1BD96B237B57B400A064F7 /* OneSignalCacheCleaner.h */,
 				9D1BD96C237B57CA00A064F7 /* OneSignalCacheCleaner.m */,
 				912411F41E73342200E41FD7 /* OneSignalHelper.h */,
@@ -1611,6 +1618,7 @@
 				7AF986492444C65300C36EAE /* OSTrackerFactory.m in Sources */,
 				CA08FC7F1FE99B25004C445F /* Requests.m in Sources */,
 				CAB269DA21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				7AC0D2182576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */,
 				CA1A6E6A20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1702,6 +1710,7 @@
 				7AF9864A2444C65300C36EAE /* OSTrackerFactory.m in Sources */,
 				CAB269DB21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
 				CA1A6E6B20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
+				7AC0D2192576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */,
 				9D1BD9612379F41B00A064F7 /* OSOutcomeEvent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1733,6 +1742,7 @@
 				912412381E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				7AF98672244975ED00C36EAE /* OSOutcomeEventParams.m in Sources */,
 				7AF9864B2444C65300C36EAE /* OSTrackerFactory.m in Sources */,
+				7AC0D21A2576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */,
 				7ABAF9D22457C3650074DFA0 /* CommonAsserts.m in Sources */,
 				03217239238278EB004F0E85 /* DelayedSelectors.m in Sources */,
 				CA63AF8720211FF800E340FB /* UnitTestCommonMethods.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
@@ -113,12 +113,12 @@ static let DELAY_TIME = 30;
         
         let requests = [NSMutableDictionary new];
     
-        requests[@"push"] = [OSRequestOnFocus withUserId:params.userId appId:params.appId activeTime:totalTimeActive netType:params.netType emailAuthToken:nil deviceType:@(DEVICE_TYPE_PUSH) influenceParams:params.influenceParams];
+        requests[@"push"] = [OSRequestOnFocus withUserId:params.userId appId:params.appId activeTime:totalTimeActive netType:params.netType emailAuthToken:nil externalIdAuthToken:params.externalIdAuthToken deviceType:@(DEVICE_TYPE_PUSH) influenceParams:params.influenceParams];
         
         // For email we omit additionalFieldsToAddToOnFocusPayload as we don't want to add
         //   outcome fields which would double report the influence time
         if (params.emailUserId)
-            requests[@"email"] = [OSRequestOnFocus withUserId:params.emailUserId appId:params.appId activeTime:totalTimeActive netType:params.netType emailAuthToken:params.emailAuthToken deviceType:@(DEVICE_TYPE_EMAIL)];
+            requests[@"email"] = [OSRequestOnFocus withUserId:params.emailUserId appId:params.appId activeTime:totalTimeActive netType:params.netType emailAuthToken:params.emailAuthToken externalIdAuthToken:nil deviceType:@(DEVICE_TYPE_EMAIL)];
 
         [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary *result) {
             [super saveUnsentActiveTime:0];

--- a/iOS_SDK/OneSignalSDK/Source/OSFocusCallParams.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSFocusCallParams.m
@@ -34,6 +34,7 @@
                    userId:(NSString *)userId
               emailUserId:(NSString *)emailUserId
            emailAuthToken:(NSString *)emailAuthToken
+      externalIdAuthToken:(NSString *)externalIdAuthToken
                   netType:(NSNumber *)netType
               timeElapsed:(NSTimeInterval)timeElapsed
           influenceParams:(NSArray *)influenceParams
@@ -42,6 +43,7 @@
     _userId = userId;
     _emailUserId = emailUserId;
     _emailAuthToken = emailAuthToken;
+    _externalIdAuthToken = externalIdAuthToken;
     _netType = netType;
     _timeElapsed = timeElapsed;
     _influenceParams = influenceParams;
@@ -51,6 +53,6 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"OSFocusCallParams appId: %@ userId: %@ emailUserId: %@ emailAuthToken: %@ netType: %@ timeElapsed: %f influenceParams: %@ onSessionEnded: %@", _appId, _userId, _emailUserId, _emailAuthToken, _netType, _timeElapsed, _influenceParams.description, _onSessionEnded ? @"YES" : @"NO"];
+    return [NSString stringWithFormat:@"OSFocusCallParams appId: %@ userId: %@ emailUserId: %@ emailAuthToken: %@ externalIdAuthToken: %@ netType: %@ timeElapsed: %f influenceParams: %@ onSessionEnded: %@", _appId, _userId, _emailUserId, _emailAuthToken, _externalIdAuthToken, _netType, _timeElapsed, _influenceParams.description, _onSessionEnded ? @"YES" : @"NO"];
 }
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -54,10 +54,12 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 @property (readwrite, nonatomic) BOOL userSubscriptionSetting; // returns setSubscription state.
 @property (readwrite, nonatomic) NSString* userId;    // AKA OneSignal PlayerId
 @property (readwrite, nonatomic) NSString* pushToken; // AKA Apple Device Token
+@property (strong, nonatomic) NSString *externalIdAuthCode;
 @property (nonatomic) ObservableSubscriptionStateType* observable;
 
 - (instancetype)initAsToWithPermision:(BOOL)permission;
 - (instancetype)initAsFrom;
+- (void)persist;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -48,6 +48,7 @@
     _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_TO defaultValue:nil];
     _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_TO defaultValue:nil];
     _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_TO];
+    _externalIdAuthCode = [standardUserDefaults getSavedStringForKey:OSUD_EXTERNAL_ID_AUTH_CODE defaultValue:nil];
     
     return self;
 }
@@ -65,8 +66,14 @@
     _userId = [standardUserDefaults getSavedStringForKey:OSUD_PLAYER_ID_FROM defaultValue:nil];
     _pushToken = [standardUserDefaults getSavedStringForKey:OSUD_PUSH_TOKEN_FROM defaultValue:nil];
     _userSubscriptionSetting = ![standardUserDefaults keyExists:OSUD_USER_SUBSCRIPTION_FROM];
+    _externalIdAuthCode = [standardUserDefaults getSavedStringForKey:OSUD_EXTERNAL_ID_AUTH_CODE defaultValue:nil];
     
     return self;
+}
+
+- (void)persist {
+    let standardUserDefaults = OneSignalUserDefaults.initStandard;
+    [standardUserDefaults saveObjectForKey:OSUD_EXTERNAL_ID_AUTH_CODE withValue:_externalIdAuthCode];
 }
 
 - (void)persistAsFrom {
@@ -79,6 +86,7 @@
     [standardUserDefaults saveStringForKey:OSUD_PLAYER_ID_FROM withValue:_userId];
     [standardUserDefaults saveObjectForKey:OSUD_PUSH_TOKEN_FROM withValue:_pushToken];
     [standardUserDefaults saveObjectForKey:OSUD_USER_SUBSCRIPTION_FROM withValue:strUserSubscriptionSetting];
+    [standardUserDefaults saveObjectForKey:OSUD_EXTERNAL_ID_AUTH_CODE withValue:_externalIdAuthCode];
 }
 
 - (instancetype)copyWithZone:(NSZone*)zone {

--- a/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
@@ -96,10 +96,10 @@ static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 60;
         let deviceType = [NSNumber numberWithInt:DEVICE_TYPE_PUSH];
         let requests = [NSMutableDictionary new];
     
-        requests[@"push"] = [OSRequestOnFocus withUserId:params.userId appId:params.appId activeTime:@(totalTimeActive) netType:params.netType emailAuthToken:nil deviceType:deviceType];
+        requests[@"push"] = [OSRequestOnFocus withUserId:params.userId appId:params.appId activeTime:@(totalTimeActive) netType:params.netType emailAuthToken:nil externalIdAuthToken:params.externalIdAuthToken deviceType:deviceType];
         
         if (params.emailUserId)
-            requests[@"email"] = [OSRequestOnFocus withUserId:params.emailUserId appId:params.appId activeTime:@(totalTimeActive) netType:params.netType emailAuthToken:params.emailAuthToken deviceType:deviceType];
+            requests[@"email"] = [OSRequestOnFocus withUserId:params.emailUserId appId:params.appId activeTime:@(totalTimeActive) netType:params.netType emailAuthToken:params.emailAuthToken externalIdAuthToken:params.externalIdAuthToken deviceType:deviceType];
 
         [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary *result) {
             [super saveUnsentActiveTime:0];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -71,6 +71,7 @@
 #import <UserNotifications/UserNotifications.h>
 
 #import "OneSignalSetEmailParameters.h"
+#import "OneSignalSetExternalIdParameters.h"
 #import "DelayedInitializationParameters.h"
 #import "OneSignalDialogController.h"
 
@@ -152,6 +153,7 @@ static BOOL shouldDelaySubscriptionUpdate = false;
     we can finish setEmail:
 */
 static OneSignalSetEmailParameters *delayedEmailParameters;
+static OneSignalSetExternalIdParameters *delayedExternalIdParameters;
 
 static NSMutableArray* pendingSendTagCallbacks;
 static OSResultSuccessBlock pendingGetTagsSuccessBlock;
@@ -445,6 +447,10 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 
 + (NSString *)mEmailUserId {
     return self.currentEmailSubscriptionState.emailUserId;
+}
+
++ (NSString *)mExternalIdAuthToken {
+    return self.currentSubscriptionState.externalIdAuthCode;
 }
 
 + (void)setMSDKType:(NSString*)type {
@@ -841,7 +847,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         if (result[IOS_REQUIRES_EMAIL_AUTHENTICATION]) {
             self.currentEmailSubscriptionState.requiresEmailAuth = [result[IOS_REQUIRES_EMAIL_AUTHENTICATION] boolValue];
             
-            // checks if a cell to setEmail: was delayed due to missing 'requiresEmailAuth' parameter
+            // checks if a call to setEmail: was delayed due to missing 'requiresEmailAuth' parameter
             if (delayedEmailParameters && self.currentSubscriptionState.userId) {
                 [self setEmail:delayedEmailParameters.email withEmailAuthHashToken:delayedEmailParameters.authToken withSuccess:delayedEmailParameters.successBlock withFailure:delayedEmailParameters.failureBlock];
                 delayedEmailParameters = nil;
@@ -849,6 +855,12 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         }
         if (result[IOS_REQUIRES_USER_ID_AUTHENTICATION]) {
             requiresUserIdAuth = [result[IOS_REQUIRES_USER_ID_AUTHENTICATION] boolValue];
+            
+            // checks if a call to setExternalUserId: was delayed due to missing 'require_user_id_auth' parameter
+            if (delayedExternalIdParameters && self.currentSubscriptionState.userId) {
+                [self setExternalUserId:delayedExternalIdParameters.externalId withExternalIdAuthHashToken:delayedExternalIdParameters.authToken withSuccess:delayedExternalIdParameters.successBlock withFailure:delayedExternalIdParameters.failureBlock];
+                delayedExternalIdParameters = nil;
+            }
         }
 
         if (!usesAutoPrompt && result[IOS_USES_PROVISIONAL_AUTHORIZATION] != (id)[NSNull null]) {
@@ -1194,10 +1206,10 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     
     NSMutableDictionary *requests = [NSMutableDictionary new];
     
-    requests[@"push"] = [OSRequestSendTagsToServer withUserId:self.currentSubscriptionState.userId appId:self.app_id tags:nowSendingTags networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:nil];
+    requests[@"push"] = [OSRequestSendTagsToServer withUserId:self.currentSubscriptionState.userId appId:self.app_id tags:nowSendingTags networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:nil withExternalIdAuthHashToken:[self mExternalIdAuthToken]];
     
     if ([self isEmailSetup])
-        requests[@"email"] = [OSRequestSendTagsToServer withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.app_id tags:nowSendingTags networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:self.currentEmailSubscriptionState.emailAuthCode];
+        requests[@"email"] = [OSRequestSendTagsToServer withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.app_id tags:nowSendingTags networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:self.currentEmailSubscriptionState.emailAuthCode withExternalIdAuthHashToken:nil];
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
         //the tags for email & push are identical so it doesn't matter what we return in the success block
@@ -1534,6 +1546,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
           withParentId:nil
           emailAuthToken:nil
           email:nil
+          externalIdAuthToken:[self mExternalIdAuthToken]
       ];
       [OneSignalClient.sharedClient executeRequest:request onSuccess:nil onFailure:nil];
       [self fireIdsAvailableCallback];
@@ -1684,9 +1697,8 @@ static dispatch_queue_t serialQueue;
 
     if (pendingExternalUserIdHashToken)
         dataDic[@"external_user_id_auth_hash"] = pendingExternalUserIdHashToken;
-    
-    pendingExternalUserId = nil;
-    pendingExternalUserIdHashToken = nil;
+    else if ([self mEmailAuthToken])
+        dataDic[@"external_user_id_auth_hash"] = [self mExternalIdAuthToken];
 
     let deviceModel = [OneSignalHelper getDeviceVariant];
     if (deviceModel)
@@ -1778,8 +1790,23 @@ static dispatch_queue_t serialQueue;
         immediateOnSessionRetry = NO;
         waitingForOneSReg = false;
         isOnSessionSuccessfulForCurrentState = true;
+        pendingExternalUserId = nil;
+        pendingExternalUserIdHashToken = nil;
 
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"on_session result: %@", results]];
+
+        // If the external user ID was sent as part of this request, we need to save it
+        // Cache the external id if it exists within the registration payload
+        if (dataDic[@"external_user_id"]) {
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:dataDic[@"external_user_id"]];
+        }
+        
+        if (dataDic[@"external_user_id_auth_hash"]) {
+            self.currentSubscriptionState.externalIdAuthCode = dataDic[@"external_user_id_auth_hash"];
+            
+            //call persistAsFrom in order to save the externalIdAuthCode to NSUserDefaults
+            [self.currentSubscriptionState persist];
+        }
 
         //update email player ID
         if (results[@"email"] && results[@"email"][@"id"]) {
@@ -1809,6 +1836,12 @@ static dispatch_queue_t serialQueue;
                 //a call to setEmail: was delayed because the push player_id did not exist yet
                 [self setEmail:delayedEmailParameters.email withEmailAuthHashToken:delayedEmailParameters.authToken withSuccess:delayedEmailParameters.successBlock withFailure:delayedEmailParameters.failureBlock];
                 delayedEmailParameters = nil;
+            }
+            
+            if (delayedExternalIdParameters) {
+                //a call to setExternalUserId: was delayed because the push player_id did not exist yet
+                [self setExternalUserId:delayedExternalIdParameters.externalId withExternalIdAuthHashToken:delayedExternalIdParameters.authToken withSuccess:delayedExternalIdParameters.successBlock withFailure:delayedExternalIdParameters.failureBlock];
+                delayedExternalIdParameters = nil;
             }
             
             // Save player_id to both standard and shared NSUserDefaults
@@ -1848,13 +1881,6 @@ static dispatch_queue_t serialQueue;
         if (results[@"push"][@"in_app_messages"]) {
             [self receivedInAppMessageJson:results[@"push"][@"in_app_messages"]];
         }
-
-        // If the external user ID was sent as part of this request, we need to save it
-        // Cache the external id if it exists within the registration payload
-        if (dataDic[@"external_user_id"]) {
-            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:dataDic[@"external_user_id"]];
-        }
-        
     } onFailure:^(NSDictionary<NSString *, NSError *> *errors) {
         waitingForOneSReg = false;
         
@@ -1961,7 +1987,7 @@ static dispatch_queue_t serialQueue;
     
     let requests = [NSMutableDictionary new];
     
-    requests[@"push"] = [OSRequestSendPurchases withUserId:self.currentSubscriptionState.userId appId:self.app_id withPurchases:purchases];
+    requests[@"push"] = [OSRequestSendPurchases withUserId:self.currentSubscriptionState.userId externalIdAuthToken:[self mExternalIdAuthToken] appId:self.app_id withPurchases:purchases];
     
     if (self.currentEmailSubscriptionState.emailUserId)
         requests[@"email"] = [OSRequestSendPurchases withUserId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:self.currentEmailSubscriptionState.emailAuthCode appId:self.app_id withPurchases:purchases];
@@ -2456,13 +2482,13 @@ static NSString *_lastnonActiveMessageId;
     //  otherwise, we should call Create Device
     // Since developers may be making UI changes when this call finishes, we will call callbacks on the main thread.
     if (self.currentEmailSubscriptionState.emailUserId) {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.app_id deviceToken:email notificationTypes:nil withParentId:nil emailAuthToken:emailAuthToken email:nil] onSuccess:^(NSDictionary *result) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.app_id deviceToken:email notificationTypes:nil withParentId:nil emailAuthToken:emailAuthToken email:nil externalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:successBlock];
         } onFailure:^(NSError *error) {
             [self callFailureBlockOnMainThread:failureBlock withError:error];
         }];
     } else {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestCreateDevice withAppId:self.app_id withDeviceType:[NSNumber numberWithInt:DEVICE_TYPE_EMAIL] withEmail:email withPlayerId:self.currentSubscriptionState.userId withEmailAuthHash:emailAuthToken] onSuccess:^(NSDictionary *result) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestCreateDevice withAppId:self.app_id withDeviceType:[NSNumber numberWithInt:DEVICE_TYPE_EMAIL] withEmail:email withPlayerId:self.currentSubscriptionState.userId withEmailAuthHash:emailAuthToken withExternalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
             
             let emailPlayerId = (NSString*) result[@"id"];
             
@@ -2474,7 +2500,7 @@ static NSString *_lastnonActiveMessageId;
                 //call persistAsFrom in order to save the emailAuthToken & playerId to NSUserDefaults
                 [self.currentEmailSubscriptionState persist];
                 
-                [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.app_id deviceToken:nil notificationTypes:@([self getNotificationTypes]) withParentId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:hashToken email:email] onSuccess:^(NSDictionary *result) {
+                [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.app_id deviceToken:nil notificationTypes:@([self getNotificationTypes]) withParentId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:hashToken email:email externalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
                     [self callSuccessBlockOnMainThread:successBlock];
                 } onFailure:^(NSError *error) {
                     [self callFailureBlockOnMainThread:failureBlock withError:error];
@@ -2543,7 +2569,8 @@ static NSString *_lastnonActiveMessageId;
                                                    notificationTypes: @([self getNotificationTypes])
                                                    withParentId:emailPlayerId
                                                    emailAuthToken:self.currentEmailSubscriptionState.emailAuthCode
-                                                   email:self.currentEmailSubscriptionState.emailAddress];
+                                                   email:self.currentEmailSubscriptionState.emailAddress
+                                     externalIdAuthToken:[self mExternalIdAuthToken]];
     
     [OneSignalClient.sharedClient executeRequest:request onSuccess:nil onFailure:^(NSError *error) {
         [self onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Encountered an error updating this user's email player record: %@", error.description]];
@@ -2645,6 +2672,7 @@ static NSString *_lastnonActiveMessageId;
         // will be sent as part of the registration/on_session request
         pendingExternalUserId = externalId;
         pendingExternalUserIdHashToken = hashToken;
+        delayedExternalIdParameters = [OneSignalSetExternalIdParameters withExternalId:externalId withAuthToken:hashToken withSuccess:successBlock withFailure:failureBlock];
         return;
     } else if (!self.currentSubscriptionState.userId || !self.app_id) {
         [OneSignal onesignal_Log:ONE_S_LL_WARN message:[NSString stringWithFormat:@"Attempted to set external user id, but %@ is not set", self.app_id == nil ? @"app_id" : @"user_id"]];
@@ -2677,8 +2705,13 @@ static NSString *_lastnonActiveMessageId;
     }
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withCompletion:^(NSDictionary<NSString *,NSDictionary *> *results) {
-        if (results[@"push"] && results[@"push"][@"success"] && [results[@"push"][@"success"] boolValue])
+        if (results[@"push"] && results[@"push"][@"success"] && [results[@"push"][@"success"] boolValue]) {
             [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:externalId];
+            self.currentSubscriptionState.externalIdAuthCode = hashToken;
+            
+            //call persistAsFrom in order to save the externalIdAuthCode to NSUserDefaults
+            [self.currentSubscriptionState persist];
+        }
         
         if (results[@"email"] && results[@"email"][@"success"] && [results[@"email"][@"success"] boolValue])
             [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_EXTERNAL_USER_ID withValue:externalId];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -67,6 +67,7 @@
 #define OSUD_PUSH_TOKEN_FROM                                                @"GT_DEVICE_TOKEN_LAST"                                             // * OSUD_PUSH_TOKEN_FROM
 #define OSUD_USER_SUBSCRIPTION_TO                                           @"ONESIGNAL_SUBSCRIPTION"                                           // * OSUD_USER_SUBSCRIPTION_TO
 #define OSUD_USER_SUBSCRIPTION_FROM                                         @"ONESIGNAL_SUBSCRIPTION_SETTING"                                   // * OSUD_USER_SUBSCRIPTION_FROM
+#define OSUD_EXTERNAL_ID_AUTH_CODE                                          @"OSUD_EXTERNAL_ID_AUTH_CODE"                                       
 // Email
 #define OSUD_EMAIL_ADDRESS                                                  @"EMAIL_ADDRESS"                                                    // * OSUD_EMAIL_ADDRESS
 #define OSUD_EMAIL_PLAYER_ID                                                @"GT_EMAIL_PLAYER_ID"                                               // * OSUD_EMAIL_PLAYER_ID

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -40,6 +40,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 + (NSString *)mEmailUserId;
 + (NSString*)mUserId;
 + (NSString *)mEmailAuthToken;
++ (NSString *)mExternalIdAuthToken;
 @end
 
 @implementation OneSignalLocation
@@ -347,9 +348,9 @@ static OneSignalLocation* singleInstance = nil;
         NSMutableDictionary *requests = [NSMutableDictionary new];
         
         if ([OneSignal mEmailUserId])
-            requests[@"email"] = [OSRequestSendLocation withUserId:[OneSignal mEmailUserId] appId:[OneSignal app_id] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive) emailAuthHashToken:[OneSignal mEmailAuthToken]];
+            requests[@"email"] = [OSRequestSendLocation withUserId:[OneSignal mEmailUserId] appId:[OneSignal app_id] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive) emailAuthHashToken:[OneSignal mEmailAuthToken] externalIdAuthToken:nil];
         
-        requests[@"push"] = [OSRequestSendLocation withUserId:[OneSignal mUserId] appId:[OneSignal app_id] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive) emailAuthHashToken:nil];
+        requests[@"push"] = [OSRequestSendLocation withUserId:[OneSignal mUserId] appId:[OneSignal app_id] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive) emailAuthHashToken:nil externalIdAuthToken:[OneSignal mExternalIdAuthToken]];
         
         [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSetExternalIdParameters.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSetExternalIdParameters.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2019 OneSignal
+ * Copyright 2020 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,28 +25,16 @@
  * THE SOFTWARE.
  */
 
-#import "OSFocusInfluenceParam.h"
+#import <Foundation/Foundation.h>
+#import "OneSignal.h"
 
-@interface OSFocusCallParams : NSObject
+@interface OneSignalSetExternalIdParameters : NSObject
 
-@property (nonatomic, readonly) NSString *appId;
-@property (nonatomic, readonly) NSString *userId;
-@property (nonatomic, readonly) NSString *emailUserId;
-@property (nonatomic, readonly) NSString *emailAuthToken;
-@property (nonatomic, readonly) NSString *externalIdAuthToken;
-@property (nonatomic, readonly) NSNumber *netType;
-@property (nonatomic, readonly) NSArray<OSFocusInfluenceParam *> *influenceParams;
-@property (nonatomic, readonly) NSTimeInterval timeElapsed;
-@property (nonatomic, readonly) BOOL onSessionEnded;
++ (instancetype)withExternalId:(NSString *)externalId withAuthToken:(NSString *)authToken withSuccess:(OSResultSuccessBlock)success withFailure:(OSFailureBlock)failure;
 
-- (id)initWithParamsAppId:(NSString *)appId
-                   userId:(NSString *)userId
-              emailUserId:(NSString *)emailUserId
-           emailAuthToken:(NSString *)emailAuthToken
-      externalIdAuthToken:(NSString *)externalIdAuthToken
-                  netType:(NSNumber *)netType
-              timeElapsed:(NSTimeInterval)timeElapsed
-          influenceParams:(NSArray<OSFocusInfluenceParam *> *)influenceParams
-           onSessionEnded:(BOOL)onSessionEnded;
+@property (strong, nonatomic) NSString *externalId;
+@property (strong, nonatomic) NSString *authToken;
+@property (nonatomic) OSResultSuccessBlock successBlock;
+@property (nonatomic) OSFailureBlock failureBlock;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSetExternalIdParameters.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSetExternalIdParameters.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2019 OneSignal
+ * Copyright 2020 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,28 +25,19 @@
  * THE SOFTWARE.
  */
 
-#import "OSFocusInfluenceParam.h"
+#import "OneSignalSetExternalIdParameters.h"
 
-@interface OSFocusCallParams : NSObject
+@implementation OneSignalSetExternalIdParameters
 
-@property (nonatomic, readonly) NSString *appId;
-@property (nonatomic, readonly) NSString *userId;
-@property (nonatomic, readonly) NSString *emailUserId;
-@property (nonatomic, readonly) NSString *emailAuthToken;
-@property (nonatomic, readonly) NSString *externalIdAuthToken;
-@property (nonatomic, readonly) NSNumber *netType;
-@property (nonatomic, readonly) NSArray<OSFocusInfluenceParam *> *influenceParams;
-@property (nonatomic, readonly) NSTimeInterval timeElapsed;
-@property (nonatomic, readonly) BOOL onSessionEnded;
-
-- (id)initWithParamsAppId:(NSString *)appId
-                   userId:(NSString *)userId
-              emailUserId:(NSString *)emailUserId
-           emailAuthToken:(NSString *)emailAuthToken
-      externalIdAuthToken:(NSString *)externalIdAuthToken
-                  netType:(NSNumber *)netType
-              timeElapsed:(NSTimeInterval)timeElapsed
-          influenceParams:(NSArray<OSFocusInfluenceParam *> *)influenceParams
-           onSessionEnded:(BOOL)onSessionEnded;
++ (instancetype)withExternalId:(NSString *)externalId withAuthToken:(NSString *)authToken withSuccess:(OSResultSuccessBlock)success withFailure:(OSFailureBlock)failure {
+    OneSignalSetExternalIdParameters *parameters = [OneSignalSetExternalIdParameters new];
+    
+    parameters.externalId = externalId;
+    parameters.authToken = authToken;
+    parameters.successBlock = success;
+    parameters.failureBlock = failure;
+    
+    return parameters;
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -50,6 +50,7 @@
 + (NSString*)mUserId;
 + (NSString *)mEmailUserId;
 + (NSString *)mEmailAuthToken;
++ (NSString *)mExternalIdAuthToken;
 
 @end
 
@@ -127,10 +128,10 @@ static BOOL lastOnFocusWasToBackground = YES;
     if (wasBadgeSet) {
         NSMutableDictionary *requests = [NSMutableDictionary new];
         
-        requests[@"push"] = [OSRequestBadgeCount withUserId:[OneSignal mUserId] appId:[OneSignal app_id] badgeCount:@0 emailAuthToken:nil];
+        requests[@"push"] = [OSRequestBadgeCount withUserId:[OneSignal mUserId] appId:[OneSignal app_id] badgeCount:@0 emailAuthToken:nil externalIdAuthToken:[OneSignal mExternalIdAuthToken]];
         
         if ([OneSignal mEmailUserId])
-            requests[@"email"] = [OSRequestBadgeCount withUserId:[OneSignal mEmailUserId] appId:[OneSignal app_id] badgeCount:@0 emailAuthToken:[OneSignal mEmailAuthToken]];
+            requests[@"email"] = [OSRequestBadgeCount withUserId:[OneSignal mEmailUserId] appId:[OneSignal app_id] badgeCount:@0 emailAuthToken:[OneSignal mEmailAuthToken] externalIdAuthToken:nil];
         
         [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
     }
@@ -190,6 +191,7 @@ static BOOL lastOnFocusWasToBackground = YES;
                                                    userId:[OneSignal mUserId]
                                               emailUserId:[OneSignal mEmailUserId]
                                            emailAuthToken:[OneSignal mEmailAuthToken]
+                                      externalIdAuthToken:[OneSignal mExternalIdAuthToken]
                                                   netType:[OneSignalHelper getNetType]
                                               timeElapsed:timeElapsed
                                           influenceParams:focusInfluenceParams

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface OSRequestSendPurchases : OneSignalRequest
-+ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId withPurchases:(NSArray *)purchases;
++ (instancetype)withUserId:(NSString *)userId externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken appId:(NSString *)appId withPurchases:(NSArray *)purchases;
 + (instancetype)withUserId:(NSString *)userId emailAuthToken:(NSString *)emailAuthToken appId:(NSString *)appId withPurchases:(NSArray *)purchases;
 @end
 
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @interface OSRequestUpdateDeviceToken : OneSignalRequest
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email;
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 @end
 
 @interface OSRequestRegisterUser : OneSignalRequest
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_END
 @end
 
 @interface OSRequestCreateDevice : OneSignalRequest
-+ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType withEmail:(NSString * _Nullable)email withPlayerId:(NSString * _Nullable)playerId withEmailAuthHash:(NSString * _Nullable)emailAuthHash;
++ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType withEmail:(NSString * _Nullable)email withPlayerId:(NSString * _Nullable)playerId withEmailAuthHash:(NSString * _Nullable)emailAuthHash withExternalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;;
 @end
 
 @interface OSRequestLogoutEmail : OneSignalRequest
@@ -85,18 +85,19 @@ NS_ASSUME_NONNULL_END
 @end
 
 @interface OSRequestSendTagsToServer : OneSignalRequest
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId tags:(NSDictionary * _Nonnull)tags networkType:(NSNumber * _Nonnull)netType withEmailAuthHashToken:(NSString * _Nullable)emailAuthToken;
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId tags:(NSDictionary * _Nonnull)tags networkType:(NSNumber * _Nonnull)netType withEmailAuthHashToken:(NSString * _Nullable)emailAuthToken withExternalIdAuthHashToken:(NSString * _Nullable)externalIdAuthToken;
 @end
 
 @interface OSRequestSendLocation : OneSignalRequest
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId location:(os_last_location * _Nonnull)coordinate networkType:(NSNumber * _Nonnull)netType backgroundState:(BOOL)backgroundState emailAuthHashToken:(NSString * _Nullable)emailAuthHash;
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId location:(os_last_location * _Nonnull)coordinate networkType:(NSNumber * _Nonnull)netType backgroundState:(BOOL)backgroundState emailAuthHashToken:(NSString * _Nullable)emailAuthHash externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 @end
 
 @interface OSRequestBadgeCount : OneSignalRequest
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
                               appId:(NSString * _Nonnull)appId
                          badgeCount:(NSNumber * _Nonnull)badgeCount
-                     emailAuthToken:(NSString * _Nullable)emailAuthHash;
+                     emailAuthToken:(NSString * _Nullable)emailAuthHash
+                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 @end
 
 @interface OSRequestOnFocus : OneSignalRequest
@@ -105,6 +106,7 @@ NS_ASSUME_NONNULL_END
                          activeTime:(NSNumber * _Nonnull)activeTime
                             netType:(NSNumber * _Nonnull)netType
                      emailAuthToken:(NSString * _Nullable)emailAuthHash
+                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
                          deviceType:(NSNumber * _Nonnull)deviceType;
 
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
@@ -112,6 +114,7 @@ NS_ASSUME_NONNULL_END
                          activeTime:(NSNumber * _Nonnull)activeTime
                             netType:(NSNumber * _Nonnull)netType
                      emailAuthToken:(NSString * _Nullable)emailAuthHash
+                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
                          deviceType:(NSNumber * _Nonnull)deviceType
                     influenceParams:(NSArray<OSFocusInfluenceParam *> * _Nonnull)influenceParams;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -77,7 +77,7 @@
 @end
 
 @implementation OSRequestSendTagsToServer
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId tags:(NSDictionary * _Nonnull)tags networkType:(NSNumber * _Nonnull)netType withEmailAuthHashToken:(NSString * _Nullable)emailAuthToken {
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId tags:(NSDictionary * _Nonnull)tags networkType:(NSNumber * _Nonnull)netType withEmailAuthHashToken:(NSString * _Nullable)emailAuthToken withExternalIdAuthHashToken:(NSString * _Nullable)externalIdAuthToken {
     let request = [OSRequestSendTagsToServer new];
     
     let params = [NSMutableDictionary new];
@@ -87,6 +87,9 @@
     
     if (emailAuthToken && emailAuthToken.length > 0)
         params[@"email_auth_hash"] = emailAuthToken;
+    
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
     
     request.parameters = params;
     request.method = PUT;
@@ -112,7 +115,7 @@
 @end
 
 @implementation OSRequestUpdateDeviceToken
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email {
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken {
     
     let request = [OSRequestUpdateDeviceToken new];
     
@@ -134,6 +137,9 @@
     if (emailAuthHash && emailAuthHash.length > 0)
         params[@"email_auth_hash"] = emailAuthHash;
     
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
+    
     request.parameters = params;
     request.method = PUT;
     request.path = [NSString stringWithFormat:@"players/%@", userId];
@@ -143,7 +149,7 @@
 @end
 
 @implementation OSRequestCreateDevice
-+ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType withEmail:(NSString * _Nullable)email withPlayerId:(NSString * _Nullable)playerId withEmailAuthHash:(NSString * _Nullable)emailAuthHash {
++ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType withEmail:(NSString * _Nullable)email withPlayerId:(NSString * _Nullable)playerId withEmailAuthHash:(NSString * _Nullable)emailAuthHash withExternalIdAuthToken:(NSString * _Nullable)externalIdAuthToken {
     let request = [OSRequestCreateDevice new];
     
     request.parameters = @{
@@ -151,6 +157,7 @@
        @"device_type" : deviceType,
        @"identifier" : email ?: [NSNull null],
        @"email_auth_hash" : emailAuthHash ?: [NSNull null],
+       @"external_user_id_auth_hash" : externalIdAuthToken ?: [NSNull null],
        @"device_player_id" : playerId ?: [NSNull null]
     };
     
@@ -193,10 +200,13 @@
 @end
 
 @implementation OSRequestSendPurchases
-+ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId withPurchases:(NSArray *)purchases {
++ (instancetype)withUserId:(NSString *)userId externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken appId:(NSString *)appId withPurchases:(NSArray *)purchases {
     let request = [OSRequestSendPurchases new];
     
-    request.parameters = @{@"app_id" : appId, @"purchases" : purchases};
+    request.parameters = @{@"app_id" : appId,
+                           @"purchases" : purchases,
+                           @"external_user_id_auth_hash" : externalIdAuthToken ?: [NSNull null]
+    };
     request.method = POST;
     request.path = [NSString stringWithFormat:@"players/%@/on_purchase", userId];
     
@@ -206,7 +216,11 @@
 + (instancetype)withUserId:(NSString *)userId emailAuthToken:(NSString *)emailAuthToken appId:(NSString *)appId withPurchases:(NSArray *)purchases {
     let request = [OSRequestSendPurchases new];
     
-    request.parameters = @{@"app_id" : appId, @"purchases" : purchases, @"email_auth_hash" : emailAuthToken ?: [NSNull null]};
+    request.parameters = @{
+        @"app_id" : appId,
+        @"purchases" : purchases,
+        @"email_auth_hash" : emailAuthToken ?: [NSNull null]
+    };
     request.method = POST;
     request.path = [NSString stringWithFormat:@"players/%@/on_purchase", userId];
     
@@ -258,7 +272,7 @@
 @end
 
 @implementation OSRequestSendLocation
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId location:(os_last_location * _Nonnull)coordinate networkType:(NSNumber * _Nonnull)netType backgroundState:(BOOL)backgroundState emailAuthHashToken:(NSString * _Nullable)emailAuthHash {
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId location:(os_last_location * _Nonnull)coordinate networkType:(NSNumber * _Nonnull)netType backgroundState:(BOOL)backgroundState emailAuthHashToken:(NSString * _Nullable)emailAuthHash externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken {
     let request = [OSRequestSendLocation new];
     
     let params = [NSMutableDictionary new];
@@ -273,6 +287,9 @@
     if (emailAuthHash && emailAuthHash.length > 0)
         params[@"email_auth_hash"] = emailAuthHash;
     
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
+    
     request.parameters = params;
     request.method = PUT;
     request.path = [NSString stringWithFormat:@"players/%@", userId];
@@ -286,7 +303,8 @@
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
                               appId:(NSString * _Nonnull)appId
                          badgeCount:(NSNumber * _Nonnull)badgeCount
-                     emailAuthToken:(NSString * _Nullable)emailAuthHash {
+                     emailAuthToken:(NSString * _Nullable)emailAuthHash
+                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken {
     let request = [OSRequestBadgeCount new];
     
     let params = [NSMutableDictionary new];
@@ -295,6 +313,9 @@
     
     if (emailAuthHash && emailAuthHash.length > 0)
         params[@"email_auth_hash"] = emailAuthHash;
+    
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
     
     request.parameters = params;
     request.method = PUT;
@@ -315,6 +336,7 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
                 activeTime:(NSNumber *)activeTime
                    netType:(NSNumber *)netType
             emailAuthToken:(NSString *)emailAuthHash
+       externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
                 deviceType:(NSNumber * _Nonnull)deviceType {
     let request = [OSRequestOnFocus new];
 
@@ -328,6 +350,9 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
 
     if (emailAuthHash && emailAuthHash.length > 0)
         params[@"email_auth_hash"] = emailAuthHash;
+    
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
 
     request.parameters = params;
     request.method = POST;
@@ -341,6 +366,7 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
                 activeTime:(NSNumber *)activeTime
                    netType:(NSNumber *)netType
             emailAuthToken:(NSString *)emailAuthHash
+       externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
                 deviceType:(NSNumber *)deviceType
            influenceParams:(NSArray <OSFocusInfluenceParam *> *)influenceParams {
     let request = [OSRequestOnFocus new];
@@ -360,6 +386,9 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
 
     if (emailAuthHash && emailAuthHash.length > 0)
         params[@"email_auth_hash"] = emailAuthHash;
+    
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
     
     request.parameters = params;
     request.method = POST;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -33,6 +33,7 @@
 
 #define TEST_EXTERNAL_USER_ID_HASH_TOKEN @"i_am_a_test_external_user_id_hash_token"
 #define TEST_EXTERNAL_USER_ID @"i_am_a_test_external_user_id"
+#define TEST_EMAIL_HASH_TOKEN @"i_am_a_test_email_hash_token"
 #define TEST_EMAIL @"test@onesignal.com"
 
 NSString * serverUrlWithPath(NSString *path);


### PR DESCRIPTION
* External id auth hash should be sent in all players and on_session calls

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/813)
<!-- Reviewable:end -->

