### PR TITLE
Add arm64 slice to XCFramework simulator build

### DIFF
--- a/iOS_SDK/OneSignalSDK/build_xcframework.sh
+++ b/iOS_SDK/OneSignalSDK/build_xcframework.sh
@@ -23,7 +23,7 @@ mkdir "${FRAMEWORK_FOLDER_NAME}"
 echo "Created ${FRAMEWORK_FOLDER_NAME}"
 echo "Archiving ${FRAMEWORK_NAME}"
 
-xcodebuild archive -scheme ${BUILD_SCHEME} -destination="iOS Simulator" -archivePath "${SIMULATOR_ARCHIVE_PATH}" -sdk iphonesimulator SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+xcodebuild archive ONLY_ACTIVE_ARCH=NO -scheme ${BUILD_SCHEME} -destination="iOS Simulator" -arch i386 -arch x86_64 -arch arm64 -archivePath "${SIMULATOR_ARCHIVE_PATH}" -sdk iphonesimulator SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
 xcodebuild archive -scheme ${BUILD_SCHEME} -destination="iOS" -archivePath "${IOS_DEVICE_ARCHIVE_PATH}" -sdk iphoneos SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 


### PR DESCRIPTION
In order to support Apple Silicon macs we need to add arm64 to iOS simulator builds. This only works with XCFrameworks since we also need arm64 for iOS devices. For now the OneSignal framework will stay with iOS simulators built for x86_64 so folks now using apple silicon that were previously using the framework now will need to use the XCFramework. This should not impact non apple silicon users at all

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/836)
<!-- Reviewable:end -->

