### PR TITLE
Crashfix: save IAM to redisplay in correct format on clear cache.

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -204,7 +204,7 @@ static BOOL _isInAppMessagingPaused = false;
             [newRedisplayDictionary removeObjectForKey:messageId];
         }
 
-        [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:newRedisplayDictionary];
+        [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:newRedisplayDictionary];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -544,7 +544,7 @@
 
     message.displayStats.lastDisplayTime = firstInterval - delay;
     // Save IAM for redisplay
-    [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+    [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
     // Set data for redisplay
     [OSMessagingControllerOverrider setMessagesForRedisplay:redisplayedInAppMessages];
     // Save IAM for dismiss
@@ -680,11 +680,11 @@
     [redisplayedInAppMessages setObject:message2 forKey:message2.messageId];
 
     [OSMessagingControllerOverrider setMessagesForRedisplay:redisplayedInAppMessages];
-    [standardUserDefaults saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+    [standardUserDefaults saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
 
     [self initOneSignalWithInAppMessage:message];
 
-    let redisplayMessagesCache = [standardUserDefaults getSavedDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
+    let redisplayMessagesCache = [standardUserDefaults getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
     XCTAssertTrue([redisplayMessagesCache objectForKey:message1.messageId]);
     XCTAssertFalse([redisplayMessagesCache objectForKey:message2.messageId]);
 }


### PR DESCRIPTION
Crash fix for [Issue 848](https://github.com/OneSignal/OneSignal-iOS-SDK/issues/848)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/884)
<!-- Reviewable:end -->

