### PR TITLE
Fix failing tests

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -489,6 +489,8 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     _outcomeEventsCache = nil;
     _outcomeEventFactory = nil;
     _outcomeEventsController = nil;
+    
+    _registerUserFinished = false;
 }
 
 // Set to false as soon as it's read.

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -206,11 +206,13 @@ static OneSignalLocation* singleInstance = nil;
     if ([self started]) {
         // We evaluate the following cases after permissions were asked (denied or given)
         CLAuthorizationStatus permissionStatus = (int)[clLocationManagerClass performSelector:@selector(authorizationStatus)];
+        BOOL showSettings = prompt && fallback && permissionStatus == kCLAuthorizationStatusDenied;
+        [OneSignal onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"internalGetLocation called showSettings: %@", showSettings ? @"YES" : @"NO"]];
         // Fallback to settings alert view when the following condition are true:
         //   - On a prompt flow
         //   - Fallback to settings is enabled
         //   - Permission were denied
-        if (prompt && fallback && permissionStatus == kCLAuthorizationStatusDenied)
+        if (showSettings)
             [self showLocationSettingsAlertController];
         else
             [self sendCurrentAuthStatusToListeners];
@@ -226,8 +228,10 @@ static OneSignalLocation* singleInstance = nil;
     
     CLAuthorizationStatus permissionStatus = (int)[clLocationManagerClass performSelector:@selector(authorizationStatus)];
     // return if permission not determined and should not prompt
-    if (permissionStatus == kCLAuthorizationStatusNotDetermined && !prompt)
+    if (permissionStatus == kCLAuthorizationStatusNotDetermined && !prompt) {
+        onesignal_Log(ONE_S_LL_DEBUG, @"internalGetLocation kCLAuthorizationStatusNotDetermined.");
         return;
+    }
     
     [self sendCurrentAuthStatusToListeners];
     locationManager = [[clLocationManagerClass alloc] init];
@@ -240,7 +244,12 @@ static OneSignalLocation* singleInstance = nil;
     NSArray* backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
     NSString* alwaysDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"];
     // use background location updates if always permission granted or prompt allowed
-    if (backgroundModes && [backgroundModes containsObject:@"location"] && alwaysDescription && (permissionStatus == kCLAuthorizationStatusAuthorizedAlways || prompt)) {
+    BOOL backgroundLocationEnable = backgroundModes && [backgroundModes containsObject:@"location"] && alwaysDescription;
+    BOOL permissionEnable = permissionStatus == kCLAuthorizationStatusAuthorizedAlways || prompt;
+    
+    [OneSignal onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"internalGetLocation called backgroundLocationEnable: %@ permissionEnable: %@", backgroundLocationEnable ? @"YES" : @"NO", permissionEnable ? @"YES" : @"NO"]];
+    
+    if (backgroundLocationEnable && permissionEnable) {
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         [locationManager performSelector:NSSelectorFromString(@"requestAlwaysAuthorization")];

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.h
@@ -30,6 +30,7 @@
 
 @interface OneSignalLocationOverrider : NSObject
 
++ (void)reset;
 + (bool)overrideStarted;
 + (void)grantLocationServices;
 + (int)overrideAuthorizationStatus;

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.m
@@ -73,6 +73,12 @@ NSArray *locations;
     locations = @[location];
 }
 
++ (void)reset {
+    // Reset request flags
+    calledRequestAlwaysAuthorization = false;
+    calledRequestWhenInUseAuthorization = false;
+}
+
 + (bool)overrideStarted {
     return startedMock;
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -57,6 +57,7 @@
 #import "OneSignalTrackFirebaseAnalytics.h"
 #import "OSMessagingControllerOverrider.h"
 #import "OneSignalLifecycleObserver.h"
+#import "OneSignalLocationOverrider.h"
 
 NSString * serverUrlWithPath(NSString *path) {
     return [OS_API_SERVER_URL stringByAppendingString:path];
@@ -208,6 +209,7 @@ static XCTestCase* _currentXCTestCase;
     [OneSignal setLogLevel:ONE_S_LL_INFO visualLevel:ONE_S_LL_NONE];
 
     [NSTimerOverrider reset];
+    [OneSignalLocationOverrider reset];
 
     [OSMessagingController.sharedInstance resetState];
 
@@ -419,6 +421,11 @@ static XCTestCase* _currentXCTestCase;
     last = stateChanges;
     fireCount++;
 }
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"OSSubscriptionStateTestObserver last: %@ fireCount: %d", last, fireCount];
+}
+
 @end
 
 @implementation OSEmailSubscriptionStateTestObserver

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1870,6 +1870,7 @@ didReceiveRemoteNotification:userInfo
     [OneSignal setAppId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba"];
     [OneSignal initWithLaunchOptions:nil];
     
+    // Subscription observer won't be trigger since it needs for register user to fire, register user won't fire due to privacy consent needed
     OSSubscriptionStateTestObserver* observer = [OSSubscriptionStateTestObserver new];
     [OneSignal addSubscriptionObserver:observer];
     
@@ -1878,17 +1879,16 @@ didReceiveRemoteNotification:userInfo
     [NSObjectOverrider runPendingSelectors];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertNil(observer->last.from.userId);
-    XCTAssertNil(observer->last.to.userId);
-    XCTAssertFalse(observer->last.to.isSubscribed);
+    // Chack that observer data is nil
+    XCTAssertNil(observer->last);
+    XCTAssertEqual(0, observer->fireCount);
     
     [OneSignal disablePush:true]; //This should not result in a a change in state because we are waiting on privacy
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertTrue(observer->last.from.isPushDisabled); //Initial from is that push is disabled
-    XCTAssertFalse(observer->last.to.isPushDisabled); //Default value after adding an observer is that push is not disabled
-    // Device registered with OneSignal so now make pushToken available.
-    XCTAssertNil(observer->last.to.pushToken);
+    // Chack that observer data is still nil
+    XCTAssertNil(observer->last);
+    XCTAssertEqual(0, observer->fireCount);
     
     [NSBundleOverrider setPrivacyState:false];
 }


### PR DESCRIPTION
Following tests were failing on master

* Fix testPushNotificationToken, observer will be always null if permission consent is required
* Fix testCallingMethodsWorks_beforeInit, OneSignalLocationOverrider data needs to be reset
* Fix testSubscriptionChangeObserverBasic, testSubscriptionChangeObserverBasic, _registerUserFinished need to be reset

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/862)
<!-- Reviewable:end -->

