### PR TITLE
Fix Dialog Issue

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -361,7 +361,6 @@
 		CA1A6E7020DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1A6E6E20DC2E73001C41B9 /* OneSignalDialogRequest.m */; };
 		CA1A6E7120DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1A6E6E20DC2E73001C41B9 /* OneSignalDialogRequest.m */; };
 		CA1A6E7220DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1A6E6E20DC2E73001C41B9 /* OneSignalDialogRequest.m */; };
-		CA1A6E7520DC2F04001C41B9 /* OneSignalDialogControllerOverrider.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1A6E7320DC2F04001C41B9 /* OneSignalDialogControllerOverrider.h */; };
 		CA1A6E7820DC2F04001C41B9 /* OneSignalDialogControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1A6E7420DC2F04001C41B9 /* OneSignalDialogControllerOverrider.m */; };
 		CA36A42C208FDEFB003EFA9A /* NSURL+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = CA36A42A208FDEFB003EFA9A /* NSURL+OneSignal.h */; };
 		CA36A42D208FDEFB003EFA9A /* NSURL+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA36A42B208FDEFB003EFA9A /* NSURL+OneSignal.m */; };
@@ -1508,7 +1507,6 @@
 				CACBAAA0218A6243000ACAA5 /* OSInAppMessage.h in Headers */,
 				91C7725E1E7CCE1000D612D0 /* OneSignalInternal.h in Headers */,
 				CAB269DF21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h in Headers */,
-				CA1A6E7520DC2F04001C41B9 /* OneSignalDialogControllerOverrider.h in Headers */,
 				9129C6BD1E89E7AB009CB6A0 /* OSSubscription.h in Headers */,
 				CA7FC89F21927229002C4FD9 /* OSDynamicTriggerController.h in Headers */,
 				DE98773C2591656A00DE07D5 /* NSDateFormatter+OneSignal.h in Headers */,

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -90,8 +90,8 @@
 }
 
 - (void)displayDialog:(OSDialogRequest * _Nonnull)request {
-    let rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-    
+    let visibleViewController = [OneSignalDialogController visibleViewController];
+
     let controller = [UIAlertController alertControllerWithTitle:request.title message:request.message preferredStyle:UIAlertControllerStyleAlert];
     
     [controller addAction:[UIAlertAction actionWithTitle:request.cancelTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
@@ -106,8 +106,8 @@
             }]];
         }
     }
-    
-    [rootViewController presentViewController:controller animated:true completion:nil];
+
+    [visibleViewController presentViewController:controller animated:true completion:nil];
 }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
@@ -137,6 +137,25 @@
 
 - (void)clearQueue {
     self.queue = [NSMutableArray new];
+}
+
++ (UIViewController *)visibleViewController {
+    let rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+    return [OneSignalDialogController getVisibleViewControllerFrom:rootViewController];
+}
+
++ (UIViewController *) getVisibleViewControllerFrom:(UIViewController *) vc {
+    if ([vc isKindOfClass:[UINavigationController class]]) {
+        return [OneSignalDialogController getVisibleViewControllerFrom:[((UINavigationController *) vc) visibleViewController]];
+    } else if ([vc isKindOfClass:[UITabBarController class]]) {
+        return [OneSignalDialogController getVisibleViewControllerFrom:[((UITabBarController *) vc) selectedViewController]];
+    } else {
+        if (vc.presentedViewController) {
+            return [OneSignalDialogController getVisibleViewControllerFrom:vc.presentedViewController];
+        } else {
+            return vc;
+        }
+    }
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -144,7 +144,7 @@
     return [OneSignalDialogController getVisibleViewControllerFrom:rootViewController];
 }
 
-+ (UIViewController *) getVisibleViewControllerFrom:(UIViewController *) vc {
++ (UIViewController *)getVisibleViewControllerFrom:(UIViewController *) vc {
     if ([vc isKindOfClass:[UINavigationController class]]) {
         return [OneSignalDialogController getVisibleViewControllerFrom:[((UINavigationController *) vc) visibleViewController]];
     } else if ([vc isKindOfClass:[UITabBarController class]]) {


### PR DESCRIPTION
There are two issues for the dialog.

1. The `OneSignalDialogControllerOverrider` was included to the SDK target mistakenly once again. Same as PR https://github.com/OneSignal/OneSignal-iOS-SDK/pull/420
1. Currently we are presenting the dialog(`UIViewController`) from `keyWindow.rootViewController`, but if the rootViewController already presented another vc, it's not allowed to present the alert controller anymore. So we need to present the alert from the visible(top most) vc.

> _[Presentation] Attempt to present <UIAlertController: 0x15b818400> on <Test.RootVC: 0x157e078e0> (from <Test.RootVC: 0x157e078e0>) which is already presenting <_TtC4TestP33_8314E842ED9EA302AFA529AE16E3E3E21VC: 0x158e04be0>__

_Tested on iOS 14.4 Xcode 12.4_

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/907)
<!-- Reviewable:end -->

