### PR TITLE
Fixed Pre-existing Notification Delegate

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -618,6 +618,14 @@ static OneSignal* singleInstance = nil;
     
     if (!curNotifCenter.delegate)
         curNotifCenter.delegate = (id)[self sharedInstance];
+    else {
+        /*
+         This handles the existing delegate that exist before the OneSignal delegate is loaded.
+         This line ends up calling the UNUserNotificationCenter+OneSignal.m file method setOneSignalUNDelegate.
+         This swizzles in the OneSignal methods into the existing non-OneSignal delegate.
+         */
+        curNotifCenter.delegate = curNotifCenter.delegate;
+    }
 }
 
 +(UNNotificationRequest*)prepareUNNotificationRequest:(OSNotificationPayload*)payload {


### PR DESCRIPTION
This happens when another library's delegate is loaded before OneSignal's delegate code.
This commit solves it by reassigning the pre loaded delegate into swizzle in OneSignal's  methods.
This issue was discovered through a Unity issue where Unity Mobile Notification Services would load their delegate before OneSignal's delegate.
https://github.com/OneSignal/OneSignal-Unity-SDK/issues/245

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/924)
<!-- Reviewable:end -->
