### PR TITLE
Add Device Type to report_received request.

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -643,7 +643,9 @@ NSString * const NOTIFICATION_IDS = @"notification_ids";
 + (instancetype _Nonnull)withPlayerId:(NSString *)playerId notificationId:(NSString *)notificationId appId:(NSString *)appId {
     let request = [OSRequestReceiveReceipts new];
     
-    request.parameters = @{@"app_id": appId, @"player_id": playerId ?: [NSNull null]};
+    request.parameters = @{@"app_id": appId,
+                           @"player_id": playerId ?: [NSNull null],
+                           @"device_type": @0};
     request.method = PUT;
     request.path = [NSString stringWithFormat:@"notifications/%@/report_received", notificationId];
 


### PR DESCRIPTION
Always sending with device_type 0 since it is from the push player. 
This improves performance in turbine when trying to create an outcome event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/973)
<!-- Reviewable:end -->
