### PR TITLE
Fix Email and SMS channel being overridden by Push Channel

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.h
@@ -53,6 +53,10 @@ withSMSAuthHashToken:(NSString * _Nullable)hashToken
          withSuccess:(OSSMSSuccessBlock _Nullable)successBlock
          withFailure:(OSSMSFailureBlock _Nullable)failureBlock;
 
+- (void)logoutSMSWithAppId:(NSString * _Nonnull)appId
+               withSuccess:(OSSMSSuccessBlock _Nullable)successBlock
+               withFailure:(OSSMSFailureBlock _Nullable)failureBlock;
+
 - (void)sendTagsWithAppId:(NSString * _Nonnull)appId
                sendingTags:(NSDictionary * _Nonnull)tag
                networkType:(NSNumber * _Nonnull)networkType

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -256,6 +256,13 @@ withSMSAuthHashToken:(NSString *)hashToken
     }
 }
 
+- (void)logoutSMSWithAppId:(NSString *)appId withSuccess:(OSSMSSuccessBlock)successBlock withFailure:(OSSMSFailureBlock)failureBlock {
+    NSString *smsNumber = self.currentSMSSubscriptionState.smsNumber;
+    [OneSignal saveSMSNumber:nil withAuthToken:nil userId:nil];
+        
+    [self callSMSSuccessBlockOnMainThread:successBlock withSMSNumber:smsNumber];
+}
+
 - (void)sendTagsWithAppId:(NSString *)appId
               sendingTags:(NSDictionary *)tags
               networkType:(NSNumber *)networkType

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -235,7 +235,7 @@ withSMSAuthHashToken:(NSString *)hashToken
             [self callFailureBlockOnMainThread:failureBlock withError:error];
         }];
     } else {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestCreateDevice withAppId:appId withDeviceType:@(DEVICE_TYPE_SMS) notificationTypes:@([OneSignal getNotificationTypes]) withSMSNumber:smsNumber withPlayerId:_currentSubscriptionState.userId withSMSAuthHash:hashToken withExternalIdAuthToken:self.currentSubscriptionState.externalIdAuthCode] onSuccess:^(NSDictionary *result) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestCreateDevice withAppId:appId withDeviceType:@(DEVICE_TYPE_SMS) withSMSNumber:smsNumber withPlayerId:_currentSubscriptionState.userId withSMSAuthHash:hashToken withExternalIdAuthToken:self.currentSubscriptionState.externalIdAuthCode] onSuccess:^(NSDictionary *result) {
             let smsPlayerId = (NSString*)result[@"id"];
             
             if (smsPlayerId) {

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateEmailSynchronizer.m
@@ -79,6 +79,7 @@ THE SOFTWARE.
     emailDataDic[@"email_auth_hash"] = self.getEmailAuthHashToken;
     emailDataDic[@"identifier"] = _currentEmailSubscriptionState.emailAddress;
     emailDataDic[@"device_player_id"] = _currentSubscriptionState.userId;
+    [emailDataDic removeObjectForKey:@"notification_types"];
     
     // If push device has external id we want to add it to the email device also
     if (registrationState.externalUserId)

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStateSMSSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStateSMSSynchronizer.m
@@ -83,6 +83,7 @@ THE SOFTWARE.
     smsDataDic[SMS_NUMBER_AUTH_HASH_KEY] = self.getSMSAuthHashToken;
     smsDataDic[SMS_NUMBER_KEY] = _currentSMSSubscriptionState.smsNumber;
     smsDataDic[@"device_player_id"] = _currentSubscriptionState.userId;
+    [smsDataDic removeObjectForKey:@"notification_types"];
 
     // If push device has external id we want to add it to the SMS device also
     if (registrationState.externalUserId)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -558,6 +558,10 @@ typedef void (^OSSMSSuccessBlock)(NSDictionary *results);
 + (void)setSMSNumber:(NSString * _Nonnull)smsNumber;
 + (void)setSMSNumber:(NSString * _Nonnull)smsNumber withSuccess:(OSSMSSuccessBlock _Nullable)successBlock withFailure:(OSSMSFailureBlock _Nullable)failureBlock;
 
+// Logs the device out of the current sms number.
++ (void)logoutSMSNumber;
++ (void)logoutSMSNumberWithSuccess:(OSSMSSuccessBlock _Nullable)successBlock withFailure:(OSSMSFailureBlock _Nullable)failureBlock;
+
 #pragma mark External User Id
 // Typedefs defining completion blocks for updating the external user id
 typedef void (^OSUpdateExternalUserIdFailureBlock)(NSError *error);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2474,7 +2474,7 @@ static NSString *_lastnonActiveMessageId;
         return;
     }
 
-    [OneSignalClient.sharedClient executeRequest:[OSRequestLogoutEmail withAppId: self.appId emailPlayerId:self.currentEmailSubscriptionState.emailUserId devicePlayerId:self.currentSubscriptionState.userId emailAuthHash:self.currentEmailSubscriptionState.emailAuthCode] onSuccess:^(NSDictionary *result) {
+    [OneSignalClient.sharedClient executeRequest:[OSRequestLogoutEmail withAppId:self.appId emailPlayerId:self.currentEmailSubscriptionState.emailUserId devicePlayerId:self.currentSubscriptionState.userId emailAuthHash:self.currentEmailSubscriptionState.emailAuthCode] onSuccess:^(NSDictionary *result) {
         
         [OneSignalUserDefaults.initStandard removeValueForKey:OSUD_EMAIL_PLAYER_ID];
         [OneSignal saveEmailAddress:nil withAuthToken:nil userId:nil];
@@ -2580,6 +2580,30 @@ static NSString *_lastnonActiveMessageId;
     }
     
     [self.stateSynchronizer setSMSNumber:smsNumber withSMSAuthHashToken:hashToken withAppId:self.appId withSuccess:successBlock withFailure:failureBlock];
+}
+
++ (void)logoutSMSNumber {
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"logoutSMSNumber"])
+        return;
+    
+    [self logoutSMSNumberWithSuccess:nil withFailure:nil];
+}
+
++ (void)logoutSMSNumberWithSuccess:(OSSMSSuccessBlock)successBlock withFailure:(OSSMSFailureBlock)failureBlock {
+    // return if the user has not granted privacy permissions
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"logoutSMSNumberWithSuccess:withFailure:"])
+        return;
+    
+    if (!self.currentSMSSubscriptionState.smsUserId) {
+        [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"SMS Player ID does not exist, cannot logout"];
+        
+        if (failureBlock)
+            failureBlock([NSError errorWithDomain:@"com.onesignal.sms" code:0 userInfo:@{@"error" : @"Attempted to log out of the user's sms number with OneSignal. The user does not currently have an sms player ID and is not logged in, so it is not possible to log out of the sms number for this device"}]);
+        return;
+    }
+    
+    [self.stateSynchronizer logoutSMSWithAppId:self.appId withSuccess:successBlock withFailure:failureBlock];
 }
 
 + (NSDate *)sessionLaunchTime {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1605,9 +1605,6 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
           appId:self.appId
           deviceToken:self.currentSubscriptionState.pushToken
           notificationTypes:@([self getNotificationTypes])
-          withParentId:nil
-          emailAuthToken:nil
-          email:nil
           externalIdAuthToken:[self mExternalIdAuthToken]
       ];
       [OneSignalClient.sharedClient executeRequest:request onSuccess:nil onFailure:nil];
@@ -2424,7 +2421,7 @@ static NSString *_lastnonActiveMessageId;
     //  otherwise, we should call Create Device
     // Since developers may be making UI changes when this call finishes, we will call callbacks on the main thread.
     if (self.currentEmailSubscriptionState.emailUserId) {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.appId deviceToken:email notificationTypes:nil withParentId:nil emailAuthToken:emailAuthToken email:nil externalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.appId deviceToken:email withParentId:nil emailAuthToken:emailAuthToken email:nil externalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:successBlock];
         } onFailure:^(NSError *error) {
             [self callFailureBlockOnMainThread:failureBlock withError:error];
@@ -2436,8 +2433,7 @@ static NSString *_lastnonActiveMessageId;
             
             if (emailPlayerId) {
                 [OneSignal saveEmailAddress:email withAuthToken:emailAuthToken userId:emailPlayerId];
-
-                [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.appId deviceToken:nil notificationTypes:@([self getNotificationTypes]) withParentId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:hashToken email:email externalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
+                [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.appId deviceToken:nil withParentId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:hashToken email:email externalIdAuthToken:[self mExternalIdAuthToken] ] onSuccess:^(NSDictionary *result) {
                     [self callSuccessBlockOnMainThread:successBlock];
                 } onFailure:^(NSError *error) {
                     [self callFailureBlockOnMainThread:failureBlock withError:error];
@@ -2497,7 +2493,6 @@ static NSString *_lastnonActiveMessageId;
     let request = [OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId
                                                    appId:self.appId
                                                    deviceToken:nil
-                                                   notificationTypes: @([self getNotificationTypes])
                                                    withParentId:emailPlayerId
                                                    emailAuthToken:self.currentEmailSubscriptionState.emailAuthCode
                                                    email:self.currentEmailSubscriptionState.emailAddress

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -69,7 +69,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @interface OSRequestUpdateDeviceToken : OneSignalRequest
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
+
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier smsAuthToken:(NSString * _Nullable)smsAuthToken externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -69,10 +69,13 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @interface OSRequestUpdateDeviceToken : OneSignalRequest
+// Push channel update device token
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
+// Email channel update device token
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
+// SMS channel update device token
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier smsAuthToken:(NSString * _Nullable)smsAuthToken externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_END
 @interface OSRequestCreateDevice : OneSignalRequest
 + (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType withEmail:(NSString * _Nullable)email withPlayerId:(NSString * _Nullable)playerId withEmailAuthHash:(NSString * _Nullable)emailAuthHash withExternalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 
-+ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType notificationTypes:(NSNumber * _Nonnull)notificationTypes withSMSNumber:(NSString * _Nullable)smsNumber withPlayerId:(NSString * _Nullable)playerId withSMSAuthHash:(NSString * _Nullable)smsAuthHash withExternalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
++ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withDeviceType:(NSNumber * _Nonnull)deviceType withSMSNumber:(NSString * _Nullable)smsNumber withPlayerId:(NSString * _Nullable)playerId withSMSAuthHash:(NSString * _Nullable)smsAuthHash withExternalIdAuthToken:(NSString * _Nullable)externalIdAuthToken;
 @end
 
 @interface OSRequestLogoutEmail : OneSignalRequest

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -88,6 +88,10 @@ NS_ASSUME_NONNULL_END
 + (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId emailPlayerId:(NSString * _Nonnull)emailPlayerId devicePlayerId:(NSString * _Nonnull)devicePlayerId emailAuthHash:(NSString * _Nullable)emailAuthHash;
 @end
 
+@interface OSRequestLogoutSMS : OneSignalRequest
++ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId smsPlayerId:(NSString * _Nonnull)smsPlayerId smsAuthHash:(NSString * _Nullable)smsAuthHash devicePlayerId:(NSString * _Nonnull)devicePlayerId;
+@end
+
 @interface OSRequestSendTagsToServer : OneSignalRequest
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId tags:(NSDictionary * _Nonnull)tags networkType:(NSNumber * _Nonnull)netType withEmailAuthHashToken:(NSString * _Nullable)emailAuthToken withExternalIdAuthHashToken:(NSString * _Nullable)externalIdAuthToken;
 

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -162,7 +162,7 @@
     
     let params = [NSMutableDictionary new];
     params[@"app_id"] = appId;
-    
+
     if (identifier)
         params[@"identifier"] = identifier;
     
@@ -206,7 +206,6 @@
        @"app_id" : appId,
        @"device_type" : deviceType,
        @"identifier" : smsNumber ?: [NSNull null],
-       @"notification_types" : notificationTypes,
        SMS_NUMBER_AUTH_HASH_KEY : smsAuthHash ?: [NSNull null],
        @"external_user_id_auth_hash" : externalIdAuthToken ?: [NSNull null],
        @"device_player_id" : playerId ?: [NSNull null]

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -125,8 +125,30 @@
 @end
 
 @implementation OSRequestUpdateDeviceToken
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes withParentId:(NSString * _Nullable)parentId emailAuthToken:(NSString * _Nullable)emailAuthHash email:(NSString * _Nullable)email externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken {
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId appId:(NSString * _Nonnull)appId deviceToken:(NSString * _Nullable)identifier notificationTypes:(NSNumber * _Nullable)notificationTypes externalIdAuthToken:(NSString * _Nullable)externalIdAuthToken {
     
+    let request = [OSRequestUpdateDeviceToken new];
+    
+    let params = [NSMutableDictionary new];
+    params[@"app_id"] = appId;
+   
+    if (notificationTypes)
+        params[@"notification_types"] = notificationTypes;
+    
+    if (identifier)
+        params[@"identifier"] = identifier;
+    
+    if (externalIdAuthToken && externalIdAuthToken.length > 0)
+        params[@"external_user_id_auth_hash"] = externalIdAuthToken;
+    
+    request.parameters = params;
+    request.method = PUT;
+    request.path = [NSString stringWithFormat:@"players/%@", userId];
+    
+    return request;
+}
+
++ (instancetype)withUserId:(NSString *)userId appId:(NSString *)appId deviceToken:(NSString *)identifier withParentId:(NSString *)parentId emailAuthToken:(NSString *)emailAuthHash email:(NSString *)email externalIdAuthToken:(NSString *)externalIdAuthToken {
     let request = [OSRequestUpdateDeviceToken new];
     
     let params = [NSMutableDictionary new];
@@ -134,9 +156,6 @@
     
     if (email)
         params[@"email"] = email;
-    
-    if (notificationTypes)
-        params[@"notification_types"] = notificationTypes;
     
     if (identifier)
         params[@"identifier"] = identifier;

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -218,7 +218,7 @@
     return request;
 }
 
-+ (instancetype)withAppId:(NSString *)appId withDeviceType:(NSNumber *)deviceType notificationTypes:(NSNumber *)notificationTypes withSMSNumber:(NSString *)smsNumber withPlayerId:(NSString *)playerId withSMSAuthHash:(NSString *)smsAuthHash withExternalIdAuthToken:(NSString *)externalIdAuthToken {
++ (instancetype)withAppId:(NSString *)appId withDeviceType:(NSNumber *)deviceType withSMSNumber:(NSString *)smsNumber withPlayerId:(NSString *)playerId withSMSAuthHash:(NSString *)smsAuthHash withExternalIdAuthToken:(NSString *)externalIdAuthToken {
     let request = [OSRequestCreateDevice new];
     
     request.parameters = @{

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -537,16 +537,6 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
     XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"device_type" : @0, @"identifier" : testEmailAddress, @"email_auth_hash" : [NSNull null], @"device_player_id" : testUserId, @"external_user_id_auth_hash" : @"external_id_auth_token"}));
 }
 
-- (void)testLogoutEmail {
-    let request = [OSRequestLogoutEmail withAppId:testAppId emailPlayerId:testEmailUserId devicePlayerId:testUserId emailAuthHash:nil];
-    
-    let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@/email_logout", testUserId]);
-    
-    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
-    
-    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"parent_player_id" : testEmailUserId, @"email_auth_hash" : [NSNull null], @"app_id" : testAppId}));
-}
-
 - (void)testUpdateNotificationTypes {
     let request = [OSRequestUpdateNotificationTypes withUserId:testUserId appId:testAppId notificationTypes:@0];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -508,13 +508,23 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
 }
 
 - (void)testUpdateDeviceToken {
-    let request = [OSRequestUpdateDeviceToken withUserId:testUserId appId:testAppId deviceToken:@"test_device_token" notificationTypes:@0 withParentId:@"test_parent_id" emailAuthToken:nil email:testEmailAddress externalIdAuthToken:@"external_id_auth_token"];
+    let request = [OSRequestUpdateDeviceToken withUserId:testUserId appId:testAppId deviceToken:@"test_device_token" notificationTypes:@0 externalIdAuthToken:@"external_id_auth_token"];
+
+    let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
+    
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
+    
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"notification_types" : @0, @"identifier" : @"test_device_token", @"external_user_id_auth_hash" : @"external_id_auth_token"}));
+}
+
+- (void)testUpdateEmailDeviceToken {
+    let request = [OSRequestUpdateDeviceToken withUserId:testUserId appId:testAppId deviceToken:@"test_device_token" withParentId:@"test_parent_id" emailAuthToken:nil email:testEmailAddress externalIdAuthToken:@"external_id_auth_token"];
     
     let correctUrl = correctUrlWithPath([NSString stringWithFormat:@"players/%@", testUserId]);
     
     XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
     
-    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"email" : testEmailAddress, @"notification_types" : @0, @"identifier" : @"test_device_token", @"parent_player_id" : @"test_parent_id", @"external_user_id_auth_hash" : @"external_id_auth_token"}));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"app_id" : testAppId, @"email" : testEmailAddress, @"identifier" : @"test_device_token", @"parent_player_id" : @"test_parent_id", @"external_user_id_auth_hash" : @"external_id_auth_token"}));
 }
 
 - (void)testCreateDevice {


### PR DESCRIPTION
* Delete notification_types param from email requests
* Remove notification_types from email request test
* Remove notification_types param from sms request
* Remove notification_types from tests
* Remove notification_types from SMS and Email on_session request

### Problem
notification_types params were being sent on all channel requests. This ended on Email and Push subscription to have notification type on Dashboard.

### Result
Removing notification_types from SMS and Email updates solved the problem. The subscription type on the dashboard is not affected by the push notification_type.

Tested with iOS 12.3 

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/899)
<!-- Reviewable:end -->

