### PR TITLE
Removing duplicate checks for set_external_user_id

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -200,16 +200,6 @@ THE SOFTWARE.
                                                                                       withAppId:appId];
     }
 
-    // Make sure this is not a duplicate request, if the email and push channels are aligned correctly with the same external id
-    if (![OneSignal shouldUpdateExternalUserId:externalId withRequests:requests]) {
-        // Use callback to return success for both cases here, since push and
-        // email (if email is not setup, email is not included) have been set already
-        let results = [OneSignal getDuplicateExternalUserIdResponse:externalId withRequests:requests];
-        if (successBlock)
-            successBlock(results);
-        return;
-    }
-
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withCompletion:^(NSDictionary<NSString *,NSDictionary *> *results) {
         if (results[OS_PUSH] && results[OS_PUSH][OS_SUCCESS] && [results[OS_PUSH][OS_SUCCESS] boolValue]) {
             [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:externalId];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2773,24 +2773,6 @@ static NSString *_lastnonActiveMessageId;
     return updateExternalUserId || updateEmailExternalUserId;
 }
 
-+ (NSMutableDictionary*)getDuplicateExternalUserIdResponse:(NSString*)externalId withRequests:(NSDictionary*)requests {
-    NSMutableDictionary *results = [NSMutableDictionary new];
-    [OneSignal onesignal_Log:ONE_S_LL_WARN message:[NSString stringWithFormat:@"Attempted to set external user id, but %@ is already set", externalId]];
-
-    results[@"push"] = @{
-        @"success" : @(true)
-    };
-
-    // Make sure to only add email if email was attempted
-    if (requests[@"email"]) {
-        results[@"email"] = @{
-            @"success" : @(true)
-        };
-    }
-
-    return results;
-}
-
 /*
  Start of outcome module
  */

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -2323,9 +2323,9 @@ didReceiveRemoteNotification:userInfo
     [OneSignal setExternalUserId:TEST_EXTERNAL_USER_ID];
 
     [UnitTestCommonMethods initOneSignal_andThreadWait];
-
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"], TEST_EXTERNAL_USER_ID);
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+    let registerUserRequest = OneSignalClientOverrider.executedRequests[1];
+    XCTAssertEqualObjects(registerUserRequest.parameters[@"external_user_id"], TEST_EXTERNAL_USER_ID);
+    XCTAssertEqualObjects(NSStringFromClass([registerUserRequest class]), NSStringFromClass([OSRequestRegisterUser class]));
 }
 
 - (void)testSetExternalUserIdAfterRegistration {
@@ -2354,21 +2354,21 @@ didReceiveRemoteNotification:userInfo
 }
 
 // Tests to make sure that the SDK will not send an external ID if it already successfully sent the same ID
-- (void)testDoesntSendExistingExternalUserIdAfterRegistration {
+- (void)testDoesSendExistingExternalUserIdAfterRegistration {
     [OneSignal setExternalUserId:TEST_EXTERNAL_USER_ID];
 
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestUpdateExternalUserId class]));
 
     [OneSignal setExternalUserId:TEST_EXTERNAL_USER_ID];
 
     // the PUT request to set external ID should not happen since the external ID
     // is the same as it was during registration
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestUpdateExternalUserId class]));
 }
 
-- (void)testDoesntSendExistingExternalUserIdBeforeRegistration {
+- (void)testDoesSendExistingExternalUserIdBeforeRegistration {
     //mimics a previous session where the external user ID was set
     [OneSignalUserDefaults.initStandard saveStringForKey:OSUD_EXTERNAL_USER_ID withValue:TEST_EXTERNAL_USER_ID];
 
@@ -2376,11 +2376,11 @@ didReceiveRemoteNotification:userInfo
 
     [UnitTestCommonMethods initOneSignal_andThreadWait];
 
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestUpdateExternalUserId class]));
 
     // the registration request should not have included external user ID
     // since it had been set already to the same value in a previous session
-    XCTAssertNil(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"]);
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"], TEST_EXTERNAL_USER_ID);
 }
 
 - (void)testSetExternalUserId_forPush_withCompletion {
@@ -2441,13 +2441,14 @@ didReceiveRemoteNotification:userInfo
     
     // 2. Init OneSignal
     [UnitTestCommonMethods initOneSignal_andThreadWait];
+    [UnitTestCommonMethods runBackgroundThreads];
     
     // 3. Make sure only push external id was attempted to be set since no email was set yet
     XCTAssertEqual(self.CALLBACK_EXTERNAL_USER_ID, TEST_EXTERNAL_USER_ID);
     XCTAssertNil(self.CALLBACK_EMAIL_EXTERNAL_USER_ID);
     
     // 3. Make sure last request was external id and had the correct external id being used in the request payload
-    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestUpdateExternalUserId class]));
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id"], TEST_EXTERNAL_USER_ID);
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"external_user_id_auth_hash"], TEST_EXTERNAL_USER_ID_HASH_TOKEN);
 }


### PR DESCRIPTION
We have seen some issues where set_external_user_id is not being set on channel records with an error that it has already been set. This PR simplifies the set_external_user_id code to always set the external user id, even if it matches the cached value for that channel. This will make setExternalUserId more reliable and simplifies the code path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/917)
<!-- Reviewable:end -->
