### PR TITLE
Give user the ability to disable onesignal load

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2766,7 +2766,7 @@ static NSString *_lastnonActiveMessageId;
 }
 
 +(BOOL) shouldDisableBasedOnProcessArguments {
-    if ([NSProcessInfo.processInfo.arguments containsObject: @"DISABLE_ONESIGNAL_SWIZZLING"]) {
+    if ([NSProcessInfo.processInfo.arguments containsObject:@"DISABLE_ONESIGNAL_SWIZZLING"]) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
This is a request to merge a community PR #297 into master. I have tested this on iOS 14.4 and Xcode 12.4 myself.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/898)
<!-- Reviewable:end -->

