### PR TITLE
Fix/direct outcomes

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -44,8 +44,6 @@
 @interface OneSignal ()
 
 + (void)handleNotificationOpened:(NSDictionary*)messageDict
-                      foreground:(BOOL)foreground
-                        isActive:(BOOL)isActive
                       actionType:(OSNotificationActionType)actionType;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -43,7 +43,7 @@
 + (void) handleDidFailRegisterForRemoteNotification:(NSError*)error;
 + (void) updateNotificationTypes:(int)notificationTypes;
 + (NSString*) appId;
-+ (void)notificationReceived:(NSDictionary*)messageDict foreground:(BOOL)foreground isActive:(BOOL)isActive wasOpened:(BOOL)opened;
++ (void)notificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
 + (BOOL) receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 + (void) processLocalActionBasedNotification:(UILocalNotification*) notification identifier:(NSString*)identifier;
 + (void) onesignal_Log:(ONE_S_LOG_LEVEL)logLevel message:(NSString*) message;
@@ -170,8 +170,7 @@ static NSArray* delegateSubclasses = nil;
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"oneSignalReceivedRemoteNotification:userInfo:"];
 
     if ([OneSignal appId]) {
-        let isActive = [application applicationState] == UIApplicationStateActive;
-        [OneSignal notificationReceived:userInfo foreground:isActive isActive:isActive wasOpened:YES];
+        [OneSignal notificationReceived:userInfo wasOpened:YES];
     }
     
     if ([self respondsToSelector:@selector(oneSignalReceivedRemoteNotification:userInfo:)])
@@ -191,7 +190,7 @@ static NSArray* delegateSubclasses = nil;
     
     if ([OneSignal appId]) {
         if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive && userInfo[@"aps"][@"alert"])
-            [OneSignal notificationReceived:userInfo foreground:YES isActive:YES wasOpened:NO];
+            [OneSignal notificationReceived:userInfo wasOpened:NO];
         else
             startedBackgroundJob = [OneSignal receiveRemoteNotification:application UserInfo:userInfo completionHandler:callExistingSelector ? nil : completionHandler];
     }

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -271,7 +271,7 @@ void finishProcessingNotification(UNNotification *notification,
     
     let userInfo = [OneSignalHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo
                                                       identifier:response.actionIdentifier];
-    let isAppForeground = [[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground;
+    let isAppForeground = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
 
     [OneSignal notificationReceived:userInfo foreground:isAppForeground isActive:isActive wasOpened:YES];
 }

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -46,7 +46,7 @@
 typedef void (^OSUNNotificationCenterCompletionHandler)(UNNotificationPresentationOptions options);
 
 @interface OneSignal (UN_extra)
-+ (void)notificationReceived:(NSDictionary*)messageDict foreground:(BOOL)foreground isActive:(BOOL)isActive wasOpened:(BOOL)opened;
++ (void)notificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName;
 + (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary *)payload withCompletion:(OSNotificationDisplayResponse)completionHandler;
 @end
@@ -193,7 +193,7 @@ void finishProcessingNotification(UNNotification *notification,
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Notification display type: %lu", (unsigned long)displayType]];
     
     if ([OneSignal appId])
-        [OneSignal notificationReceived:notification.request.content.userInfo foreground:YES isActive:YES wasOpened:NO];
+        [OneSignal notificationReceived:notification.request.content.userInfo wasOpened:NO];
 
     
     // Call orginal selector if one was set.
@@ -267,13 +267,10 @@ void finishProcessingNotification(UNNotification *notification,
     if (![OneSignalHelper isOneSignalPayload:response.notification.request.content.userInfo])
         return;
     
-    let isActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
-    
     let userInfo = [OneSignalHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo
                                                       identifier:response.actionIdentifier];
-    let isAppForeground = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
 
-    [OneSignal notificationReceived:userInfo foreground:isAppForeground isActive:isActive wasOpened:YES];
+    [OneSignal notificationReceived:userInfo wasOpened:YES];
 }
 
 // Calls depercated pre-iOS 10 selector if one is set on the AppDelegate.

--- a/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationV2Tests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OutcomeIntegrationV2Tests.m
@@ -1111,4 +1111,169 @@
     }];
     [RestClientAsserts assertNumberOfMeasureSourcesRequests:2];
 }
+
+
+- (void)testUnattributedSessionToDirectSessionWhileInactive {
+    // 1. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    [[OneSignal outcomeEventsCache] saveOutcomesV2ServiceEnabled:YES];
+    
+    // 2. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is UNATTRIBUTED
+    NSArray<OSInfluence *> *sessionInfluences = [OneSignal.sessionManager getInfluences];
+    for (OSInfluence *influence in sessionInfluences) {
+        switch (influence.influenceChannel) {
+            case IN_APP_MESSAGE:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+            case NOTIFICATION:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+        }
+    }
+
+    //Make app inactive. This actually involves backgrounding foregroudning backgrounding and then inactive.
+    [UnitTestCommonMethods pullDownNotificationCenter];
+
+    // 3. Receive 1 notification and open it
+    [UnitTestCommonMethods receiveNotification:@"test_notification_1" wasOpened:YES];
+    
+    // 4. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    
+    // 5. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is direct
+    sessionInfluences = [OneSignal.sessionManager getInfluences];
+    for (OSInfluence *influence in sessionInfluences) {
+        switch (influence.influenceChannel) {
+            case IN_APP_MESSAGE:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+            case NOTIFICATION:
+                XCTAssertEqual(influence.influenceType, DIRECT);
+                XCTAssertEqual(influence.ids.count, 1);
+                [CommonAsserts assertArrayEqualsWithExpected:influence.ids actual:@[@"test_notification_1"]];
+                break;
+        }
+    }
+}
+
+- (void)testDirectSessionToDirectSessionWhileInactive {
+    // 1. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    [[OneSignal outcomeEventsCache] saveOutcomesV2ServiceEnabled:YES];
+    
+    [UnitTestCommonMethods pullDownNotificationCenter];
+    
+    // 2. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is UNATTRIBUTED
+    NSArray<OSInfluence *> *sessionInfluences = [OneSignal.sessionManager getInfluences];
+
+    // 3. Receive notification 1 and open it
+    [UnitTestCommonMethods receiveNotification:@"test_notification_1" wasOpened:YES];
+    
+    // 4. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    
+    // 5. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is direct
+    sessionInfluences = [OneSignal.sessionManager getInfluences];
+    for (OSInfluence *influence in sessionInfluences) {
+        switch (influence.influenceChannel) {
+            case IN_APP_MESSAGE:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+            case NOTIFICATION:
+                XCTAssertEqual(influence.influenceType, DIRECT);
+                XCTAssertEqual(influence.ids.count, 1);
+                [CommonAsserts assertArrayEqualsWithExpected:influence.ids actual:@[@"test_notification_1"]];
+                break;
+        }
+    }
+    
+    //Make app inactive. This actually involves backgrounding foregroudning backgrounding and then inactive.
+    [UnitTestCommonMethods pullDownNotificationCenter];
+    
+    // 6. Receive notification 2 and open it
+    [UnitTestCommonMethods receiveNotification:@"test_notification_2" wasOpened:YES];
+    
+    // 7. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    
+    // 8. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is direct
+    sessionInfluences = [OneSignal.sessionManager getInfluences];
+    for (OSInfluence *influence in sessionInfluences) {
+        switch (influence.influenceChannel) {
+            case IN_APP_MESSAGE:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+            case NOTIFICATION:
+                XCTAssertEqual(influence.influenceType, DIRECT);
+                XCTAssertEqual(influence.ids.count, 1);
+                [CommonAsserts assertArrayEqualsWithExpected:influence.ids actual:@[@"test_notification_2"]];
+                break;
+        }
+    }
+}
+
+- (void)testIndirectSessionToDirectSessionWhileInactive {
+    // 1. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    [[OneSignal outcomeEventsCache] saveOutcomesV2ServiceEnabled:YES];
+    
+    // Background app
+    [UnitTestCommonMethods backgroundApp];
+    
+    // 2. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is UNATTRIBUTED
+    NSArray<OSInfluence *> *sessionInfluences = [OneSignal.sessionManager getInfluences];
+
+    // 3. Receive notification 1 and open it
+    [UnitTestCommonMethods receiveNotification:@"test_notification_1" wasOpened:NO];
+    
+    // 4. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    
+    // 5. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is INDIRECT
+    sessionInfluences = [OneSignal.sessionManager getInfluences];
+    for (OSInfluence *influence in sessionInfluences) {
+        switch (influence.influenceChannel) {
+            case IN_APP_MESSAGE:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+            case NOTIFICATION:
+                XCTAssertEqual(influence.influenceType, INDIRECT);
+                XCTAssertEqual(influence.ids.count, 1);
+                [CommonAsserts assertArrayEqualsWithExpected:influence.ids actual:@[@"test_notification_1"]];
+                break;
+        }
+    }
+    
+    //Make app inactive. This actually involves backgrounding foregroudning backgrounding and then inactive.
+    [UnitTestCommonMethods pullDownNotificationCenter];
+    
+    // 6. Receive notification 2 and open it
+    [UnitTestCommonMethods receiveNotification:@"test_notification_2" wasOpened:YES];
+    
+    // 7. Open app
+    [UnitTestCommonMethods initOneSignal_andThreadWaitWithForeground];
+    
+    // 8. Make sure IN_APP_MESSAGE influence is UNATTRIBUTED and Notifications is direct
+    sessionInfluences = [OneSignal.sessionManager getInfluences];
+    for (OSInfluence *influence in sessionInfluences) {
+        switch (influence.influenceChannel) {
+            case IN_APP_MESSAGE:
+                XCTAssertEqual(influence.influenceType, UNATTRIBUTED);
+                XCTAssertEqual(influence.ids, nil);
+                break;
+            case NOTIFICATION:
+                XCTAssertEqual(influence.influenceType, DIRECT);
+                XCTAssertEqual(influence.ids.count, 1);
+                [CommonAsserts assertArrayEqualsWithExpected:influence.ids actual:@[@"test_notification_2"]];
+                break;
+        }
+    }
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -64,6 +64,8 @@ withNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundB
 + (void)beforeEachTest:(XCTestCase *)testCase;
 + (void)foregroundApp;
 + (void)backgroundApp;
++ (void)setAppInactive;
++ (void)pullDownNotificationCenter;
 + (void)useSceneLifecycle:(BOOL)useSceneLifecycle;
 + (void)setCurrentNotificationPermissionAsUnanswered;
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -61,7 +61,7 @@ NSString * serverUrlWithPath(NSString *path) {
 
 @interface OneSignal ()
 
-+ (void)notificationReceived:(NSDictionary*)messageDict foreground:(BOOL)foreground isActive:(BOOL)isActive wasOpened:(BOOL)opened;
++ (void)notificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
 
 @end
 
@@ -367,10 +367,7 @@ static XCTestCase* _currentXCTestCase;
 }
 
 + (void)handleNotificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened {
-    BOOL foreground = UIApplication.sharedApplication.applicationState != UIApplicationStateBackground;
-    BOOL isActive = UIApplication.sharedApplication.applicationState == UIApplicationStateActive;
-    
-    [OneSignal notificationReceived:messageDict foreground:foreground isActive:isActive wasOpened:opened];
+    [OneSignal notificationReceived:messageDict wasOpened:opened];
 }
 
 + (NSDictionary*)createNotificationUserInfo:(NSString *)notificationId {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -272,6 +272,17 @@ static XCTestCase* _currentXCTestCase;
     }
 }
 
++ (void)setAppInactive {
+    UIApplicationOverrider.currentUIApplicationState = UIApplicationStateInactive;
+}
+
++ (void)pullDownNotificationCenter {
+    [self backgroundApp];
+    [self foregroundApp];
+    [self backgroundApp];
+    [self setAppInactive];
+}
+
 //Call this method before init OneSignal. Make sure not to overwrite the NSBundleDictionary in later calls.
 + (void)useSceneLifecycle:(BOOL)useSceneLifecycle {
     NSMutableDictionary *currentBundleDictionary = [[NSMutableDictionary alloc] initWithDictionary:NSBundleOverrider.nsbundleDictionary];


### PR DESCRIPTION
The primary goal of this PR is to fix Direct Sessions in the major release.

The problem was that we were relying on the `foreground` variable to decide if we should upgrade the session,


```
if (!foreground) {
        OneSignal.appEntryState = NOTIFICATION_CLICK;
        [OneSignal.sessionManager onDirectInfluenceFromNotificationOpen:_appEntryState withNotificationId:messageId];
}
```

and in the major release I had changed the setting of the foreground variable to:
`let isAppForeground = [[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground;`
From:
`let isAppForeground = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;`

This was to account for the inactive state which is technically in the foreground.

The first commit on this branch just flips it back to `[[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;` to fix direct outcomes.

However, I don't think we need foreground or isActive to be passed around at all anymore. Since we are using the native iOS call for willShowInForeground we don't need to track the states on notification received. We were only logging those variables and (improperly) using them for direct outcomes. So I removed the foreground and isActive variables and am checking the state directly when deciding if we need to upgrade the session for direct outcomes. 

I also added unit tests for outcomes while in the inactive state

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/823)
<!-- Reviewable:end -->

