### PR TITLE
Fixing never updating location until the app is restarted

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
@@ -33,12 +33,15 @@
 	<string>Test Location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Test Location2</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>test always and when in use</string>
 	<key>OneSignal_disable_badge_clearing</key>
 	<false/>
 	<key>OneSignal_require_privacy_consent</key>
 	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>location</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -281,6 +281,11 @@ static OneSignalLocation* singleInstance = nil;
     }];
 }
 
++ (void)requestLocation {
+    onesignal_Log(ONE_S_LL_DEBUG, @"OneSignalLocation Requesting Updated Location");
+    [locationManager performSelector:@selector(requestLocation)];
+}
+
 #pragma mark CLLocationManagerDelegate
 
 - (void)locationManager:(id)manager didUpdateLocations:(NSArray *)locations {
@@ -316,8 +321,7 @@ static OneSignalLocation* singleInstance = nil;
     if (!sendLocationTimer)
         [OneSignalLocation resetSendTimer];
     
-    if (!initialLocationSent)
-        [OneSignalLocation sendLocation];
+    [OneSignalLocation sendLocation];
     
     [OneSignalLocation sendAndClearLocationListener:PERMISSION_GRANTED];
 }
@@ -329,11 +333,10 @@ static OneSignalLocation* singleInstance = nil;
 
 + (void)resetSendTimer {
     NSTimeInterval requiredWaitTime = [UIApplication sharedApplication].applicationState == UIApplicationStateActive ? foregroundSendLocationWaitTime : backgroundSendLocationWaitTime;
-    sendLocationTimer = [NSTimer scheduledTimerWithTimeInterval:requiredWaitTime target:self selector:@selector(sendLocation) userInfo:nil repeats:NO];
+    sendLocationTimer = [NSTimer scheduledTimerWithTimeInterval:requiredWaitTime target:self selector:@selector(requestLocation) userInfo:nil repeats:NO];
 }
 
 + (void)sendLocation {
-    
     // return if the user has not granted privacy permissions
     if ([OneSignal requiresUserPrivacyConsent])
         return;


### PR DESCRIPTION
We were calling `locationManager stopUpdatingLocation`, but were then never calling `startUpdatingLocation` or `requestLocation` so the only time we would update the location is when the app was completely restarted. 
To fix this and keep battery usage as low as possible we use the timer to just call `requestLocation`, which triggers an updateLocation callback once. updateLocation will now always call `sendLocation` instead of the timer calling it.

Additionally I am adding more location descriptions and background modes to the dev app so that we can test background location updates.

To test this feature I used the simulator's location features which included simulating a freeway drive. In order for this to work I had to set the default Xcode location simulation (under debug) to none. If you don't do this the location will be static. 

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/856)
<!-- Reviewable:end -->

