### PR TITLE
2.X.X NSUserDefaults crash fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -200,7 +200,7 @@ static BOOL _isInAppMessagingPaused = false;
             [newRedisplayDictionary removeObjectForKey:messageId];
         }
 
-        [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:newRedisplayDictionary];
+        [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:newRedisplayDictionary];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #import "OneSignal.h"
 #import "OneSignalUserDefaults.h"
 #import "OneSignalCommonDefines.h"
+#import "OSInAppMessagingDefines.h"
 #import "OneSignalHelper.h"
 
 @interface OneSignal ()
@@ -45,6 +46,7 @@ THE SOFTWARE.
 
 - (void)migrate {
     [self migrateToVersion_02_14_00_AndGreater];
+    [self migrateIAMRedisplayCache];
     [self saveCurrentSDKVersion];
 }
 
@@ -74,6 +76,36 @@ THE SOFTWARE.
         if (attributedCacheUniqueOutcomeEvents) {
             [NSKeyedArchiver setClassName:@"OSCachedUniqueOutcome" forClass:[OSCachedUniqueOutcome class]];
             [[OneSignal outcomeEventsCache] saveAttributedUniqueOutcomeEventNotificationIds:attributedCacheUniqueOutcomeEvents];
+        }
+    }
+}
+
+// Devices could potentially have bad data in the OS_IAM_REDISPLAY_DICTIONARY
+// that was saved as a dictionary and not CodeableData. Try to detect if that is the case
+// and save it is as CodeableData instead.
+- (void)migrateIAMRedisplayCache {
+    let iamRedisplayCacheFixVersion = 30203;
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    if (sdkVersion >= iamRedisplayCacheFixVersion)
+        return;
+    
+    @try {
+        __unused NSMutableDictionary *redisplayDict =[[NSMutableDictionary alloc] initWithDictionary:[OneSignalUserDefaults.initStandard
+                                                        getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY
+                                                        defaultValue:[NSMutableDictionary new]]];
+    } @catch (NSException *exception) {
+        @try {
+            // The redisplay IAMs might have been saved as a dictionary.
+            // Try to read them as a dictionary and then save them as a codeable.
+            NSMutableDictionary *redisplayDict = [[NSMutableDictionary alloc] initWithDictionary:[OneSignalUserDefaults.initStandard
+                                                                    getSavedDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY
+                                                                    defaultValue:[NSMutableDictionary new]]];
+            [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY
+                                                                    withValue:redisplayDict];
+        } @catch (NSException *exception) {
+            //Clear the cached redisplay dictionary of bad data
+            [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY
+                                                                    withValue:nil];
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -84,7 +84,7 @@ THE SOFTWARE.
 // that was saved as a dictionary and not CodeableData. Try to detect if that is the case
 // and save it is as CodeableData instead.
 - (void)migrateIAMRedisplayCache {
-    let iamRedisplayCacheFixVersion = 30203;
+    let iamRedisplayCacheFixVersion = 21604;
     long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
     if (sdkVersion >= iamRedisplayCacheFixVersion)
         return;

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -522,7 +522,7 @@
     
     message.displayStats.lastDisplayTime = firstInterval - delay;
     // Save IAM for redisplay
-    [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+    [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
     // Set data for redisplay
     [OSMessagingControllerOverrider setMessagesForRedisplay:redisplayedInAppMessages];
     // Save IAM for dismiss
@@ -658,11 +658,11 @@
     [redisplayedInAppMessages setObject:message2 forKey:message2.messageId];
     
     [OSMessagingControllerOverrider setMessagesForRedisplay:redisplayedInAppMessages];
-    [standardUserDefaults saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
-    
+    [standardUserDefaults saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+
     [self initOneSignalWithInAppMessage:message];
-    
-    let redisplayMessagesCache = [standardUserDefaults getSavedDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
+
+    NSMutableDictionary *redisplayMessagesCache = [standardUserDefaults getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
     XCTAssertTrue([redisplayMessagesCache objectForKey:message1.messageId]);
     XCTAssertFalse([redisplayMessagesCache objectForKey:message2.messageId]);
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
@@ -37,6 +37,10 @@
 #import "UnitTestCommonMethods.h"
 #import "OneSignalUserDefaults.h"
 #import "OneSignalCommonDefines.h"
+#import "OSInAppMessagingDefines.h"
+#import "OneSignalUserDefaults.h"
+#import "OSInAppMessage.h"
+#import "OSInAppMessagingHelpers.h"
 #import "CommonAsserts.h"
   
 @interface MigrationTests : XCTestCase
@@ -236,5 +240,56 @@
     NSInteger sdkVersionAfterMigration = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
     XCTAssertEqual([[OneSignal sdk_version_raw] intValue], sdkVersionAfterMigration);
 }
+
+- (void)testIAMCachedEmptyDictionaryToCachedCodeableMigration {
+    NSDictionary<NSString *, OSInAppMessage *>*emptyDict = [NSMutableDictionary new];
+    [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:emptyDict];
+    
+    [migrationController migrate];
+}
+
+- (void)testIAMCachedDictionaryToCachedCodeableMigration {
+    NSMutableDictionary <NSString *, OSInAppMessage *> *emptyDict = [NSMutableDictionary new];
+    
+    [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:emptyDict];
+    
+    [migrationController migrate];
+    
+    NSDictionary<NSString *, OSInAppMessage *>*retrievedDict = [OneSignalUserDefaults.initStandard
+                                                                getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
+    XCTAssertEqualObjects(emptyDict, retrievedDict);
+}
+
+- (void)testIAMCachedCodeableMigration {
+    let limit = 5;
+    let delay = 60;
+    let message = [OSInAppMessageTestHelper testMessageWithRedisplayLimit:limit delay:@(delay)];
+    message.isDisplayedInSession = true;
+    NSMutableDictionary <NSString *, OSInAppMessage *> *redisplayedInAppMessages = [NSMutableDictionary new];
+    [redisplayedInAppMessages setObject:message forKey:message.messageId];
+    
+    [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+    
+    [migrationController migrate];
+    
+    NSDictionary<NSString *, OSInAppMessage *>*retrievedDict = [OneSignalUserDefaults.initStandard
+                                                                getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
+    XCTAssertEqualObjects(redisplayedInAppMessages, retrievedDict);
+}
+
+- (void)testIAMNilCacheToNilMigration {
+    
+    [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:nil];
+    
+    [migrationController migrate];
+    
+    NSDictionary<NSString *, OSInAppMessage *>*retrievedDict = [OneSignalUserDefaults.initStandard
+                                                                getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
+    XCTAssertNil(retrievedDict);
+}
+
+
+
+
 
 @end


### PR DESCRIPTION
This is a (mostly) cherry-picked version of the NSUserDefaults crash fix for the 2.X.X branch.

The difference being that the 2.X.X branch does not have UnitTests running in a test application so we cannot remove NSUserDefaultsOverrider. This shouldn't matter since we shouldn't be doing new development in this branch anyways.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/896)
<!-- Reviewable:end -->

