### PR TITLE
Fixing the logic for suppress_launch_url

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1978,7 +1978,7 @@ static NSString *_lastnonActiveMessageId;
     onesignal_Log(ONE_S_LL_VERBOSE, [NSString stringWithFormat:@"handleNotificationOpened called! isActive: %@ notificationId: %@",
                                      isActive ? @"YES" : @"NO", messageId]);
 
-    if ([OneSignal shouldSuppressURL]) {
+    if (![OneSignal shouldSuppressURL]) {
         // Try to fetch the open url to launch
         [OneSignal launchWebURL:notification.launchURL];
     }

--- a/iOS_SDK/OneSignalSDK/UnitTestApp/Info.plist
+++ b/iOS_SDK/OneSignalSDK/UnitTestApp/Info.plist
@@ -29,7 +29,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>OneSignal_suppress_launch_urls</key>
-	<false/>
+	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
The boolean for `suppress_launch_url` was being used opposite of how it should be. This PR flips the logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/882)
<!-- Reviewable:end -->
