### PR TITLE
External user id not being sent fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -148,6 +148,13 @@ THE SOFTWARE.
         //update push player id
         if (results.count > 0 && results[OS_PUSH][@"id"]) {
             self.currentSubscriptionState.userId = results[OS_PUSH][@"id"];
+            
+            // Player record was deleted so we should reset external user id
+            let cachedPlayerId = [OneSignalUserDefaults.initStandard getSavedStringForKey:OSUD_PLAYER_ID_TO defaultValue:nil];
+            if (cachedPlayerId && ![results[OS_PUSH][@"id"] isEqualToString:cachedPlayerId]) {
+                [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat: @"Player id has changed. Clearing cached external user id"]];
+                [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:nil];
+            }
 
             // Save player_id to both standard and shared NSUserDefaults
             [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_PLAYER_ID_TO withValue:self.currentSubscriptionState.userId];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2562,9 +2562,7 @@ static NSString *_lastnonActiveMessageId;
     bool updateExternalUserId = ![self.existingPushExternalUserId isEqualToString:externalId]
                                 && !requests[@"email"];
 
-    // If we are making a request to email user, we need validate both external user ids
-    bool updateEmailExternalUserId = (![self.existingPushExternalUserId isEqualToString:externalId]
-                                      && requests[@"email"]
+    bool updateEmailExternalUserId = (requests[@"email"]
                                       && ![self.existingEmailExternalUserId isEqualToString:externalId]);
 
     return updateExternalUserId || updateEmailExternalUserId;


### PR DESCRIPTION
This PR fixes two scenarios where we were not sending the external user id when we should be.

1. When we have already set the external push user id, and are now trying to set the external email user id to the same value. For this we had a comment "If we are making a request to email user, we need validate both external user ids", but I am not sure why that is the case.
1. When you have a cached external user id, but the player has been deleted from the dashboard and you are trying to set the external user id to the cached value

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/903)
<!-- Reviewable:end -->

