### PR TITLE
Always create new player ids on app install

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 @property (strong, nonatomic, readwrite, nullable) NSString *deviceOs;
 @property (strong, nonatomic, readwrite, nullable) NSNumber *timezone;
 @property (strong, nonatomic, readwrite, nullable) NSString *timezoneId;
+//This property is no longer being populated with vendor id
 @property (strong, nonatomic, readwrite, nullable) NSString *adId;
 @property (strong, nonatomic, readwrite, nullable) NSString *sdk;
 @property (strong, nonatomic, readwrite, nullable) NSString *sdkType;

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.h
@@ -33,8 +33,6 @@ THE SOFTWARE.
 @property (strong, nonatomic, readwrite, nullable) NSString *deviceOs;
 @property (strong, nonatomic, readwrite, nullable) NSNumber *timezone;
 @property (strong, nonatomic, readwrite, nullable) NSString *timezoneId;
-//This property is no longer being populated with vendor id
-@property (strong, nonatomic, readwrite, nullable) NSString *adId;
 @property (strong, nonatomic, readwrite, nullable) NSString *sdk;
 @property (strong, nonatomic, readwrite, nullable) NSString *sdkType;
 @property (strong, nonatomic, readwrite, nullable) NSString *externalUserId;

--- a/iOS_SDK/OneSignalSDK/Source/OSUserState.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUserState.m
@@ -37,7 +37,6 @@ THE SOFTWARE.
                    _deviceOs, @"device_os",
                    _timezone, @"timezone",
                    _timezoneId, @"timezone_id",
-                   _adId, @"ad_id",
                    _sdk, @"sdk",
                    nil];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1743,7 +1743,6 @@ static dispatch_queue_t serialQueue;
     userState.deviceOs = [[UIDevice currentDevice] systemVersion];
     userState.timezone = [NSNumber numberWithInt:(int)[[NSTimeZone localTimeZone] secondsFromGMT]];
     userState.timezoneId = [[NSTimeZone localTimeZone] name];
-    userState.adId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
     userState.sdk = ONESIGNAL_VERSION;
 
     // should be set to true even before the API request is finished


### PR DESCRIPTION
This pr removes the usage of identifierForVendor to prevent creating a new player id for a reinstalled app.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/914)
<!-- Reviewable:end -->

