### PR TITLE
Fixing logic for delaying setting external user id

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -849,7 +849,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
             requiresUserIdAuth = [result[IOS_REQUIRES_USER_ID_AUTHENTICATION] boolValue];
             
             // checks if a call to setExternalUserId: was delayed due to missing 'require_user_id_auth' parameter
-            if (delayedExternalIdParameters && self.currentSubscriptionState.userId) {
+            if (delayedExternalIdParameters) {
                 [self setExternalUserId:delayedExternalIdParameters.externalId withExternalIdAuthHashToken:delayedExternalIdParameters.authToken withSuccess:delayedExternalIdParameters.successBlock withFailure:delayedExternalIdParameters.failureBlock];
                 delayedExternalIdParameters = nil;
             }
@@ -2541,7 +2541,7 @@ static NSString *_lastnonActiveMessageId;
         return;
 
     // Can't set the external id if init is not done or the app id or user id has not ben set yet
-    if (!performedOnSessionRequest) {
+    if (!_didCallDownloadParameters) {
         // will be sent as part of the registration/on_session request
         pendingExternalUserId = externalId;
         pendingExternalUserIdHashToken = hashToken;


### PR DESCRIPTION
We sometimes we don't create a new session if we force quit and come back
within 30 seconds. This caused a bug where we would never send external ids.
To fix this we just need to check that we have called for remote params

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/835)
<!-- Reviewable:end -->

