### PR TITLE
Fix pre-existing notification delegate

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2945,10 +2945,7 @@ static NSString *_lastnonActiveMessageId;
     if (!NSClassFromString(@"UNUserNotificationCenter"))
         return;
 
-    [OneSignalUNUserNotificationCenter swizzleSelectors];
-
-    // Set our own delegate if one hasn't been set already from something else.
-    [OneSignalHelper registerAsUNNotificationCenterDelegate];
+    [OneSignalUNUserNotificationCenter setup];
 }
 
 +(BOOL) shouldDisableBasedOnProcessArguments {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -51,7 +51,6 @@
 + (BOOL)handleIAMPreview:(OSNotification *)notification;
 
 // - iOS 10
-+ (void)registerAsUNNotificationCenterDelegate;
 + (void)clearCachedMedia;
 + (UNNotificationRequest*)prepareUNNotificationRequest:(OSNotification*)notification;
 + (void)addNotificationRequest:(OSNotification*)notification completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -518,7 +518,7 @@ OneSignalWebView *webVC;
     return notification;
 }
 
-//Shared instance as OneSignal is delegate of UNUserNotificationCenterDelegate and CLLocationManagerDelegate
+//Shared instance as OneSignal is delegate CLLocationManagerDelegate
 static OneSignal* singleInstance = nil;
 + (OneSignal*)sharedInstance {
     @synchronized( singleInstance ) {
@@ -537,20 +537,6 @@ static OneSignal* singleInstance = nil;
         [randomString appendFormat:@"%C", [letters characterAtIndex:rand]];
     }
     return randomString;
-}
-
-+ (void)registerAsUNNotificationCenterDelegate {
-    let curNotifCenter = [UNUserNotificationCenter currentNotificationCenter];
-    
-    /*
-        Sets the OneSignal shared instance as a delegate of UNUserNotificationCenter
-        OneSignal does not implement the delegate methods, we simply set it as a delegate
-        in order to swizzle the UNUserNotificationCenter methods in case the developer
-        does not set a UNUserNotificationCenter delegate themselves
-    */
-    
-    if (!curNotifCenter.delegate)
-        curNotifCenter.delegate = (id)[self sharedInstance];
 }
 
 + (UNNotificationRequest*)prepareUNNotificationRequest:(OSNotification*)notification {

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
@@ -32,6 +32,7 @@
 
 @interface OneSignalUNUserNotificationCenter : NSObject
 + (void)swizzleSelectors;
++ (void)swizzleSelectorsOnDelegate:(id)delegate;
 + (void)setUseiOS10_2_workaround:(BOOL)enable;
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
@@ -31,8 +31,10 @@
 #import "OneSignal.h"
 
 @interface OneSignalUNUserNotificationCenter : NSObject
++ (void)setup;
 + (void)swizzleSelectors;
 + (void)swizzleSelectorsOnDelegate:(id)delegate;
++ (void)registerDelegate;
 + (void)setUseiOS10_2_workaround:(BOOL)enable;
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -119,6 +119,15 @@ __weak static id previousDelegate;
 
     if (!curNotifCenter.delegate)
         curNotifCenter.delegate = (id)OSUNUserNotificationCenterDelegate.sharedInstance;
+    else {
+        /*
+         This handles the case where a delegate may have already been assigned before
+           OneSignal is loaded into memory.
+         This re-assignment triggers setOneSignalUNDelegate providing it with the
+           existing delegate instance so OneSignal can swizzle in its logic.
+         */
+        curNotifCenter.delegate = curNotifCenter.delegate;
+    }
 }
 
 static BOOL useiOS10_2_workaround = true;

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -140,11 +140,18 @@ static UNNotificationSettings* cachedUNNotificationSettings;
         [self setOneSignalUNDelegate:delegate];
         return;
     }
-    
+
     previousDelegate = delegate;
-    
+
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"OneSignalUNUserNotificationCenter setOneSignalUNDelegate Fired!"];
-    
+
+    [OneSignalUNUserNotificationCenter swizzleSelectorsOnDelegate:delegate];
+
+    // Call orignal iOS implemenation
+    [self setOneSignalUNDelegate:delegate];
+}
+
++ (void)swizzleSelectorsOnDelegate:(id)delegate {
     delegateUNClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UNUserNotificationCenterDelegate));
     delegateUNSubclasses = ClassGetSubclasses(delegateUNClass);
     
@@ -153,8 +160,6 @@ static UNNotificationSettings* cachedUNNotificationSettings;
     
     injectToProperClass(@selector(onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:),
                         @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:), delegateUNSubclasses, [OneSignalUNUserNotificationCenter class], delegateUNClass);
-    
-    [self setOneSignalUNDelegate:delegate];
 }
 
 + (void)forwardNotificationWithCenter:(UNUserNotificationCenter *)center

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -109,16 +109,17 @@ __weak static id previousDelegate;
 
 + (void)registerDelegate {
     let curNotifCenter = [UNUserNotificationCenter currentNotificationCenter];
-    
-    /*
-        Sets the OneSignal shared instance as a delegate of UNUserNotificationCenter
-        OneSignal does not implement the delegate methods, we simply set it as a delegate
-        in order to swizzle the UNUserNotificationCenter methods in case the developer
-        does not set a UNUserNotificationCenter delegate themselves
-    */
 
-    if (!curNotifCenter.delegate)
+    if (!curNotifCenter.delegate) {
+        /*
+          Set OSUNUserNotificationCenterDelegate.sharedInstance as a
+            UNUserNotificationCenterDelegate.
+          Note that OSUNUserNotificationCenterDelegate does not contain the methods such as
+            "willPresentNotification" as this assigment triggers setOneSignalUNDelegate which
+            will attach the selectors to the class at runtime.
+         */
         curNotifCenter.delegate = (id)OSUNUserNotificationCenterDelegate.sharedInstance;
+    }
     else {
         /*
          This handles the case where a delegate may have already been assigned before

--- a/iOS_SDK/OneSignalSDK/UnitTests/OneSignalUNUserNotificationCenterSwizzingTest.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OneSignalUNUserNotificationCenterSwizzingTest.m
@@ -55,4 +55,25 @@
     [OneSignalUNUserNotificationCenterHelper restoreDelegateAsOneSignal];
 }
 
+- (void)testUNUserNotificationCenterDelegateAssignedBeforeOneSignal {
+    [OneSignalUNUserNotificationCenterHelper putIntoPreloadedState];
+
+    // Create and assign a delegate with iOS
+    let dummyDelegate = [DummyNotificationCenterDelegate new];
+    UNUserNotificationCenter.currentNotificationCenter.delegate = dummyDelegate;
+    
+    // Save original implemenation reference, before OneSignal is loaded.
+    IMP originalDummyImp = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
+
+    // Setup the OneSignal delegate where it will be loaded into memeory
+    [OneSignalUNUserNotificationCenter setup];
+
+    IMP swizzledDummyImp = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
+    
+    // Since we swizzled the implemenations should be different.
+    XCTAssertNotEqual(originalDummyImp, swizzledDummyImp);
+    
+    [OneSignalUNUserNotificationCenterHelper restoreDelegateAsOneSignal];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/OneSignalUNUserNotificationCenterSwizzingTest.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OneSignalUNUserNotificationCenterSwizzingTest.m
@@ -1,0 +1,58 @@
+#import <objc/runtime.h>
+
+#import <XCTest/XCTest.h>
+
+#import "UnitTestCommonMethods.h"
+#import "OneSignalExtensionBadgeHandler.h"
+#import "UNUserNotificationCenterOverrider.h"
+#import "UNUserNotificationCenter+OneSignal.h"
+#import "OneSignalHelperOverrider.h"
+#import "OneSignalHelper.h"
+#import "DummyNotificationCenterDelegate.h"
+#import "OneSignalUNUserNotificationCenterHelper.h"
+
+@interface OneSignalUNUserNotificationCenterSwizzingTest : XCTestCase
+@end
+
+@implementation OneSignalUNUserNotificationCenterSwizzingTest
+
+// Called BEFORE each test method
+- (void)setUp {
+    [super setUp];
+    [UnitTestCommonMethods beforeEachTest:self];
+    
+    [OneSignalUNUserNotificationCenter setUseiOS10_2_workaround:true];
+}
+
+// Called AFTER each test method
+- (void)tearDown {
+    [super tearDown];
+}
+
+// Tests to make sure that UNNotificationCenter setDelegate: duplicate calls don't double-swizzle for the same object
+- (void)testAUNUserNotificationCenterDelegateAssigningDoesSwizzle {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+
+    let dummyDelegate = [[DummyNotificationCenterDelegate alloc] init];
+
+    IMP original = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
+
+    // This triggers UNUserNotificationCenter+OneSignal.m setOneSignalUNDelegate which does the implemenation swizzling
+    center.delegate = dummyDelegate;
+
+    IMP swizzled = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
+    // Since we swizzled the implemenations should be different.
+    XCTAssertNotEqual(original, swizzled);
+
+    // Calling setDelegate: a second time on the same object should not re-exchange method implementations
+    // thus the new method implementation should still be the same, swizzled == newSwizzled should be true
+    center.delegate = dummyDelegate;
+
+    IMP newSwizzled = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
+
+    XCTAssertEqual(swizzled, newSwizzled);
+
+    [OneSignalUNUserNotificationCenterHelper restoreDelegateAsOneSignal];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OneSignalUNUserNotificationCenterHelper : NSObject
++ (void)restoreDelegateAsOneSignal;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.h
@@ -4,6 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OneSignalUNUserNotificationCenterHelper : NSObject
 + (void)restoreDelegateAsOneSignal;
++ (void)putIntoPreloadedState;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
@@ -18,7 +18,7 @@
     // Clear the delegate and call registerAsUNNotificationCenterDelegate so it assigns OneSignal
     //   as the delegate like it does the first time when it is loaded into memory.
     UNUserNotificationCenter.currentNotificationCenter.delegate = nil;
-    [OneSignalHelper registerAsUNNotificationCenterDelegate];
+    [OneSignalUNUserNotificationCenter registerDelegate];
 
     // Undo our temp unswizzle by swizzle one more time. Undo our undo :)
     [OneSignalUNUserNotificationCenter swizzleSelectors];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
@@ -1,0 +1,26 @@
+#import "OneSignalUNUserNotificationCenterHelper.h"
+
+#import "UNUserNotificationCenter+OneSignal.h"
+#import "OneSignalHelper.h"
+
+@implementation OneSignalUNUserNotificationCenterHelper
+
+// Call this after you assign UNUserNotificationCenter.currentNotificationCenter.delegate to restore
+//   the delegate as well as swizzling effects.
+// In a nutshell this swizzles a 2nd time in reverse to swap method implementations back.
++ (void)restoreDelegateAsOneSignal {
+    // Undo swizzling of notification events by swizzling again to swap method implementations back.
+    [OneSignalUNUserNotificationCenter swizzleSelectorsOnDelegate:UNUserNotificationCenter.currentNotificationCenter.delegate];
+
+    // Temp unswizzle setDelegate, so we can re-assign the delegate below without side-effects.
+    [OneSignalUNUserNotificationCenter swizzleSelectors];
+
+    // Clear the delegate and call registerAsUNNotificationCenterDelegate so it assigns OneSignal
+    //   as the delegate like it does the first time when it is loaded into memory.
+    UNUserNotificationCenter.currentNotificationCenter.delegate = nil;
+    [OneSignalHelper registerAsUNNotificationCenterDelegate];
+
+    // Undo our temp unswizzle by swizzle one more time. Undo our undo :)
+    [OneSignalUNUserNotificationCenter swizzleSelectors];
+}
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
@@ -23,4 +23,15 @@
     // Undo our temp unswizzle by swizzle one more time. Undo our undo :)
     [OneSignalUNUserNotificationCenter swizzleSelectors];
 }
+
+// OneSignal auto swizzles UNUserNotificationCenterDelegate when the class is loaded into memory.
+// This undoes this affect so we can test setup a pre-loaded OneSignal state.
+// Why? This way we can setup a senario where someone else's delegate is assigned before OneSignal get loaded.
++ (void)putIntoPreloadedState {
+    // Swizzle to undo the swizzle. (yes, swizzling a 2nd time reverses the swizzling)
+    [OneSignalUNUserNotificationCenter swizzleSelectors];
+    
+    // Unassign OneSignal as the delegate
+    UNUserNotificationCenter.currentNotificationCenter.delegate = nil;
+}
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1999,32 +1999,6 @@ didReceiveRemoteNotification:userInfo
     
     [NSBundleOverrider setPrivacyState:false];
 }
-  
-// Tests to make sure that UNNotificationCenter setDelegate: duplicate calls don't double-swizzle for the same object
-- (void)testAUNUserNotificationCenterDelegateAssigningDoesSwizzle {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-
-    let dummyDelegate = [[DummyNotificationCenterDelegate alloc] init];
-
-    IMP original = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
-
-    // This triggers UNUserNotificationCenter+OneSignal.m setOneSignalUNDelegate which does the implemenation swizzling
-    center.delegate = dummyDelegate;
-
-    IMP swizzled = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
-    // Since we swizzled the implemenations should be different.
-    XCTAssertNotEqual(original, swizzled);
-
-    // Calling setDelegate: a second time on the same object should not re-exchange method implementations
-    // thus the new method implementation should still be the same, swizzled == newSwizzled should be true
-    center.delegate = dummyDelegate;
-
-    IMP newSwizzled = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
-
-    XCTAssertEqual(swizzled, newSwizzled);
-
-    [OneSignalUNUserNotificationCenterHelper restoreDelegateAsOneSignal];
-}
 
 - (NSDictionary *)setUpWillShowInForegroundHandlerTestWithBlock:(OSNotificationWillShowInForegroundBlock)willShowInForegroundBlock withNotificationOpenedBlock:(OSNotificationOpenedBlock)openedBlock withPayload: (NSDictionary *)payload {
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -55,6 +55,7 @@
 #import "OneSignalExtensionBadgeHandler.h"
 #import "OneSignalDialogControllerOverrider.h"
 #import "OneSignalNotificationCategoryController.h"
+#import "OneSignalUNUserNotificationCenterHelper.h"
 
 // Shadows
 #import "NSObjectOverrider.h"
@@ -2000,14 +2001,10 @@ didReceiveRemoteNotification:userInfo
 }
   
 // Tests to make sure that UNNotificationCenter setDelegate: duplicate calls don't double-swizzle for the same object
-// Keep static to keep the reference around otherwise it goes out of scope and breaks other tests.
-//   TODO: Could instead revert the swizzling instead of having a static reference.
-//         However this dummy does not have any side effects.
-static DummyNotificationCenterDelegate *dummyDelegate;
-- (void)testUNUserNotificationCenterDelegateAssigningDoesSwizzle {
+- (void)testAUNUserNotificationCenterDelegateAssigningDoesSwizzle {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
-    dummyDelegate = [[DummyNotificationCenterDelegate alloc] init];
+    let dummyDelegate = [[DummyNotificationCenterDelegate alloc] init];
 
     IMP original = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
 
@@ -2025,6 +2022,8 @@ static DummyNotificationCenterDelegate *dummyDelegate;
     IMP newSwizzled = class_getMethodImplementation([dummyDelegate class], @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:));
 
     XCTAssertEqual(swizzled, newSwizzled);
+
+    [OneSignalUNUserNotificationCenterHelper restoreDelegateAsOneSignal];
 }
 
 - (NSDictionary *)setUpWillShowInForegroundHandlerTestWithBlock:(OSNotificationWillShowInForegroundBlock)willShowInForegroundBlock withNotificationOpenedBlock:(OSNotificationOpenedBlock)openedBlock withPayload: (NSDictionary *)payload {


### PR DESCRIPTION
## Summary
This fixes an issue where OneSignal's notification open event would not fire if a UNUserNotificationCenterDelegate was assigned before the OneSignal was loaded into memory.

## Details
This commit solves it by reassigning the pre-loaded delegate into swizzle in OneSignal's methods.
This issue was discovered through a Unity issue where Unity Mobile Notification Services would load their delegate before OneSignal's delegate.
* OneSignal/OneSignal-Unity-SDK#245

## Tests
* Added a new test to cover this specific pre-existing case.

## Related PR
This applies the same fix from PR #924 but includes some refactoring to make it testable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/926)
<!-- Reviewable:end -->
