### PR TITLE
Remove device identifier from register user dictionary

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1624,7 +1624,6 @@ static dispatch_queue_t serialQueue;
                    [[UIDevice currentDevice] systemVersion], @"device_os",
                    [NSNumber numberWithInt:(int)[[NSTimeZone localTimeZone] secondsFromGMT]], @"timezone",
                    [NSNumber numberWithInt:DEVICE_TYPE_PUSH], @"device_type",
-                   [[[UIDevice currentDevice] identifierForVendor] UUIDString], @"ad_id",
                    ONESIGNAL_VERSION, @"sdk",
                    nil];
     


### PR DESCRIPTION
The device identifier was being used to not create a new player record if a user had multiple apps installed from the same developer. This was different from android confusing to customers so the functionality is being removed

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/849)
<!-- Reviewable:end -->

