### PR TITLE
Creation of Channel States

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -90,6 +90,22 @@
 		7A2E90622460DA1500B3428C /* OutcomeIntegrationV2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A2E90612460DA1500B3428C /* OutcomeIntegrationV2Tests.m */; };
 		7A5A818224897693002E07C8 /* MigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5A818124897693002E07C8 /* MigrationTests.m */; };
 		7A5A8185248990CD002E07C8 /* OSIndirectNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5A8184248990CD002E07C8 /* OSIndirectNotification.m */; };
+		7A5E71F325A66DDB00CB5605 /* OSUserStateSynchronizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A5E71F225A66DDB00CB5605 /* OSUserStateSynchronizer.h */; };
+		7A5E71FC25A66DEC00CB5605 /* OSUserStateSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E71FB25A66DEC00CB5605 /* OSUserStateSynchronizer.m */; };
+		7A5E71FD25A66DEC00CB5605 /* OSUserStateSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E71FB25A66DEC00CB5605 /* OSUserStateSynchronizer.m */; };
+		7A5E71FE25A66DEC00CB5605 /* OSUserStateSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E71FB25A66DEC00CB5605 /* OSUserStateSynchronizer.m */; };
+		7A5E720725A66E0A00CB5605 /* OSUserStatePushSynchronizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A5E720625A66E0A00CB5605 /* OSUserStatePushSynchronizer.h */; };
+		7A5E721025A66E1600CB5605 /* OSUserStatePushSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E720F25A66E1600CB5605 /* OSUserStatePushSynchronizer.m */; };
+		7A5E721125A66E1600CB5605 /* OSUserStatePushSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E720F25A66E1600CB5605 /* OSUserStatePushSynchronizer.m */; };
+		7A5E721225A66E1600CB5605 /* OSUserStatePushSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E720F25A66E1600CB5605 /* OSUserStatePushSynchronizer.m */; };
+		7A5E721B25A66E2900CB5605 /* OSUserStateEmailSynchronizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A5E721A25A66E2900CB5605 /* OSUserStateEmailSynchronizer.h */; };
+		7A5E722425A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E722325A66E3300CB5605 /* OSUserStateEmailSynchronizer.m */; };
+		7A5E722525A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E722325A66E3300CB5605 /* OSUserStateEmailSynchronizer.m */; };
+		7A5E722625A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E722325A66E3300CB5605 /* OSUserStateEmailSynchronizer.m */; };
+		7A5E725925A66E9800CB5605 /* OSStateSynchronizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A5E725825A66E9800CB5605 /* OSStateSynchronizer.h */; };
+		7A5E726225A66EA400CB5605 /* OSStateSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E726125A66EA400CB5605 /* OSStateSynchronizer.m */; };
+		7A5E726325A66EA400CB5605 /* OSStateSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E726125A66EA400CB5605 /* OSStateSynchronizer.m */; };
+		7A5E726425A66EA400CB5605 /* OSStateSynchronizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E726125A66EA400CB5605 /* OSStateSynchronizer.m */; };
 		7A600B42245378ED00514A53 /* OSFocusInfluenceParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */; };
 		7A600B442453790700514A53 /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
 		7A600B452453790700514A53 /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
@@ -533,6 +549,14 @@
 		7A5A818124897693002E07C8 /* MigrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MigrationTests.m; sourceTree = "<group>"; };
 		7A5A8184248990CD002E07C8 /* OSIndirectNotification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSIndirectNotification.m; sourceTree = "<group>"; };
 		7A5A8186248990DA002E07C8 /* OSIndirectNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSIndirectNotification.h; sourceTree = "<group>"; };
+		7A5E71F225A66DDB00CB5605 /* OSUserStateSynchronizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUserStateSynchronizer.h; sourceTree = "<group>"; };
+		7A5E71FB25A66DEC00CB5605 /* OSUserStateSynchronizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUserStateSynchronizer.m; sourceTree = "<group>"; };
+		7A5E720625A66E0A00CB5605 /* OSUserStatePushSynchronizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUserStatePushSynchronizer.h; sourceTree = "<group>"; };
+		7A5E720F25A66E1600CB5605 /* OSUserStatePushSynchronizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUserStatePushSynchronizer.m; sourceTree = "<group>"; };
+		7A5E721A25A66E2900CB5605 /* OSUserStateEmailSynchronizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUserStateEmailSynchronizer.h; sourceTree = "<group>"; };
+		7A5E722325A66E3300CB5605 /* OSUserStateEmailSynchronizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUserStateEmailSynchronizer.m; sourceTree = "<group>"; };
+		7A5E725825A66E9800CB5605 /* OSStateSynchronizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSStateSynchronizer.h; sourceTree = "<group>"; };
+		7A5E726125A66EA400CB5605 /* OSStateSynchronizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSStateSynchronizer.m; sourceTree = "<group>"; };
 		7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSFocusInfluenceParam.h; sourceTree = "<group>"; };
 		7A600B432453790700514A53 /* OSFocusInfluenceParam.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSFocusInfluenceParam.m; sourceTree = "<group>"; };
 		7A65D628246627AD007FF196 /* OSInAppMessageViewOverrider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageViewOverrider.h; sourceTree = "<group>"; };
@@ -1198,6 +1222,14 @@
 				CA810FCF202BA97300A60FED /* OSEmailSubscription.h */,
 				CA810FD0202BA97300A60FED /* OSEmailSubscription.m */,
 				7A676BE424981CEC003957CC /* OSDeviceState.m */,
+				7A5E71F225A66DDB00CB5605 /* OSUserStateSynchronizer.h */,
+				7A5E71FB25A66DEC00CB5605 /* OSUserStateSynchronizer.m */,
+				7A5E720625A66E0A00CB5605 /* OSUserStatePushSynchronizer.h */,
+				7A5E720F25A66E1600CB5605 /* OSUserStatePushSynchronizer.m */,
+				7A5E721A25A66E2900CB5605 /* OSUserStateEmailSynchronizer.h */,
+				7A5E722325A66E3300CB5605 /* OSUserStateEmailSynchronizer.m */,
+				7A5E725825A66E9800CB5605 /* OSStateSynchronizer.h */,
+				7A5E726125A66EA400CB5605 /* OSStateSynchronizer.m */,
 			);
 			name = State;
 			sourceTree = "<group>";
@@ -1369,6 +1401,7 @@
 				7AF5174524FDC2AA00B076BC /* OSRemoteParamController.h in Headers */,
 				CA08FC781FE99B13004C445F /* OneSignalRequest.h in Headers */,
 				CACBAAA8218A6280000ACAA5 /* OSJSONHandling.h in Headers */,
+				7A5E720725A66E0A00CB5605 /* OSUserStatePushSynchronizer.h in Headers */,
 				912412211E73342200E41FD7 /* OneSignalLocation.h in Headers */,
 				912412291E73342200E41FD7 /* OneSignalReachability.h in Headers */,
 				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
@@ -1398,6 +1431,7 @@
 				CA1A6E6920DC2E31001C41B9 /* OneSignalDialogController.h in Headers */,
 				7AF98662244975A100C36EAE /* OSOutcomeSourceBody.h in Headers */,
 				CA08FC7E1FE99B25004C445F /* Requests.h in Headers */,
+				7A5E721B25A66E2900CB5605 /* OSUserStateEmailSynchronizer.h in Headers */,
 				7AF9865624452A8C00C36EAE /* OSInfluence.h in Headers */,
 				912412411E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.h in Headers */,
 				7AF98684244A32D900C36EAE /* OSOutcomeEventsV2Repository.h in Headers */,
@@ -1416,12 +1450,14 @@
 				7AF9865324451F3900C36EAE /* OSFocusCallParams.h in Headers */,
 				CAB269D921B0B6F000F8A43C /* OSInAppMessageAction.h in Headers */,
 				DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */,
+				7A5E71F325A66DDB00CB5605 /* OSUserStateSynchronizer.h in Headers */,
 				7AECE59C23675F5700537907 /* OSFocusTimeProcessorFactory.h in Headers */,
 				7AECE59A23674ADC00537907 /* OSUnattributedFocusTimeProcessor.h in Headers */,
 				CA63AFC22022670A00E340FB /* ReattemptRequest.h in Headers */,
 				CACBAA9B218A6243000ACAA5 /* OSMessagingController.h in Headers */,
 				7AF9863F2444C44300C36EAE /* OSInAppMessageTracker.h in Headers */,
 				9124121D1E73342200E41FD7 /* OneSignalJailbreakDetection.h in Headers */,
+				7A5E725925A66E9800CB5605 /* OSStateSynchronizer.h in Headers */,
 				9129C6B71E89E59B009CB6A0 /* OSPermission.h in Headers */,
 				7A72EB1223E252DD00B4D50F /* OSInAppMessageDisplayStats.h in Headers */,
 				912412151E73342200E41FD7 /* OneSignalHelper.h in Headers */,
@@ -1676,9 +1712,11 @@
 				9124121E1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
 				CA08FC791FE99B13004C445F /* OneSignalRequest.m in Sources */,
 				912412471E73369600E41FD7 /* OneSignalHelper.m in Sources */,
+				7A5E722425A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */,
 				7A880F312404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,
 				9124122E1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122A1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
+				7A5E71FC25A66DEC00CB5605 /* OSUserStateSynchronizer.m in Sources */,
 				91F58D7D1E7C7F330017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
 				9129C6B81E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				CA8E19062193C76D009DA223 /* OSInAppMessagingHelpers.m in Sources */,
@@ -1687,6 +1725,7 @@
 				7A12EBDD23060B37005C4FA5 /* OSIndirectInfluence.m in Sources */,
 				9D1BD96D237B57CA00A064F7 /* OneSignalCacheCleaner.m in Sources */,
 				7A674F1B2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */,
+				7A5E721025A66E1600CB5605 /* OSUserStatePushSynchronizer.m in Sources */,
 				CA36A42D208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
 				912412421E73342200E41FD7 /* UNUserNotificationCenter+OneSignal.m in Sources */,
 				DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */,
@@ -1706,6 +1745,7 @@
 				CA4742E5218B8FF30020DC8C /* OSTriggerController.m in Sources */,
 				CA70E3352023D51000019273 /* OneSignalSetEmailParameters.m in Sources */,
 				CAB269E021B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */,
+				7A5E726225A66EA400CB5605 /* OSStateSynchronizer.m in Sources */,
 				91B6EA411E85D38F00B5CF01 /* OSObservable.m in Sources */,
 				7AF986432444C47400C36EAE /* OSNotificationTracker.m in Sources */,
 				DE367CC724EEF2BE00165207 /* OSInAppMessagePage.m in Sources */,
@@ -1769,9 +1809,11 @@
 				9124122F1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122B1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				7A880F322404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,
+				7A5E722525A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */,
 				0338566D1FBBDB190002F7C1 /* OneSignalTrackFirebaseAnalytics.m in Sources */,
 				7AECE59723674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				91F58D841E7C88220017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
+				7A5E71FD25A66DEC00CB5605 /* OSUserStateSynchronizer.m in Sources */,
 				CA8E19072193C76D009DA223 /* OSInAppMessagingHelpers.m in Sources */,
 				9129C6B91E89E59B009CB6A0 /* OSPermission.m in Sources */,
 				9D1BD96E237B57CA00A064F7 /* OneSignalCacheCleaner.m in Sources */,
@@ -1780,6 +1822,7 @@
 				7A1232AB235E17B8002B6CE3 /* OneSignalOutcomeEventsController.m in Sources */,
 				CA36A42E208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */,
 				0338566B1FBBD2270002F7C1 /* OSNotification.m in Sources */,
+				7A5E721125A66E1600CB5605 /* OSUserStatePushSynchronizer.m in Sources */,
 				9DDFEEF323189C0E00EAE0BB /* OneSignalViewHelper.m in Sources */,
 				7A880F2C23FB45FB0081F5E8 /* OSInAppMessageOutcome.m in Sources */,
 				DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */,
@@ -1799,6 +1842,7 @@
 				CA70E3362023D51300019273 /* OneSignalSetEmailParameters.m in Sources */,
 				CAB269E121B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */,
 				7AF986442444C47400C36EAE /* OSNotificationTracker.m in Sources */,
+				7A5E726325A66EA400CB5605 /* OSStateSynchronizer.m in Sources */,
 				912412271E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				912412331E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				DE367CC824EEF2BE00165207 /* OSInAppMessagePage.m in Sources */,
@@ -1878,6 +1922,7 @@
 				CAABF34D205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */,
 				912412301E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				91F58D851E7C88230017D24D /* OneSignalNotificationSettingsIOS10.m in Sources */,
+				7A5E722625A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */,
 				DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
@@ -1886,6 +1931,7 @@
 				CAB269E221B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */,
 				9D1BD96A237A28FC00A064F7 /* OSCachedUniqueOutcome.m in Sources */,
 				CAA4ED0120646762005BD59B /* BadgeTests.m in Sources */,
+				7A5E726425A66EA400CB5605 /* OSStateSynchronizer.m in Sources */,
 				7AF9866C244975CF00C36EAE /* OSOutcomeSource.m in Sources */,
 				912412491E73369800E41FD7 /* OneSignalHelper.m in Sources */,
 				CA1A6E7820DC2F04001C41B9 /* OneSignalDialogControllerOverrider.m in Sources */,
@@ -1894,6 +1940,7 @@
 				7A1232A2235E1743002B6CE3 /* OneSignal.m in Sources */,
 				4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */,
 				CA42CAC320D99CB90001F2F2 /* ProvisionalAuthorizationTests.m in Sources */,
+				7A5E721225A66E1600CB5605 /* OSUserStatePushSynchronizer.m in Sources */,
 				5B58E4F8237CE7B4009401E0 /* UIDeviceOverrider.m in Sources */,
 				CA8E19022193C6B0009DA223 /* InAppMessagingIntegrationTests.m in Sources */,
 				7AA2848B2406FC6500C25D76 /* OSInAppMessageTag.m in Sources */,
@@ -1933,6 +1980,7 @@
 				4529DEDB1FA8284E00CEAB1D /* NSDataOverrider.m in Sources */,
 				7AD1723A2416D53B00A78B19 /* OSInAppMessageLocationPrompt.m in Sources */,
 				CA7FC8A221927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
+				7A5E71FE25A66DEC00CB5605 /* OSUserStateSynchronizer.m in Sources */,
 				9D3300F623145AF3000F0A83 /* OneSignalViewHelper.m in Sources */,
 				7AF9868224497BE100C36EAE /* OSOutcomeEventsV1Repository.m in Sources */,
 				7A600B462453790700514A53 /* OSFocusInfluenceParam.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		7ADE379422E8B69C00263048 /* OneSignalOutcomeEventsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ADE379322E8B69C00263048 /* OneSignalOutcomeEventsController.m */; };
 		7ADE37AD22F2554400263048 /* OneSignalOutcomeEventsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ADE379322E8B69C00263048 /* OneSignalOutcomeEventsController.m */; };
 		7ADF891C230DB5BD0054E0D6 /* UnitTestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DEF51FA8460C00CEAB1D /* UnitTestAppDelegate.m */; };
+		7AE28B8825B8ADF400529100 /* OSMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AE28B8725B8ADF400529100 /* OSMacros.h */; };
 		7AECE59023674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AECE58F23674A9700537907 /* OSAttributedFocusTimeProcessor.m */; };
 		7AECE59123674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AECE58F23674A9700537907 /* OSAttributedFocusTimeProcessor.m */; };
 		7AECE59223674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AECE58F23674A9700537907 /* OSAttributedFocusTimeProcessor.m */; };
@@ -608,6 +609,7 @@
 		7AD8DDE8234BD3CF00747A8A /* OneSignalUserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalUserDefaults.h; sourceTree = "<group>"; };
 		7ADE379322E8B69C00263048 /* OneSignalOutcomeEventsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OneSignalOutcomeEventsController.m; sourceTree = "<group>"; };
 		7ADE379522E8B70700263048 /* OneSignalOutcomeEventsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalOutcomeEventsController.h; sourceTree = "<group>"; };
+		7AE28B8725B8ADF400529100 /* OSMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSMacros.h; sourceTree = "<group>"; };
 		7AECE58F23674A9700537907 /* OSAttributedFocusTimeProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSAttributedFocusTimeProcessor.m; sourceTree = "<group>"; };
 		7AECE59323674AA700537907 /* OSAttributedFocusTimeProcessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSAttributedFocusTimeProcessor.h; sourceTree = "<group>"; };
 		7AECE59523674AB700537907 /* OSUnattributedFocusTimeProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUnattributedFocusTimeProcessor.m; sourceTree = "<group>"; };
@@ -1192,6 +1194,7 @@
 				CAAEA68521ED68A30049CF15 /* OneSignalNotificationCategoryController.m */,
 				7A93269225AF4E6700BBEC27 /* OSPendingCallbacks.h */,
 				7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */,
+				7AE28B8725B8ADF400529100 /* OSMacros.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1435,6 +1438,7 @@
 				91F58D7A1E7C7D3F0017D24D /* OneSignalNotificationSettings.h in Headers */,
 				CA4742E4218B8FF30020DC8C /* OSTriggerController.h in Headers */,
 				7A1232AA235E17B4002B6CE3 /* OSSessionManager.h in Headers */,
+				7AE28B8825B8ADF400529100 /* OSMacros.h in Headers */,
 				DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */,
 				9D1BD9642379F42700A064F7 /* OSInfluenceDataDefines.h in Headers */,
 				7A674F192360D813001F9ACD /* OSBaseFocusTimeProcessor.h in Headers */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -127,6 +127,14 @@
 		7A880F322404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A880F302404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m */; };
 		7A880F332404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A880F302404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m */; };
 		7A9173A2231971E5007848FA /* OneSignalReceiveReceiptsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A9173A1231971E5007848FA /* OneSignalReceiveReceiptsController.m */; };
+		7A93264825A8DD3600BBEC27 /* OSUserState.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A93264725A8DD3600BBEC27 /* OSUserState.h */; };
+		7A93265125A8DD4300BBEC27 /* OSUserState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93265025A8DD4300BBEC27 /* OSUserState.m */; };
+		7A93265225A8DD4300BBEC27 /* OSUserState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93265025A8DD4300BBEC27 /* OSUserState.m */; };
+		7A93265325A8DD4300BBEC27 /* OSUserState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93265025A8DD4300BBEC27 /* OSUserState.m */; };
+		7A93266A25AC985500BBEC27 /* OSLocationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A93266925AC985500BBEC27 /* OSLocationState.h */; };
+		7A93267325AC986400BBEC27 /* OSLocationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93267225AC986400BBEC27 /* OSLocationState.m */; };
+		7A93267425AC986400BBEC27 /* OSLocationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93267225AC986400BBEC27 /* OSLocationState.m */; };
+		7A93267525AC986400BBEC27 /* OSLocationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93267225AC986400BBEC27 /* OSLocationState.m */; };
 		7A94D8E1249ABF0000E90B40 /* OSUniqueOutcomeNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */; };
 		7AA2848A2406FC6400C25D76 /* OSInAppMessageTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F2D8E2406EFC5007799A9 /* OSInAppMessageTag.m */; };
 		7AA2848B2406FC6500C25D76 /* OSInAppMessageTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F2D8E2406EFC5007799A9 /* OSInAppMessageTag.m */; };
@@ -573,6 +581,10 @@
 		7A880F302404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessagePushPrompt.m; sourceTree = "<group>"; };
 		7A9173A1231971E5007848FA /* OneSignalReceiveReceiptsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalReceiveReceiptsController.m; sourceTree = "<group>"; };
 		7A9173A3231971F8007848FA /* OneSignalReceiveReceiptsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalReceiveReceiptsController.h; sourceTree = "<group>"; };
+		7A93264725A8DD3600BBEC27 /* OSUserState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUserState.h; sourceTree = "<group>"; };
+		7A93265025A8DD4300BBEC27 /* OSUserState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUserState.m; sourceTree = "<group>"; };
+		7A93266925AC985500BBEC27 /* OSLocationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSLocationState.h; sourceTree = "<group>"; };
+		7A93267225AC986400BBEC27 /* OSLocationState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSLocationState.m; sourceTree = "<group>"; };
 		7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUniqueOutcomeNotification.m; sourceTree = "<group>"; };
 		7A94D8E2249ABF0C00E90B40 /* OSUniqueOutcomeNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUniqueOutcomeNotification.h; sourceTree = "<group>"; };
 		7AAA60652485D0090004FADE /* OSMigrationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSMigrationController.h; sourceTree = "<group>"; };
@@ -1230,6 +1242,10 @@
 				7A5E722325A66E3300CB5605 /* OSUserStateEmailSynchronizer.m */,
 				7A5E725825A66E9800CB5605 /* OSStateSynchronizer.h */,
 				7A5E726125A66EA400CB5605 /* OSStateSynchronizer.m */,
+				7A93264725A8DD3600BBEC27 /* OSUserState.h */,
+				7A93265025A8DD4300BBEC27 /* OSUserState.m */,
+				7A93266925AC985500BBEC27 /* OSLocationState.h */,
+				7A93267225AC986400BBEC27 /* OSLocationState.m */,
 			);
 			name = State;
 			sourceTree = "<group>";
@@ -1403,6 +1419,7 @@
 				CACBAAA8218A6280000ACAA5 /* OSJSONHandling.h in Headers */,
 				7A5E720725A66E0A00CB5605 /* OSUserStatePushSynchronizer.h in Headers */,
 				912412211E73342200E41FD7 /* OneSignalLocation.h in Headers */,
+				7A93266A25AC985500BBEC27 /* OSLocationState.h in Headers */,
 				912412291E73342200E41FD7 /* OneSignalReachability.h in Headers */,
 				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
 				7AF98668244975C200C36EAE /* OSOutcomeSource.h in Headers */,
@@ -1458,6 +1475,7 @@
 				7AF9863F2444C44300C36EAE /* OSInAppMessageTracker.h in Headers */,
 				9124121D1E73342200E41FD7 /* OneSignalJailbreakDetection.h in Headers */,
 				7A5E725925A66E9800CB5605 /* OSStateSynchronizer.h in Headers */,
+				7A93264825A8DD3600BBEC27 /* OSUserState.h in Headers */,
 				9129C6B71E89E59B009CB6A0 /* OSPermission.h in Headers */,
 				7A72EB1223E252DD00B4D50F /* OSInAppMessageDisplayStats.h in Headers */,
 				912412151E73342200E41FD7 /* OneSignalHelper.h in Headers */,
@@ -1712,6 +1730,7 @@
 				9124121E1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
 				CA08FC791FE99B13004C445F /* OneSignalRequest.m in Sources */,
 				912412471E73369600E41FD7 /* OneSignalHelper.m in Sources */,
+				7A93267325AC986400BBEC27 /* OSLocationState.m in Sources */,
 				7A5E722425A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */,
 				7A880F312404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,
 				9124122E1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
@@ -1767,6 +1786,7 @@
 				7AECE59623674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				1AF75EAE1E8567FD0097B315 /* NSString+OneSignal.m in Sources */,
 				454F94F51FAD2E5A00D74CCF /* OSNotification.m in Sources */,
+				7A93265125A8DD4300BBEC27 /* OSUserState.m in Sources */,
 				9129C6BE1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				7AECE59023674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				7ADE379422E8B69C00263048 /* OneSignalOutcomeEventsController.m in Sources */,
@@ -1809,6 +1829,7 @@
 				9124122F1E73342200E41FD7 /* OneSignalSelectorHelpers.m in Sources */,
 				9124122B1E73342200E41FD7 /* OneSignalReachability.m in Sources */,
 				7A880F322404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,
+				7A93267425AC986400BBEC27 /* OSLocationState.m in Sources */,
 				7A5E722525A66E3300CB5605 /* OSUserStateEmailSynchronizer.m in Sources */,
 				0338566D1FBBDB190002F7C1 /* OneSignalTrackFirebaseAnalytics.m in Sources */,
 				7AECE59723674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
@@ -1864,6 +1885,7 @@
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
 				9129C6BF1E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
+				7A93265225A8DD4300BBEC27 /* OSUserState.m in Sources */,
 				CAABF34C205B157B0042F8E5 /* OneSignalExtensionBadgeHandler.m in Sources */,
 				038C63822387450300CA4310 /* OneSignalReceiveReceiptsController.m in Sources */,
 				7AECE59123674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
@@ -1985,6 +2007,7 @@
 				7AF9868224497BE100C36EAE /* OSOutcomeEventsV1Repository.m in Sources */,
 				7A600B462453790700514A53 /* OSFocusInfluenceParam.m in Sources */,
 				4529DEF31FA8440A00CEAB1D /* UIAlertViewOverrider.m in Sources */,
+				7A93265325A8DD4300BBEC27 /* OSUserState.m in Sources */,
 				CA8E18FF2193A1A5009DA223 /* NSTimerOverrider.m in Sources */,
 				7AF9868E244A556F00C36EAE /* OSOutcomeEventsFactory.m in Sources */,
 				7AF986452444C47400C36EAE /* OSNotificationTracker.m in Sources */,
@@ -1997,6 +2020,7 @@
 				7AECE59823674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				7A5A818224897693002E07C8 /* MigrationTests.m in Sources */,
 				7AECE5A023675F6300537907 /* OSFocusTimeProcessorFactory.m in Sources */,
+				7A93267525AC986400BBEC27 /* OSLocationState.m in Sources */,
 				DE367CC924EEF2BE00165207 /* OSInAppMessagePage.m in Sources */,
 				9129C6C01E89E7AB009CB6A0 /* OSSubscription.m in Sources */,
 				7AC8D3A824993A0E0023EDE8 /* OSDeviceState.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -135,6 +135,10 @@
 		7A93267325AC986400BBEC27 /* OSLocationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93267225AC986400BBEC27 /* OSLocationState.m */; };
 		7A93267425AC986400BBEC27 /* OSLocationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93267225AC986400BBEC27 /* OSLocationState.m */; };
 		7A93267525AC986400BBEC27 /* OSLocationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93267225AC986400BBEC27 /* OSLocationState.m */; };
+		7A93269325AF4E6700BBEC27 /* OSPendingCallbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A93269225AF4E6700BBEC27 /* OSPendingCallbacks.h */; };
+		7A93269C25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */; };
+		7A93269D25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */; };
+		7A93269E25AF4F0300BBEC27 /* OSPendingCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */; };
 		7A94D8E1249ABF0000E90B40 /* OSUniqueOutcomeNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */; };
 		7AA2848A2406FC6400C25D76 /* OSInAppMessageTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F2D8E2406EFC5007799A9 /* OSInAppMessageTag.m */; };
 		7AA2848B2406FC6500C25D76 /* OSInAppMessageTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F2D8E2406EFC5007799A9 /* OSInAppMessageTag.m */; };
@@ -585,6 +589,8 @@
 		7A93265025A8DD4300BBEC27 /* OSUserState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUserState.m; sourceTree = "<group>"; };
 		7A93266925AC985500BBEC27 /* OSLocationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSLocationState.h; sourceTree = "<group>"; };
 		7A93267225AC986400BBEC27 /* OSLocationState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSLocationState.m; sourceTree = "<group>"; };
+		7A93269225AF4E6700BBEC27 /* OSPendingCallbacks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSPendingCallbacks.h; sourceTree = "<group>"; };
+		7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSPendingCallbacks.m; sourceTree = "<group>"; };
 		7A94D8E0249ABF0000E90B40 /* OSUniqueOutcomeNotification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSUniqueOutcomeNotification.m; sourceTree = "<group>"; };
 		7A94D8E2249ABF0C00E90B40 /* OSUniqueOutcomeNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSUniqueOutcomeNotification.h; sourceTree = "<group>"; };
 		7AAA60652485D0090004FADE /* OSMigrationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSMigrationController.h; sourceTree = "<group>"; };
@@ -1184,6 +1190,8 @@
 				CAABF34A205B15780042F8E5 /* OneSignalExtensionBadgeHandler.m */,
 				CAAEA68621ED68A40049CF15 /* OneSignalNotificationCategoryController.h */,
 				CAAEA68521ED68A30049CF15 /* OneSignalNotificationCategoryController.m */,
+				7A93269225AF4E6700BBEC27 /* OSPendingCallbacks.h */,
+				7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1420,6 +1428,7 @@
 				7A5E720725A66E0A00CB5605 /* OSUserStatePushSynchronizer.h in Headers */,
 				912412211E73342200E41FD7 /* OneSignalLocation.h in Headers */,
 				7A93266A25AC985500BBEC27 /* OSLocationState.h in Headers */,
+				7A93269325AF4E6700BBEC27 /* OSPendingCallbacks.h in Headers */,
 				912412291E73342200E41FD7 /* OneSignalReachability.h in Headers */,
 				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
 				7AF98668244975C200C36EAE /* OSOutcomeSource.h in Headers */,
@@ -1781,6 +1790,7 @@
 				CA63AFC32022670A00E340FB /* ReattemptRequest.m in Sources */,
 				912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				CACBAAA4218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */,
+				7A93269C25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */,
 				DE20425E24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
 				CA7FC8A021927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				7AECE59623674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
@@ -1880,6 +1890,7 @@
 				CA7FC8A121927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				9D1BD965237A08A400A064F7 /* OneSignalUserDefaults.m in Sources */,
+				7A93269D25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */,
 				DE20425F24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
 				7AF9863C2444C43900C36EAE /* OSInAppMessageTracker.m in Sources */,
 				1AF75EB01E8569720097B315 /* NSString+OneSignal.m in Sources */,
@@ -2017,6 +2028,7 @@
 				CA4742E7218B8FF30020DC8C /* OSTriggerController.m in Sources */,
 				4529DEEA1FA8360C00CEAB1D /* UIApplicationOverrider.m in Sources */,
 				912412281E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
+				7A93269E25AF4F0300BBEC27 /* OSPendingCallbacks.m in Sources */,
 				7AECE59823674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				7A5A818224897693002E07C8 /* MigrationTests.m in Sources */,
 				7AECE5A023675F6300537907 /* OSFocusTimeProcessorFactory.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSChannelTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSChannelTracker.m
@@ -32,9 +32,7 @@ THE SOFTWARE.
 #import "OSInfluence.h"
 #import "OSChannelTracker.h"
 #import "OSIndirectInfluence.h"
-
-#define mustOverride() @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"%s must be overridden in a subclass/category", __PRETTY_FUNCTION__] userInfo:nil]
-#define methodNotImplemented() mustOverride()
+#import "OSMacros.h"
 
 @implementation OSChannelTracker
 

--- a/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.h
@@ -51,6 +51,7 @@ typedef OSObservable<NSObject<OSEmailSubscriptionObserver>*, OSEmailSubscription
 - (void)persist;
 - (void)setEmailUserId:(NSString *)emailUserId;
 - (void)setEmailAddress:(NSString *)emailAddress;
+- (BOOL)isEmailSetup;
 - (BOOL)compare:(OSEmailSubscriptionState *)from;
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
@@ -62,7 +62,7 @@
 
 - (NSString *)description {
     @synchronized (self) {
-        return [NSString stringWithFormat:@"<OSEmailSubscriptionState: emailAddress: %@, emailUserId: %@>", self.emailAddress, self.emailUserId];
+        return [NSString stringWithFormat:@"<OSEmailSubscriptionState: emailAddress: %@, emailUserId: %@, emailAuthCode: %@>", self.emailAddress, self.emailUserId, self.emailAuthCode];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSEmailSubscription.m
@@ -79,7 +79,6 @@
     return copy;
 }
 
-
 - (void)setEmailUserId:(NSString *)emailUserId {
     BOOL changed = emailUserId != _emailUserId;
     _emailUserId = emailUserId;
@@ -90,6 +89,10 @@
 
 - (void)setEmailAddress:(NSString *)emailAddress {
     _emailAddress = emailAddress;
+}
+
+- (BOOL)isEmailSetup {
+    return _emailUserId && (!_requiresEmailAuth || _emailAuthCode);
 }
 
 - (NSDictionary *)toDictionary {

--- a/iOS_SDK/OneSignalSDK/Source/OSLocationState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSLocationState.h
@@ -25,18 +25,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef OSStateSynchronizer_h
-#define OSStateSynchronizer_h
+#ifndef OSLocationState_h
+#define OSLocationState_h
 
-#import "OneSignal.h"
+@interface OSLocationState : NSObject
 
-@interface OSStateSynchronizer : NSObject
-
-- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
-
-- (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
-
+@property (strong, nonatomic, readwrite, nullable) NSNumber *latitude;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *longitude;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *verticalAccuracy;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *accuracy;
 
 @end
 
-#endif /* OSStateSynchronizer_h */
+#endif /* OSLocationState_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSLocationState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSLocationState.h
@@ -25,9 +25,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef OSLocationState_h
-#define OSLocationState_h
-
 @interface OSLocationState : NSObject
 
 @property (strong, nonatomic, readwrite, nullable) NSNumber *latitude;
@@ -38,5 +35,3 @@ THE SOFTWARE.
 - (NSDictionary*)toDictionary;
 
 @end
-
-#endif /* OSLocationState_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSLocationState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSLocationState.h
@@ -35,6 +35,8 @@ THE SOFTWARE.
 @property (strong, nonatomic, readwrite, nullable) NSNumber *verticalAccuracy;
 @property (strong, nonatomic, readwrite, nullable) NSNumber *accuracy;
 
+- (NSDictionary*)toDictionary;
+
 @end
 
 #endif /* OSLocationState_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSLocationState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSLocationState.m
@@ -25,18 +25,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef OSStateSynchronizer_h
-#define OSStateSynchronizer_h
-
-#import "OneSignal.h"
-
-@interface OSStateSynchronizer : NSObject
-
-- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
-
-- (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
-
-
-@end
-
-#endif /* OSStateSynchronizer_h */
+#import <Foundation/Foundation.h>
+#import "OSLocationState.h"

--- a/iOS_SDK/OneSignalSDK/Source/OSLocationState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSLocationState.m
@@ -27,3 +27,18 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSLocationState.h"
+
+@implementation OSLocationState
+
+- (NSDictionary *)toDictionary {
+    NSDictionary *dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
+                   _latitude, @"lat",
+                   _longitude, @"long",
+                   _verticalAccuracy, @"loc_acc_vert",
+                   _accuracy, @"loc_acc",
+                   nil];
+    
+    return dataDic;
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSMacros.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMacros.h
@@ -1,0 +1,29 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#define mustOverride() @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"%s must be overridden in a subclass/category", __PRETTY_FUNCTION__] userInfo:nil]
+#define methodNotImplemented() mustOverride()

--- a/iOS_SDK/OneSignalSDK/Source/OSObservable.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSObservable.m
@@ -69,7 +69,6 @@ SEL changeSelector;
     
     @synchronized(observers) {
         NSArray *obs = [observers copy];
-        
         for (id observer in obs) {
             fired = true;
             if (changeSelector) {

--- a/iOS_SDK/OneSignalSDK/Source/OSOutcomeEventsRepository.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSOutcomeEventsRepository.m
@@ -29,9 +29,7 @@ THE SOFTWARE.
 #import "OSCachedUniqueOutcome.h"
 #import "OSOutcomeEventsRepository.h"
 #import "OneSignalInternal.h"
-
-#define mustOverride() @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"%s must be overridden in a subclass/category", __PRETTY_FUNCTION__] userInfo:nil]
-#define methodNotImplemented() mustOverride()
+#import "OSMacros.h"
 
 @implementation OSOutcomeEventsRepository
 

--- a/iOS_SDK/OneSignalSDK/Source/OSPendingCallbacks.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPendingCallbacks.h
@@ -25,13 +25,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#import "OSUserStateSynchronizer.h"
+#import "OneSignal.h"
 
-#ifndef OSUserStateEmailSynchronizer_h
-#define OSUserStateEmailSynchronizer_h
+#ifndef OSPendingCallbacks_h
+#define OSPendingCallbacks_h
 
-@interface OSUserStateEmailSynchronizer : OSUserStateSynchronizer
+@interface OSPendingCallbacks : NSObject
+
+ @property OSResultSuccessBlock successBlock;
+ @property OSFailureBlock failureBlock;
 
 @end
 
-#endif /* OSUserStateEmailSynchronizer_h */
+#endif /* OSPendingCallbacks_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSPendingCallbacks.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPendingCallbacks.m
@@ -25,13 +25,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#import "OSUserStateSynchronizer.h"
+#import <Foundation/Foundation.h>
+#import "OSPendingCallbacks.h"
 
-#ifndef OSUserStateEmailSynchronizer_h
-#define OSUserStateEmailSynchronizer_h
-
-@interface OSUserStateEmailSynchronizer : OSUserStateSynchronizer
-
+@implementation OSPendingCallbacks
 @end
-
-#endif /* OSUserStateEmailSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -53,6 +53,8 @@ withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
 
 - (void)sendPurchases:(NSArray * _Nonnull)purchases appId:(NSString * _Nonnull)appId;
 
+- (void)sendBadgeCount:(NSNumber * _Nonnull)badgeCount appId:(NSString * _Nonnull)appId;
+
 @end
 
 #endif /* OSStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -25,20 +25,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef OSStateSynchronizer_h
-#define OSStateSynchronizer_h
-
 #import "OneSignal.h"
 #import "OSUserState.h"
 #import "OneSignalClient.h"
 
+#ifndef OSStateSynchronizer_h
+#define OSStateSynchronizer_h
+
 @interface OSStateSynchronizer : NSObject
 
-- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
+- (instancetype _Nonnull)initWithSubscriptionState:(OSSubscriptionState * _Nonnull)subscriptionState
+                        withEmailSubscriptionState:(OSEmailSubscriptionState * _Nonnull)emailSubscriptionState;
 
-- (void)registerUserWithState:(OSUserState * _Nonnull)registrationState withSuccess:(OSMultipleSuccessBlock)successBlock onFailure:(OSMultipleFailureBlock)failureBlock;
-- (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
+- (void)registerUserWithState:(OSUserState * _Nonnull)registrationState
+                  withSuccess:(OSMultipleSuccessBlock _Nullable)successBlock
+                    onFailure:(OSMultipleFailureBlock _Nullable)failureBlock;
 
+- (void)setExternalUserId:(NSString * _Nonnull)externalId
+withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
+                withAppId:(NSString * _Nonnull)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock
+              withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
+
+- (void)sendTagsWithAppId:(NSString * _Nonnull)appId
+               sendingTags:(NSDictionary * _Nonnull)tag
+               networkType:(NSNumber * _Nonnull)networkType
+      processingCallbacks:(NSArray * _Nullable)nowProcessingCallbacks;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -28,7 +28,13 @@ THE SOFTWARE.
 #ifndef OSStateSynchronizer_h
 #define OSStateSynchronizer_h
 
+#import "OneSignal.h"
+
 @interface OSStateSynchronizer : NSObject
+
+- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
+
+- (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #import "OSUserState.h"
 #import "OneSignalClient.h"
 #import "OneSignalLocation.h"
+#import "OSFocusCallParams.h"
 
 #ifndef OSStateSynchronizer_h
 #define OSStateSynchronizer_h
@@ -56,7 +57,15 @@ withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
 
 - (void)sendBadgeCount:(NSNumber * _Nonnull)badgeCount appId:(NSString * _Nonnull)appId;
 
-- (void)sendLocation:(os_last_location *)lastLocation appId:(NSString *)appId networkType:(NSNumber *)networkType backgroundState:(BOOL)background;
+- (void)sendLocation:(os_last_location * _Nonnull)lastLocation
+               appId:(NSString * _Nonnull)appId
+         networkType:(NSNumber * _Nonnull)networkType
+     backgroundState:(BOOL)background;
+
+- (void)sendOnFocusTime:(NSNumber * _Nonnull)totalTimeActive
+                 params:(OSFocusCallParams * _Nonnull)params
+            withSuccess:(OSMultipleSuccessBlock _Nullable)successBlock
+              onFailure:(OSMultipleFailureBlock _Nullable)failureBlock;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #import "OneSignal.h"
 #import "OSUserState.h"
 #import "OneSignalClient.h"
+#import "OneSignalLocation.h"
 
 #ifndef OSStateSynchronizer_h
 #define OSStateSynchronizer_h
@@ -54,6 +55,8 @@ withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
 - (void)sendPurchases:(NSArray * _Nonnull)purchases appId:(NSString * _Nonnull)appId;
 
 - (void)sendBadgeCount:(NSNumber * _Nonnull)badgeCount appId:(NSString * _Nonnull)appId;
+
+- (void)sendLocation:(os_last_location *)lastLocation appId:(NSString *)appId networkType:(NSNumber *)networkType backgroundState:(BOOL)background;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -31,9 +31,6 @@ THE SOFTWARE.
 #import "OneSignalLocation.h"
 #import "OSFocusCallParams.h"
 
-#ifndef OSStateSynchronizer_h
-#define OSStateSynchronizer_h
-
 @interface OSStateSynchronizer : NSObject
 
 - (instancetype _Nonnull)initWithSubscriptionState:(OSSubscriptionState * _Nonnull)subscriptionState
@@ -68,5 +65,3 @@ withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
               onFailure:(OSMultipleFailureBlock _Nullable)failureBlock;
 
 @end
-
-#endif /* OSStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -29,11 +29,14 @@ THE SOFTWARE.
 #define OSStateSynchronizer_h
 
 #import "OneSignal.h"
+#import "OSUserState.h"
+#import "OneSignalClient.h"
 
 @interface OSStateSynchronizer : NSObject
 
 - (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
 
+- (void)registerUserWithState:(OSUserState * _Nonnull)registrationState withSuccess:(OSMultipleSuccessBlock)successBlock onFailure:(OSMultipleFailureBlock)failureBlock;
 - (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
 
 

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -1,0 +1,35 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef OSStateSynchronizer_h
+#define OSStateSynchronizer_h
+
+@interface OSStateSynchronizer : NSObject
+
+@end
+
+#endif /* OSStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -51,6 +51,8 @@ withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
                networkType:(NSNumber * _Nonnull)networkType
       processingCallbacks:(NSArray * _Nullable)nowProcessingCallbacks;
 
+- (void)sendPurchases:(NSArray * _Nonnull)purchases appId:(NSString * _Nonnull)appId;
+
 @end
 
 #endif /* OSStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -30,7 +30,6 @@ THE SOFTWARE.
 #import "OSUserStateSynchronizer.h"
 #import "OSUserStatePushSynchronizer.h"
 #import "OSUserStateEmailSynchronizer.h"
-#import "OneSignalClient.h"
 #import "Requests.h"
 #import "OneSignalCommonDefines.h"
 #import "OneSignalUserDefaults.h"
@@ -40,6 +39,7 @@ THE SOFTWARE.
 + (BOOL)isEmailSetup;
 + (BOOL)shouldUpdateExternalUserId:(NSString*)externalId withRequests:(NSDictionary*)requests;
 + (NSMutableDictionary*)getDuplicateExternalUserIdResponse:(NSString*)externalId withRequests:(NSDictionary*)requests;
++ (void)emailChangedWithNewEmailPlayerId:(NSString * _Nullable)emailPlayerId;
 
 @end
 
@@ -73,6 +73,83 @@ THE SOFTWARE.
 
 - (OSUserStateSynchronizer *)getEmailStateSynchronizer {
     return [_userStateSynchronizers objectForKey:OS_EMAIL];
+}
+
+- (void)registerUserWithState:(OSUserState *)registrationState withSuccess:(OSMultipleSuccessBlock)successBlock onFailure:(OSMultipleFailureBlock)failureBlock {
+    let requests = [NSMutableDictionary new];
+    let pushDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
+    pushDataDic[@"identifier"] = self.currentSubscriptionState.pushToken;
+    
+    requests[OS_PUSH] = [[self getPushStateSynchronizer] registerUserWithData:pushDataDic userId:self.currentSubscriptionState.userId];
+    
+    if ([OneSignal isEmailSetup]) {
+        let emailDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
+        emailDataDic[@"device_type"] = [NSNumber numberWithInt:DEVICE_TYPE_EMAIL];
+        emailDataDic[@"email_auth_hash"] = self.currentEmailSubscriptionState.emailAuthCode;
+        
+        // If push device has external id we want to add it to the email device also
+        if (registrationState.externalUserId)
+            emailDataDic[@"external_user_id"] = registrationState.externalUserId;
+
+        requests[OS_EMAIL] = [[self getEmailStateSynchronizer] registerUserWithData:emailDataDic userId:self.currentEmailSubscriptionState.emailUserId];
+    } else {
+        // If no email is setup clear the email external user id
+        [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_EXTERNAL_USER_ID withValue:nil];
+    }
+    
+    [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"on_session result: %@", results]];
+
+        // If the external user ID was sent as part of this request, we need to save it
+        // Cache the external id if it exists within the registration payload
+        if (registrationState.externalUserId)
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:registrationState.externalUserId];
+        
+        if (registrationState.externalUserIdHash) {
+            self.currentSubscriptionState.externalIdAuthCode = registrationState.externalUserIdHash;
+            
+            //call persistAsFrom in order to save the externalIdAuthCode to NSUserDefaults
+            [self.currentSubscriptionState persist];
+        }
+
+        // Update email player ID
+        if (results[OS_EMAIL] && results[OS_EMAIL][@"id"]) {
+            
+            // Check to see if the email player_id or email_auth_token are different from what were previously saved
+            // if so, we should update the server with this change
+            
+            if (self.currentEmailSubscriptionState.emailUserId && ![self.currentEmailSubscriptionState.emailUserId isEqualToString:results[OS_EMAIL][@"id"]] && self.currentEmailSubscriptionState.emailAuthCode) {
+                [OneSignal emailChangedWithNewEmailPlayerId:results[OS_EMAIL][@"id"]];
+                [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_EXTERNAL_USER_ID withValue:nil];
+            }
+            
+            self.currentEmailSubscriptionState.emailUserId = results[OS_EMAIL][@"id"];
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_PLAYER_ID withValue:self.currentEmailSubscriptionState.emailUserId];
+
+            // Email successfully updated, so if there was an external user id we should cache it for email now
+            if (registrationState.externalUserId)
+                [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_EXTERNAL_USER_ID withValue:registrationState.externalUserId];
+
+        }
+        
+        //update push player id
+        if (results.count > 0 && results[OS_PUSH][@"id"]) {
+            self.currentSubscriptionState.userId = results[OS_PUSH][@"id"];
+            
+            // Save player_id to both standard and shared NSUserDefaults
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PLAYER_ID_TO withValue:self.currentSubscriptionState.userId];
+            [OneSignalUserDefaults.initShared saveStringForKey:OSUD_PLAYER_ID_TO withValue:self.currentSubscriptionState.userId];
+        }
+        
+        if (successBlock)
+            successBlock(results);
+    } onFailure:^(NSDictionary<NSString *, NSError *> *errors) {
+        for (NSString *key in @[OS_PUSH, OS_EMAIL])
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat: @"Encountered error during %@ registration with OneSignal: %@", key, errors[key]]];
+
+        if (failureBlock)
+            failureBlock(errors);
+    }];
 }
 
 - (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock {

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -262,4 +262,20 @@ THE SOFTWARE.
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
 }
 
+- (void)sendLocation:(os_last_location *)lastLocation
+               appId:(NSString *)appId
+         networkType:(NSNumber *)networkType
+     backgroundState:(BOOL)background {
+    let pushStateSyncronizer = [self getPushStateSynchronizer];
+    let emailStateSyncronizer = [self getEmailStateSynchronizer];
+    
+    let requests = [NSMutableDictionary new];
+    requests[OS_PUSH] = [pushStateSyncronizer sendLocation:lastLocation appId:appId userId:_currentSubscriptionState.userId networkType:networkType backgroundState:background emailAuthHashToken:nil externalIdAuthHashToken:_currentSubscriptionState.externalIdAuthCode];
+    
+    if (emailStateSyncronizer)
+        requests[OS_EMAIL] = [emailStateSyncronizer sendLocation:lastLocation appId:appId userId:_currentEmailSubscriptionState.emailUserId networkType:networkType backgroundState:background emailAuthHashToken:_currentEmailSubscriptionState.emailAuthCode externalIdAuthHashToken:nil];
+    
+    [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -1,0 +1,33 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#import <Foundation/Foundation.h>
+#import "OSStateSynchronizer.h"
+
+@implementation OSStateSynchronizer
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -43,6 +43,7 @@ THE SOFTWARE.
 + (void)setUserId:(NSString *)userId;
 + (void)setEmailUserId:(NSString *)emailUserId;
 + (void)saveExternalIdAuthToken:(NSString *)hashToken;
++ (void)registerUserFinished;
 
 @end
 
@@ -108,6 +109,7 @@ THE SOFTWARE.
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"on_session result: %@", results]];
+        [OneSignal registerUserFinished];
 
         // If the external user ID was sent as part of this request, we need to save it
         // Cache the external id if it exists within the registration payload
@@ -152,6 +154,7 @@ THE SOFTWARE.
         for (NSString *key in @[OS_PUSH, OS_EMAIL])
             [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat: @"Encountered error during %@ registration with OneSignal: %@", key, errors[key]]];
 
+        [OneSignal registerUserFinished];
         if (failureBlock)
             failureBlock(errors);
     }];

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -27,7 +27,94 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSStateSynchronizer.h"
+#import "OSUserStateSynchronizer.h"
+#import "OSUserStatePushSynchronizer.h"
+#import "OSUserStateEmailSynchronizer.h"
+#import "OneSignalClient.h"
+#import "Requests.h"
+#import "OneSignalCommonDefines.h"
+#import "OneSignalUserDefaults.h"
+
+@interface OneSignal ()
+
++ (BOOL)isEmailSetup;
++ (BOOL)shouldUpdateExternalUserId:(NSString*)externalId withRequests:(NSDictionary*)requests;
++ (NSMutableDictionary*)getDuplicateExternalUserIdResponse:(NSString*)externalId withRequests:(NSDictionary*)requests;
+
+@end
+
+@interface OSStateSynchronizer ()
+
+@property (strong, nonatomic, readwrite, nonnull) NSDictionary<NSString *, OSUserStateSynchronizer *> *userStateSynchronizers;
+@property (strong, nonatomic, readwrite, nonnull) OSSubscriptionState *currentSubscriptionState;
+@property (strong, nonatomic, readwrite, nonnull) OSEmailSubscriptionState *currentEmailSubscriptionState;
+
+@end
 
 @implementation OSStateSynchronizer
+
+- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState
+               withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState {
+    self = [super init];
+    if (self) {
+        _userStateSynchronizers = @{
+            OS_PUSH  : [OSUserStatePushSynchronizer new],
+            OS_EMAIL : [OSUserStateEmailSynchronizer new]
+        };
+        _currentSubscriptionState = subscriptionState;
+        _currentEmailSubscriptionState = emailSubscriptionState;
+    }
+    return self;
+}
+
+- (OSUserStateSynchronizer *)getPushStateSynchronizer {
+    return [_userStateSynchronizers objectForKey:OS_PUSH];
+}
+
+- (OSUserStateSynchronizer *)getEmailStateSynchronizer {
+    return [_userStateSynchronizers objectForKey:OS_EMAIL];
+}
+
+- (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock {
+    // Begin constructing the request for the external id update
+    let requests = [NSMutableDictionary new];
+    requests[OS_PUSH] = [[self getPushStateSynchronizer] setExternalUserId:externalId
+                                               withExternalIdAuthHashToken:hashToken
+                                                                withUserId:_currentSubscriptionState.userId
+                                                                 withAppId:appId];
+    
+    // Check if the email has been set, this will decide on updtaing the external id for the email channel
+    if ([OneSignal isEmailSetup])
+        requests[OS_EMAIL] =  [[self getEmailStateSynchronizer] setExternalUserId:externalId
+                                                      withExternalIdAuthHashToken:hashToken
+                                                                       withUserId:_currentEmailSubscriptionState.emailUserId
+                                                                        withAppId:appId];
+
+    // Make sure this is not a duplicate request, if the email and push channels are aligned correctly with the same external id
+    if (![OneSignal shouldUpdateExternalUserId:externalId withRequests:requests]) {
+        // Use callback to return success for both cases here, since push and
+        // email (if email is not setup, email is not included) have been set already
+        let results = [OneSignal getDuplicateExternalUserIdResponse:externalId withRequests:requests];
+        if (successBlock)
+            successBlock(results);
+        return;
+    }
+
+    [OneSignalClient.sharedClient executeSimultaneousRequests:requests withCompletion:^(NSDictionary<NSString *,NSDictionary *> *results) {
+        if (results[OS_PUSH] && results[OS_PUSH][OS_SUCCESS] && [results[OS_PUSH][OS_SUCCESS] boolValue]) {
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:externalId];
+            _currentSubscriptionState.externalIdAuthCode = hashToken;
+            
+            // Call persistAsFrom in order to save the externalIdAuthCode to NSUserDefaults
+            [_currentSubscriptionState persist];
+        }
+        
+        if (results[OS_EMAIL] && results[OS_EMAIL][OS_SUCCESS] && [results[OS_EMAIL][OS_SUCCESS] boolValue])
+            [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EMAIL_EXTERNAL_USER_ID withValue:externalId];
+
+        if (successBlock)
+            successBlock(results);
+    }];
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -249,4 +249,17 @@ THE SOFTWARE.
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
 }
 
+- (void)sendBadgeCount:(NSNumber *)badgeCount appId:(NSString *)appId {
+    let pushStateSyncronizer = [self getPushStateSynchronizer];
+    let emailStateSyncronizer = [self getEmailStateSynchronizer];
+    
+    let requests = [NSMutableDictionary new];
+    requests[OS_PUSH] = [pushStateSyncronizer sendBadgeCount:badgeCount appId:appId userId:_currentSubscriptionState.userId emailAuthHashToken:nil externalIdAuthHashToken:_currentSubscriptionState.externalIdAuthCode];
+    
+    if (emailStateSyncronizer)
+        requests[OS_EMAIL] = [pushStateSyncronizer sendBadgeCount:badgeCount appId:appId userId:_currentEmailSubscriptionState.emailUserId emailAuthHashToken:_currentEmailSubscriptionState.emailAuthCode externalIdAuthHashToken:nil];
+    
+    [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -233,4 +233,20 @@ THE SOFTWARE.
     }];
 }
 
+- (void)sendPurchases:(NSArray *)purchases appId:(NSString *)appId {
+    if (!_currentSubscriptionState.userId)
+        return;
+    
+    let pushStateSyncronizer = [self getPushStateSynchronizer];
+    let emailStateSyncronizer = [self getEmailStateSynchronizer];
+    
+    let requests = [NSMutableDictionary new];
+    requests[OS_PUSH] = [pushStateSyncronizer sendPurchases:purchases appId:appId userId:_currentSubscriptionState.userId externalIdAuthToken:_currentSubscriptionState.externalIdAuthCode];
+    
+    if (emailStateSyncronizer)
+        requests[OS_EMAIL] = [emailStateSyncronizer sendPurchases:purchases appId:appId userId:_currentEmailSubscriptionState.emailUserId externalIdAuthToken:_currentEmailSubscriptionState.emailAuthCode];
+
+    [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -154,8 +154,8 @@
 }
 
 - (NSString*)description {
-    static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, isPushDisabled: %d, isSubscribed: %d>";
-    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.isPushDisabled, self.isSubscribed];
+    static NSString* format = @"<OSSubscriptionState: userId: %@, pushToken: %@, isPushDisabled: %d, isSubscribed: %d, externalIdAuthCode: %@>";
+    return [NSString stringWithFormat:format, self.userId, self.pushToken, self.isPushDisabled, self.isSubscribed, self.externalIdAuthCode];
 }
 
 - (NSDictionary*)toDictionary {

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -127,6 +127,7 @@
 - (void)setIsPushDisabled:(BOOL)isPushDisabled {
     BOOL changed = isPushDisabled != _isPushDisabled;
     _isPushDisabled = isPushDisabled;
+
     if (self.observable && changed)
         [self.observable notifyChange:self];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.h
@@ -25,9 +25,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef OSUserState_h
-#define OSUserState_h
-
 #import "OSLocationState.h"
 
 @interface OSUserState : NSObject
@@ -56,5 +53,3 @@ THE SOFTWARE.
 - (NSDictionary *_Nonnull)toDictionary;
 
 @end
-
-#endif /* OSUserState_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.h
@@ -43,7 +43,7 @@ THE SOFTWARE.
 @property (strong, nonatomic, readwrite, nullable) NSString *externalUserIdHash;
 @property (strong, nonatomic, readwrite, nullable) NSString *deviceModel;
 @property (strong, nonatomic, readwrite, nullable) NSString *gameVersion;
-@property (strong, nonatomic, readwrite, nullable) BOOL isRooted;
+@property (nonatomic, readwrite) BOOL isRooted;
 @property (strong, nonatomic, readwrite, nullable) NSNumber *netType;
 @property (strong, nonatomic, readwrite, nullable) NSString *iOSBundle;
 @property (strong, nonatomic, readwrite, nullable) NSString *language;
@@ -52,6 +52,8 @@ THE SOFTWARE.
 @property (strong, nonatomic, readwrite, nullable) NSNumber *testType;
 @property (strong, nonatomic, readwrite, nullable) NSDictionary* tags;
 @property (strong, nonatomic, readwrite, nullable) OSLocationState *locationState;
+
+- (NSDictionary *_Nonnull)toDictionary;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.h
@@ -1,0 +1,58 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef OSUserState_h
+#define OSUserState_h
+
+#import "OSLocationState.h"
+
+@interface OSUserState : NSObject
+
+@property (strong, nonatomic, readwrite, nullable) NSString *appId;
+@property (strong, nonatomic, readwrite, nullable) NSString *deviceOs;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *deviceType;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *timezone;
+@property (strong, nonatomic, readwrite, nullable) NSString *adId;
+@property (strong, nonatomic, readwrite, nullable) NSString *sdk;
+@property (strong, nonatomic, readwrite, nullable) NSString *sdkType;
+@property (strong, nonatomic, readwrite, nullable) NSString *externalUserId;
+@property (strong, nonatomic, readwrite, nullable) NSString *externalUserIdHash;
+@property (strong, nonatomic, readwrite, nullable) NSString *deviceModel;
+@property (strong, nonatomic, readwrite, nullable) NSString *gameVersion;
+@property (strong, nonatomic, readwrite, nullable) BOOL isRooted;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *netType;
+@property (strong, nonatomic, readwrite, nullable) NSString *iOSBundle;
+@property (strong, nonatomic, readwrite, nullable) NSString *language;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *notificationTypes;
+@property (strong, nonatomic, readwrite, nullable) NSString *carrier;
+@property (strong, nonatomic, readwrite, nullable) NSNumber *testType;
+@property (strong, nonatomic, readwrite, nullable) NSDictionary* tags;
+@property (strong, nonatomic, readwrite, nullable) OSLocationState *locationState;
+
+@end
+
+#endif /* OSUserState_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.m
@@ -25,18 +25,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef OSStateSynchronizer_h
-#define OSStateSynchronizer_h
 
-#import "OneSignal.h"
+#import <Foundation/Foundation.h>
+#import "OSUserState.h"
 
-@interface OSStateSynchronizer : NSObject
-
-- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState withEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
-
-- (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock;
-
+@implementation OSUserState
 
 @end
-
-#endif /* OSStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.m
@@ -31,4 +31,48 @@ THE SOFTWARE.
 
 @implementation OSUserState
 
+- (NSDictionary*)toDictionary {
+    NSMutableDictionary *dataDic = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                   _appId, @"app_id",
+                   _deviceOs, @"device_os",
+                   _timezone, @"timezone",
+                   _deviceType, @"device_type",
+                   _adId, @"ad_id",
+                   _sdk, @"sdk",
+                   nil];
+    
+    if (_externalUserId)
+        dataDic[@"external_user_id"] = _externalUserId;
+    if (_externalUserIdHash)
+        dataDic[@"external_user_id_auth_hash"] = _externalUserIdHash;
+    if (_deviceModel)
+        dataDic[@"device_model"] = _deviceModel;
+    if (_gameVersion)
+        dataDic[@"game_version"] = _gameVersion;
+    if (self.isRooted)
+        dataDic[@"rooted"] = @YES;
+    
+    dataDic[@"net_type"] = _netType;
+    
+    if (_sdk)
+        dataDic[@"sdk_type"] = _sdk;
+    if (_iOSBundle)
+        dataDic[@"ios_bundle"] = _iOSBundle;
+    if (_language)
+        dataDic[@"language"] = _language;
+    
+    dataDic[@"notification_types"] = _notificationTypes;
+    
+    if (_carrier)
+        dataDic[@"carrier"] = _carrier;
+    if (_testType)
+        dataDic[@"test_type"] = _testType;
+    if (_tags)
+        dataDic[@"tags"] = _tags;
+    if (_locationState)
+        [dataDic addEntriesFromDictionary:_locationState.toDictionary];
+    
+    return dataDic;
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
@@ -28,7 +28,9 @@ THE SOFTWARE.
 #ifndef OSUserStateEmailSynchronizer_h
 #define OSUserStateEmailSynchronizer_h
 
-@interface OSUserStateEmailSynchronizer : NSObject
+#import "OSUserStateSynchronizer.h"
+
+@interface OSUserStateEmailSynchronizer : OSUserStateSynchronizer
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
@@ -29,4 +29,6 @@ THE SOFTWARE.
 
 @interface OSUserStateEmailSynchronizer : OSUserStateSynchronizer
 
+- (instancetype)initWithEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
@@ -27,11 +27,6 @@ THE SOFTWARE.
 
 #import "OSUserStateSynchronizer.h"
 
-#ifndef OSUserStateEmailSynchronizer_h
-#define OSUserStateEmailSynchronizer_h
-
 @interface OSUserStateEmailSynchronizer : OSUserStateSynchronizer
 
 @end
-
-#endif /* OSUserStateEmailSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
@@ -1,0 +1,35 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef OSUserStateEmailSynchronizer_h
+#define OSUserStateEmailSynchronizer_h
+
+@interface OSUserStateEmailSynchronizer : NSObject
+
+@end
+
+#endif /* OSUserStateEmailSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -30,4 +30,6 @@ THE SOFTWARE.
 
 @implementation OSUserStateEmailSynchronizer
 
+
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -27,9 +27,57 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSUserStateEmailSynchronizer.h"
+#import "OSEmailSubscription.h"
+
+@interface OSUserStateEmailSynchronizer ()
+
+@property (strong, nonatomic, readwrite, nonnull) OSEmailSubscriptionState *currentEmailSubscriptionState;
+
+@end
 
 @implementation OSUserStateEmailSynchronizer
 
+- (instancetype)initWithEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState {
+    self = [super init];
+    if (self)
+        _currentEmailSubscriptionState = emailSubscriptionState;
+    return self;
+}
 
+- (NSString *)getId {
+    return _currentEmailSubscriptionState.emailUserId;
+}
+
+- (NSString *)getIdAuthHashToken {
+    return _currentEmailSubscriptionState.emailAuthCode;
+}
+
+- (NSString *)getExternalIdAuthHashToken {
+    return nil;
+}
+
+- (NSString *)getEmailAuthHashToken {
+    return [self getIdAuthHashToken];
+}
+
+- (NSString *)getChannelId {
+    return OS_EMAIL;
+}
+
+- (NSNumber *)getDeviceType {
+    return @(DEVICE_TYPE_EMAIL);
+}
+
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState {
+    NSMutableDictionary *emailDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
+    emailDataDic[@"device_type"] = self.getDeviceType;
+    emailDataDic[@"email_auth_hash"] = self.getEmailAuthHashToken;
+    
+    // If push device has external id we want to add it to the email device also
+    if (registrationState.externalUserId)
+        emailDataDic[@"external_user_id"] = registrationState.externalUserId;
+    
+    return emailDataDic;
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -1,0 +1,33 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#import <Foundation/Foundation.h>
+#import "OSUserStateEmailSynchronizer.h"
+
+@implementation OSUserStateEmailSynchronizer
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
@@ -27,13 +27,8 @@ THE SOFTWARE.
 
 #import "OSUserStateSynchronizer.h"
 
-#ifndef OSUserStatePushSynchronizer_h
-#define OSUserStatePushSynchronizer_h
-
 @interface OSUserStatePushSynchronizer : OSUserStateSynchronizer
 
 
 
 @end
-
-#endif /* OSUserStatePushSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
@@ -1,0 +1,35 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef OSUserStatePushSynchronizer_h
+#define OSUserStatePushSynchronizer_h
+
+@interface OSUserStatePushSynchronizer : NSObject
+
+@end
+
+#endif /* OSUserStatePushSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
@@ -28,7 +28,11 @@ THE SOFTWARE.
 #ifndef OSUserStatePushSynchronizer_h
 #define OSUserStatePushSynchronizer_h
 
-@interface OSUserStatePushSynchronizer : NSObject
+#import "OSUserStateSynchronizer.h"
+
+@interface OSUserStatePushSynchronizer : OSUserStateSynchronizer
+
+
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
@@ -29,6 +29,6 @@ THE SOFTWARE.
 
 @interface OSUserStatePushSynchronizer : OSUserStateSynchronizer
 
-
+- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
@@ -25,10 +25,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#import "OSUserStateSynchronizer.h"
+
 #ifndef OSUserStatePushSynchronizer_h
 #define OSUserStatePushSynchronizer_h
-
-#import "OSUserStateSynchronizer.h"
 
 @interface OSUserStatePushSynchronizer : OSUserStateSynchronizer
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -27,8 +27,52 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSUserStatePushSynchronizer.h"
+#import "OSSubscription.h"
+
+@interface OSUserStatePushSynchronizer ()
+
+@property (strong, nonatomic, readwrite, nonnull) OSSubscriptionState *currentSubscriptionState;
+
+@end
 
 @implementation OSUserStatePushSynchronizer
 
+- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState {
+    self = [super init];
+    if (self)
+        _currentSubscriptionState = subscriptionState;
+    return self;
+}
+
+- (NSString *)getId {
+    return _currentSubscriptionState.userId;
+}
+
+- (NSString *)getIdAuthHashToken {
+    return _currentSubscriptionState.externalIdAuthCode;
+}
+
+- (NSString *)getExternalIdAuthHashToken {
+    return [self getIdAuthHashToken];
+}
+
+- (NSString *)getEmailAuthHashToken {
+    return nil;
+}
+
+- (NSString *)getChannelId {
+    return OS_PUSH;
+}
+
+- (NSNumber *)getDeviceType {
+    return @(DEVICE_TYPE_PUSH);
+}
+
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState {
+    NSMutableDictionary *pushDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
+    pushDataDic[@"identifier"] = _currentSubscriptionState.pushToken;
+    
+    return pushDataDic;
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -1,0 +1,33 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#import <Foundation/Foundation.h>
+#import "OSUserStatePushSynchronizer.h"
+
+@implementation OSUserStatePushSynchronizer
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -30,4 +30,5 @@ THE SOFTWARE.
 
 @implementation OSUserStatePushSynchronizer
 
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -29,9 +29,6 @@ THE SOFTWARE.
 #import "Requests.h"
 #import "OneSignalLocation.h"
 
-#ifndef OSUserStateSynchronizer_h
-#define OSUserStateSynchronizer_h
-
 @interface OSUserStateSynchronizer : NSObject
 
 - (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationData
@@ -78,5 +75,3 @@ THE SOFTWARE.
                                influenceParams:(NSArray <OSFocusInfluenceParam *> * _Nullable)influenceParams;
 
 @end
-
-#endif /* OSUserStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -1,0 +1,37 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#import "OneSignal.h"
+
+#ifndef OSUserStateSynchronizer_h
+#define OSUserStateSynchronizer_h
+
+@interface OSUserStateSynchronizer : NSObject
+
+@end
+
+#endif /* OSUserStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -48,6 +48,11 @@ THE SOFTWARE.
                                         emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
                                    externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
 
+- (OSRequestSendPurchases * _Nonnull)sendPurchases:(NSArray * _Nonnull)purchases
+                                             appId:(NSString * _Nonnull)appId
+                                            userId:(NSString * _Nonnull)userId
+                               externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
+
 @end
 
 #endif /* OSUserStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -30,7 +30,11 @@ THE SOFTWARE.
 #ifndef OSUserStateSynchronizer_h
 #define OSUserStateSynchronizer_h
 
+#import "Requests.h"
+
 @interface OSUserStateSynchronizer : NSObject
+
+- (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withUserId:(NSString *)userId withAppId:(NSString *)appId;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -54,7 +54,7 @@ THE SOFTWARE.
                                             userId:(NSString * _Nonnull)userId
                                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
-- (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber *)badgeCount
+- (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber * _Nonnull)badgeCount
                                            appId:(NSString * _Nonnull)appId
                                           userId:(NSString * _Nonnull)userId
                               emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
@@ -67,6 +67,15 @@ THE SOFTWARE.
                                  backgroundState:(BOOL)background
                               emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
                          externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+
+- (OSRequestOnFocus * _Nonnull)sendOnFocusTime:(NSNumber * _Nonnull)activeTime
+                                        userId:(NSString * _Nonnull)userId
+                                         appId:(NSString * _Nonnull)appId
+                                       netType:(NSNumber * _Nonnull)netType
+                                emailAuthToken:(NSString * _Nullable)emailAuthHash
+                           externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
+                                    deviceType:(NSNumber * _Nonnull)deviceType
+                               influenceParams:(NSArray <OSFocusInfluenceParam *> * _Nullable)influenceParams;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #import "OneSignal.h"
 #import "Requests.h"
+#import "OneSignalLocation.h"
 
 #ifndef OSUserStateSynchronizer_h
 #define OSUserStateSynchronizer_h
@@ -56,6 +57,14 @@ THE SOFTWARE.
 - (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber *)badgeCount
                                            appId:(NSString * _Nonnull)appId
                                           userId:(NSString * _Nonnull)userId
+                              emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
+                         externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+
+- (OSRequestSendLocation * _Nonnull)sendLocation:(os_last_location * _Nonnull)lastLocation
+                                           appId:(NSString * _Nonnull)appId
+                                          userId:(NSString * _Nonnull)userId
+                                     networkType:(NSNumber * _Nonnull)networkType
+                                 backgroundState:(BOOL)background
                               emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
                          externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -28,50 +28,48 @@ THE SOFTWARE.
 #import "OneSignal.h"
 #import "Requests.h"
 #import "OneSignalLocation.h"
+#import "OSUserState.h"
 
 @interface OSUserStateSynchronizer : NSObject
 
-- (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationData
-                                                  userId:(NSString * _Nullable)userId;
+- (NSString * _Nonnull)getId;
+
+- (NSString * _Nullable)getIdAuthHashToken;
+
+- (NSString * _Nullable)getExternalIdAuthHashToken;
+
+- (NSString * _Nullable)getEmailAuthHashToken;
+
+- (NSString * _Nonnull)getChannelId;
+
+- (NSNumber * _Nonnull)getDeviceType;
+
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState;
+
+- (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationDatad;
 
 - (OSRequestUpdateExternalUserId * _Nonnull)setExternalUserId:(NSString *_Nonnull)externalId
                                   withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
-                                                   withUserId:(NSString * _Nonnull)userId
                                                     withAppId:(NSString * _Nonnull)appId;
 
-- (OSRequestSendTagsToServer * _Nonnull)sendTagsWithUserId:(NSString * _Nonnull)userId
-                                                     appId:(NSString * _Nonnull)appId
+- (OSRequestSendTagsToServer * _Nonnull)sendTagsWithAppId:(NSString * _Nonnull)appId
                                                sendingTags:(NSDictionary * _Nonnull)tags
-                                               networkType:(NSNumber * _Nonnull)networkType
-                                        emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
-                                   externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+                                               networkType:(NSNumber * _Nonnull)networkType;
 
 - (OSRequestSendPurchases * _Nonnull)sendPurchases:(NSArray * _Nonnull)purchases
-                                             appId:(NSString * _Nonnull)appId
-                                            userId:(NSString * _Nonnull)userId
-                               externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
+                                             appId:(NSString * _Nonnull)appId;
 
 - (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber * _Nonnull)badgeCount
-                                           appId:(NSString * _Nonnull)appId
-                                          userId:(NSString * _Nonnull)userId
-                              emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
-                         externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+                                           appId:(NSString * _Nonnull)appId;
 
 - (OSRequestSendLocation * _Nonnull)sendLocation:(os_last_location * _Nonnull)lastLocation
                                            appId:(NSString * _Nonnull)appId
-                                          userId:(NSString * _Nonnull)userId
                                      networkType:(NSNumber * _Nonnull)networkType
-                                 backgroundState:(BOOL)background
-                              emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
-                         externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+                                 backgroundState:(BOOL)background;
 
 - (OSRequestOnFocus * _Nonnull)sendOnFocusTime:(NSNumber * _Nonnull)activeTime
-                                        userId:(NSString * _Nonnull)userId
                                          appId:(NSString * _Nonnull)appId
                                        netType:(NSNumber * _Nonnull)netType
-                                emailAuthToken:(NSString * _Nullable)emailAuthHash
-                           externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
-                                    deviceType:(NSNumber * _Nonnull)deviceType
                                influenceParams:(NSArray <OSFocusInfluenceParam *> * _Nullable)influenceParams;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 
 @interface OSUserStateSynchronizer : NSObject
 
+- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary * _Nonnull)registrationData userId:(NSString * _Nullable)userId;
 - (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withUserId:(NSString *)userId withAppId:(NSString *)appId;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -53,6 +53,12 @@ THE SOFTWARE.
                                             userId:(NSString * _Nonnull)userId
                                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
+- (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber *)badgeCount
+                                           appId:(NSString * _Nonnull)appId
+                                          userId:(NSString * _Nonnull)userId
+                              emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
+                         externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+
 @end
 
 #endif /* OSUserStateSynchronizer_h */

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -26,16 +26,27 @@ THE SOFTWARE.
 */
 
 #import "OneSignal.h"
+#import "Requests.h"
 
 #ifndef OSUserStateSynchronizer_h
 #define OSUserStateSynchronizer_h
 
-#import "Requests.h"
-
 @interface OSUserStateSynchronizer : NSObject
 
-- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary * _Nonnull)registrationData userId:(NSString * _Nullable)userId;
-- (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withUserId:(NSString *)userId withAppId:(NSString *)appId;
+- (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationData
+                                                  userId:(NSString * _Nullable)userId;
+
+- (OSRequestUpdateExternalUserId * _Nonnull)setExternalUserId:(NSString *_Nonnull)externalId
+                                  withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
+                                                   withUserId:(NSString * _Nonnull)userId
+                                                    withAppId:(NSString * _Nonnull)appId;
+
+- (OSRequestSendTagsToServer * _Nonnull)sendTagsWithUserId:(NSString * _Nonnull)userId
+                                                     appId:(NSString * _Nonnull)appId
+                                               sendingTags:(NSDictionary * _Nonnull)tags
+                                               networkType:(NSNumber * _Nonnull)networkType
+                                        emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
+                                   externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -27,65 +27,60 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSUserStateSynchronizer.h"
-
+#import "OSMacros.h"
 
 @implementation OSUserStateSynchronizer
 
-- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData
-                                         userId:(NSString *)userId {
-    return [OSRequestRegisterUser withData:registrationData userId:userId];
+- (NSString *)getId { mustOverride(); }
+
+- (NSString *)getExternalIdAuthHashToken { mustOverride(); }
+
+- (NSString *)getEmailAuthHashToken { mustOverride(); }
+
+- (NSNumber *)getDeviceType { mustOverride(); }
+
+- (NSString *)getChannelId { mustOverride(); }
+
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState { mustOverride(); }
+
+- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData {
+    return [OSRequestRegisterUser withData:registrationData userId:[self getId]];
 }
 
 - (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId
                          withExternalIdAuthHashToken:(NSString *)hashToken
-                                          withUserId:(NSString *)userId
                                            withAppId:(NSString *)appId {
-    return [OSRequestUpdateExternalUserId withUserId:externalId withUserIdHashToken:hashToken withOneSignalUserId:userId appId:appId];
+    return [OSRequestUpdateExternalUserId withUserId:externalId withUserIdHashToken:hashToken withOneSignalUserId:[self getId] appId:appId];
 }
 
-- (OSRequestSendTagsToServer *)sendTagsWithUserId:(NSString *)userId
-                                            appId:(NSString *)appId
+- (OSRequestSendTagsToServer *)sendTagsWithAppId:(NSString *)appId
                                       sendingTags:(NSDictionary *)tags
-                                      networkType:(NSNumber *)networkType
-                               emailAuthHashToken:(NSString *)emailAuthHashToken
-                          externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestSendTagsToServer withUserId:userId appId:appId tags:tags networkType:networkType withEmailAuthHashToken:emailAuthHashToken withExternalIdAuthHashToken:externalIdAuthHashToken];
+                                      networkType:(NSNumber *)networkType{
+    return [OSRequestSendTagsToServer withUserId:[self getId] appId:appId tags:tags networkType:networkType withEmailAuthHashToken:[self getEmailAuthHashToken] withExternalIdAuthHashToken:[self getExternalIdAuthHashToken]];
 }
 
 - (OSRequestSendPurchases *)sendPurchases:(NSArray *)purchases
-                                    appId:(NSString *)appId
-                                   userId:(NSString *)userId
-                      externalIdAuthToken:(NSString *)externalIdAuthToken {
-    return [OSRequestSendPurchases withUserId:userId externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
+                                    appId:(NSString *)appId {
+    return [OSRequestSendPurchases withUserId:[self getId] externalIdAuthToken:[self getIdAuthHashToken] appId:appId withPurchases:purchases];
 }
 
 - (OSRequestBadgeCount *)sendBadgeCount:(NSNumber *)badgeCount
-                                  appId:(NSString *)appId
-                                 userId:(NSString *)userId
-                     emailAuthHashToken:(NSString *)emailAuthHashToken
-                externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestBadgeCount withUserId:userId appId:appId badgeCount:badgeCount emailAuthToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+                                  appId:(NSString *)appId{
+    return [OSRequestBadgeCount withUserId:[self getId] appId:appId badgeCount:badgeCount emailAuthToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken]];
 }
 
 - (OSRequestSendLocation *)sendLocation:(os_last_location *)lastLocation
                                   appId:(NSString *)appId
-                                 userId:(NSString *)userId
                             networkType:(NSNumber *)networkType
-                        backgroundState:(BOOL)background
-                     emailAuthHashToken:(NSString *)emailAuthHashToken
-                externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestSendLocation withUserId:userId appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+                        backgroundState:(BOOL)background{
+    return [OSRequestSendLocation withUserId:[self getId] appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken]];
 }
 
 - (OSRequestOnFocus *)sendOnFocusTime:(NSNumber *)activeTime
-                               userId:(NSString *)userId
                                 appId:(NSString *)appId
                               netType:(NSNumber *)netType
-                       emailAuthToken:(NSString *)emailAuthHash
-                  externalIdAuthToken:(NSString *)externalIdAuthToken
-                           deviceType:(NSNumber *)deviceType
                       influenceParams:(NSArray <OSFocusInfluenceParam *> *)influenceParams {
-    return [OSRequestOnFocus withUserId:userId appId:appId activeTime:activeTime netType:netType emailAuthToken:emailAuthHash externalIdAuthToken:externalIdAuthToken deviceType:deviceType influenceParams:influenceParams];
+    return [OSRequestOnFocus withUserId:[self getId] appId:appId activeTime:activeTime netType:netType emailAuthToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken] deviceType:[self getDeviceType] influenceParams:influenceParams];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -28,6 +28,16 @@ THE SOFTWARE.
 #import <Foundation/Foundation.h>
 #import "OSUserStateSynchronizer.h"
 
+#define mustOverride() @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"%s must be overridden in a subclass/category", __PRETTY_FUNCTION__] userInfo:nil]
+#define methodNotImplemented() mustOverride()
+
 @implementation OSUserStateSynchronizer
+
+- (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId
+                         withExternalIdAuthHashToken:(NSString *)hashToken
+                                          withUserId:(NSString *)userId
+                                           withAppId:(NSString *)appId {
+    return [OSRequestUpdateExternalUserId withUserId:externalId withUserIdHashToken:hashToken withOneSignalUserId:userId appId:appId];
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -61,4 +61,8 @@ THE SOFTWARE.
     return [OSRequestSendPurchases withUserId:userId externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
 }
 
+- (OSRequestBadgeCount *)sendBadgeCount:(NSNumber *)badgeCount appId:(NSString *)appId userId:(NSString *)userId emailAuthHashToken:(NSString *)emailAuthHashToken externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
+    return [OSRequestBadgeCount withUserId:userId appId:appId badgeCount:badgeCount emailAuthToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -1,0 +1,33 @@
+/**
+Modified MIT License
+
+Copyright 2021 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#import <Foundation/Foundation.h>
+#import "OSUserStateSynchronizer.h"
+
+@implementation OSUserStateSynchronizer
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -28,8 +28,6 @@ THE SOFTWARE.
 #import <Foundation/Foundation.h>
 #import "OSUserStateSynchronizer.h"
 
-#define mustOverride() @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"%s must be overridden in a subclass/category", __PRETTY_FUNCTION__] userInfo:nil]
-#define methodNotImplemented() mustOverride()
 
 @implementation OSUserStateSynchronizer
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -33,6 +33,10 @@ THE SOFTWARE.
 
 @implementation OSUserStateSynchronizer
 
+- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData userId:(NSString *)userId {
+    return [OSRequestRegisterUser withData:registrationData userId:userId];
+}
+
 - (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId
                          withExternalIdAuthHashToken:(NSString *)hashToken
                                           withUserId:(NSString *)userId

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -33,7 +33,8 @@ THE SOFTWARE.
 
 @implementation OSUserStateSynchronizer
 
-- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData userId:(NSString *)userId {
+- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData
+                                         userId:(NSString *)userId {
     return [OSRequestRegisterUser withData:registrationData userId:userId];
 }
 
@@ -42,6 +43,15 @@ THE SOFTWARE.
                                           withUserId:(NSString *)userId
                                            withAppId:(NSString *)appId {
     return [OSRequestUpdateExternalUserId withUserId:externalId withUserIdHashToken:hashToken withOneSignalUserId:userId appId:appId];
+}
+
+- (OSRequestSendTagsToServer *)sendTagsWithUserId:(NSString *)userId
+                                            appId:(NSString *)appId
+                                      sendingTags:(NSDictionary *)tags
+                                      networkType:(NSNumber *)networkType
+                               emailAuthHashToken:(NSString *)emailAuthHashToken
+                          externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
+    return [OSRequestSendTagsToServer withUserId:userId appId:appId tags:tags networkType:networkType withEmailAuthHashToken:emailAuthHashToken withExternalIdAuthHashToken:externalIdAuthHashToken];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -79,4 +79,15 @@ THE SOFTWARE.
     return [OSRequestSendLocation withUserId:userId appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
 }
 
+- (OSRequestOnFocus *)sendOnFocusTime:(NSNumber *)activeTime
+                               userId:(NSString *)userId
+                                appId:(NSString *)appId
+                              netType:(NSNumber *)netType
+                       emailAuthToken:(NSString *)emailAuthHash
+                  externalIdAuthToken:(NSString *)externalIdAuthToken
+                           deviceType:(NSNumber *)deviceType
+                      influenceParams:(NSArray <OSFocusInfluenceParam *> *)influenceParams {
+    return [OSRequestOnFocus withUserId:userId appId:appId activeTime:activeTime netType:netType emailAuthToken:emailAuthHash externalIdAuthToken:externalIdAuthToken deviceType:deviceType influenceParams:influenceParams];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -61,8 +61,22 @@ THE SOFTWARE.
     return [OSRequestSendPurchases withUserId:userId externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
 }
 
-- (OSRequestBadgeCount *)sendBadgeCount:(NSNumber *)badgeCount appId:(NSString *)appId userId:(NSString *)userId emailAuthHashToken:(NSString *)emailAuthHashToken externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
+- (OSRequestBadgeCount *)sendBadgeCount:(NSNumber *)badgeCount
+                                  appId:(NSString *)appId
+                                 userId:(NSString *)userId
+                     emailAuthHashToken:(NSString *)emailAuthHashToken
+                externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
     return [OSRequestBadgeCount withUserId:userId appId:appId badgeCount:badgeCount emailAuthToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+}
+
+- (OSRequestSendLocation *)sendLocation:(os_last_location *)lastLocation
+                                  appId:(NSString *)appId
+                                 userId:(NSString *)userId
+                            networkType:(NSNumber *)networkType
+                        backgroundState:(BOOL)background
+                     emailAuthHashToken:(NSString *)emailAuthHashToken
+                externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
+    return [OSRequestSendLocation withUserId:userId appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -54,4 +54,11 @@ THE SOFTWARE.
     return [OSRequestSendTagsToServer withUserId:userId appId:appId tags:tags networkType:networkType withEmailAuthHashToken:emailAuthHashToken withExternalIdAuthHashToken:externalIdAuthHashToken];
 }
 
+- (OSRequestSendPurchases *)sendPurchases:(NSArray *)purchases
+                                    appId:(NSString *)appId
+                                   userId:(NSString *)userId
+                      externalIdAuthToken:(NSString *)externalIdAuthToken {
+    return [OSRequestSendPurchases withUserId:userId externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -425,6 +425,10 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     self.currentSubscriptionState.userId = userId;
 }
 
++ (void)registerUserFinished {
+    _registerUserFinished = true;
+}
+
 + (NSString *)mEmailAuthToken {
     return self.currentEmailSubscriptionState.emailAuthCode;
 }
@@ -1717,7 +1721,6 @@ static dispatch_queue_t serialQueue;
     
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Calling OneSignal create/on_session"];
     [self.stateSynchronizer registerUserWithState:userState withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
-        _registerUserFinished = true;
         immediateOnSessionRetry = NO;
         waitingForOneSReg = false;
         isOnSessionSuccessfulForCurrentState = true;
@@ -1770,7 +1773,6 @@ static dispatch_queue_t serialQueue;
             [self receivedInAppMessageJson:results[@"push"][@"in_app_messages"]];
         }
     } onFailure:^(NSDictionary<NSString *, NSError *> *errors) {
-        _registerUserFinished = true;
         waitingForOneSReg = false;
         
         // If the failed registration is priority, force the next one to be a high priority
@@ -2473,7 +2475,7 @@ static NSString *_lastnonActiveMessageId;
         delayedExternalIdParameters = [OneSignalSetExternalIdParameters withExternalId:externalId withAuthToken:hashToken withSuccess:successBlock withFailure:failureBlock];
         return;
     } else if (!appId) {
-        [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"Attempted to set external user id, butapp_id is not set"];
+        [OneSignal onesignal_Log:ONE_S_LL_WARN message:@"Attempted to set external user id, but app_id is not set"];
         if (failureBlock)
             failureBlock([NSError errorWithDomain:@"com.onesignal" code:0 userInfo:@{@"error" : [NSString stringWithFormat:@"%@ is not set", appId == nil ? @"app_id" : @"user_id"]}]);
         return;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1207,7 +1207,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     
     requests[@"push"] = [OSRequestSendTagsToServer withUserId:self.currentSubscriptionState.userId appId:self.appId tags:nowSendingTags networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:nil withExternalIdAuthHashToken:[self mExternalIdAuthToken]];
     
-    if ([self isEmailSetup])
+    if ([self.currentEmailSubscriptionState isEmailSetup])
         requests[@"email"] = [OSRequestSendTagsToServer withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.appId tags:nowSendingTags networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:self.currentEmailSubscriptionState.emailAuthCode withExternalIdAuthHashToken:nil];
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
@@ -2560,10 +2560,6 @@ static NSString *_lastnonActiveMessageId;
 
 + (NSString*)existingEmailExternalUserId {
     return [OneSignalUserDefaults.initStandard getSavedStringForKey:OSUD_EMAIL_EXTERNAL_USER_ID defaultValue:@""];
-}
-
-+ (BOOL)isEmailSetup {
-    return self.currentEmailSubscriptionState.emailUserId && (!self.currentEmailSubscriptionState.requiresEmailAuth || self.currentEmailSubscriptionState.emailAuthCode);
 }
 
 + (BOOL)shouldUpdateExternalUserId:(NSString*)externalId withRequests:(NSDictionary*)requests {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1697,7 +1697,7 @@ static dispatch_queue_t serialQueue;
     // Make sure we only call create or on_session once per open of the app.
     if (![self shouldRegisterNow])
         return;
-    
+
     [_outcomeEventsController clearOutcomes];
     [_sessionManager restartSessionIfNeeded:_appEntryState];
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -462,7 +462,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     mSDKType = type;
 }
 
-+ (void) setWaitingForApnsResponse:(BOOL)value {
++ (void)setWaitingForApnsResponse:(BOOL)value {
     waitingForApnsResponse = value;
 }
 
@@ -1861,19 +1861,8 @@ static dispatch_queue_t serialQueue;
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
     
-    if (!self.currentSubscriptionState.userId)
-        return;
-    
-    let requests = [NSMutableDictionary new];
-    
-    requests[@"push"] = [OSRequestSendPurchases withUserId:self.currentSubscriptionState.userId externalIdAuthToken:[self mExternalIdAuthToken] appId:self.appId withPurchases:purchases];
-    
-    if (self.currentEmailSubscriptionState.emailUserId)
-        requests[@"email"] = [OSRequestSendPurchases withUserId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:self.currentEmailSubscriptionState.emailAuthCode appId:self.appId withPurchases:purchases];
-    
-    [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
+    [OneSignal.stateSynchronizer sendPurchases:purchases appId:self.appId];
 }
-
 
 static NSString *_lastAppActiveMessageId;
 + (void)setLastAppActiveMessageId:(NSString*)value { _lastAppActiveMessageId = value; }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -181,6 +181,11 @@ typedef enum {BACKGROUND, END_SESSION} FocusEventType;
 typedef enum {ATTRIBUTED, NOT_ATTRIBUTED} FocusAttributionState;
 #define focusAttributionStateString(enum) [@[@"ATTRIBUTED", @"NOT_ATTRIBUTED"] objectAtIndex:enum]
 
+// OneSignal constants
+#define OS_PUSH @"push"
+#define OS_EMAIL @"email"
+#define OS_SUCCESS @"success"
+
 // OneSignal API Client Defines
 typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 #define OS_API_CLIENT_STRINGS @[@"GET", @"POST", @"HEAD", @"PUT", @"DELETE", @"OPTIONS", @"CONNECT", @"TRACE"]

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -186,6 +186,8 @@ typedef enum {ATTRIBUTED, NOT_ATTRIBUTED} FocusAttributionState;
 #define OS_EMAIL @"email"
 #define OS_SUCCESS @"success"
 
+#define OS_CHANNELS @[OS_PUSH, OS_EMAIL]
+
 // OneSignal API Client Defines
 typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 #define OS_API_CLIENT_STRINGS @[@"GET", @"POST", @"HEAD", @"PUT", @"DELETE", @"OPTIONS", @"CONNECT", @"TRACE"]

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -409,7 +409,7 @@ OneSignalWebView *webVC;
     return NO;
 }
 
-+ (NSNumber*)getNetType {
++ (NSNumber *)getNetType {
     OneSignalReachability* reachability = [OneSignalReachability reachabilityForInternetConnection];
     NetworkStatus status = [reachability currentReachabilityStatus];
     if (status == ReachableViaWiFi)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -34,6 +34,7 @@
 #import "OneSignalClient.h"
 #import "Requests.h"
 #import "OneSignalDialogController.h"
+#import "OSStateSynchronizer.h"
 
 @interface OneSignal ()
 void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
@@ -41,6 +42,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 + (NSString*)mUserId;
 + (NSString *)mEmailAuthToken;
 + (NSString *)mExternalIdAuthToken;
++ (OSStateSynchronizer *)stateSynchronizer;
 @end
 
 @implementation OneSignalLocation
@@ -368,14 +370,7 @@ static OneSignalLocation* singleInstance = nil;
         
         initialLocationSent = YES;
         
-        NSMutableDictionary *requests = [NSMutableDictionary new];
-        
-        if ([OneSignal mEmailUserId])
-            requests[@"email"] = [OSRequestSendLocation withUserId:[OneSignal mEmailUserId] appId:[OneSignal appId] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive) emailAuthHashToken:[OneSignal mEmailAuthToken] externalIdAuthToken:nil];
-        
-        requests[@"push"] = [OSRequestSendLocation withUserId:[OneSignal mUserId] appId:[OneSignal appId] location:lastLocation networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive) emailAuthHashToken:nil externalIdAuthToken:[OneSignal mExternalIdAuthToken]];
-        
-        [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
+        [OneSignal.stateSynchronizer sendLocation:lastLocation appId:[OneSignal appId] networkType:[OneSignalHelper getNetType] backgroundState:([UIApplication sharedApplication].applicationState != UIApplicationStateActive)];
     }
     
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -41,6 +41,7 @@
 #import "OSFocusCallParams.h"
 #import "OSFocusInfluenceParam.h"
 #import "OSMessagingController.h"
+#import "OSStateSynchronizer.h"
 
 @interface OneSignal ()
 
@@ -51,6 +52,7 @@
 + (NSString *)mEmailUserId;
 + (NSString *)mEmailAuthToken;
 + (NSString *)mExternalIdAuthToken;
++ (OSStateSynchronizer *)stateSynchronizer;
 
 @end
 
@@ -125,16 +127,8 @@ static BOOL lastOnFocusWasToBackground = YES;
         return;
     
     // If badge was set, clear it on the server as well.
-    if (wasBadgeSet) {
-        NSMutableDictionary *requests = [NSMutableDictionary new];
-        
-        requests[@"push"] = [OSRequestBadgeCount withUserId:[OneSignal mUserId] appId:[OneSignal appId] badgeCount:@0 emailAuthToken:nil externalIdAuthToken:[OneSignal mExternalIdAuthToken]];
-        
-        if ([OneSignal mEmailUserId])
-            requests[@"email"] = [OSRequestBadgeCount withUserId:[OneSignal mEmailUserId] appId:[OneSignal appId] badgeCount:@0 emailAuthToken:[OneSignal mEmailAuthToken] externalIdAuthToken:nil];
-        
-        [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
-    }
+    if (wasBadgeSet)
+        [OneSignal.stateSynchronizer sendBadgeCount:@0 appId:[OneSignal appId]];
 }
 
 + (void)applicationBackgrounded {

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -107,14 +107,6 @@ NS_ASSUME_NONNULL_END
                             netType:(NSNumber * _Nonnull)netType
                      emailAuthToken:(NSString * _Nullable)emailAuthHash
                 externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
-                         deviceType:(NSNumber * _Nonnull)deviceType;
-
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
-                              appId:(NSString * _Nonnull)appId
-                         activeTime:(NSNumber * _Nonnull)activeTime
-                            netType:(NSNumber * _Nonnull)netType
-                     emailAuthToken:(NSString * _Nullable)emailAuthHash
-                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
                          deviceType:(NSNumber * _Nonnull)deviceType
                     influenceParams:(NSArray<OSFocusInfluenceParam *> * _Nonnull)influenceParams;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -379,9 +379,11 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
     params[@"net_type"] = netType;
     params[@"device_type"] = deviceType;
     
-    for (OSFocusInfluenceParam *influenceParam in influenceParams) {
-        params[influenceParam.influenceKey] = influenceParam.influenceIds;
-        params[influenceParam.influenceDirectKey] = @(influenceParam.directInfluence);
+    if (influenceParams) {
+        for (OSFocusInfluenceParam *influenceParam in influenceParams) {
+            params[influenceParam.influenceKey] = influenceParam.influenceIds;
+            params[influenceParam.influenceDirectKey] = @(influenceParam.directInfluence);
+        }
     }
 
     if (emailAuthHash && emailAuthHash.length > 0)

--- a/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/EmailTests.m
@@ -478,9 +478,9 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
     
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertTrue([observer->last.to.description isEqualToString: @"<OSEmailSubscriptionState: emailAddress: test@test.com, emailUserId: 1234>"]);
-    XCTAssertTrue([observer->last.from.description isEqualToString:@"<OSEmailSubscriptionState: emailAddress: (null), emailUserId: (null)>"]);
-    XCTAssertTrue([observer->last.description isEqualToString:@"<OSEmailSubscriptionStateChanges:\nfrom: <OSEmailSubscriptionState: emailAddress: (null), emailUserId: (null)>,\nto:   <OSEmailSubscriptionState: emailAddress: test@test.com, emailUserId: 1234>\n>"]);
+    XCTAssertTrue([observer->last.to.description isEqualToString: @"<OSEmailSubscriptionState: emailAddress: test@test.com, emailUserId: 1234, emailAuthCode: (null)>"]);
+    XCTAssertTrue([observer->last.from.description isEqualToString:@"<OSEmailSubscriptionState: emailAddress: (null), emailUserId: (null), emailAuthCode: (null)>"]);
+    XCTAssertTrue([observer->last.description isEqualToString:@"<OSEmailSubscriptionStateChanges:\nfrom: <OSEmailSubscriptionState: emailAddress: (null), emailUserId: (null), emailAuthCode: (null)>,\nto:   <OSEmailSubscriptionState: emailAddress: test@test.com, emailUserId: 1234, emailAuthCode: (null)>\n>"]);
 }
 
 - (void)testSetExternalIdForEmailPlayer {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -602,6 +602,7 @@
     
     XCTAssertEqual(observer->last.from.isSubscribed, true);
     XCTAssertEqual(observer->last.to.isSubscribed, false);
+    XCTAssertEqual(observer->fireCount, 2);
 }
 
 - (void)testSubscriptionChangeObserverWhenPromptNotShown {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2746,7 +2746,6 @@ didReceiveRemoteNotification:userInfo
 - (void)testRemoveExternalUserId_forPushAndEmail_withAuthHash {
     // 1. Init OneSignal
     [UnitTestCommonMethods initOneSignal_andThreadWait];
-    
     // 2. Set email
     [OneSignal setEmail:TEST_EMAIL withEmailAuthHashToken:TEST_EMAIL_HASH_TOKEN];
     [UnitTestCommonMethods runBackgroundThreads];


### PR DESCRIPTION
This PR is focused on removing channel server requests from OneSignal.m.

This is based on the first phase of SMS integration refactor.
OSStateSynchronizer will handle all the channel requests.
OSUserStateSynchronizer will be a bridge to the server requests.
OSUserState will handle all the registration data.
OSLocationState will handle user location data for registration.

It is recommended to review commit by commit.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/857)
<!-- Reviewable:end -->

