### PR TITLE
Use Binary Target For Swift PM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,10 +11,12 @@ let package = Package(
             targets: ["OneSignal"]),
     ],
     targets: [
-        .binaryTarget(
-          name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.0.1/OneSignal.xcframework.zip",
-          checksum: "3f36d8f8f3bde549ae4409972b09088fe969c1845d3419dccf2e8a56ebeac25f"
-        )
+        .target(
+            name: "OneSignal",
+            dependencies: [],
+            path: "iOS_SDK/OneSignalSDK/",
+            sources: ["Source"],
+            publicHeadersPath:"SwiftPM/Public/Headers"),
     ]
 )
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,12 +11,10 @@ let package = Package(
             targets: ["OneSignal"]),
     ],
     targets: [
-        .target(
-            name: "OneSignal",
-            dependencies: [],
-            path: "iOS_SDK/OneSignalSDK/",
-            sources: ["Source"],
-            publicHeadersPath:"SwiftPM/Public/Headers"),
+        .binaryTarget(
+          name: "OneSignal",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.0.1/OneSignal.xcframework.zip",
+          checksum: "3f36d8f8f3bde549ae4409972b09088fe969c1845d3419dccf2e8a56ebeac25f"
+        )
     ]
 )
-

--- a/iOS_SDK/OneSignalSDK/build_xcframework.sh
+++ b/iOS_SDK/OneSignalSDK/build_xcframework.sh
@@ -9,6 +9,8 @@ FRAMEWORK_NAME="OneSignal"
 
 FRAMEWORK_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/${FRAMEWORK_NAME}.xcframework"
 
+FRAMEWORK_ZIP_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/${FRAMEWORK_NAME}.xcframework.zip"
+
 BUILD_SCHEME="OneSignalFramework"
 
 SIMULATOR_ARCHIVE_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/simulator.xcarchive"
@@ -16,6 +18,8 @@ SIMULATOR_ARCHIVE_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/simulator.xcarch
 IOS_DEVICE_ARCHIVE_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/iOS.xcarchive"
 
 CATALYST_ARCHIVE_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/catalyst.xcarchive"
+
+SWIFT_PACKAGE_PATH="../../Package.swift"
 
 rm -rf "${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}"
 echo "Deleted ${FRAMEWORK_FOLDER_NAME}"
@@ -30,8 +34,24 @@ xcodebuild archive -scheme ${BUILD_SCHEME} -destination="iOS" -archivePath "${IO
 xcodebuild archive -scheme ${BUILD_SCHEME} -destination='platform=macOS,arch=x86_64,variant=Mac Catalyst' -archivePath "${CATALYST_ARCHIVE_PATH}" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
 xcodebuild -create-xcframework -framework ${SIMULATOR_ARCHIVE_PATH}/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework -framework ${IOS_DEVICE_ARCHIVE_PATH}/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework -framework ${CATALYST_ARCHIVE_PATH}/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework -output "${FRAMEWORK_PATH}"
+# Remove the old Zipped XCFramework and create a new Zip
+rm -rf "${FRAMEWORK_ZIP_PATH}"
+ditto -c -k --sequesterRsrc --keepParent "${FRAMEWORK_PATH}" "${FRAMEWORK_ZIP_PATH}" 
 
+# Compute the checksum for the Zipped framework
+CHECKSUM=$(swift package compute-checksum "${FRAMEWORK_ZIP_PATH}")
+SWIFT_PM_CHECKSUM_LINE="          checksum: \"${CHECKSUM}\""
+# Use sed to remove line 17 from the Swift.package and replace it with the new checksum
+sed -i '' "17s/.*/$SWIFT_PM_CHECKSUM_LINE/" "${SWIFT_PACKAGE_PATH}"
+#Ask for the new release version number to be placed in the package URL
+echo -e "\033[1mEnter the new SDK release version number\033[0m"
+read VERSION_NUMBER
+SWIFT_PM_URL_LINE="          url: \"https:\/\/github.com\/OneSignal\/OneSignal-iOS-SDK\/releases\/download\/${VERSION_NUMBER}\/OneSignal.xcframework.zip\","
+# Use sed to remove line 16 from the Swift.package and replace it with the new URL for the new release
+sed -i '' "16s/.*/$SWIFT_PM_URL_LINE/" "${SWIFT_PACKAGE_PATH}"
+#Open XCFramework folder to drag zip into new release
 rm -rf "${SIMULATOR_ARCHIVE_PATH}"
 rm -rf "${IOS_DEVICE_ARCHIVE_PATH}"
 rm -rf "${CATALYST_ARCHIVE_PATH}"
 open "${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}"
+

--- a/iOS_SDK/OneSignalSDK/build_xcframework.sh
+++ b/iOS_SDK/OneSignalSDK/build_xcframework.sh
@@ -19,8 +19,6 @@ IOS_DEVICE_ARCHIVE_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/iOS.xcarchive"
 
 CATALYST_ARCHIVE_PATH="${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}/catalyst.xcarchive"
 
-SWIFT_PACKAGE_PATH="../../Package.swift"
-
 rm -rf "${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}"
 echo "Deleted ${FRAMEWORK_FOLDER_NAME}"
 mkdir "${FRAMEWORK_FOLDER_NAME}"
@@ -34,24 +32,5 @@ xcodebuild archive -scheme ${BUILD_SCHEME} -destination="iOS" -archivePath "${IO
 xcodebuild archive -scheme ${BUILD_SCHEME} -destination='platform=macOS,arch=x86_64,variant=Mac Catalyst' -archivePath "${CATALYST_ARCHIVE_PATH}" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
 xcodebuild -create-xcframework -framework ${SIMULATOR_ARCHIVE_PATH}/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework -framework ${IOS_DEVICE_ARCHIVE_PATH}/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework -framework ${CATALYST_ARCHIVE_PATH}/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework -output "${FRAMEWORK_PATH}"
-# Remove the old Zipped XCFramework and create a new Zip
-rm -rf "${FRAMEWORK_ZIP_PATH}"
-ditto -c -k --sequesterRsrc --keepParent "${FRAMEWORK_PATH}" "${FRAMEWORK_ZIP_PATH}" 
 
-# Compute the checksum for the Zipped framework
-CHECKSUM=$(swift package compute-checksum "${FRAMEWORK_ZIP_PATH}")
-SWIFT_PM_CHECKSUM_LINE="          checksum: \"${CHECKSUM}\""
-# Use sed to remove line 17 from the Swift.package and replace it with the new checksum
-sed -i '' "17s/.*/$SWIFT_PM_CHECKSUM_LINE/" "${SWIFT_PACKAGE_PATH}"
-#Ask for the new release version number to be placed in the package URL
-echo -e "\033[1mEnter the new SDK release version number\033[0m"
-read VERSION_NUMBER
-SWIFT_PM_URL_LINE="          url: \"https:\/\/github.com\/OneSignal\/OneSignal-iOS-SDK\/releases\/download\/${VERSION_NUMBER}\/OneSignal.xcframework.zip\","
-# Use sed to remove line 16 from the Swift.package and replace it with the new URL for the new release
-sed -i '' "16s/.*/$SWIFT_PM_URL_LINE/" "${SWIFT_PACKAGE_PATH}"
-#Open XCFramework folder to drag zip into new release
-rm -rf "${SIMULATOR_ARCHIVE_PATH}"
-rm -rf "${IOS_DEVICE_ARCHIVE_PATH}"
-rm -rf "${CATALYST_ARCHIVE_PATH}"
-open "${WORKING_DIR}/${FRAMEWORK_FOLDER_NAME}"
-
+echo "XCFramework build completed ${FRAMEWORK_NAME}"


### PR DESCRIPTION
Using a [Binary Target](https://developer.apple.com/documentation/swift_packages/distributing_binary_frameworks_as_swift_packages) for Swift PM instead of the standard SwiftPM Target primarily gets us 2 things

1. Significantly faster (minutes) Swift PM Install speed
1. A much easier path to adding Swift files within the SDK

However, Binary Targets are only available with Xcode 12 so developers on Xcode 11 would lose SwiftPM support. They could still use Cocoapods with both the Framework and XCFramework.

To use a binary target we need to:


*  update the Swift Package to use Swift tools 5.3 (this is what breaks Xcode 11)
*  use a `.binaryTarget` which requires a URL to a zipped XCFramework, and a checksum to validate the archive.
  * The checksum is computed using `swift package compute-checksum FILENAME`
* Host the archived Framework in a CDN or as an Asset in the GitHub release

This PR


- Updates the Swift.package to use the binary target
- Updates the `build_xcframework.sh` script to 
    - zip the framework once it has been built 
    - compute the checksum for the archive 
    - automatically replace the checksum in the `Swift.package` file
    - Ask for the new release version number
    - automatically replace the version in the URL in the `Swift.package` file

With the script updated in this way the only change to our release process will be to attach the zipped archive to our GitHub releases as an asset.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/837)
<!-- Reviewable:end -->

