### PR TITLE
Background location updates

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -46,9 +46,8 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 @implementation OneSignalLocation
 
 //Track time until next location fire event
-const NSTimeInterval foregroundSendLocationWaitTime = 5 * 60.0;
-const NSTimeInterval backgroundSendLocationWaitTime = 9.75 * 60.0;
-NSTimer* sendLocationTimer = nil;
+const NSTimeInterval foregroundSendLocationWaitTime = 0.5 * 60.0;
+NSTimer* requestLocationTimer = nil;
 os_last_location *lastLocation;
 bool initialLocationSent = false;
 UIBackgroundTaskIdentifier fcTask;
@@ -143,25 +142,24 @@ static OneSignalLocation* singleInstance = nil;
         Otherwise set timer to NULL
     **/
     
-    NSTimeInterval remainingTimerTime = sendLocationTimer.fireDate.timeIntervalSinceNow;
-    NSTimeInterval requiredWaitTime = isActive ? foregroundSendLocationWaitTime : backgroundSendLocationWaitTime ;
+    NSTimeInterval remainingTimerTime = requestLocationTimer.fireDate.timeIntervalSinceNow;
+    NSTimeInterval requiredWaitTime = foregroundSendLocationWaitTime;
     NSTimeInterval adjustedTime = remainingTimerTime > 0 ? remainingTimerTime : requiredWaitTime;
 
     if (isActive) {
-        if(sendLocationTimer && initialLocationSent) {
+        if(requestLocationTimer && initialLocationSent) {
             //Keep timer going with the remaining time
-            [sendLocationTimer invalidate];
-            sendLocationTimer = [NSTimer scheduledTimerWithTimeInterval:adjustedTime target:self selector:@selector(sendLocation) userInfo:nil repeats:NO];
+            [requestLocationTimer invalidate];
+            requestLocationTimer = [NSTimer scheduledTimerWithTimeInterval:adjustedTime target:self selector:@selector(requestLocation) userInfo:nil repeats:NO];
         }
     } else {
         //Check if always granted
         if ((int)[NSClassFromString(@"CLLocationManager") performSelector:@selector(authorizationStatus)] == kCLAuthorizationStatusAuthorizedAlways) {
             [OneSignalLocation beginTask];
-            [sendLocationTimer invalidate];
-            sendLocationTimer = [NSTimer scheduledTimerWithTimeInterval:adjustedTime target:self selector:@selector(requestLocation) userInfo:nil repeats:NO];
-            [[NSRunLoop mainRunLoop] addTimer:sendLocationTimer forMode:NSRunLoopCommonModes];
+            [requestLocationTimer invalidate];
+            [self requestLocation];
         } else {
-            sendLocationTimer = NULL;
+            requestLocationTimer = NULL;
         }
     }
 }
@@ -283,7 +281,8 @@ static OneSignalLocation* singleInstance = nil;
 
 + (void)requestLocation {
     onesignal_Log(ONE_S_LL_DEBUG, @"OneSignalLocation Requesting Updated Location");
-    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {        [locationManager performSelector:@selector(startMonitoringSignificantLocationChanges)];
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+        [locationManager performSelector:@selector(startMonitoringSignificantLocationChanges)];
     } else {
         [locationManager performSelector:@selector(requestLocation)];
     }
@@ -301,7 +300,7 @@ static OneSignalLocation* singleInstance = nil;
     [manager performSelector:@selector(stopUpdatingLocation)];
     if ([UIApplication sharedApplication].applicationState != UIApplicationStateBackground) {
         [manager performSelector:@selector(stopMonitoringSignificantLocationChanges)];
-        if (!sendLocationTimer)
+        if (!requestLocationTimer)
             [OneSignalLocation resetSendTimer];
     }
     
@@ -338,8 +337,9 @@ static OneSignalLocation* singleInstance = nil;
 }
 
 + (void)resetSendTimer {
-    NSTimeInterval requiredWaitTime = [UIApplication sharedApplication].applicationState == UIApplicationStateActive ? foregroundSendLocationWaitTime : backgroundSendLocationWaitTime;
-    sendLocationTimer = [NSTimer scheduledTimerWithTimeInterval:requiredWaitTime target:self selector:@selector(requestLocation) userInfo:nil repeats:NO];
+    [requestLocationTimer invalidate];
+    NSTimeInterval requiredWaitTime = foregroundSendLocationWaitTime;
+    requestLocationTimer = [NSTimer scheduledTimerWithTimeInterval:requiredWaitTime target:self selector:@selector(requestLocation) userInfo:nil repeats:NO];
 }
 
 + (void)sendLocation {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -46,7 +46,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message);
 @implementation OneSignalLocation
 
 //Track time until next location fire event
-const NSTimeInterval foregroundSendLocationWaitTime = 0.5 * 60.0;
+const NSTimeInterval foregroundSendLocationWaitTime = 5 * 60.0;
 NSTimer* requestLocationTimer = nil;
 os_last_location *lastLocation;
 bool initialLocationSent = false;
@@ -281,7 +281,9 @@ static OneSignalLocation* singleInstance = nil;
 
 + (void)requestLocation {
     onesignal_Log(ONE_S_LL_DEBUG, @"OneSignalLocation Requesting Updated Location");
-    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+    id clLocationManagerClass = NSClassFromString(@"CLLocationManager");
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground
+        && [clLocationManagerClass performSelector:@selector(significantLocationChangeMonitoringAvailable)]) {
         [locationManager performSelector:@selector(startMonitoringSignificantLocationChanges)];
     } else {
         [locationManager performSelector:@selector(requestLocation)];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -283,7 +283,11 @@ static OneSignalLocation* singleInstance = nil;
 
 + (void)requestLocation {
     onesignal_Log(ONE_S_LL_DEBUG, @"OneSignalLocation Requesting Updated Location");
-    [locationManager performSelector:@selector(requestLocation)];
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+        [locationManager performSelector:@selector(startUpdatingLocation)];
+    } else {
+        [locationManager performSelector:@selector(requestLocation)];
+    }
 }
 
 #pragma mark CLLocationManagerDelegate
@@ -295,8 +299,9 @@ static OneSignalLocation* singleInstance = nil;
         [OneSignalLocation sendAndClearLocationListener:PERMISSION_DENIED];
         return;
     }
-    
-    [manager performSelector:@selector(stopUpdatingLocation)];
+    if ([UIApplication sharedApplication].applicationState != UIApplicationStateBackground) {
+        [manager performSelector:@selector(stopUpdatingLocation)];
+    }
     
     id location = locations.lastObject;
     


### PR DESCRIPTION
This PR enables background location updates using Apple's significant changes API. When the app is backgrounded and always allow location is enabled we kick off a background task that uses `startMonitoringSignificantLocationChanges` to send location updates. [This API](https://developer.apple.com/documentation/corelocation/getting_the_user_s_location/using_the_significant-change_location_service?language=objc) will wake the app to send location updates even if the user has swiped the app away. 

## Location Distance and Time
It seems "significant location" isn't configurable and could be 500 meters or more and at most every 5 minutes per Apple's note, although it was sending more often than every 5 minutes in my testing.
> Apps can expect a notification as soon as the device moves 500 meters or more from its previous notification. It should not expect notifications more frequently than once every five minutes. If the device is able to retrieve data from the network, the location manager is much more likely to deliver notifications in a timely manner.

https://developer.apple.com/documentation/corelocation/cllocationmanager/1423531-startmonitoringsignificantlocati?language=objc

It seems that it is not possible to do a time based poll of the users location in the background.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/859)
<!-- Reviewable:end -->

