### PR TITLE
Randomly delay notification received calls to control traffic volume

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/NotificationService.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/NotificationService.m
@@ -28,7 +28,9 @@
     
     NSLog(@"START!!!!!! request.content.userInfo: %@", request.content.userInfo);
     
-    [OneSignal didReceiveNotificationExtensionRequest:self.receivedRequest withMutableNotificationContent:self.bestAttemptContent];
+    [OneSignal didReceiveNotificationExtensionRequest:self.receivedRequest
+                       withMutableNotificationContent:self.bestAttemptContent
+                                   withContentHandler:contentHandler];
     // DEBUGGING: Uncomment the 2 lines below and comment out the one above to ensure this extension is excuting
     //            Note, this extension only runs when mutable-content is set
     //            Setting an attachment or action buttons automatically adds this
@@ -42,7 +44,7 @@
     
     
 //    [NSThread sleepForTimeInterval:25.0f];
-    self.contentHandler(self.bestAttemptContent);
+    //self.contentHandler(self.bestAttemptContent);
     
 //    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 25 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
 //        self.contentHandler(self.bestAttemptContent);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -489,7 +489,7 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 // Process from Notification Service Extension.
 // Used for iOS Media Attachemtns and Action Buttons.
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent __deprecated_msg("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.");
-+ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent * _Nullable))contentHandler;
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;
 
 #pragma mark Tags

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -488,7 +488,8 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 // iOS 10 only
 // Process from Notification Service Extension.
 // Used for iOS Media Attachemtns and Action Buttons.
-+ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent __deprecated_msg("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.");
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;
 
 #pragma mark Tags

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2342,6 +2342,15 @@ static NSString *_lastnonActiveMessageId;
             withMutableNotificationContent:replacementContent];
 }
 
+// Called from the app's Notification Service Extension. Calls contentHandler() to display the notification
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request             withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent
+                                                     withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
+    return [OneSignalNotificationServiceExtensionHandler
+            didReceiveNotificationExtensionRequest:request
+            withMutableNotificationContent:replacementContent
+            withContentHandler:contentHandler];
+}
+
 
 // Called from the app's Notification Service Extension
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2343,8 +2343,8 @@ static NSString *_lastnonActiveMessageId;
 }
 
 // Called from the app's Notification Service Extension. Calls contentHandler() to display the notification
-+ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request             withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent
-                                                     withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request                              withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent
+                withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
     return [OneSignalNotificationServiceExtensionHandler
             didReceiveNotificationExtensionRequest:request
             withMutableNotificationContent:replacementContent

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -258,7 +258,10 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
     #define MAX_CATEGORIES_SIZE 128
 
     // Defines how long the SDK will wait for a OSPredisplayNotification's complete method to execute
-#define CUSTOM_DISPLAY_TYPE_TIMEOUT 25.0
+    #define CUSTOM_DISPLAY_TYPE_TIMEOUT 25.0
+
+    // Defines the maximum delay time for confirmed deliveries
+    #define MAX_CONF_DELIVERY_DELAY 25.0
 #else
     // Test defines for API Client
     #define REATTEMPT_DELAY 0.004
@@ -274,7 +277,11 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 
     // Unit testing value for how long the SDK will wait for a
     // OSPredisplayNotification's complete method to execute
-#define CUSTOM_DISPLAY_TYPE_TIMEOUT 0.05
+    #define CUSTOM_DISPLAY_TYPE_TIMEOUT 0.05
+
+    // We don't want to delay confirmed deliveries in unit tests
+    #define MAX_CONF_DELIVERY_DELAY 0
+
 #endif
 
 // A max timeout for a request, which might include multiple reattempts

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalCommonDefines.h
@@ -244,6 +244,8 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 #define DEVICE_TYPE_EMAIL 11
 #define DEVICE_TYPE_SMS 14
 
+#define MAX_NSE_LIFETIME_SECOUNDS 30
+
 #ifndef OS_TEST
     // OneSignal API Client Defines
     #define REATTEMPT_DELAY 30.0

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.h
@@ -33,6 +33,8 @@
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request
                                          withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent;
 
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent withContentHandler:(void (^)(UNNotificationContent *))contentHandler;
+
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest *)request
                                         withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -79,7 +79,7 @@
         contentHandler(replacementContent);
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
         [self onNotificationReceived:receivedNotificationId withBlockingTask:semaphore];
-        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC));
     } else {
         [self onNotificationReceived:receivedNotificationId withBlockingTask:nil];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -41,7 +41,14 @@
 
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request
                                          withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
+    return [OneSignalNotificationServiceExtensionHandler
+            didReceiveNotificationExtensionRequest:request
+            withMutableNotificationContent:replacementContent
+            withContentHandler:nil];
+}
 
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request             withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent
+                                                       withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"NSE request received"];
     
     if (!replacementContent)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.h
@@ -41,4 +41,11 @@
                           successBlock:(nullable OSResultSuccessBlock)success
                           failureBlock:(nullable OSFailureBlock)failure;
 
+- (void)sendReceiveReceiptWithPlayerId:(nonnull NSString *)playerId
+                        notificationId:(nonnull NSString *)notificationId
+                                 appId:(nonnull NSString *)appId
+                                 delay:(int)delay
+                          successBlock:(nullable OSResultSuccessBlock)success
+                          failureBlock:(nullable OSFailureBlock)failure;
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -63,6 +63,21 @@
                           successBlock:(nullable OSResultSuccessBlock)success
                           failureBlock:(nullable OSFailureBlock)failure {
     
+    [self sendReceiveReceiptWithPlayerId:playerId
+                          notificationId:notificationId
+                                   appId:appId
+                                   delay:0
+                            successBlock:nil
+                            failureBlock:nil];
+}
+
+- (void)sendReceiveReceiptWithPlayerId:(nonnull NSString *)playerId
+                        notificationId:(nonnull NSString *)notificationId
+                                 appId:(nonnull NSString *)appId
+                                 delay:(int)delay
+                          successBlock:(nullable OSResultSuccessBlock)success
+                          failureBlock:(nullable OSFailureBlock)failure {
+    
     let message = [NSString stringWithFormat:@"OneSignal sendReceiveReceiptWithPlayerId playerId:%@ notificationId: %@, appId: %@", playerId, notificationId, appId];
     [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:message];
 
@@ -78,28 +93,20 @@
 
     let request = [OSRequestReceiveReceipts withPlayerId:playerId notificationId:notificationId appId:appId];
     
-    // Randomize send of confirmed deliveries to lessen traffic for high recipient notifications
-    int randomDelay = arc4random_uniform(MAX_CONF_DELIVERY_DELAY);
-    NSLog(@"ECM conf delivery sending after: %i second(s)", randomDelay);
-    dispatch_time_t dispatchTime = dispatch_time(DISPATCH_TIME_NOW, randomDelay * NSEC_PER_SEC);
+    NSLog(@"ECM conf delivery sending after: %i second(s)", delay);
+    dispatch_time_t dispatchTime = dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC);
     dispatch_after(dispatchTime, dispatch_get_main_queue(), ^{
-        NSLog(@"ECM conf delivery now sending after: %i second(s)", randomDelay);
+        NSLog(@"ECM conf delivery now sending after: %i second(s)", delay);
         [OneSignalClient.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
             NSLog(@"ECM successfully confirmed delivery");
             if (success) {
-                
                 success(result);
             }
-                
-            
         } onFailure:^(NSError *error) {
             NSLog(@"ECM failed confirmed delivery");
             if (failure) {
-                
                 failure(error);
-
             }
-                            
         }];
     });
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -83,11 +83,15 @@
 
     if (!appId) {
         [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:@"appId not available from shared UserDefaults!"];
+        if (failure)
+            failure(nil);
         return;
     }
     
     if (![self isReceiveReceiptsEnabled]) {
         [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:@"Receieve receipts disabled"];
+        if (failure)
+            failure(nil);
         return;
     }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalReceiveReceiptsController.m
@@ -93,17 +93,14 @@
 
     let request = [OSRequestReceiveReceipts withPlayerId:playerId notificationId:notificationId appId:appId];
     
-    NSLog(@"ECM conf delivery sending after: %i second(s)", delay);
     dispatch_time_t dispatchTime = dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC);
     dispatch_after(dispatchTime, dispatch_get_main_queue(), ^{
-        NSLog(@"ECM conf delivery now sending after: %i second(s)", delay);
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal sendReceiveReceiptWithPlayerId now sending confirmed delievery after: %i second delay", delay]];
         [OneSignalClient.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
-            NSLog(@"ECM successfully confirmed delivery");
             if (success) {
                 success(result);
             }
         } onFailure:^(NSError *error) {
-            NSLog(@"ECM failed confirmed delivery");
             if (failure) {
                 failure(error);
             }

--- a/iOS_SDK/OneSignalSDK/UnitTests/BadgeTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/BadgeTests.m
@@ -82,9 +82,11 @@
     } mutableCopy];
     
     UNNotificationResponse *notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     //test that receiving a notification with badge_inc updates the badge icon number
     [OneSignal didReceiveNotificationExtensionRequest:notifResponse.notification.request withMutableNotificationContent:nil];
+    #pragma clang diagnostic pop
     
     XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 3);
     
@@ -93,7 +95,10 @@
     
     UNNotificationResponse *newNotifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [OneSignal didReceiveNotificationExtensionRequest:newNotifResponse.notification.request withMutableNotificationContent:nil];
+    #pragma clang diagnostic pop
     
     XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 2);
 }
@@ -114,10 +119,11 @@
     } mutableCopy];
     
     UNNotificationResponse *notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
-    
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     //test that receiving a notification with badge_inc updates the badge icon number
     [OneSignal didReceiveNotificationExtensionRequest:notifResponse.notification.request withMutableNotificationContent:nil];
-    
+    #pragma clang diagnostic pop
     XCTAssert(OneSignalExtensionBadgeHandler.currentCachedBadgeValue == 54);
     
     [userInfo setObject:@{@"mutable-content" : @1, @"alert" : @"test msg"} forKey:@"aps"];
@@ -126,9 +132,11 @@
     UNNotificationResponse *newNotifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
     UNMutableNotificationContent *mutableContent = [newNotifResponse.notification.request.content mutableCopy];
-    
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     //tests to make sure the extension is correctly modifying the badge value of the replacement content
     let replacementContent = [OneSignal didReceiveNotificationExtensionRequest:newNotifResponse.notification.request withMutableNotificationContent:mutableContent];
+    #pragma clang diagnostic pop
     
     XCTAssert([replacementContent.badge intValue] == 53);
     
@@ -153,9 +161,11 @@
     UNNotificationResponse *notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
     UNMutableNotificationContent *mutableContent = [notifResponse.notification.request.content mutableCopy];
-    
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     //Since the notification is trying to set a negative value, the SDK should keep the badge count == 0
     let replacementContent = [OneSignal didReceiveNotificationExtensionRequest:notifResponse.notification.request withMutableNotificationContent:mutableContent];
+    #pragma clang diagnostic pop
     
     XCTAssert(replacementContent.badge.intValue == 0);
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -55,7 +55,6 @@
 #import "OneSignalExtensionBadgeHandler.h"
 #import "OneSignalDialogControllerOverrider.h"
 #import "OneSignalNotificationCategoryController.h"
-#import "OneSignalUNUserNotificationCenterHelper.h"
 
 // Shadows
 #import "NSObjectOverrider.h"

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -894,8 +894,11 @@ and the app was cold started from opening a notficiation open that the developer
     // The Notification Service Extension runs where the notification received id tracked.
     //   Note: This is normally a separate process but can't emulate that here.
     let response = [self createNotificationResponseForAnalyticsTests];
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [OneSignal didReceiveNotificationExtensionRequest:response.notification.request
                        withMutableNotificationContent:nil];
+    #pragma clang diagnostic pop
     
     // Make sure we are tracking the notification received event to firebase.
     XCTAssertEqual(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents.count, 1);
@@ -1715,7 +1718,11 @@ didReceiveRemoteNotification:userInfo
     
     [[notifResponse notification].request.content setValue:@"some_category" forKey:@"categoryIdentifier"];
     
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
+    #pragma clang diagnostic pop
+    
     
     // Make sure we didn't override an existing category
     XCTAssertEqualObjects(content.categoryIdentifier, @"some_category");
@@ -1771,8 +1778,10 @@ didReceiveRemoteNotification:userInfo
     
     [[notifResponse notification].request.content setValue:@"some_category" forKey:@"categoryIdentifier"];
     
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
-    
+    #pragma clang diagnostic pop
     // Make sure we didn't override an existing category
     XCTAssertEqualObjects(content.categoryIdentifier, @"some_category");
     // Make sure attachments were added.
@@ -1842,7 +1851,10 @@ didReceiveRemoteNotification:userInfo
     
     id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
     
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
+    #pragma clang diagnostic pop
 
     // Make sure attachments were added.
     XCTAssertEqualObjects(content.attachments[0].identifier, @"id");
@@ -1872,6 +1884,38 @@ didReceiveRemoteNotification:userInfo
     XCTAssertNil(content.attachments);
 }
 
+// iOS 10 - Notification Service Extension test
+- (void) testServiceExtensionContentHandlerFired {
+    id userInfo = @{@"aps": @{
+                        @"mutable-content": @1,
+                        @"alert": @"Message Body"
+                        },
+                    @"os_data": @{
+                        @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+                        @"buttons": @[@{@"i": @"id1", @"n": @"text1"}],
+                        @"att": @{ @"id": @"http://domain.com/file.jpg" }
+                    }};
+    
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+    
+    // create an expectation that is fulfilled when the contentHandler is fired and when didReceiveNotificationExtensionRequest
+    // returns. This indicates that the semaphore waiting on the confirmed delivery has been signaled.
+    XCTestExpectation *contentExpectation = [self expectationWithDescription:@"onesignal_extension_content_handler_fired"];
+    contentExpectation.expectedFulfillmentCount = 2;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil withContentHandler:^(UNNotificationContent * _Nonnull replacementContent) {
+            [contentExpectation fulfill];
+        }];
+        // If didReceiveNotificationExtenionRequest has returned then the semaphore has been signaled or timed out
+        [contentExpectation fulfill];
+        // Make sure butons were added.
+        XCTAssertEqualObjects(content.categoryIdentifier, @"__onesignal__dynamic__b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+    });
+    [self waitForExpectations:@[contentExpectation] timeout:1];
+}
+/*
+ (void (^)(UNNotificationContent * _Nonnull))contentHandler
+ */
 -(void)testBuildOSRequest {
     let request = [OSRequestSendTagsToServer withUserId:@"12345" appId:@"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" tags:@{@"tag1" : @"test1", @"tag2" : @"test2"} networkType:[OneSignalHelper getNetType] withEmailAuthHashToken:nil withExternalIdAuthHashToken:nil];
     
@@ -2123,7 +2167,10 @@ didReceiveRemoteNotification:userInfo
     
     [[notifResponse notification].request.content setValue:@"some_category" forKey:@"categoryIdentifier"];
     
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
+    #pragma clang diagnostic pop
     
     return content.attachments.firstObject;
 }
@@ -2985,8 +3032,11 @@ didReceiveRemoteNotification:userInfo
 
     let notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:notification];
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     let content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request withMutableNotificationContent:nil];
-
+    #pragma clang diagnostic pop
+    
     let ids = OneSignalNotificationCategoryController.sharedInstance.existingRegisteredCategoryIds;
 
     XCTAssertEqual(ids.count, 1);


### PR DESCRIPTION
Notifications sent to a large number of subscribers can result in a very large number of confirmed deliveries hitting our backend at the same time. This PR randomly delays the confirmed delivery between 0 and 25 seconds. In order to do this we need have a blocking task on the NSE process until the confirmed delivery is sent. We don't want to delay the actual receipt of the notification, so this requires that OneSignal is passed the contentHandler from the NSE and calls it before waiting for the confirmed delivery to finish.

To achieve this I have created a new public method and marked the previous method as deprecated.
`+ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent * _Nullable))contentHandler;`

OneSignal will now call `contentHandler(replacementContent)` to trigger the notification display so this is no longer needed in the customer's NotificationService file. Any additional changes to the notification content will need to take place BEFORE calling OneSignal's `didReceiveNotificationExtensionRequest` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/934)
<!-- Reviewable:end -->
