### PR TITLE
Fixing IAM displaying twice on cold start

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -160,7 +160,6 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)updateInAppMessagesFromCache {
     self.messages = [OneSignalUserDefaults.initStandard getSavedCodeableDataForKey:OS_IAM_MESSAGES_ARRAY defaultValue:[NSArray new]];
-
     [self evaluateMessages];
 }
 
@@ -241,8 +240,9 @@ static BOOL _isInAppMessagingPaused = false;
             [self.messageDisplayQueue addObject:message];
         
         // Return early if an IAM is already showing
-        if (self.isInAppMessageShowing)
+        if (self.isInAppMessageShowing || !OneSignal.isRegisterUserFinished) {
             return;
+        }
         // Return early if the app is not active
         if (![UIApplication applicationIsActive]) {
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Pause IAMs display due to app inactivity"];
@@ -286,7 +286,6 @@ static BOOL _isInAppMessagingPaused = false;
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app messages will not show while paused"];
         return;
     }
-    
     self.isInAppMessageShowing = true;
     [self showMessage:message];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -240,7 +240,7 @@ static BOOL _isInAppMessagingPaused = false;
             [self.messageDisplayQueue addObject:message];
         
         // Return early if an IAM is already showing
-        if (self.isInAppMessageShowing || !OneSignal.isRegisterUserFinished) {
+        if (self.isInAppMessageShowing) {
             return;
         }
         // Return early if the app is not active
@@ -484,7 +484,8 @@ static BOOL _isInAppMessagingPaused = false;
 - (BOOL)shouldShowInAppMessage:(OSInAppMessage *)message {
     return ![self.seenInAppMessages containsObject:message.messageId] &&
            [self.triggerController messageMatchesTriggers:message] &&
-           ![message isFinished];
+           ![message isFinished] &&
+           OneSignal.isRegisterUserFinished;
 }
 
 - (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {

--- a/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSStateSynchronizer.m
@@ -48,7 +48,7 @@ THE SOFTWARE.
 + (void)saveExternalIdAuthToken:(NSString *)hashToken;
 + (void)saveSMSNumber:(NSString *)smsNumber withAuthToken:(NSString *)smsAuthToken userId:(NSString *)smsPlayerId;
 + (void)registerUserFinished;
-
++ (void)registerUserSuccessful;
 @end
 
 @interface OSStateSynchronizer ()
@@ -129,7 +129,7 @@ THE SOFTWARE.
 
     [OneSignalClient.sharedClient executeSimultaneousRequests:requests withSuccess:^(NSDictionary<NSString *, NSDictionary *> *results) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"on_session result: %@", results]];
-        [OneSignal registerUserFinished];
+        [OneSignal registerUserSuccessful];
 
         // If the external user ID was sent as part of this request, we need to save it
         // Cache the external id if it exists within the registration payload
@@ -186,6 +186,7 @@ THE SOFTWARE.
         for (NSString *key in @[OS_PUSH, OS_EMAIL])
             [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat: @"Encountered error during %@ registration with OneSignal: %@", key, errors[key]]];
 
+        [OneSignal registerUserFinished];
         if (failureBlock)
             failureBlock(errors);
     }];

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.m
@@ -181,7 +181,7 @@
     OSSubscriptionStateChanges* stateChanges = [OSSubscriptionStateChanges alloc];
     stateChanges.from = OneSignal.lastSubscriptionState;
     stateChanges.to = [state copy];
-    if (OneSignal.isRegisterUserFinished) {
+    if (OneSignal.isRegisterUserSuccessful) {
         BOOL hasReceiver = [OneSignal.subscriptionStateChangesObserver notifyChange:stateChanges];
         
         if (hasReceiver) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -471,9 +471,14 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 + (void)setUserId:(NSString *)userId {
     self.currentSubscriptionState.userId = userId;
 }
-
+// This is set to true even if register user fails
 + (void)registerUserFinished {
     _registerUserFinished = true;
+}
+// If successful then register user is also finished
++ (void)registerUserSuccessful {
+    _registerUserSuccessful = true;
+    [OneSignal registerUserFinished];
 }
 
 + (NSString *)mEmailAuthToken {
@@ -593,6 +598,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     _outcomeEventsController = nil;
     
     _registerUserFinished = false;
+    _registerUserSuccessful = false;
     
     _delayedSMSParameters = nil;
 }
@@ -1653,6 +1659,11 @@ static BOOL _registerUserFinished = false;
     return _registerUserFinished || isOnSessionSuccessfulForCurrentState;
 }
 
+static BOOL _registerUserSuccessful = false;
++ (BOOL)isRegisterUserSuccessful {
+    return _registerUserSuccessful || isOnSessionSuccessfulForCurrentState;
+}
+
 + (BOOL)shouldRegisterNow {
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
@@ -1822,6 +1833,7 @@ static dispatch_queue_t serialQueue;
 + (void)registerUserInternal {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registerUserInternal"];
     _registerUserFinished = false;
+    _registerUserSuccessful = false;
 
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
@@ -1928,7 +1940,6 @@ static dispatch_queue_t serialQueue;
                     callbackSet.failureBlock(error);
             }
         }
-        
         [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
     }];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1928,6 +1928,8 @@ static dispatch_queue_t serialQueue;
                     callbackSet.failureBlock(error);
             }
         }
+        
+        [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
     }];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -79,7 +79,10 @@
 
 @property (class, readonly) BOOL didCallDownloadParameters;
 @property (class, readonly) BOOL downloadedParameters;
+//Indicates we have attempted to register the user and it has succeeded or failed
 @property (class, readonly) BOOL isRegisterUserFinished;
+//Indicates that registering the user was successful
+@property (class, readonly) BOOL isRegisterUserSuccessful;
 
 @property (class) NSObject<OneSignalNotificationSettings>* _Nonnull osNotificationSettings;
 @property (class) OSPermissionState* _Nonnull currentPermissionState;

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -473,7 +473,7 @@
     [OneSignal pauseInAppMessages:false];
 
     // IAM should not be shown since we have not initialized OneSignal
-    XCTAssertEqual(1, OSMessagingControllerOverrider.messageDisplayQueue.count);
+    XCTAssertEqual(0, OSMessagingControllerOverrider.messageDisplayQueue.count);
     XCTAssertFalse(OSMessagingControllerOverrider.isInAppMessageShowing);
     
     [self initOneSignalWithInAppMessage:message];


### PR DESCRIPTION
If we display IAMs prior to receiving the response to on session, we could be displaying cached IAMs that have been paused, or edited. Additionally this is causing an issue where we display IAMs twice because of the `self.messages = newMessages` line in `updateInAppMessagesFromOnSession`. We overwrite the `seenInSession` variable of the old object with the new one. By waiting to display IAMs until onSession has returned we fix this issue. To avoid a case where cached IAMs aren't shown when onSession fails I am now calling `updateInAppMessagesFromCache` in the failure block of `registerUserInternal`.

When trying to display a message before onSession has completed we will add it to the queue. We will then evaluate the message queue again once onSession finishes. If onSession fails we will still show cached IAMs because `updateInAppMessagesFromCache` calls `evaluateMessages`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/949)
<!-- Reviewable:end -->
