### PR TITLE
Fix IAM redisplay multiple times

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -361,7 +361,7 @@ static BOOL _isInAppMessagingPaused = false;
         message.displayStats.lastDisplayTime = redisplayMessageSavedData.displayStats.lastDisplayTime;
 
         // Message that don't have triggers should display only once per session
-        BOOL triggerHasChanged = message.isTriggerChanged || (!redisplayMessageSavedData.isDisplayedInSession && [message.triggers count] == 0);
+        BOOL triggerHasChanged = [self hasMessageTriggerChanged:message];
 
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"setDataForRedisplay with message: %@ \ntriggerHasChanged: %@ \nno triggers: %@ \ndisplayed in session saved: %@", message, message.isTriggerChanged ? @"YES" : @"NO", [message.triggers count] == 0 ? @"YES" : @"NO", redisplayMessageSavedData.isDisplayedInSession  ? @"YES" : @"NO"]];
         // Check if conditions are correct for redisplay
@@ -376,6 +376,18 @@ static BOOL _isInAppMessagingPaused = false;
             return;
         }
     }
+}
+
+- (BOOL)hasMessageTriggerChanged:(OSInAppMessage *)message {
+    // Message that only have dynamic trigger should display only once per session
+    BOOL messageHasOnlyDynamicTrigger = [self.triggerController messageHasOnlyDynamicTriggers:message];
+    if (messageHasOnlyDynamicTrigger)
+        return !message.isDisplayedInSession;
+
+    // Message that don't have triggers should display only once per session
+    BOOL shouldMessageDisplayInSession = !message.isDisplayedInSession && [message.triggers count] == 0;
+
+    return message.isTriggerChanged || shouldMessageDisplayInSession;
 }
 
 /*
@@ -497,7 +509,6 @@ static BOOL _isInAppMessagingPaused = false;
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"not persisting %@",message.displayStats]];
         return;
     }
-
 
     let displayTimeSeconds = self.dateGenerator();
     message.displayStats.lastDisplayTime = displayTimeSeconds;

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)messageMatchesTriggers:(OSInAppMessage *)message;
 - (BOOL)hasSharedTriggers:(OSInAppMessage *)message newTriggersKeys:(NSArray<NSString *> *)newTriggersKeys;
+- (BOOL)messageHasOnlyDynamicTriggers:(OSInAppMessage *)message;
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers;
 - (void)removeTriggersForKeys:(NSArray<NSString *> *)keys;
 - (NSDictionary<NSString *, id> *)getTriggers;

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
@@ -97,6 +97,26 @@
     return NO;
 }
 
+/*
+ * Part of redisplay logic
+ *
+ * If message has only dynamic trigger return true, otherwise false
+ */
+- (BOOL)messageHasOnlyDynamicTriggers:(OSInAppMessage *)message {
+    if (message.triggers == nil || message.triggers.count == 0)
+        return false;
+
+    for (NSArray <OSTrigger *> *andConditions in message.triggers) {
+        for (OSTrigger *trigger in andConditions) {
+            if ([trigger.kind isEqualToString:OS_DYNAMIC_TRIGGER_KIND_CUSTOM])
+                // At least one trigger is not dynamic
+                return false;
+         }
+    }
+
+    return true;
+}
+
 #pragma mark Private Methods
 
 - (void)timeSinceLastMessage:(NSDate *)date {

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -267,15 +267,21 @@
     (all the triggers for the message evaluate to true), the SDK should display the message. This
     test verifies that the message actually gets displayed.
 */
-- (void)testIAMIsDisplayed {
+- (void)testIAMIsDisplayedOncePerSession {
+    [OneSignal pauseInAppMessages:false];
+    
     let trigger = [OSTrigger dynamicTriggerWithKind:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withOperator:OSTriggerOperatorTypeLessThan withValue:@10.0];
 
-    let message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[trigger]]];
+    let message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[trigger]] withRedisplayLimit:@10 delay:@0];
 
     [self initOneSignalWithInAppMessage:message];
     
     XCTAssertFalse(NSTimerOverrider.hasScheduledTimer);
     XCTAssertEqual(OSMessagingControllerOverrider.messageDisplayQueue.count, 1);
+    
+    [OSMessagingControllerOverrider dismissCurrentMessage];
+    
+    XCTAssertEqual(OSMessagingControllerOverrider.messageDisplayQueue.count, 0);
 }
 
 // if we have two messages that are both valid to displayed add them to the queue (triggers are all true),


### PR DESCRIPTION
* When IAM only has dynamic triggers it can end redisplaying multiple times on the same session
* Limit IAM with only dynamic trigger to display once per session
* Add test for escenario

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/829)
<!-- Reviewable:end -->

