### PR TITLE
Calling the failure block of send tags for bad input

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1248,17 +1248,27 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 + (void)sendTags:(NSDictionary*)keyValuePair onSuccess:(OSResultSuccessBlock)successBlock onFailure:(OSFailureBlock)failureBlock {
     
     // return if the user has not granted privacy permissions
-    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"sendTags:onSuccess:onFailure:"])
+    if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:@"sendTags:onSuccess:onFailure:"]) {
+        NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called sendTags:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+        failureBlock(error);
         return;
+    }
+        
    
     if (![NSJSONSerialization isValidJSONObject:keyValuePair]) {
-        onesignal_Log(ONE_S_LL_WARN, [NSString stringWithFormat:@"sendTags JSON Invalid: The following key/value pairs you attempted to send as tags are not valid JSON: %@", keyValuePair]);
+        NSString *errorMessage = [NSString stringWithFormat:@"sendTags JSON Invalid: The following key/value pairs you attempted to send as tags are not valid JSON: %@", keyValuePair];
+        onesignal_Log(ONE_S_LL_WARN, errorMessage);
+        NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : errorMessage}];
+        failureBlock(error);
         return;
     }
     
     for (NSString *key in [keyValuePair allKeys]) {
         if ([keyValuePair[key] isKindOfClass:[NSDictionary class]]) {
-            onesignal_Log(ONE_S_LL_WARN, @"sendTags Tags JSON must not contain nested objects");
+            NSString *errorMessage = @"sendTags Tags JSON must not contain nested objects";
+            onesignal_Log(ONE_S_LL_WARN, errorMessage);
+            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : errorMessage}];
+            failureBlock(error);
             return;
         }
     }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -1388,8 +1388,15 @@ didReceiveRemoteNotification:userInfo
     [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    XCTestExpectation *errorExpectation = [self expectationWithDescription:@"onesignal_failure_block_called"];
+    errorExpectation.expectedFulfillmentCount = 1;
     //The OneSignal class is not a valid json object
-    [OneSignal sendTags:@{@"key1": @"value1", @"key2": [OneSignal new]}];
+    [OneSignal sendTags:@{@"key1": @"value1", @"key2": [OneSignal new]} onSuccess:^(NSDictionary *result) {
+        XCTAssertNotNil(nil); //Assert if success is called
+    } onFailure:^(NSError *error) {
+        XCTAssertEqualObjects(error.domain, @"com.onesignal.tags");
+        [errorExpectation fulfill];
+    }];
     
     // Make sure the tags were not sent.
     [NSObjectOverrider runPendingSelectors];
@@ -1397,6 +1404,7 @@ didReceiveRemoteNotification:userInfo
     [NSObjectOverrider runPendingSelectors];
     
     XCTAssertEqual(OneSignalClientOverrider.networkRequestCount, 2);
+    [self waitForExpectations:@[errorExpectation] timeout:1];
 }
 
 - (void)testDeleteTags {


### PR DESCRIPTION
Previously we would log a warning and return on bad input for the sendTags method. Now we will also call the failure block with an error object with information on what went wrong. This fixes #951

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/952)
<!-- Reviewable:end -->
