### PR TITLE
Fix clearing badge count on reinstall

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2181,8 +2181,7 @@ static NSString *_lastnonActiveMessageId;
     else
         disableBadgeClearing = NO;
     
-    if (disableBadgeClearing ||
-        ([self.osNotificationSettings getNotificationPermissionState].notificationTypes & NOTIFICATION_TYPE_BADGE) == 0)
+    if (disableBadgeClearing)
         return false;
     
     bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -507,10 +507,10 @@
     [UnitTestCommonMethods answerNotificationPrompt:true];
     [UnitTestCommonMethods runBackgroundThreads];
     
-    XCTAssertEqual(observer->fireCount, 3);
+    XCTAssertEqual(observer->fireCount, 2);
     
     XCTAssertEqualObjects([observer->last description],
-                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: Denied, provisional: 0>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>\n>");
+                          @"<OSSubscriptionStateChanges:\nfrom: <OSPermissionState: hasPrompted: 1, status: NotDetermined, provisional: 0>,\nto:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>\n>");
 }
 
 - (void)testDeliverQuietly {


### PR DESCRIPTION
Badges were not being cleared on app reinstall until the user was prompted for push permissions, because we were checking for badge permissions before clearing badges. We don't need permission to set the badge count to 0 and in fact if they don't have permission then we definitely should be setting it to 0. 

This change affected a unit test that was trying to reproduce an iOS 10.2.1 issue where permissions would be set to denied when backgrounding on the push prompt. I am not sure if this change fixed the iOS 10.2.1 issue, but I modified the test so that it passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/939)
<!-- Reviewable:end -->
