### PR TITLE
Fix subscription observers firing on launch

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.m
@@ -73,7 +73,7 @@ SEL changeSelector;
         for (id observer in obs) {
             fired = true;
             if (changeSelector) {
-                // Any Obserable setup to fire a custom selector with changeSelector
+                // Any Observable setup to fire a custom selector with changeSelector
                 //  is external to our SDK. Run on the main thread in case the
                 //  app developer needs to update UI elements.
                 

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -180,11 +180,13 @@
     OSSubscriptionStateChanges* stateChanges = [OSSubscriptionStateChanges alloc];
     stateChanges.from = OneSignal.lastSubscriptionState;
     stateChanges.to = [state copy];
-    
-    BOOL hasReceiver = [OneSignal.subscriptionStateChangesObserver notifyChange:stateChanges];
-    if (hasReceiver) {
-        OneSignal.lastSubscriptionState = [state copy];
-        [OneSignal.lastSubscriptionState persistAsFrom];
+    if (OneSignal.isRegisterUserFinished) {
+        BOOL hasReceiver = [OneSignal.subscriptionStateChangesObserver notifyChange:stateChanges];
+        
+        if (hasReceiver) {
+            OneSignal.lastSubscriptionState = [state copy];
+            [OneSignal.lastSubscriptionState persistAsFrom];
+        }
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -834,7 +834,6 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 + (void)downloadIOSParamsWithAppId:(NSString *)appId {
     [self onesignal_Log:ONE_S_LL_DEBUG message:@"Downloading iOS parameters for this application"];
     _didCallDownloadParameters = true;
-    
     [OneSignalClient.sharedClient executeRequest:[OSRequestGetIosParams withUserId:self.currentSubscriptionState.userId appId:appId] onSuccess:^(NSDictionary *result) {
         if (result[IOS_REQUIRES_EMAIL_AUTHENTICATION]) {
             self.currentEmailSubscriptionState.requiresEmailAuth = [result[IOS_REQUIRES_EMAIL_AUTHENTICATION] boolValue];
@@ -1536,6 +1535,11 @@ static BOOL isOnSessionSuccessfulForCurrentState = false;
     isOnSessionSuccessfulForCurrentState = value;
 }
 
+static BOOL _registerUserFinished = false;
++ (BOOL)isRegisterUserFinished {
+    return _registerUserFinished || isOnSessionSuccessfulForCurrentState;
+}
+
 + (BOOL)shouldRegisterNow {
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
@@ -1600,7 +1604,7 @@ static dispatch_queue_t serialQueue;
 }
 
 + (void)registerUserInternal {
-    
+    _registerUserFinished = false;
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
@@ -1727,6 +1731,7 @@ static dispatch_queue_t serialQueue;
     }
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
+        _registerUserFinished = true;
         immediateOnSessionRetry = NO;
         waitingForOneSReg = false;
         isOnSessionSuccessfulForCurrentState = true;
@@ -1820,6 +1825,7 @@ static dispatch_queue_t serialQueue;
             [self receivedInAppMessageJson:results[@"push"][@"in_app_messages"]];
         }
     } onFailure:^(NSDictionary<NSString *, NSError *> *errors) {
+        _registerUserFinished = true;
         waitingForOneSReg = false;
         
         for (NSString *key in @[@"push", @"email"])

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -76,6 +76,7 @@
 
 @property (class, readonly) BOOL didCallDownloadParameters;
 @property (class, readonly) BOOL downloadedParameters;
+@property (class, readonly) BOOL isRegisterUserFinished;
 
 @property (class) NSObject<OneSignalNotificationSettings>* _Nonnull osNotificationSettings;
 @property (class) OSPermissionState* _Nonnull currentPermissionState;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -595,6 +595,7 @@
     
     XCTAssertEqual(observer->last.from.isSubscribed, false);
     XCTAssertEqual(observer->last.to.isSubscribed, true);
+    XCTAssertEqual(observer->fireCount, 1);
     
     [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
@@ -614,14 +615,14 @@
     [UnitTestCommonMethods runBackgroundThreads];
     [NSObjectOverrider runPendingSelectors];
     [UnitTestCommonMethods runBackgroundThreads];
-    
+    XCTAssertEqual(observer->fireCount, 1);
     XCTAssertNil(observer->last.from.userId);
     XCTAssertEqualObjects(observer->last.to.userId, @"1234");
     XCTAssertFalse(observer->last.to.isSubscribed);
     
     [OneSignal disablePush:true];
     [UnitTestCommonMethods runBackgroundThreads];
-    
+    XCTAssertEqual(observer->fireCount, 2);
     XCTAssertFalse(observer->last.from.isPushDisabled);
     XCTAssertTrue(observer->last.to.isPushDisabled);
     // Device registered with OneSignal so now make pushToken available.
@@ -642,6 +643,7 @@
     // Device should be reported a subscribed now as all conditions are true.
     [OneSignal disablePush:false];
     [UnitTestCommonMethods runBackgroundThreads];
+    XCTAssertEqual(observer->fireCount, 4);
     XCTAssertFalse(observer->last.from.isSubscribed);
     XCTAssertTrue(observer->last.to.isSubscribed);
 }


### PR DESCRIPTION
The OSSubscriptionObserver was firing 3 times on launch for a fresh install.


1. For prompting permission
1. getting the APNs token
1. For registering the user

Now it will only fire after register user has been called and either succeeded or failed. For subsequent launches we rely on the `isOnSessionSuccessfulForCurrentState` boolean.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/853)
<!-- Reviewable:end -->

