### PR TITLE
Generalize Channel data access

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -290,12 +290,12 @@ THE SOFTWARE.
     let emailStateSyncronizer = [self getEmailStateSynchronizer];
     
     let requests = [NSMutableDictionary new];
-    requests[OS_PUSH] = [pushStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType deviceType:@(DEVICE_TYPE_PUSH) influenceParams:params.influenceParams];
+    requests[OS_PUSH] = [pushStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType influenceParams:params.influenceParams];
     
     // For email we omit additionalFieldsToAddToOnFocusPayload as we don't want to add
     //   outcome fields which would double report the influence time
     if (emailStateSyncronizer && params.emailUserId)
-        requests[OS_EMAIL] = [emailStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType deviceType:@(DEVICE_TYPE_EMAIL) influenceParams:nil];
+        requests[OS_EMAIL] = [emailStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType influenceParams:nil];
 
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary *result) {
         if (successBlock)

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -212,10 +212,10 @@ THE SOFTWARE.
     let emailStateSyncronizer = [self getEmailStateSynchronizer];
     
     let requests = [NSMutableDictionary new];
-    requests[OS_PUSH] = [pushStateSyncronizer sendTagsWithAppId:appId sendingTags:tags networkType:networkType emailAuthHashToken:nil externalIdAuthHashToken:_currentSubscriptionState.externalIdAuthCode];
+    requests[OS_PUSH] = [pushStateSyncronizer sendTagsWithAppId:appId sendingTags:tags networkType:networkType];
     
     if (emailStateSyncronizer)
-        requests[OS_EMAIL] = [emailStateSyncronizer sendTagsWithAppId:appId sendingTags:tags networkType:networkType emailAuthHashToken:_currentEmailSubscriptionState.emailAuthCode externalIdAuthHashToken:nil];
+        requests[OS_EMAIL] = [emailStateSyncronizer sendTagsWithAppId:appId sendingTags:tags networkType:networkType];
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
         // The tags for email & push are identical so it doesn't matter what we return in the success block
@@ -245,10 +245,10 @@ THE SOFTWARE.
     let emailStateSyncronizer = [self getEmailStateSynchronizer];
     
     let requests = [NSMutableDictionary new];
-    requests[OS_PUSH] = [pushStateSyncronizer sendPurchases:purchases appId:appId externalIdAuthToken:_currentSubscriptionState.externalIdAuthCode];
+    requests[OS_PUSH] = [pushStateSyncronizer sendPurchases:purchases appId:appId];
     
     if (emailStateSyncronizer)
-        requests[OS_EMAIL] = [emailStateSyncronizer sendPurchases:purchases appId:appId externalIdAuthToken:_currentEmailSubscriptionState.emailAuthCode];
+        requests[OS_EMAIL] = [emailStateSyncronizer sendPurchases:purchases appId:appId];
 
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
 }
@@ -258,10 +258,10 @@ THE SOFTWARE.
     let emailStateSyncronizer = [self getEmailStateSynchronizer];
     
     let requests = [NSMutableDictionary new];
-    requests[OS_PUSH] = [pushStateSyncronizer sendBadgeCount:badgeCount appId:appId emailAuthHashToken:nil externalIdAuthHashToken:_currentSubscriptionState.externalIdAuthCode];
+    requests[OS_PUSH] = [pushStateSyncronizer sendBadgeCount:badgeCount appId:appId];
     
     if (emailStateSyncronizer)
-        requests[OS_EMAIL] = [pushStateSyncronizer sendBadgeCount:badgeCount appId:appId emailAuthHashToken:_currentEmailSubscriptionState.emailAuthCode externalIdAuthHashToken:nil];
+        requests[OS_EMAIL] = [pushStateSyncronizer sendBadgeCount:badgeCount appId:appId];
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
 }
@@ -274,10 +274,10 @@ THE SOFTWARE.
     let emailStateSyncronizer = [self getEmailStateSynchronizer];
     
     let requests = [NSMutableDictionary new];
-    requests[OS_PUSH] = [pushStateSyncronizer sendLocation:lastLocation appId:appId networkType:networkType backgroundState:background emailAuthHashToken:nil externalIdAuthHashToken:_currentSubscriptionState.externalIdAuthCode];
+    requests[OS_PUSH] = [pushStateSyncronizer sendLocation:lastLocation appId:appId networkType:networkType backgroundState:background];
     
     if (emailStateSyncronizer)
-        requests[OS_EMAIL] = [emailStateSyncronizer sendLocation:lastLocation appId:appId networkType:networkType backgroundState:background emailAuthHashToken:_currentEmailSubscriptionState.emailAuthCode externalIdAuthHashToken:nil];
+        requests[OS_EMAIL] = [emailStateSyncronizer sendLocation:lastLocation appId:appId networkType:networkType backgroundState:background];
     
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:nil onFailure:nil];
 }
@@ -290,12 +290,12 @@ THE SOFTWARE.
     let emailStateSyncronizer = [self getEmailStateSynchronizer];
     
     let requests = [NSMutableDictionary new];
-    requests[OS_PUSH] = [pushStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType emailAuthToken:nil externalIdAuthToken:params.externalIdAuthToken deviceType:@(DEVICE_TYPE_PUSH) influenceParams:params.influenceParams];
+    requests[OS_PUSH] = [pushStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType deviceType:@(DEVICE_TYPE_PUSH) influenceParams:params.influenceParams];
     
     // For email we omit additionalFieldsToAddToOnFocusPayload as we don't want to add
     //   outcome fields which would double report the influence time
     if (emailStateSyncronizer && params.emailUserId)
-        requests[OS_EMAIL] = [emailStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType emailAuthToken:params.emailAuthToken externalIdAuthToken:nil deviceType:@(DEVICE_TYPE_EMAIL) influenceParams:nil];
+        requests[OS_EMAIL] = [emailStateSyncronizer sendOnFocusTime:totalTimeActive appId:params.appId netType:params.netType deviceType:@(DEVICE_TYPE_EMAIL) influenceParams:nil];
 
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary *result) {
         if (successBlock)

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -98,7 +98,6 @@ THE SOFTWARE.
 
 - (void)registerUserWithState:(OSUserState *)registrationState withSuccess:(OSMultipleSuccessBlock)successBlock onFailure:(OSMultipleFailureBlock)failureBlock {
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         let registrationData = [userStateSynchronizer getRegistrationData:registrationState];
@@ -112,6 +111,7 @@ THE SOFTWARE.
 
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"on_session result: %@", results]];
+        [OneSignal registerUserFinished];
 
         // If the external user ID was sent as part of this request, we need to save it
         // Cache the external id if it exists within the registration payload
@@ -167,7 +167,6 @@ THE SOFTWARE.
 
 - (void)setExternalUserId:(NSString *)externalId withExternalIdAuthHashToken:(NSString *)hashToken withAppId:(NSString *)appId withSuccess:(OSUpdateExternalUserIdSuccessBlock _Nullable)successBlock withFailure:(OSUpdateExternalUserIdFailureBlock _Nullable)failureBlock {
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         requests[userStateSynchronizer.getChannelId] = [userStateSynchronizer setExternalUserId:externalId
@@ -205,7 +204,6 @@ THE SOFTWARE.
               networkType:(NSNumber *)networkType
       processingCallbacks:(NSArray *)nowProcessingCallbacks {
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         requests[userStateSynchronizer.getChannelId] = [userStateSynchronizer sendTagsWithAppId:appId sendingTags:tags networkType:networkType];
@@ -236,7 +234,6 @@ THE SOFTWARE.
         return;
     
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         requests[userStateSynchronizer.getChannelId] = [userStateSynchronizer sendPurchases:purchases appId:appId];
@@ -247,7 +244,6 @@ THE SOFTWARE.
 
 - (void)sendBadgeCount:(NSNumber *)badgeCount appId:(NSString *)appId {
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         requests[userStateSynchronizer.getChannelId] = [userStateSynchronizer sendBadgeCount:badgeCount appId:appId];
@@ -261,7 +257,6 @@ THE SOFTWARE.
          networkType:(NSNumber *)networkType
      backgroundState:(BOOL)background {
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         requests[userStateSynchronizer.getChannelId] = [userStateSynchronizer sendLocation:lastLocation appId:appId networkType:networkType backgroundState:background];
@@ -275,7 +270,6 @@ THE SOFTWARE.
             withSuccess:(OSMultipleSuccessBlock)successBlock
               onFailure:(OSMultipleFailureBlock)failureBlock {
     let stateSyncronizer = [self getStateSynchronizers];
-    // Begin constructing the request for the external id update
     let requests = [NSMutableDictionary new];
     for (OSUserStateSynchronizer* userStateSynchronizer in stateSyncronizer) {
         // For email we omit additionalFieldsToAddToOnFocusPayload as we don't want to add

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.h
@@ -29,4 +29,6 @@ THE SOFTWARE.
 
 @interface OSUserStateEmailSynchronizer : OSUserStateSynchronizer
 
+- (instancetype)initWithEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState;
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -60,4 +60,8 @@ THE SOFTWARE.
     return [self getIdAuthHashToken];
 }
 
+- (NSNumber *)getDeviceType {
+    return @(DEVICE_TYPE_EMAIL);
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -27,9 +27,29 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSUserStateEmailSynchronizer.h"
+#import "OSEmailSubscription.h"
+
+@interface OSUserStateEmailSynchronizer ()
+
+@property (strong, nonatomic, readwrite, nonnull) OSEmailSubscriptionState *currentEmailSubscriptionState;
+
+@end
 
 @implementation OSUserStateEmailSynchronizer
 
+- (instancetype)initWithEmailSubscriptionState:(OSEmailSubscriptionState *)emailSubscriptionState {
+    self = [super init];
+    if (self)
+        _currentEmailSubscriptionState = emailSubscriptionState;
+    return self;
+}
 
+- (NSString *)getId {
+    return _currentEmailSubscriptionState.emailUserId;
+}
+
+- (NSString *)getAuthHashToken {
+    return _currentEmailSubscriptionState.emailAuthCode;
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -48,8 +48,16 @@ THE SOFTWARE.
     return _currentEmailSubscriptionState.emailUserId;
 }
 
-- (NSString *)getAuthHashToken {
+- (NSString *)getIdAuthHashToken {
     return _currentEmailSubscriptionState.emailAuthCode;
+}
+
+- (NSString *)getExternalIdAuthHashToken {
+    return nil;
+}
+
+- (NSString *)getEmailAuthHashToken {
+    return [self getIdAuthHashToken];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -68,4 +68,16 @@ THE SOFTWARE.
     return @(DEVICE_TYPE_EMAIL);
 }
 
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState {
+    NSMutableDictionary *emailDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
+    emailDataDic[@"device_type"] = self.getDeviceType;
+    emailDataDic[@"email_auth_hash"] = self.getEmailAuthHashToken;
+    
+    // If push device has external id we want to add it to the email device also
+    if (registrationState.externalUserId)
+        emailDataDic[@"external_user_id"] = registrationState.externalUserId;
+    
+    return emailDataDic;
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -60,6 +60,10 @@ THE SOFTWARE.
     return [self getIdAuthHashToken];
 }
 
+- (NSString *)getChannelId {
+    return OS_EMAIL;
+}
+
 - (NSNumber *)getDeviceType {
     return @(DEVICE_TYPE_EMAIL);
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.h
@@ -29,6 +29,6 @@ THE SOFTWARE.
 
 @interface OSUserStatePushSynchronizer : OSUserStateSynchronizer
 
-
+- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -60,4 +60,8 @@ THE SOFTWARE.
     return nil;
 }
 
+- (NSNumber *)getDeviceType {
+    return @(DEVICE_TYPE_PUSH);
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -27,8 +27,29 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSUserStatePushSynchronizer.h"
+#import "OSSubscription.h"
+
+@interface OSUserStatePushSynchronizer ()
+
+@property (strong, nonatomic, readwrite, nonnull) OSSubscriptionState *currentSubscriptionState;
+
+@end
 
 @implementation OSUserStatePushSynchronizer
 
+- (instancetype)initWithSubscriptionState:(OSSubscriptionState *)subscriptionState {
+    self = [super init];
+    if (self)
+        _currentSubscriptionState = subscriptionState;
+    return self;
+}
+
+- (NSString *)getId {
+    return _currentSubscriptionState.userId;
+}
+
+- (NSString *)getAuthHashToken {
+    return _currentSubscriptionState.externalIdAuthCode;
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -60,6 +60,10 @@ THE SOFTWARE.
     return nil;
 }
 
+- (NSString *)getChannelId {
+    return OS_PUSH;
+}
+
 - (NSNumber *)getDeviceType {
     return @(DEVICE_TYPE_PUSH);
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -48,8 +48,16 @@ THE SOFTWARE.
     return _currentSubscriptionState.userId;
 }
 
-- (NSString *)getAuthHashToken {
+- (NSString *)getIdAuthHashToken {
     return _currentSubscriptionState.externalIdAuthCode;
+}
+
+- (NSString *)getExternalIdAuthHashToken {
+    return [self getIdAuthHashToken];
+}
+
+- (NSString *)getEmailAuthHashToken {
+    return nil;
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -68,4 +68,11 @@ THE SOFTWARE.
     return @(DEVICE_TYPE_PUSH);
 }
 
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState {
+    NSMutableDictionary *pushDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
+    pushDataDic[@"identifier"] = _currentSubscriptionState.pushToken;
+    
+    return pushDataDic;
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -33,7 +33,11 @@ THE SOFTWARE.
 
 - (NSString * _Nonnull)getId;
 
-- (NSString * _Nonnull)getAuthHashToken;
+- (NSString * _Nullable)getIdAuthHashToken;
+
+- (NSString * _Nullable)getExternalIdAuthHashToken;
+
+- (NSString * _Nullable)getEmailAuthHashToken;
 
 - (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationDatad;
 
@@ -43,31 +47,22 @@ THE SOFTWARE.
 
 - (OSRequestSendTagsToServer * _Nonnull)sendTagsWithAppId:(NSString * _Nonnull)appId
                                                sendingTags:(NSDictionary * _Nonnull)tags
-                                               networkType:(NSNumber * _Nonnull)networkType
-                                        emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
-                                   externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+                                               networkType:(NSNumber * _Nonnull)networkType;
 
 - (OSRequestSendPurchases * _Nonnull)sendPurchases:(NSArray * _Nonnull)purchases
-                                             appId:(NSString * _Nonnull)appId
-                               externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
+                                             appId:(NSString * _Nonnull)appId;
 
 - (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber * _Nonnull)badgeCount
-                                           appId:(NSString * _Nonnull)appId
-                              emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
-                         externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+                                           appId:(NSString * _Nonnull)appId;
 
 - (OSRequestSendLocation * _Nonnull)sendLocation:(os_last_location * _Nonnull)lastLocation
                                            appId:(NSString * _Nonnull)appId
                                      networkType:(NSNumber * _Nonnull)networkType
-                                 backgroundState:(BOOL)background
-                              emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
-                         externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
+                                 backgroundState:(BOOL)background;
 
 - (OSRequestOnFocus * _Nonnull)sendOnFocusTime:(NSNumber * _Nonnull)activeTime
                                          appId:(NSString * _Nonnull)appId
                                        netType:(NSNumber * _Nonnull)netType
-                                emailAuthToken:(NSString * _Nullable)emailAuthHash
-                           externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken
                                     deviceType:(NSNumber * _Nonnull)deviceType
                                influenceParams:(NSArray <OSFocusInfluenceParam *> * _Nullable)influenceParams;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #import "OneSignal.h"
 #import "Requests.h"
 #import "OneSignalLocation.h"
+#import "OSUserState.h"
 
 @interface OSUserStateSynchronizer : NSObject
 
@@ -42,6 +43,8 @@ THE SOFTWARE.
 - (NSString * _Nonnull)getChannelId;
 
 - (NSNumber * _Nonnull)getDeviceType;
+
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState;
 
 - (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationDatad;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -31,16 +31,17 @@ THE SOFTWARE.
 
 @interface OSUserStateSynchronizer : NSObject
 
-- (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationData
-                                                  userId:(NSString * _Nullable)userId;
+- (NSString * _Nonnull)getId;
+
+- (NSString * _Nonnull)getAuthHashToken;
+
+- (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationDatad;
 
 - (OSRequestUpdateExternalUserId * _Nonnull)setExternalUserId:(NSString *_Nonnull)externalId
                                   withExternalIdAuthHashToken:(NSString * _Nullable)hashToken
-                                                   withUserId:(NSString * _Nonnull)userId
                                                     withAppId:(NSString * _Nonnull)appId;
 
-- (OSRequestSendTagsToServer * _Nonnull)sendTagsWithUserId:(NSString * _Nonnull)userId
-                                                     appId:(NSString * _Nonnull)appId
+- (OSRequestSendTagsToServer * _Nonnull)sendTagsWithAppId:(NSString * _Nonnull)appId
                                                sendingTags:(NSDictionary * _Nonnull)tags
                                                networkType:(NSNumber * _Nonnull)networkType
                                         emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
@@ -48,25 +49,21 @@ THE SOFTWARE.
 
 - (OSRequestSendPurchases * _Nonnull)sendPurchases:(NSArray * _Nonnull)purchases
                                              appId:(NSString * _Nonnull)appId
-                                            userId:(NSString * _Nonnull)userId
                                externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
 - (OSRequestBadgeCount * _Nonnull)sendBadgeCount:(NSNumber * _Nonnull)badgeCount
                                            appId:(NSString * _Nonnull)appId
-                                          userId:(NSString * _Nonnull)userId
                               emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
                          externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
 
 - (OSRequestSendLocation * _Nonnull)sendLocation:(os_last_location * _Nonnull)lastLocation
                                            appId:(NSString * _Nonnull)appId
-                                          userId:(NSString * _Nonnull)userId
                                      networkType:(NSNumber * _Nonnull)networkType
                                  backgroundState:(BOOL)background
                               emailAuthHashToken:(NSString * _Nullable)emailAuthHashToken
                          externalIdAuthHashToken:(NSString * _Nullable)externalIdAuthHashToken;
 
 - (OSRequestOnFocus * _Nonnull)sendOnFocusTime:(NSNumber * _Nonnull)activeTime
-                                        userId:(NSString * _Nonnull)userId
                                          appId:(NSString * _Nonnull)appId
                                        netType:(NSNumber * _Nonnull)netType
                                 emailAuthToken:(NSString * _Nullable)emailAuthHash

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -39,6 +39,8 @@ THE SOFTWARE.
 
 - (NSString * _Nullable)getEmailAuthHashToken;
 
+- (NSNumber * _Nonnull)getDeviceType;
+
 - (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationDatad;
 
 - (OSRequestUpdateExternalUserId * _Nonnull)setExternalUserId:(NSString *_Nonnull)externalId
@@ -63,7 +65,6 @@ THE SOFTWARE.
 - (OSRequestOnFocus * _Nonnull)sendOnFocusTime:(NSNumber * _Nonnull)activeTime
                                          appId:(NSString * _Nonnull)appId
                                        netType:(NSNumber * _Nonnull)netType
-                                    deviceType:(NSNumber * _Nonnull)deviceType
                                influenceParams:(NSArray <OSFocusInfluenceParam *> * _Nullable)influenceParams;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.h
@@ -39,6 +39,8 @@ THE SOFTWARE.
 
 - (NSString * _Nullable)getEmailAuthHashToken;
 
+- (NSString * _Nonnull)getChannelId;
+
 - (NSNumber * _Nonnull)getDeviceType;
 
 - (OSRequestRegisterUser * _Nonnull)registerUserWithData:(NSDictionary * _Nonnull)registrationDatad;

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -39,6 +39,8 @@ THE SOFTWARE.
 
 - (NSNumber *)getDeviceType { mustOverride(); }
 
+- (NSString *)getChannelId { mustOverride(); }
+
 - (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData {
     return [OSRequestRegisterUser withData:registrationData userId:[self getId]];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -37,6 +37,8 @@ THE SOFTWARE.
 
 - (NSString *)getEmailAuthHashToken { mustOverride(); }
 
+- (NSNumber *)getDeviceType { mustOverride(); }
+
 - (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData {
     return [OSRequestRegisterUser withData:registrationData userId:[self getId]];
 }
@@ -73,9 +75,8 @@ THE SOFTWARE.
 - (OSRequestOnFocus *)sendOnFocusTime:(NSNumber *)activeTime
                                 appId:(NSString *)appId
                               netType:(NSNumber *)netType
-                           deviceType:(NSNumber *)deviceType
                       influenceParams:(NSArray <OSFocusInfluenceParam *> *)influenceParams {
-    return [OSRequestOnFocus withUserId:[self getId] appId:appId activeTime:activeTime netType:netType emailAuthToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken] deviceType:deviceType influenceParams:influenceParams];
+    return [OSRequestOnFocus withUserId:[self getId] appId:appId activeTime:activeTime netType:netType emailAuthToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken] deviceType:[self getDeviceType] influenceParams:influenceParams];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -41,6 +41,8 @@ THE SOFTWARE.
 
 - (NSString *)getChannelId { mustOverride(); }
 
+- (NSDictionary *)getRegistrationData:(OSUserState *)registrationState { mustOverride(); }
+
 - (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData {
     return [OSRequestRegisterUser withData:registrationData userId:[self getId]];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -27,65 +27,60 @@ THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "OSUserStateSynchronizer.h"
-
+#import "OSMacros.h"
 
 @implementation OSUserStateSynchronizer
 
-- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData
-                                         userId:(NSString *)userId {
-    return [OSRequestRegisterUser withData:registrationData userId:userId];
+- (NSString *)getId  { mustOverride(); }
+
+- (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData {
+    return [OSRequestRegisterUser withData:registrationData userId:[self getId]];
 }
 
 - (OSRequestUpdateExternalUserId *)setExternalUserId:(NSString *)externalId
                          withExternalIdAuthHashToken:(NSString *)hashToken
-                                          withUserId:(NSString *)userId
                                            withAppId:(NSString *)appId {
-    return [OSRequestUpdateExternalUserId withUserId:externalId withUserIdHashToken:hashToken withOneSignalUserId:userId appId:appId];
+    return [OSRequestUpdateExternalUserId withUserId:externalId withUserIdHashToken:hashToken withOneSignalUserId:[self getId] appId:appId];
 }
 
-- (OSRequestSendTagsToServer *)sendTagsWithUserId:(NSString *)userId
-                                            appId:(NSString *)appId
+- (OSRequestSendTagsToServer *)sendTagsWithAppId:(NSString *)appId
                                       sendingTags:(NSDictionary *)tags
                                       networkType:(NSNumber *)networkType
                                emailAuthHashToken:(NSString *)emailAuthHashToken
                           externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestSendTagsToServer withUserId:userId appId:appId tags:tags networkType:networkType withEmailAuthHashToken:emailAuthHashToken withExternalIdAuthHashToken:externalIdAuthHashToken];
+    return [OSRequestSendTagsToServer withUserId:[self getId] appId:appId tags:tags networkType:networkType withEmailAuthHashToken:emailAuthHashToken withExternalIdAuthHashToken:externalIdAuthHashToken];
 }
 
 - (OSRequestSendPurchases *)sendPurchases:(NSArray *)purchases
                                     appId:(NSString *)appId
-                                   userId:(NSString *)userId
                       externalIdAuthToken:(NSString *)externalIdAuthToken {
-    return [OSRequestSendPurchases withUserId:userId externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
+    return [OSRequestSendPurchases withUserId:[self getId] externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
 }
 
 - (OSRequestBadgeCount *)sendBadgeCount:(NSNumber *)badgeCount
                                   appId:(NSString *)appId
-                                 userId:(NSString *)userId
                      emailAuthHashToken:(NSString *)emailAuthHashToken
                 externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestBadgeCount withUserId:userId appId:appId badgeCount:badgeCount emailAuthToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+    return [OSRequestBadgeCount withUserId:[self getId] appId:appId badgeCount:badgeCount emailAuthToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
 }
 
 - (OSRequestSendLocation *)sendLocation:(os_last_location *)lastLocation
                                   appId:(NSString *)appId
-                                 userId:(NSString *)userId
                             networkType:(NSNumber *)networkType
                         backgroundState:(BOOL)background
                      emailAuthHashToken:(NSString *)emailAuthHashToken
                 externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestSendLocation withUserId:userId appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+    return [OSRequestSendLocation withUserId:[self getId] appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
 }
 
 - (OSRequestOnFocus *)sendOnFocusTime:(NSNumber *)activeTime
-                               userId:(NSString *)userId
                                 appId:(NSString *)appId
                               netType:(NSNumber *)netType
                        emailAuthToken:(NSString *)emailAuthHash
                   externalIdAuthToken:(NSString *)externalIdAuthToken
                            deviceType:(NSNumber *)deviceType
                       influenceParams:(NSArray <OSFocusInfluenceParam *> *)influenceParams {
-    return [OSRequestOnFocus withUserId:userId appId:appId activeTime:activeTime netType:netType emailAuthToken:emailAuthHash externalIdAuthToken:externalIdAuthToken deviceType:deviceType influenceParams:influenceParams];
+    return [OSRequestOnFocus withUserId:[self getId] appId:appId activeTime:activeTime netType:netType emailAuthToken:emailAuthHash externalIdAuthToken:externalIdAuthToken deviceType:deviceType influenceParams:influenceParams];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSynchronizer.m
@@ -31,7 +31,11 @@ THE SOFTWARE.
 
 @implementation OSUserStateSynchronizer
 
-- (NSString *)getId  { mustOverride(); }
+- (NSString *)getId { mustOverride(); }
+
+- (NSString *)getExternalIdAuthHashToken { mustOverride(); }
+
+- (NSString *)getEmailAuthHashToken { mustOverride(); }
 
 - (OSRequestRegisterUser *)registerUserWithData:(NSDictionary *)registrationData {
     return [OSRequestRegisterUser withData:registrationData userId:[self getId]];
@@ -45,42 +49,33 @@ THE SOFTWARE.
 
 - (OSRequestSendTagsToServer *)sendTagsWithAppId:(NSString *)appId
                                       sendingTags:(NSDictionary *)tags
-                                      networkType:(NSNumber *)networkType
-                               emailAuthHashToken:(NSString *)emailAuthHashToken
-                          externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestSendTagsToServer withUserId:[self getId] appId:appId tags:tags networkType:networkType withEmailAuthHashToken:emailAuthHashToken withExternalIdAuthHashToken:externalIdAuthHashToken];
+                                      networkType:(NSNumber *)networkType{
+    return [OSRequestSendTagsToServer withUserId:[self getId] appId:appId tags:tags networkType:networkType withEmailAuthHashToken:[self getEmailAuthHashToken] withExternalIdAuthHashToken:[self getExternalIdAuthHashToken]];
 }
 
 - (OSRequestSendPurchases *)sendPurchases:(NSArray *)purchases
-                                    appId:(NSString *)appId
-                      externalIdAuthToken:(NSString *)externalIdAuthToken {
-    return [OSRequestSendPurchases withUserId:[self getId] externalIdAuthToken:externalIdAuthToken appId:appId withPurchases:purchases];
+                                    appId:(NSString *)appId {
+    return [OSRequestSendPurchases withUserId:[self getId] externalIdAuthToken:[self getIdAuthHashToken] appId:appId withPurchases:purchases];
 }
 
 - (OSRequestBadgeCount *)sendBadgeCount:(NSNumber *)badgeCount
-                                  appId:(NSString *)appId
-                     emailAuthHashToken:(NSString *)emailAuthHashToken
-                externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestBadgeCount withUserId:[self getId] appId:appId badgeCount:badgeCount emailAuthToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+                                  appId:(NSString *)appId{
+    return [OSRequestBadgeCount withUserId:[self getId] appId:appId badgeCount:badgeCount emailAuthToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken]];
 }
 
 - (OSRequestSendLocation *)sendLocation:(os_last_location *)lastLocation
                                   appId:(NSString *)appId
                             networkType:(NSNumber *)networkType
-                        backgroundState:(BOOL)background
-                     emailAuthHashToken:(NSString *)emailAuthHashToken
-                externalIdAuthHashToken:(NSString *)externalIdAuthHashToken {
-    return [OSRequestSendLocation withUserId:[self getId] appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:emailAuthHashToken externalIdAuthToken:externalIdAuthHashToken];
+                        backgroundState:(BOOL)background{
+    return [OSRequestSendLocation withUserId:[self getId] appId:appId location:lastLocation networkType:networkType backgroundState:background emailAuthHashToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken]];
 }
 
 - (OSRequestOnFocus *)sendOnFocusTime:(NSNumber *)activeTime
                                 appId:(NSString *)appId
                               netType:(NSNumber *)netType
-                       emailAuthToken:(NSString *)emailAuthHash
-                  externalIdAuthToken:(NSString *)externalIdAuthToken
                            deviceType:(NSNumber *)deviceType
                       influenceParams:(NSArray <OSFocusInfluenceParam *> *)influenceParams {
-    return [OSRequestOnFocus withUserId:[self getId] appId:appId activeTime:activeTime netType:netType emailAuthToken:emailAuthHash externalIdAuthToken:externalIdAuthToken deviceType:deviceType influenceParams:influenceParams];
+    return [OSRequestOnFocus withUserId:[self getId] appId:appId activeTime:activeTime netType:netType emailAuthToken:[self getEmailAuthHashToken] externalIdAuthToken:[self getExternalIdAuthHashToken] deviceType:deviceType influenceParams:influenceParams];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1697,7 +1697,7 @@ static dispatch_queue_t serialQueue;
     // Make sure we only call create or on_session once per open of the app.
     if (![self shouldRegisterNow])
         return;
-    
+
     [_outcomeEventsController clearOutcomes];
     [_sessionManager restartSessionIfNeeded:_appEntryState];
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -186,6 +186,8 @@ typedef enum {ATTRIBUTED, NOT_ATTRIBUTED} FocusAttributionState;
 #define OS_EMAIL @"email"
 #define OS_SUCCESS @"success"
 
+#define OS_CHANNELS @[OS_PUSH, OS_EMAIL]
+
 // OneSignal API Client Defines
 typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 #define OS_API_CLIENT_STRINGS @[@"GET", @"POST", @"HEAD", @"PUT", @"DELETE", @"OPTIONS", @"CONNECT", @"TRACE"]


### PR DESCRIPTION
Make the server requests more generic. This will smooth SMS integration by making every channel Synchronizer responsible for retrieving the data specific for its channel.

 OSStateSynchronizer will only handle an array of OSUserStateSynchronizer, and all requests are made with the same data.

It is recommended to review commit by commit.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/858)
<!-- Reviewable:end -->

