### PR TITLE
Fix saving NSNull in tags to userDefaults

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSPlayerTags.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPlayerTags.m
@@ -101,7 +101,18 @@ NSMutableDictionary<NSString *, NSString *> *_tagsToSend;
     _tags = [standardUserDefaults getSavedDictionaryForKey:OSUD_PLAYER_TAGS defaultValue:nil];
 }
 
+- (void)removeNSNullFromTags {
+    NSMutableDictionary *tagsDict = [NSMutableDictionary dictionaryWithDictionary:_tags];
+    for (id key in tagsDict.allKeys) {
+        if ([tagsDict[key] isKindOfClass:[NSNull class]]) {
+            tagsDict[key] = nil;
+        }
+    }
+    _tags = tagsDict;
+}
+
 - (void)saveTagsToUserDefaults {
+    [self removeNSNullFromTags];
     let standardUserDefaults = OneSignalUserDefaults.initStandard;
     [standardUserDefaults saveDictionaryForKey:OSUD_PLAYER_TAGS withValue:_tags];
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1364,6 +1364,38 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 4);
 }
 
+- (void)testSendNSNullInTags {
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    
+    [OneSignal sendTags:@{@"key1": @"value1", @"key2": [NSNull new]}];
+    
+    // Make sure all tags where send in 1 network call.
+    [NSObjectOverrider runPendingSelectors];
+    [UnitTestCommonMethods runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key1"], @"value1");
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"tags"][@"key2"], [NSNull new]);
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 3);
+}
+
+- (void)testSendBadObjectInTags {
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    //The OneSignal class is not a valid json object
+    [OneSignal sendTags:@{@"key1": @"value1", @"key2": [OneSignal new]}];
+    
+    // Make sure the tags were not sent.
+    [NSObjectOverrider runPendingSelectors];
+    [UnitTestCommonMethods runBackgroundThreads];
+    [NSObjectOverrider runPendingSelectors];
+    
+    XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+}
+
 - (void)testDeleteTags {
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);


### PR DESCRIPTION
OSPlayerTags attempts to save the tags dictionary to `NSUserDefaults`.  Sending a tag with a null value in flutter gets translated into `NSNull` instead of `nil` in Objective-C. When trying to save `NSNull` to `NSUserDefaults` the app will crash. This is a case where `NSNull` is considered a valid json object so it gets past our initial checks, but it isn't allowed to be saved to user defaults. 

To fix this I am looking for `NSNull` values in the dictionary and converting them to `nil` prior to saving the tags dictionary. 

Fixes #918

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/921)
<!-- Reviewable:end -->
