### PR TITLE
Fix provision detection

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalMobileProvision.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalMobileProvision.m
@@ -46,8 +46,7 @@
         
         // If embedded.mobileprovision not found, try Mac Catalyst bundle struct and unique filename
         if (!provisioningPath) {
-            NSString *bundleURL = [[NSBundle mainBundle] bundleURL].absoluteString;
-            provisioningPath = [[[bundleURL componentsSeparatedByString:@"file://"] objectAtIndex:1] stringByAppendingString:@"Contents/embedded.provisionprofile"];
+            provisioningPath = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"Contents/embedded.provisionprofile"];
         }
         
         // NSISOLatin1 keeps the binary wrapper from being parsed as unicode and dropped as invalid


### PR DESCRIPTION
Fix provision detection when path to provision file contains spaces

We use multiple schemas in our app and their names contain spaces, therefore build artefacts directories names contain spaces as well. Handling provision path as URL percent-encodes those spaces, so the file cannot be read even though it is present

```
provisioningPath = .../Mac%20Beta%20Debug-maccatalyst/AppName.app/Contents/embedded.provisionprofile
```

Building provisioning profile path as path string in the first place resolves this issue

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/909)
<!-- Reviewable:end -->

