### PR TITLE
Forwarding notification from willPresentInForeground for non OneSignal notifications

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -157,6 +157,24 @@ static UNNotificationSettings* cachedUNNotificationSettings;
     [self setOneSignalUNDelegate:delegate];
 }
 
++ (void)forwardNotificationWithCenter:(UNUserNotificationCenter *)center
+                         notification:(UNNotification *)notification
+                      OneSignalCenter:(id)instance
+                    completionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
+    // Call orginal selector if one was set.
+    if ([instance respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)])
+        [instance onesignalUserNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+    // Or call a legacy AppDelegate selector
+    else {
+        [OneSignalUNUserNotificationCenter callLegacyAppDeletegateSelector:notification
+                                                isTextReply:false
+                                           actionIdentifier:nil
+                                                   userText:nil
+                                    fromPresentNotification:true
+                                      withCompletionHandler:^() {}];
+    }
+}
+
 // Apple's docs - Called when a notification is delivered to a foreground app.
 // NOTE: iOS behavior - Calling completionHandler with 0 means userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: does not trigger.
 //  - callLegacyAppDeletegateSelector is called from here due to this case.
@@ -166,10 +184,10 @@ static UNNotificationSettings* cachedUNNotificationSettings;
     
     // return if the user has not granted privacy permissions or if not a OneSignal payload
     if ([OneSignal shouldLogMissingPrivacyConsentErrorWithMethodName:nil] || ![OneSignalHelper isOneSignalPayload:notification.request.content.userInfo]) {
-        if ([self respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)])
-            [self onesignalUserNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
-        else
+        [OneSignalUNUserNotificationCenter forwardNotificationWithCenter:center notification:notification OneSignalCenter:self completionHandler:completionHandler];
+        if (![self respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)]) {
             completionHandler(7);
+        }
         return;
     }
 
@@ -196,18 +214,7 @@ void finishProcessingNotification(UNNotification *notification,
         [OneSignal notificationReceived:notification.request.content.userInfo wasOpened:NO];
 
     
-    // Call orginal selector if one was set.
-    if ([instance respondsToSelector:@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)])
-        [instance onesignalUserNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
-    // Or call a legacy AppDelegate selector
-    else {
-        [OneSignalUNUserNotificationCenter callLegacyAppDeletegateSelector:notification
-                                                               isTextReply:false
-                                                          actionIdentifier:nil
-                                                                  userText:nil
-                                                   fromPresentNotification:true
-                                                     withCompletionHandler:^() {}];
-    }
+    [OneSignalUNUserNotificationCenter forwardNotificationWithCenter:center notification:notification OneSignalCenter:instance completionHandler:completionHandler];
     
     // Calling completionHandler for the following reasons:
     //   App dev may have not implented userNotificationCenter:willPresentNotification.


### PR DESCRIPTION
This is the 3.X.X version of the fix

This issue manifested primarily when customers tried to integrate with Firebase and OneSignal at the same time. Notifications sent from Firebase would not be forwarded by OneSignal correctly but notifications sent from OneSignal were forwarded.
This only happened when the application did not set the `UNUserNotificationCenter` delegate.

This has been tested in iOS native.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/877)
<!-- Reviewable:end -->

