### PR TITLE
Fix content available notif firing opened handler when received in foreground

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2216,7 +2216,7 @@ static NSString *_lastnonActiveMessageId;
     else if (application.applicationState == UIApplicationStateActive) {
         [OneSignalHelper lastMessageReceived:userInfo];
 
-        if (![OneSignalHelper isRemoteSilentNotification:userInfo] && (userInfo[@"title"] && [userInfo[@"title"] length] > 0)) {
+        if ([OneSignalHelper isDisplayableNotification:userInfo]) {
              [OneSignal notificationReceived:userInfo wasOpened:YES];
         }
         return startedBackgroundJob;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2216,7 +2216,7 @@ static NSString *_lastnonActiveMessageId;
     else if (application.applicationState == UIApplicationStateActive) {
         [OneSignalHelper lastMessageReceived:userInfo];
 
-        if (![OneSignalHelper isRemoteSilentNotification:userInfo]) {
+        if (![OneSignalHelper isRemoteSilentNotification:userInfo] && (userInfo[@"title"] && [userInfo[@"title"] length] > 0)) {
              [OneSignal notificationReceived:userInfo wasOpened:YES];
         }
         return startedBackgroundJob;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -60,6 +60,7 @@
 + (UILocalNotification*)prepareUILocalNotification:(OSNotification*)notification;
 + (BOOL)verifyURL:(NSString*)urlString;
 + (BOOL)isRemoteSilentNotification:(NSDictionary*)msg;
++ (BOOL)isDisplayableNotification:(NSDictionary*)msg;
 + (void)addAttachments:(OSNotification*)notification toNotificationContent:(UNMutableNotificationContent*)content;
 + (void)addActionButtons:(OSNotification*)notification toNotificationContent:(UNMutableNotificationContent*)content;
 + (BOOL)isOneSignalPayload:(NSDictionary *)payload;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -282,6 +282,13 @@ OneSignalWebView *webVC;
     return true;
 }
 
++ (BOOL)isDisplayableNotification:(NSDictionary*)msg {
+    if ([self isRemoteSilentNotification:msg]) {
+        return false;
+    }
+    return msg[@"aps"][@"alert"] != nil;
+}
+
 + (void)lastMessageReceived:(NSDictionary*)message {
     lastMessageReceived = message;
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1547,10 +1547,14 @@ didReceiveRemoteNotification:userInfo
     __block BOOL receivedWasFire = false;
     [UnitTestCommonMethods initOneSignalWithHandlers:^(OSNotification *notif, OSNotificationDisplayResponse completion) {
         receivedWasFire = true;
-    } notificationOpenedHandler:nil];
+    } notificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
+        receivedWasFire = true;
+    }];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    id userInfo = @{@"aps": @{@"content_available": @1},
+    id userInfo = @{@"aps": @{@"content_available": @1,
+                              @"badge" : @54
+                    },
                     @"custom": @{
                             @"i": @"b2f7f966-d8cc-11e4-1111-df8f05be55bb"
                             }
@@ -1570,10 +1574,14 @@ didReceiveRemoteNotification:userInfo
     __block BOOL receivedWasFire = false;
     [UnitTestCommonMethods initOneSignalWithHandlers:^(OSNotification *notif, OSNotificationDisplayResponse completion) {
         receivedWasFire = true;
-    } notificationOpenedHandler:nil];
+    } notificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
+        receivedWasFire = true;
+    }];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    id userInfo = @{@"aps": @{@"content_available": @1},
+    id userInfo = @{@"aps": @{@"content_available": @1,
+                              @"badge" : @54
+                            },
                     @"custom": @{
                             @"i": @"b2f7f966-d8cc-11e4-1111-df8f05be55bb"
                             }
@@ -1583,7 +1591,6 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods runBackgroundThreads];
     
     XCTAssertEqual(receivedWasFire, false);
-    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
 - (UNNotificationCategory*)unNotificagionCategoryWithId:(NSString*)identifier {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1563,6 +1563,29 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
 }
 
+// Tests that a slient content-available 1 notification doesn't trigger an on_session or count it has opened.
+- (void)testContentAvailableDoesNotTriggerOpenWhenInForeground  {
+    UIApplicationOverrider.currentUIApplicationState = UIApplicationStateActive;
+    
+    __block BOOL receivedWasFire = false;
+    [UnitTestCommonMethods initOneSignalWithHandlers:^(OSNotification *notif, OSNotificationDisplayResponse completion) {
+        receivedWasFire = true;
+    } notificationOpenedHandler:nil];
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    id userInfo = @{@"aps": @{@"content_available": @1},
+                    @"custom": @{
+                            @"i": @"b2f7f966-d8cc-11e4-1111-df8f05be55bb"
+                            }
+                    };
+    
+    [self fireDidReceiveRemoteNotification:userInfo];
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    XCTAssertEqual(receivedWasFire, false);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 1);
+}
+
 - (UNNotificationCategory*)unNotificagionCategoryWithId:(NSString*)identifier {
     return [UNNotificationCategory
             categoryWithIdentifier:identifier


### PR DESCRIPTION
https://app.asana.com/0/1198177413178126/1199361722609493

When a content available notification **with a badge count or sound** and **without a title**  is received when the app is in the foreground it will not be displayed, but the notification opened handler will fire. This PR makes it so that the opened handler will no longer fire. 

The reason it was firing is that we were not treating it as a remote silent notification because it contains a badge count or sound.

We now check `isDisplayableNotification` before firing notification received with opened as true
```
+ (BOOL)isDisplayableNotification:(NSDictionary*)msg {
    if ([self isRemoteSilentNotification:msg]) {
        return false;
    }
    return (msg[@"title"] && [msg[@"title"] length] > 0) || (msg[@"body"] && [msg[@"body"] length] > 0);
}
```
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/842)
<!-- Reviewable:end -->

