### PR TITLE
Fix images not displaying with new NSE method

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -73,11 +73,11 @@
     
     // Trigger the notification to be shown with the replacementContent
     if (contentHandler) {
-        contentHandler(replacementContent);
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
         [self onNotificationReceived:receivedNotificationId withBlockingTask:semaphore];
         // Download Media Attachments after kicking off the confirmed delivery task
         [OneSignalHelper addAttachments:notification toNotificationContent:replacementContent];
+        contentHandler(replacementContent);
         dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, MAX_NSE_LIFETIME_SECOUNDS * NSEC_PER_SEC));
     } else {
         [self onNotificationReceived:receivedNotificationId withBlockingTask:nil];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1839,7 +1839,7 @@ didReceiveRemoteNotification:userInfo
 }
 
 // iOS 10 - Notification Service Extension test - local file
-- (void) testDidReceiveNotificationExtensionRequestLocalFile {
+- (void)testDidReceiveNotificationExtensionRequestLocalFile {
     id userInfo = @{@"aps": @{
                             @"mutable-content": @1,
                             @"alert": @"Message Body"
@@ -1910,6 +1910,9 @@ didReceiveRemoteNotification:userInfo
         [contentExpectation fulfill];
         // Make sure butons were added.
         XCTAssertEqualObjects(content.categoryIdentifier, @"__onesignal__dynamic__b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+        // Make sure attachments were added.
+        XCTAssertEqualObjects(content.attachments[0].identifier, @"id");
+        XCTAssertEqualObjects(content.attachments[0].URL.scheme, @"file");
     });
     [self waitForExpectations:@[contentExpectation] timeout:1];
 }


### PR DESCRIPTION
In SDK version 3.5.1 If the app provided the contentHandler completion block to our extension handler, it was being called before downloading attachments so images were not added to notifications. This is fixed and unit tested

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/943)
<!-- Reviewable:end -->
