### PR TITLE
Remove alert for launch URLs

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -868,19 +868,7 @@ static OneSignal* singleInstance = nil;
             });
         }];
     };
-    
-    if (url) {
-        let message = NSLocalizedString(([NSString stringWithFormat:@"Would you like to open %@://%@", url.scheme, url.host]), @"Asks whether the user wants to open the URL");
-        let title = NSLocalizedString(@"Open Website?", @"A title asking if the user wants to open a URL/website");
-        let openAction = NSLocalizedString(@"Open", @"Allows the user to open the URL/website");
-        let cancelAction = NSLocalizedString(@"Cancel", @"The user won't open the URL/website");
-        
-        [[OneSignalDialogController sharedInstance] presentDialogWithTitle:title withMessage:message withActions:@[openAction] cancelTitle:cancelAction withActionCompletion:^(int tappedActionIndex) {
-            openUrlBlock(tappedActionIndex > -1);
-        }];
-    } else {
-        openUrlBlock(true);
-    }
+    openUrlBlock(true);
 }
 
 + (void)runOnMainThread:(void(^)())block {


### PR DESCRIPTION
This alert was causing problems for customers where it could be dismissed when the app was opened. It does not seem to be a desirable function so we will remove it. This change in behavior will need to be communicated to customers, but the change will not cause any build issues.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/901)
<!-- Reviewable:end -->

