### PR TITLE
Fixing impressions being sent for in-active IAMs

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -57,7 +57,7 @@
 - (NSString *)getTagsString {
     NSError *error;
     OSPlayerTags *tags = [OneSignal getPlayerTags];
-    if (!tags.allTags) {
+    if (!tags.allTags || tags.allTags.count <= 0 ) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"[getTagsString] no tags found for the player"];
         return nil;
     }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)messageViewDidSelectAction:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action;
 - (void)messageViewDidDisplayPage:(OSInAppMessage *)message withPageId:(NSString *)pageId;
 - (void)messageViewControllerWasDismissed;
-- (void)webViewContentFinishedLoading;
+- (void)webViewContentFinishedLoading:(OSInAppMessage *)message;
 - (void)messageIsNotActive:(OSInAppMessage *)message;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)messageViewDidDisplayPage:(OSInAppMessage *)message withPageId:(NSString *)pageId;
 - (void)messageViewControllerWasDismissed;
 - (void)webViewContentFinishedLoading;
+- (void)messageIsNotActive:(OSInAppMessage *)message;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -266,6 +266,9 @@
 
 - (void)encounteredErrorLoadingMessageContent:(NSError * _Nullable)error {
     let message = [NSString stringWithFormat:@"An error occurred while attempting to load message content: %@", error.description ?: @"Unknown Error"];
+    if (error.code == 410 || [error.description containsString:@"In-App Message is not active"]) {
+        [self.delegate messageIsNotActive:self.message];
+    }
     [OneSignal onesignal_Log:ONE_S_LL_ERROR message:message];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -652,7 +652,7 @@
                 // The page is fully loaded and should now be displayed
                 // This is only fired once the javascript on the page sends the "rendering_complete" type event
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [self.delegate webViewContentFinishedLoading];
+                    [self.delegate webViewContentFinishedLoading:self.message];
                     [OneSignalHelper performSelector:@selector(displayMessage) onMainThreadOnObject:self withObject:nil afterDelay:0.0f];
                 });
                 break;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -266,7 +266,7 @@
 
 - (void)encounteredErrorLoadingMessageContent:(NSError * _Nullable)error {
     let message = [NSString stringWithFormat:@"An error occurred while attempting to load message content: %@", error.description ?: @"Unknown Error"];
-    if (error.code == 410 || [error.description containsString:@"In-App Message is not active"]) {
+    if (error.code == 410 || error.code == 404) {
         [self.delegate messageIsNotActive:self.message];
     }
     [OneSignal onesignal_Log:ONE_S_LL_ERROR message:message];

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -187,6 +187,19 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
+- (void)deleteInactiveMessage:(OSInAppMessage *)message {
+    let deleteMessage = [NSString stringWithFormat:@"Deleting inactive in-app message from cache: %@", message.messageId];
+    [OneSignal onesignal_Log:ONE_S_LL_ERROR message:deleteMessage];
+    NSMutableArray *newMessagesArray = [NSMutableArray arrayWithArray:self.messages];
+    [newMessagesArray removeObject: message];
+    self.messages = newMessagesArray;
+    if (self.messages) {
+        [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_MESSAGES_ARRAY withValue:self.messages];
+    } else {
+        [OneSignalUserDefaults.initStandard removeValueForKey:OS_IAM_MESSAGES_ARRAY];
+    }
+}
+
 /*
  Part of redisplay logic
  Remove IAMs that the last display time was six month ago
@@ -675,6 +688,10 @@ static BOOL _isInAppMessagingPaused = false;
     dispatch_async(dispatch_get_main_queue(), ^{
            [self messageViewPageImpressionRequest:message withPageId:pageId];
     });
+}
+
+- (void)messageIsNotActive:(OSInAppMessage *)message {
+    [self deleteInactiveMessage:message];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/Source/OSPlayerTags.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSPlayerTags.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 @interface OSPlayerTags : NSObject
 
-@property (nonatomic, strong, nullable, readwrite) NSMutableDictionary *tagsToSend;
+@property (nonatomic, strong, nullable, readonly) NSDictionary *tagsToSend;
 
 - (NSDictionary *_Nullable) allTags;
 
@@ -38,6 +38,10 @@ THE SOFTWARE.
 - (void)addTagValue:(NSString *_Nonnull)value forKey:(NSString *_Nullable)key;
 
 - (void)deleteTags:(NSArray *_Nonnull)keys;
+
+- (void)setTagsToSend:(NSDictionary * _Nullable)tagsToSend;
+
+- (void)addTagsToSend:(NSDictionary * _Nullable)tags;
 
 - (NSString *_Nullable)tagValueForKey:(NSString *_Nonnull)key;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSPlayerTags.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSPlayerTags.m
@@ -34,13 +34,13 @@ THE SOFTWARE.
 @implementation OSPlayerTags
 
 NSDictionary<NSString *, NSString *> *_tags;
-NSMutableDictionary<NSString *, NSString *> *_tagsToSend;
+NSDictionary<NSString *, NSString *> *_tagsToSend;
 
 -(id)init {
     self = [super init];
     if (self) {
         _tags = [NSDictionary new];
-        _tagsToSend = [NSMutableDictionary new];
+        _tagsToSend = [NSDictionary new];
         [self loadTagsFromUserDefaults];
     }
     return self;
@@ -57,7 +57,13 @@ NSMutableDictionary<NSString *, NSString *> *_tagsToSend;
     return _tagsToSend;
 }
 
-- (void)setTagsToSend:(NSMutableDictionary *)tagsToSend {
+- (void)addTagsToSend:(NSDictionary *)tags {
+    NSMutableDictionary *newTagsToSend = [NSMutableDictionary dictionaryWithDictionary:_tagsToSend];
+    [newTagsToSend addEntriesFromDictionary:tags];
+    [self setTagsToSend:newTagsToSend];
+}
+
+- (void)setTagsToSend:(NSDictionary<NSString *, NSString *> *)tagsToSend {
     _tagsToSend = tagsToSend;
     [self addTags:tagsToSend];
 }
@@ -88,6 +94,12 @@ NSMutableDictionary<NSString *, NSString *> *_tagsToSend;
         [newDict removeObjectForKey:key];
     }
     _tags = newDict;
+    
+    NSMutableDictionary *newToSendDict = [NSMutableDictionary dictionaryWithDictionary:_tagsToSend];
+    for (NSString *key in keys) {
+        [newToSendDict removeObjectForKey:key];
+    }
+    _tagsToSend = newToSendDict;
 }
 
 - (void)addTagValue:(NSString *)value forKey:(NSString *)key {

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -45,6 +45,7 @@
     request.parameters = @{@"app_id" : appId};
     request.method = GET;
     request.path = [NSString stringWithFormat:@"players/%@", userId];
+    request.disableLocalCaching = true;
     
     return request;
 }
@@ -533,6 +534,7 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
     request.method = GET;
     request.parameters = @{@"app_id": appId};
     request.path = [NSString stringWithFormat:@"in_app_messages/%@/variants/%@/html", messageId, variantId];
+    request.disableLocalCaching = true;
 
     return request;
 }
@@ -550,7 +552,8 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
     };
 
     request.path = @"in_app_messages/device_preview";
-
+    request.disableLocalCaching = true;
+    
     return request;
 }
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -388,6 +388,8 @@
     }];
 
     [OneSignal addTrigger:@"prop1" withValue:@2];
+    
+    [UnitTestCommonMethods runLongBackgroundThreads];
 
     // IAM should be shown instantly and be within the messageDisplayQueue
     XCTAssertEqual(1, OSMessagingControllerOverrider.messageDisplayQueue.count);
@@ -420,7 +422,10 @@
 
     [OneSignal addTrigger:@"prop1" withValue:@2];
 
+    [UnitTestCommonMethods runLongBackgroundThreads];
+    
     XCTAssertEqual(1, OSMessagingControllerOverrider.messageDisplayQueue.count);
+   
     // The display should cause an new "viewed" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestInAppMessageViewed class]));
 
@@ -747,9 +752,11 @@
     // the trigger should immediately evaluate to true and should
     // be shown once the SDK is fully initialized.
     [OneSignalClientOverrider setMockResponseForRequest:NSStringFromClass([OSRequestRegisterUser class]) withResponse:registrationResponse];
-    
+
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
+    [UnitTestCommonMethods runLongBackgroundThreads];
+
     // the message should now be displayed
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestInAppMessageViewed class]));
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
@@ -87,16 +87,23 @@
 + (void)load {
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wundeclared-selector"
-    injectToProperClass(@selector(overrideShowAndImpressMessage:), @selector(showAndImpressMessage:), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
+    injectToProperClass(@selector(overrideShowMessage:), @selector(showMessage:), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
+    injectToProperClass(@selector(overrideWebViewContentFinishedLoading:), @selector(webViewContentFinishedLoading:), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
     #pragma clang diagnostic pop
 }
 
-- (void)overrideShowAndImpressMessage:(OSInAppMessage *)message {
+- (void)overrideShowMessage:(OSInAppMessage *)message {
     dispatch_async(dispatch_get_main_queue(), ^{
         let viewController = [[OSInAppMessageViewController alloc] initWithMessage:message delegate:OSMessagingController.self];
         [viewController viewDidLoad];
+        [OSMessagingController.sharedInstance webViewContentFinishedLoading:message];
     });
-    [OSMessagingController.sharedInstance messageViewImpressionRequest:message];
+}
+
+- (void)overrideWebViewContentFinishedLoading:(OSInAppMessage *)message {
+    if (message) {
+        [OSMessagingController.sharedInstance messageViewImpressionRequest:message];
+    }
 }
 
 + (void)dismissCurrentMessage {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -59,6 +59,7 @@ withNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundB
  withNotificationOpenedHandler:(OSNotificationOpenedBlock)notificationOpenedDelegate;
 
 + (void)runBackgroundThreads;
++ (void)runLongBackgroundThreads;
 + (void)clearStateForAppRestart:(XCTestCase *)testCase;
 + (void)beforeAllTest;
 + (void)beforeAllTest:(XCTestCase *)testCase;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -157,28 +157,9 @@ static XCTestCase* _currentXCTestCase;
     
     [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
     
-    // the httpQueue makes sure all HTTP request mocks are sync'ed
-    
-    dispatch_queue_t registerUserQueue, notifSettingsQueue;
     for(int i = 0; i < 10; i++) {
         [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-        [OneSignalHelperOverrider runBackgroundThreads];
-        
-        notifSettingsQueue = [OneSignalNotificationSettingsIOS10 getQueue];
-        if (notifSettingsQueue)
-            dispatch_sync(notifSettingsQueue, ^{});
-        
-        registerUserQueue = [OneSignal getRegisterQueue];
-        if (registerUserQueue)
-            dispatch_sync(registerUserQueue, ^{});
-        
-        [OneSignalClientOverrider runBackgroundThreads];
-        
-        [UNUserNotificationCenterOverrider runBackgroundThreads];
-        
-        dispatch_barrier_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{});
-        
-        [UIApplicationOverrider runBackgroundThreads];
+        [UnitTestCommonMethods runThreadsOnEachQueue];
     }
     
     NSLog(@"END runLongBackgroundThreads");
@@ -192,30 +173,34 @@ static XCTestCase* _currentXCTestCase;
     
     [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
     
-    // the httpQueue makes sure all HTTP request mocks are sync'ed
-    
-    dispatch_queue_t registerUserQueue, notifSettingsQueue;
     for(int i = 0; i < 10; i++) {
-        [OneSignalHelperOverrider runBackgroundThreads];
-        
-        notifSettingsQueue = [OneSignalNotificationSettingsIOS10 getQueue];
-        if (notifSettingsQueue)
-            dispatch_sync(notifSettingsQueue, ^{});
-        
-        registerUserQueue = [OneSignal getRegisterQueue];
-        if (registerUserQueue)
-            dispatch_sync(registerUserQueue, ^{});
-        
-        [OneSignalClientOverrider runBackgroundThreads];
-        
-        [UNUserNotificationCenterOverrider runBackgroundThreads];
-        
-        dispatch_barrier_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{});
-        
-        [UIApplicationOverrider runBackgroundThreads];
+        [UnitTestCommonMethods runThreadsOnEachQueue];
     }
     
     NSLog(@"END runBackgroundThreads");
+}
+
++ (void)runThreadsOnEachQueue {
+    // the httpQueue makes sure all HTTP request mocks are sync'ed
+    dispatch_queue_t registerUserQueue, notifSettingsQueue;
+    
+    [OneSignalHelperOverrider runBackgroundThreads];
+    
+    notifSettingsQueue = [OneSignalNotificationSettingsIOS10 getQueue];
+    if (notifSettingsQueue)
+        dispatch_sync(notifSettingsQueue, ^{});
+    
+    registerUserQueue = [OneSignal getRegisterQueue];
+    if (registerUserQueue)
+        dispatch_sync(registerUserQueue, ^{});
+    
+    [OneSignalClientOverrider runBackgroundThreads];
+    
+    [UNUserNotificationCenterOverrider runBackgroundThreads];
+    
+    dispatch_barrier_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{});
+    
+    [UIApplicationOverrider runBackgroundThreads];
 }
 
 + (void)clearStateForAppRestart:(XCTestCase *)testCase {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -149,6 +149,42 @@ static XCTestCase* _currentXCTestCase;
 }
 
 /*
+ Runs any blocks passed to dispatch_async() with delays after each call
+ This will allow more time for chained async methods to complete
+ */
++ (void)runLongBackgroundThreads {
+    NSLog(@"START runLongBackgroundThreads");
+    
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    
+    // the httpQueue makes sure all HTTP request mocks are sync'ed
+    
+    dispatch_queue_t registerUserQueue, notifSettingsQueue;
+    for(int i = 0; i < 10; i++) {
+        [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        [OneSignalHelperOverrider runBackgroundThreads];
+        
+        notifSettingsQueue = [OneSignalNotificationSettingsIOS10 getQueue];
+        if (notifSettingsQueue)
+            dispatch_sync(notifSettingsQueue, ^{});
+        
+        registerUserQueue = [OneSignal getRegisterQueue];
+        if (registerUserQueue)
+            dispatch_sync(registerUserQueue, ^{});
+        
+        [OneSignalClientOverrider runBackgroundThreads];
+        
+        [UNUserNotificationCenterOverrider runBackgroundThreads];
+        
+        dispatch_barrier_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{});
+        
+        [UIApplicationOverrider runBackgroundThreads];
+    }
+    
+    NSLog(@"END runLongBackgroundThreads");
+}
+
+/*
  Runs any blocks passed to dispatch_async()
  */
 + (void)runBackgroundThreads {


### PR DESCRIPTION
Prior to this PR we would send an IAM impression before validating that we were successfully able to load the html content and display the IAM to the user. This meant that we would still send impressions for cached paused/completed IAMs that would receive a "410 IAM is in-active" error for the loadHTMLContent request. The IAM would not display to the user, but we should not be sending these impressions.

Now we will send IAM impressions in response to the webViewContentFinishedLoading callback which is triggered by the rendering_complete event from the webview's javascript. This guarantees that any errors that occur before displaying the IAM will result in an impression not being sent. 

Additionally we will now delete IAMs from the cache that receive the in-active error when loading HTML content so we don't keep trying to display in-active IAMs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/931)
<!-- Reviewable:end -->
