### PR TITLE
Lowered tests log level to warn to fix TravisCI

### DIFF
--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -202,7 +202,7 @@ static XCTestCase* _currentXCTestCase;
     
     [UIAlertViewOverrider reset];
 
-    [OneSignal setLogLevel:ONE_S_LL_INFO visualLevel:ONE_S_LL_NONE];
+    [OneSignal setLogLevel:ONE_S_LL_WARN visualLevel:ONE_S_LL_NONE];
 
     [NSTimerOverrider reset];
 


### PR DESCRIPTION
* Logs are now to long and TravisCI is killing the job

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/827)
<!-- Reviewable:end -->

