### PR TITLE
Add missing device_type from PUSH Channel

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.h
@@ -31,7 +31,6 @@ THE SOFTWARE.
 
 @property (strong, nonatomic, readwrite, nullable) NSString *appId;
 @property (strong, nonatomic, readwrite, nullable) NSString *deviceOs;
-@property (strong, nonatomic, readwrite, nullable) NSNumber *deviceType;
 @property (strong, nonatomic, readwrite, nullable) NSNumber *timezone;
 @property (strong, nonatomic, readwrite, nullable) NSString *timezoneId;
 @property (strong, nonatomic, readwrite, nullable) NSString *adId;

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.m
@@ -37,7 +37,6 @@ THE SOFTWARE.
                    _deviceOs, @"device_os",
                    _timezone, @"timezone",
                    _timezoneId, @"timezone_id",
-                   _deviceType, @"device_type",
                    _adId, @"ad_id",
                    _sdk, @"sdk",
                    nil];

--- a/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserStatePushSynchronizer.m
@@ -71,6 +71,7 @@ THE SOFTWARE.
 - (NSDictionary *)getRegistrationData:(OSUserState *)registrationState {
     NSMutableDictionary *pushDataDic = (NSMutableDictionary *)[registrationState.toDictionary mutableCopy];
     pushDataDic[@"identifier"] = _currentSubscriptionState.pushToken;
+    pushDataDic[@"device_type"] = self.getDeviceType;
     
     return pushDataDic;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1649,7 +1649,6 @@ static dispatch_queue_t serialQueue;
     let userState = [OSUserState new];
     userState.appId = appId;
     userState.deviceOs = [[UIDevice currentDevice] systemVersion];
-    userState.deviceType = [NSNumber numberWithInt:DEVICE_TYPE_PUSH];
     userState.timezone = [NSNumber numberWithInt:(int)[[NSTimeZone localTimeZone] secondsFromGMT]];
     userState.timezoneId = [[NSTimeZone localTimeZone] name];
     userState.adId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];


### PR DESCRIPTION
* Device type population is the responsibility of each channel synchronizer, remove device type from UserState rely on Push synchronizer
* Fix testBasicInitTest and testInitOnSimulator failing tests, tests were failing due to missing device_type under push channel

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/905)
<!-- Reviewable:end -->

