### PR TITLE
Improving logging for tag substitution

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -58,6 +58,7 @@
     NSError *error;
     OSPlayerTags *tags = [OneSignal getPlayerTags];
     if (!tags.allTags) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"[getTagsString] no tags found for the player"];
         return nil;
     }
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:tags.allTags
@@ -92,6 +93,7 @@
     dispatch_sync(dispatch_get_main_queue(), ^{
         NSLog(@"222222 [self.webView loadHTMLString:html baseURL:url];");
         NSString *taggedHTML = [self addTagsToHTML:html];
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"loadedHtmlContent with Tags: \n%@", taggedHTML]];
         [self.webView loadHTMLString:taggedHTML baseURL:url];
     });
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -225,7 +225,7 @@
             return;
         }
         
-        let message = [NSString stringWithFormat:@"In App Messaging htmlContent.html: %@", data[@"hmtl"]];
+        let message = [NSString stringWithFormat:@"In App Messaging htmlContent.html: %@", data[@"html"]];
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:message];
         
         if (!self.message.isPreview)


### PR DESCRIPTION
We were not logging the results of tag substitution for IAMs, and one of the logs was trying to access hMtl instead of hTml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/929)
<!-- Reviewable:end -->
