### PR TITLE
validating successful malloc for lastLocation and classes

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -331,7 +331,10 @@ static OneSignalLocation* singleInstance = nil;
     @synchronized(OneSignalLocation.mutexObjectForLastLocation) {
         if (!lastLocation)
             lastLocation = (os_last_location*)malloc(sizeof(os_last_location));
-        
+        if (lastLocation == NULL) {
+            onesignal_Log(ONE_S_LL_ERROR, @"OneSignalLocation: unable to allocate memory for os_last_location");
+            return;
+        }
         lastLocation->verticalAccuracy = [[location valueForKey:@"verticalAccuracy"] doubleValue];
         lastLocation->horizontalAccuracy = [[location valueForKey:@"horizontalAccuracy"] doubleValue];
         lastLocation->cords = cords;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
@@ -112,7 +112,11 @@ void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasse
 
 NSArray* ClassGetSubclasses(Class parentClass) {
     int numClasses = objc_getClassList(NULL, 0);
-    Class *classes = (Class*)malloc(sizeof(Class) * numClasses);
+    int memSize = sizeof(Class) * numClasses;
+    Class *classes = (Class*)malloc(memSize);
+    if (classes == NULL && memSize) {
+        return [NSMutableArray array];
+    }
     
     objc_getClassList(classes, numClasses);
     


### PR DESCRIPTION
Whenever we use malloc we should validate that it was successful since it could fail. Failing would cause a crash by trying to use an object that is actually NULL.
Fixes #967

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/969)
<!-- Reviewable:end -->
