### PR TITLE
WIP - Register with OneSignal without delay; If we have a token or won't be getting one w/o permission

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1502,18 +1502,10 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     let isPushTokenDifferent = ![deviceToken isEqualToString:self.currentSubscriptionState.pushToken];
     self.currentSubscriptionState.pushToken = deviceToken;
 
-    // iOS 9+ - We get a token right away but give the user 30 sec to respond notification permission prompt.
-    // The goal is to only have 1 server call.
-    [self.osNotificationSettings getNotificationPermissionState:^(OSPermissionState *status) {
-        if (status.answeredPrompt || status.provisional) {
-            if ([self shouldRegisterNow])
-                [self registerUser];
-            else if (isPushTokenDifferent)
-                [self playerPutForPushTokenAndNotificationTypes];
-        } else {
-            [self registerUserAfterDelay];
-        }
-    }];
+    if ([self shouldRegisterNow])
+        [self registerUser];
+    else if (isPushTokenDifferent)
+        [self playerPutForPushTokenAndNotificationTypes];
 }
 
 + (void)playerPutForPushTokenAndNotificationTypes {


### PR DESCRIPTION
* We want to register as soon as we get a push token without delaying.
* The network optimization noted in the deleted comment is a very small
and has negative impacts such as delaying when IAMs are shown

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/891)
<!-- Reviewable:end -->

