### PR TITLE
Interruption Level and Relevance Score

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -189,12 +189,20 @@
     if (aps[@"thread-id"]) {
         _threadId = (NSString *)aps[@"thread-id"];
     }
+
+    if (aps[@"relevance-score"]) {
+        _relevanceScore = (NSNumber *)aps[@"relevance-score"];
+    }
+    
+    if (aps[@"interruption-level"]) {
+        _interruptionLevel = (NSString *)aps[@"interruption-level"];
+    }
     
     _category = aps[@"category"];
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat: @"notificationId=%@ templateId=%@ templateName=%@ contentAvailable=%@ mutableContent=%@ category=%@ rawPayload=%@", _notificationId, _templateId, _templateName, _contentAvailable ? @"YES" : @"NO", _mutableContent ? @"YES" : @"NO", _category, _rawPayload];
+    return [NSString stringWithFormat: @"notificationId=%@ templateId=%@ templateName=%@ contentAvailable=%@ mutableContent=%@ category=%@ relevanceScore=%@ interruptionLevel=%@ rawPayload=%@", _notificationId, _templateId, _templateName, _contentAvailable ? @"YES" : @"NO", _mutableContent ? @"YES" : @"NO", _category, _relevanceScore, _interruptionLevel, _rawPayload];
 }
 
 - (NSDictionary *)jsonRepresentation {
@@ -253,6 +261,12 @@
     
     if (self.category)
         [obj setObject:self.category forKeyedSubscript: @"category"];
+    
+    if (self.relevanceScore)
+        [obj setObject:self.relevanceScore forKeyedSubscript: @"relevanceScore"];
+    
+    if (self.interruptionLevel)
+        [obj setObject:self.interruptionLevel forKeyedSubscript: @"interruptionLevel"];
 
     return obj;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -130,6 +130,12 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 /* iOS 10+ : Groups notifications into threads */
 @property(readonly, nullable)NSString *threadId;
 
+/* iOS 15+ : Relevance Score for notification summary */
+@property(readonly, nullable)NSNumber *relevanceScore;
+
+/* iOS 15+ : Interruption Level */
+@property(readonly)NSString *interruptionLevel;
+
 /* Parses an APNS push payload into a OSNotification object.
    Useful to call from your NotificationServiceExtension when the
       didReceiveNotificationRequest:withContentHandler: method fires. */

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3119,6 +3119,8 @@ didReceiveRemoteNotification:userInfo
                             @"content-available": @1,
                             @"mutable-content": @1,
                             @"alert": @"Message Body",
+                            @"relevance-score": @0.15,
+                            @"interruption-level": @"time-sensitive",
                         },
                         @"os_data": @{
                             @"i": @"notif id",


### PR DESCRIPTION
This PR adds the `interruptionLevel` string and the `relevanceScore` double to the `OSNotification` object. These are iOS 15 only properties that can be sent via APNs payload local notification creation. OneSignal does not change any behavior according to these properties, but they will now appear in the `OSNotification` object for OneSignal notifications that utilize them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/963)
<!-- Reviewable:end -->
