### PR TITLE
Running setApplicationIconBadgeNumber on mainThread

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2221,7 +2221,9 @@ static NSString *_lastnonActiveMessageId;
     bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;
     
     if (fromNotifOpened || wasBadgeSet) {
-        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        [OneSignalHelper runOnMainThread:^{
+            [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        }];
     }
 
     return wasBadgeSet;


### PR DESCRIPTION
This is a UIApplication method so we need to run it on the main thread. It can be run on background threads through wrapper SDKs.

This fixes [react-native issue 1262](https://github.com/OneSignal/react-native-onesignal/issues/1262)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/970)
<!-- Reviewable:end -->
