### PR TITLE
Fix showing IAMS past stop time

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -123,11 +123,11 @@
 		7ABAF9D62457D3FF0074DFA0 /* ChannelTrackersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9D52457D3FF0074DFA0 /* ChannelTrackersTests.m */; };
 		7ABAF9D82457DD620074DFA0 /* SessionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9D72457DD620074DFA0 /* SessionManagerTests.m */; };
 		7ABAF9E324606E940074DFA0 /* OutcomeV2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ABAF9E224606E940074DFA0 /* OutcomeV2Tests.m */; };
-		7AC8D3A824993A0E0023EDE8 /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
-		7AC8D3A924993A0F0023EDE8 /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
 		7AC0D2182576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */; };
 		7AC0D2192576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */; };
 		7AC0D21A2576944F00E29448 /* OneSignalSetExternalIdParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0D2172576944F00E29448 /* OneSignalSetExternalIdParameters.m */; };
+		7AC8D3A824993A0E0023EDE8 /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
+		7AC8D3A924993A0F0023EDE8 /* OSDeviceState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A676BE424981CEC003957CC /* OSDeviceState.m */; };
 		7AD172382416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
 		7AD172392416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
 		7AD1723A2416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AD172372416D53B00A78B19 /* OSInAppMessageLocationPrompt.m */; };
@@ -429,6 +429,10 @@
 		DE20425F24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */; };
 		DE20426024E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */; };
 		DE5EFECA24D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */; };
+		DE98772B2591656200DE07D5 /* NSDateFormatter+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE98772A2591655800DE07D5 /* NSDateFormatter+OneSignal.m */; };
+		DE9877332591656200DE07D5 /* NSDateFormatter+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE98772A2591655800DE07D5 /* NSDateFormatter+OneSignal.m */; };
+		DE9877342591656300DE07D5 /* NSDateFormatter+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DE98772A2591655800DE07D5 /* NSDateFormatter+OneSignal.m */; };
+		DE98773C2591656A00DE07D5 /* NSDateFormatter+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DE9877292591654600DE07D5 /* NSDateFormatter+OneSignal.h */; };
 		DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */; };
 		DEF5CCF52539321A0003E9CC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF5CCF42539321A0003E9CC /* AppDelegate.m */; };
 		DEF5CCFB2539321A0003E9CC /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF5CCFA2539321A0003E9CC /* ViewController.m */; };
@@ -728,6 +732,8 @@
 		DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+OneSignal.m"; sourceTree = "<group>"; };
 		DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageViewControllerOverrider.m; sourceTree = "<group>"; };
 		DE5EFECB24D8DC0E0032632D /* OSInAppMessageViewControllerOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageViewControllerOverrider.h; sourceTree = "<group>"; };
+		DE9877292591654600DE07D5 /* NSDateFormatter+OneSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDateFormatter+OneSignal.h"; sourceTree = "<group>"; };
+		DE98772A2591655800DE07D5 /* NSDateFormatter+OneSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+OneSignal.m"; sourceTree = "<group>"; };
 		DEF5CCF12539321A0003E9CC /* UnitTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UnitTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEF5CCF32539321A0003E9CC /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DEF5CCF42539321A0003E9CC /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -1168,6 +1174,8 @@
 				CA1A6E6E20DC2E73001C41B9 /* OneSignalDialogRequest.m */,
 				DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */,
 				DE20425D24E21C2C00350E4F /* UIApplication+OneSignal.m */,
+				DE9877292591654600DE07D5 /* NSDateFormatter+OneSignal.h */,
+				DE98772A2591655800DE07D5 /* NSDateFormatter+OneSignal.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1418,6 +1426,7 @@
 				CA1A6E7520DC2F04001C41B9 /* OneSignalDialogControllerOverrider.h in Headers */,
 				9129C6BD1E89E7AB009CB6A0 /* OSSubscription.h in Headers */,
 				CA7FC89F21927229002C4FD9 /* OSDynamicTriggerController.h in Headers */,
+				DE98773C2591656A00DE07D5 /* NSDateFormatter+OneSignal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1636,6 +1645,7 @@
 			files = (
 				9D1BD968237A28FC00A064F7 /* OSCachedUniqueOutcome.m in Sources */,
 				7A9173A2231971E5007848FA /* OneSignalReceiveReceiptsController.m in Sources */,
+				DE98772B2591656200DE07D5 /* NSDateFormatter+OneSignal.m in Sources */,
 				7AD172382416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */,
 				9124120E1E73342200E41FD7 /* OneSignal.m in Sources */,
 				CACBAA97218A6243000ACAA5 /* OSMessagingController.m in Sources */,
@@ -1727,6 +1737,7 @@
 			files = (
 				9D1BD969237A28FC00A064F7 /* OSCachedUniqueOutcome.m in Sources */,
 				9124120F1E73342200E41FD7 /* OneSignal.m in Sources */,
+				DE9877332591656200DE07D5 /* NSDateFormatter+OneSignal.m in Sources */,
 				7AD172392416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */,
 				CACBAA98218A6243000ACAA5 /* OSMessagingController.m in Sources */,
 				CA36F35A21C33A2500300C77 /* OSInAppMessageController.m in Sources */,
@@ -1830,6 +1841,7 @@
 				CA4743A02190FEA80020DC8C /* OSTrigger.m in Sources */,
 				912412201E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
 				7AF9863D2444C43900C36EAE /* OSInAppMessageTracker.m in Sources */,
+				DE9877342591656300DE07D5 /* NSDateFormatter+OneSignal.m in Sources */,
 				CAAEA68921ED68A40049CF15 /* OneSignalNotificationCategoryController.m in Sources */,
 				7ABAF9D82457DD620074DFA0 /* SessionManagerTests.m in Sources */,
 				CA85C15320604AEA003AB529 /* RequestTests.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/NSDateFormatter+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/NSDateFormatter+OneSignal.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2020 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,41 +26,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessagingDefines.h"
-#import "OSInAppMessageDisplayStats.h"
-#import "OSJSONHandling.h"
-#import "OneSignal.h"
-#import "OSTrigger.h"
-
-NS_ASSUME_NONNULL_BEGIN
-
-@interface OSInAppMessage : NSObject <NSCoding, OSJSONDecodable, OSJSONEncodable>
-
-@property (strong, nonatomic, nonnull) NSString *messageId;
-@property (strong, nonatomic, nonnull) NSDictionary<NSString *, NSDictionary <NSString *, NSString *> *> *variants;
-@property (strong, nonatomic, nonnull) NSArray<NSArray <OSTrigger *> *> *triggers;
-
-@property (nonatomic) OSInAppMessageDisplayPosition position;
-@property (nonatomic) OSInAppMessageDisplayStats *displayStats;
-@property (nonatomic) BOOL actionTaken;
-@property (nonatomic) BOOL isPreview;
-@property (nonatomic) BOOL isDisplayedInSession;
-@property (nonatomic) BOOL isTriggerChanged;
-@property (nonatomic) BOOL dragToDismissDisabled;
-@property (nonatomic) NSNumber *height;
-@property (nonatomic, nullable) NSDate *endTime;
-
-- (BOOL)isBanner;
-- (BOOL)takeActionAsUnique;
-
-- (NSSet<NSString *> *)getClickedClickIds;
-- (BOOL)isClickAvailable:(NSString *)clickId;
-
-- (void)clearClickIds;
-- (void)addClickId:(NSString *)clickId;
-
-- (BOOL)isFinished;
-
+@interface NSDateFormatter (OneSignal)
++ (instancetype)iso8601DateFormatter;
 @end
-
-NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/NSDateFormatter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/NSDateFormatter+OneSignal.m
@@ -1,0 +1,41 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2020 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "NSDateFormatter+OneSignal.h"
+
+@implementation NSDateFormatter (OneSignal)
+
++ (instancetype)iso8601DateFormatter {
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    [dateFormatter setCalendar:[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601]];
+    [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+    [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"];
+    return dateFormatter;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessage.m
@@ -101,6 +101,13 @@
         message.displayStats = [OSInAppMessageDisplayStats instanceWithJson:json[@"redisplay"]];
     else
         message.displayStats = [[OSInAppMessageDisplayStats alloc] init];
+    
+    if (json[@"end_time"] && [json[@"end_time"] isKindOfClass:[NSString class]]) {
+        NSString *stringEndTime = json[@"end_time"];
+        NSDateFormatter *dateFormatter = [NSDateFormatter iso8601DateFormatter];
+        NSDate *endTime = [dateFormatter dateFromString:stringEndTime];
+        message.endTime = endTime;
+    }
 
     if (json[@"triggers"] && [json[@"triggers"] isKindOfClass:[NSArray class]]) {
         let triggers = [NSMutableArray new];
@@ -160,11 +167,13 @@
         json[@"redisplay"] = [_displayStats jsonRepresentation];
     }
     
+    json[@"end_time"] = [[NSDateFormatter iso8601DateFormatter] stringFromDate:self.endTime];
+    
     return json;
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"OSInAppMessage:  \nmessageId: %@  \ntriggers: %@ \ndisplayed_in_session: %@ \ndisplayStats: %@", self.messageId, self.triggers, self.isDisplayedInSession ? @"YES" : @"NO", self.displayStats];
+    return [NSString stringWithFormat:@"OSInAppMessage:  \nmessageId: %@  \ntriggers: %@ \ndisplayed_in_session: %@ \ndisplayStats: %@ \nendTime: %@", self.messageId, self.triggers, self.isDisplayedInSession ? @"YES" : @"NO", self.displayStats, self.endTime];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -192,6 +201,7 @@
     [encoder encodeObject:_displayStats forKey:@"displayStats"];
     //TODO: This will need to be changed when we add core data or database to iOS, see android implementation for reference
     [encoder encodeBool:_isDisplayedInSession forKey:@"displayed_in_session"];
+    [encoder encodeObject:_endTime forKey:@"endTime"];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder {
@@ -202,8 +212,16 @@
         _displayStats = [decoder decodeObjectForKey:@"displayStats"];
         //TODO: This will need to be changed when we add core data or database to iOS, see android implementation for reference
         _isDisplayedInSession = [decoder decodeBoolForKey:@"displayed_in_session"];
+        _endTime = [decoder decodeObjectForKey:@"endTime"];
     }
     return self;
+}
+
+- (BOOL)isFinished {
+    if (!self.endTime) {
+        return NO;
+    }
+    return [self.endTime compare:[NSDate date]] == NSOrderedAscending;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -396,7 +396,8 @@ static BOOL _isInAppMessagingPaused = false;
  */
 - (BOOL)shouldShowInAppMessage:(OSInAppMessage *)message {
     return ![self.seenInAppMessages containsObject:message.messageId] &&
-           [self.triggerController messageMatchesTriggers:message];
+           [self.triggerController messageMatchesTriggers:message] &&
+           ![message isFinished];
 }
 
 - (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -29,6 +29,7 @@
 #import "OneSignalInternal.h"
 #import "OneSignalWebView.h"
 #import "UIApplication+OneSignal.h"
+#import "NSDateFormatter+OneSignal.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -284,6 +284,27 @@
     XCTAssertEqual(OSMessagingControllerOverrider.messageDisplayQueue.count, 0);
 }
 
+- (void)testIAMsDontDisplayPastEndTime {
+    [OneSignal pauseInAppMessages:false];
+
+    let message = [OSInAppMessageTestHelper testMessageWithPastEndTime:YES];
+
+    [self initOneSignalWithInAppMessage:message];
+    
+    XCTAssertEqual(OSMessagingControllerOverrider.isInAppMessageShowing, false);
+}
+
+- (void)testIAMsDoDisplayWithFutureEndTime {
+    [OneSignal pauseInAppMessages:false];
+
+    let message = [OSInAppMessageTestHelper testMessageWithPastEndTime:NO];
+
+    [self initOneSignalWithInAppMessage:message];
+    
+    XCTAssertEqual(OSMessagingControllerOverrider.isInAppMessageShowing, true);
+}
+
+
 // if we have two messages that are both valid to displayed add them to the queue (triggers are all true),
 - (void)testIAMsDontOverlap {
     [OSMessagingController.sharedInstance setTriggerWithName:@"prop1" withValue:@2];

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
@@ -60,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (OSInAppMessage *)testMessagePreview;
 + (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers;
 + (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
++ (OSInAppMessage *)testMessageWithPastEndTime:(BOOL)pastEndTime;
 + (NSDictionary *)testRegistrationJsonWithMessages:(NSArray<NSDictionary *> *)messages;
 + (NSDictionary *)testMessageJsonWithTriggerPropertyName:(NSString *)property withId:(NSString *)triggerId withOperator:(OSTriggerOperatorType)type withValue:(id)value;
 + (NSDictionary*)testInAppMessageGetContainsWithHTML:(NSString *)html;

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
@@ -167,11 +167,17 @@ int messageIdIncrementer = 0;
     return [OSInAppMessage instanceWithData:data];
 }
 
-+ (OSInAppMessage *)testMessagePreview {
-    let messageJson = self.testMessagePreviewJson;
-
-    let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
++ (OSInAppMessage *)testMessageWithPastEndTime:(BOOL)pastEndTime {
+    let messageJson = self.testMessageJson;
     
+    NSMutableDictionary *messageJsonWithEndTime = [[NSMutableDictionary alloc] initWithDictionary:messageJson];
+    if (pastEndTime) {
+        messageJsonWithEndTime[@"end_time"] = @"1960-01-01T00:00:00.000Z";
+    } else {
+        messageJsonWithEndTime[@"end_time"] = @"2200-01-01T00:00:00.000Z";
+    }
+    let data = [NSJSONSerialization dataWithJSONObject:messageJsonWithEndTime options:0 error:nil];
+
     return [OSInAppMessage instanceWithData:data];
 }
 


### PR DESCRIPTION
This change involves reading in end_time from JSON when creating an IAM
so that we can decide to not show the IAM (Cached case) if the IAM
should be finished. The date comes in iso8601 format so I added a
NSDateFormatter category with that format to easily retrieve it.
Note we cannot use the Apple provided iso8601 date formatter class until
we drop iOS 9 support.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/841)
<!-- Reviewable:end -->

