### PR TITLE
Fix tags not sent when backgrounding quickly

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1286,6 +1286,16 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
        [OneSignalHelper performSelector:@selector(sendTagsToServer) onMainThreadOnObject:self withObject:nil afterDelay:5];
 }
 
++ (void)sendTagsOnBackground {
+    if (!self.playerTags.tagsToSend || self.playerTags.tagsToSend.count <= 0)
+        return;
+    
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(sendTagsToServer) object:nil];
+    [OneSignalHelper dispatch_async_on_main_queue:^{
+        [self sendTagsToServer];
+    }];
+}
+
 // Called only with a delay to batch network calls.
 + (void)sendTagsToServer {
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -67,6 +67,7 @@
 + (void)setIsOnSessionSuccessfulForCurrentState:(BOOL)value;
 + (BOOL)shouldRegisterNow;
 + (void)receivedInAppMessageJson:(NSArray<NSDictionary *> *_Nullable)messagesJson;
++ (void)sendTagsOnBackground;
 
 + (NSDate *_Nonnull)sessionLaunchTime;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -91,8 +91,10 @@ static OneSignalLifecycleObserver* _instance = nil;
 - (void)willResignActive {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"application/scene willResignActive"];
     
-    if ([OneSignal appId])
+    if ([OneSignal appId]) {
         [OneSignalTracker onFocus:YES];
+        [OneSignal sendTagsOnBackground];
+    }
 }
 
 - (void)didEnterBackground {


### PR DESCRIPTION
In order to control bandwidth and prevent abuse of sending tags we batch sendTags calls by sending them after a 5 second delay. If the app is backgrounded within those 5 seconds then the tags will not be sent to the server. This pr fixes the issue by sending tags when the app is backgrounded utilizing our `lifecycleObserver`

This pr also has unrelated warning cleanup and a dev project fix

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/913)
<!-- Reviewable:end -->

