### PR TITLE
IAM lifecycle events

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignal/OneSignal.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSInAppMessageDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignal/OneSignal.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSInAppMessageDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSSubscriptionObserver, OSEmailSubscriptionObserver, OSInAppMessageLifecycleHandler>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -84,7 +84,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal addPermissionObserver:self];
     [OneSignal addSubscriptionObserver:self];
     [OneSignal addEmailSubscriptionObserver:self];
-    [OneSignal setInAppMessageDelegate:self];
+    [OneSignal setInAppMessageLifecycleHandler:self];
     [OneSignal pauseInAppMessages:true];
 
     [OneSignal setNotificationWillShowInForegroundHandler:notificationReceiverBlock];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -84,7 +84,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal addPermissionObserver:self];
     [OneSignal addSubscriptionObserver:self];
     [OneSignal addEmailSubscriptionObserver:self];
-    
+    [OneSignal setInAppMessageDelegate:self];
     [OneSignal pauseInAppMessages:true];
 
     [OneSignal setNotificationWillShowInForegroundHandler:notificationReceiverBlock];
@@ -125,6 +125,35 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 - (void)onOSEmailSubscriptionChanged:(OSEmailSubscriptionStateChanges *)stateChanges {
     NSLog(@"onOSEmailSubscriptionChanged: %@", stateChanges);
 }
+
+#pragma mark OSInAppMessageDelegate
+
+- (void)handleMessageAction:(OSInAppMessageAction *)action {
+    NSLog(@"OSInAppMessageDelegate: handling message action: %@",action);
+    return;
+}
+
+- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message {
+    NSLog(@"OSInAppMessageDelegate: onWillDisplay Message: %@",message);
+    return;
+}
+
+- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message {
+    NSLog(@"OSInAppMessageDelegate: onDidDisplay Message: %@",message);
+    return;
+}
+
+- (void)onWillDismissInAppMessage:(OSInAppMessage *)message {
+    NSLog(@"OSInAppMessageDelegate: onWillDismiss Message: %@",message);
+    return;
+}
+
+- (void)onDidDismissInAppMessage:(OSInAppMessage *)message {
+    NSLog(@"OSInAppMessageDelegate: onDidDismiss Message: %@",message);
+    return;
+}
+
+#pragma mark UIApplicationDelegate methods
 
 - (void)applicationWillResignActive:(UIApplication *)application {
 }

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -464,10 +464,10 @@
 		CACBAA9D218A6243000ACAA5 /* OSInAppMessageView.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA92218A6242000ACAA5 /* OSInAppMessageView.m */; };
 		CACBAA9E218A6243000ACAA5 /* OSInAppMessageView.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA92218A6242000ACAA5 /* OSInAppMessageView.m */; };
 		CACBAA9F218A6243000ACAA5 /* OSInAppMessageView.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA92218A6242000ACAA5 /* OSInAppMessageView.m */; };
-		CACBAAA0218A6243000ACAA5 /* OSInAppMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = CACBAA93218A6243000ACAA5 /* OSInAppMessage.h */; };
-		CACBAAA1218A6243000ACAA5 /* OSInAppMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA94218A6243000ACAA5 /* OSInAppMessage.m */; };
-		CACBAAA2218A6243000ACAA5 /* OSInAppMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA94218A6243000ACAA5 /* OSInAppMessage.m */; };
-		CACBAAA3218A6243000ACAA5 /* OSInAppMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA94218A6243000ACAA5 /* OSInAppMessage.m */; };
+		CACBAAA0218A6243000ACAA5 /* OSInAppMessageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = CACBAA93218A6243000ACAA5 /* OSInAppMessageInternal.h */; };
+		CACBAAA1218A6243000ACAA5 /* OSInAppMessageInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */; };
+		CACBAAA2218A6243000ACAA5 /* OSInAppMessageInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */; };
+		CACBAAA3218A6243000ACAA5 /* OSInAppMessageInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */; };
 		CACBAAA4218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA95218A6243000ACAA5 /* OSInAppMessageViewController.m */; };
 		CACBAAA5218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA95218A6243000ACAA5 /* OSInAppMessageViewController.m */; };
 		CACBAAA6218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CACBAA95218A6243000ACAA5 /* OSInAppMessageViewController.m */; };
@@ -818,8 +818,8 @@
 		CACBAA90218A6242000ACAA5 /* OSMessagingController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSMessagingController.h; sourceTree = "<group>"; };
 		CACBAA91218A6242000ACAA5 /* OSInAppMessageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageView.h; sourceTree = "<group>"; };
 		CACBAA92218A6242000ACAA5 /* OSInAppMessageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageView.m; sourceTree = "<group>"; };
-		CACBAA93218A6243000ACAA5 /* OSInAppMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSInAppMessage.h; sourceTree = "<group>"; };
-		CACBAA94218A6243000ACAA5 /* OSInAppMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessage.m; sourceTree = "<group>"; };
+		CACBAA93218A6243000ACAA5 /* OSInAppMessageInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageInternal.h; sourceTree = "<group>"; };
+		CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageInternal.m; sourceTree = "<group>"; };
 		CACBAA95218A6243000ACAA5 /* OSInAppMessageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageViewController.m; sourceTree = "<group>"; };
 		CACBAAA7218A6280000ACAA5 /* OSJSONHandling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSJSONHandling.h; sourceTree = "<group>"; };
 		CACBAAA9218A65AE000ACAA5 /* InAppMessagingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InAppMessagingTests.m; sourceTree = "<group>"; };
@@ -1413,8 +1413,8 @@
 			children = (
 				CA47439B2190FEA80020DC8C /* OSTrigger.h */,
 				CA47439C2190FEA80020DC8C /* OSTrigger.m */,
-				CACBAA93218A6243000ACAA5 /* OSInAppMessage.h */,
-				CACBAA94218A6243000ACAA5 /* OSInAppMessage.m */,
+				CACBAA93218A6243000ACAA5 /* OSInAppMessageInternal.h */,
+				CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */,
 				CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */,
 				CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */,
 				CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */,
@@ -1583,7 +1583,7 @@
 				7A1232A5235E179B002B6CE3 /* OSIndirectInfluence.h in Headers */,
 				91F58D7F1E7C7F5F0017D24D /* OneSignalNotificationSettingsIOS10.h in Headers */,
 				912412391E73342200E41FD7 /* OneSignalWebView.h in Headers */,
-				CACBAAA0218A6243000ACAA5 /* OSInAppMessage.h in Headers */,
+				CACBAAA0218A6243000ACAA5 /* OSInAppMessageInternal.h in Headers */,
 				91C7725E1E7CCE1000D612D0 /* OneSignalInternal.h in Headers */,
 				CAB269DF21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h in Headers */,
 				9129C6BD1E89E7AB009CB6A0 /* OSSubscription.h in Headers */,
@@ -1884,7 +1884,7 @@
 				A6D7093D26962C95007B3347 /* OneSignalSetLanguageParameters.m in Sources */,
 				7AF9865E2447C13C00C36EAE /* OSInfluenceDataRepository.m in Sources */,
 				7AECE59E23675F6300537907 /* OSFocusTimeProcessorFactory.m in Sources */,
-				CACBAAA1218A6243000ACAA5 /* OSInAppMessage.m in Sources */,
+				CACBAAA1218A6243000ACAA5 /* OSInAppMessageInternal.m in Sources */,
 				CA63AFC32022670A00E340FB /* ReattemptRequest.m in Sources */,
 				912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				CACBAAA4218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */,
@@ -1985,7 +1985,7 @@
 				A63E9E3C26742B5F00EA273E /* LanguageContext.m in Sources */,
 				7AC8D3A924993A0F0023EDE8 /* OSDeviceState.m in Sources */,
 				CA810FD2202BA97600A60FED /* OSEmailSubscription.m in Sources */,
-				CACBAAA2218A6243000ACAA5 /* OSInAppMessage.m in Sources */,
+				CACBAAA2218A6243000ACAA5 /* OSInAppMessageInternal.m in Sources */,
 				7A674F1C2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */,
 				7AF9868124497BE100C36EAE /* OSOutcomeEventsV1Repository.m in Sources */,
 				7AFE856C2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
@@ -2112,7 +2112,7 @@
 				CAE2E5AA215D80380036FD32 /* OneSignalNotificationServiceExtensionHandler.m in Sources */,
 				4529DEDE1FA828E500CEAB1D /* NSDateOverrider.m in Sources */,
 				CA08FC871FE99BB4004C445F /* OneSignalClientOverrider.m in Sources */,
-				CACBAAA3218A6243000ACAA5 /* OSInAppMessage.m in Sources */,
+				CACBAAA3218A6243000ACAA5 /* OSInAppMessageInternal.m in Sources */,
 				7AF5174C24FE980400B076BC /* RemoteParamsTests.m in Sources */,
 				CACBAAA6218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */,
 				912412401E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageController.h
@@ -26,12 +26,12 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OneSignalClient.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OSInAppMessage (OSInAppMessageController)
+@interface OSInAppMessageInternal (OSInAppMessageController)
 
 - (void)loadMessageHTMLContentWithResult:(OSResultSuccessBlock _Nullable)successBlock failure:(OSFailureBlock _Nullable)failureBlock;
 - (void)loadPreviewMessageHTMLContentWithUUID:(NSString * _Nonnull)previewUUID success:(OSResultSuccessBlock _Nullable)successBlock failure:(OSFailureBlock _Nullable)failureBlock;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageController.m
@@ -30,7 +30,7 @@
 #import "OSInAppMessagingDefines.h"
 
 
-@implementation OSInAppMessage (OSInAppMessageController)
+@implementation OSInAppMessageInternal (OSInAppMessageController)
 
 - (void)loadMessageHTMLContentWithResult:(OSResultSuccessBlock _Nullable)successBlock failure:(OSFailureBlock _Nullable)failureBlock {
     let variantId = [self variantId];

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.h
@@ -34,7 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OSInAppMessage : NSObject <NSCoding, OSJSONDecodable, OSJSONEncodable>
+@interface OSInAppMessageInternal : NSObject <NSCoding, OSJSONDecodable, OSJSONEncodable>
 
 @property (strong, nonatomic, nonnull) NSString *messageId;
 @property (strong, nonatomic, nonnull) NSDictionary<NSString *, NSDictionary <NSString *, NSString *> *> *variants;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.h
@@ -34,9 +34,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OSInAppMessageInternal : NSObject <NSCoding, OSJSONDecodable, OSJSONEncodable>
+@interface OSInAppMessageInternal : OSInAppMessage <NSCoding, OSJSONDecodable, OSJSONEncodable>
 
-@property (strong, nonatomic, nonnull) NSString *messageId;
 @property (strong, nonatomic, nonnull) NSDictionary<NSString *, NSDictionary <NSString *, NSString *> *> *variants;
 @property (strong, nonatomic, nonnull) NSArray<NSArray <OSTrigger *> *> *triggers;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
@@ -205,7 +205,7 @@
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder {
-    [encoder encodeObject:_messageId forKey:@"messageId"];
+    [encoder encodeObject:self.messageId forKey:@"messageId"];
     [encoder encodeObject:_variants forKey:@"variants"];
     [encoder encodeObject:_triggers forKey:@"triggers"];
     [encoder encodeObject:_displayStats forKey:@"displayStats"];
@@ -217,7 +217,7 @@
 
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
-        _messageId = [decoder decodeObjectForKey:@"messageId"];
+        self.messageId = [decoder decodeObjectForKey:@"messageId"];
         _variants = [decoder decodeObjectForKey:@"variants"];
         _triggers = [decoder decodeObjectForKey:@"triggers"];
         _displayStats = [decoder decodeObjectForKey:@"displayStats"];

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
@@ -25,18 +25,18 @@
  * THE SOFTWARE.
  */
 
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OneSignalHelper.h"
 #import "OneSignalCommonDefines.h"
 
-@interface OSInAppMessage ()
+@interface OSInAppMessageInternal ()
 
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *clickedClickIds;
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *viewedPageIds;
 
 @end
 
-@implementation OSInAppMessage
+@implementation OSInAppMessageInternal
 
 - (instancetype)init {
     if (self = [super init]) {
@@ -87,7 +87,7 @@
 }
 
 + (instancetype)instanceWithJson:(NSDictionary * _Nonnull)json {
-    let message = [OSInAppMessage new];
+    let message = [OSInAppMessageInternal new];
     
     if (json[@"id"] && [json[@"id"] isKindOfClass:[NSString class]])
         message.messageId = json[@"id"];
@@ -144,7 +144,7 @@
 }
 
 + (instancetype)instancePreviewFromNotification:(OSNotification *)notification {
-    let message = [OSInAppMessage new];
+    let message = [OSInAppMessageInternal new];
     message.messageId = [notification additionalData][ONESIGNAL_IAM_PREVIEW];
     message.isPreview = true;
     return message;
@@ -191,11 +191,11 @@
     return YES;
   }
 
-  if (![object isKindOfClass:[OSInAppMessage class]]) {
+  if (![object isKindOfClass:[OSInAppMessageInternal class]]) {
     return NO;
   }
 
-  OSInAppMessage *iam = object;
+  OSInAppMessageInternal *iam = object;
     
   return [self.messageId isEqualToString:iam.messageId];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
@@ -29,6 +29,9 @@
 #import "OneSignalHelper.h"
 #import "OneSignalCommonDefines.h"
 
+@implementation OSInAppMessage
+@end
+
 @interface OSInAppMessageInternal ()
 
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *clickedClickIds;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.h
@@ -26,7 +26,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import <WebKit/WebKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nonatomic, nullable) id<OSInAppMessageViewDelegate> delegate;
 
-- (instancetype _Nonnull)initWithMessage:(OSInAppMessage *)inAppMessage withScriptMessageHandler:(id<WKScriptMessageHandler>)messageHandler;
+- (instancetype _Nonnull)initWithMessage:(OSInAppMessageInternal *)inAppMessage withScriptMessageHandler:(id<WKScriptMessageHandler>)messageHandler;
 - (void)resetWebViewToMaxBoundsAndResizeHeight:(void (^) (NSNumber *newHeight)) completion;
 - (void)setupWebViewConstraints;
 - (void)loadReplacementURL:(NSURL *)url;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -35,7 +35,7 @@
 
 @interface OSInAppMessageView () <UIScrollViewDelegate, WKUIDelegate, WKNavigationDelegate>
 
-@property (strong, nonatomic, nonnull) OSInAppMessage *message;
+@property (strong, nonatomic, nonnull) OSInAppMessageInternal *message;
 @property (strong, nonatomic, nonnull) WKWebView *webView;
 @property (nonatomic) BOOL loaded;
 
@@ -44,7 +44,7 @@
 
 @implementation OSInAppMessageView
 
-- (instancetype _Nonnull)initWithMessage:(OSInAppMessage *)inAppMessage withScriptMessageHandler:(id<WKScriptMessageHandler>)messageHandler {
+- (instancetype _Nonnull)initWithMessage:(OSInAppMessageInternal *)inAppMessage withScriptMessageHandler:(id<WKScriptMessageHandler>)messageHandler {
     if (self = [super init]) {
         self.message = inAppMessage;
         self.translatesAutoresizingMaskIntoConstraints = false;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -38,7 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
 - (void)messageViewDidDisplayPage:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
-- (void)messageViewControllerWasDismissed;
+- (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message;
+- (void)messageViewControllerWasDismissed:(OSInAppMessageInternal *)message displayed:(BOOL)displayed;
 - (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message;
 - (void)messageIsNotActive:(OSInAppMessageInternal *)message;
 - (void)messageWillDisplay:(OSInAppMessageInternal *)message;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)messageViewControllerWasDismissed;
 - (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message;
 - (void)messageIsNotActive:(OSInAppMessageInternal *)message;
+- (void)messageWillDisplay:(OSInAppMessageInternal *)message;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSInAppMessageView.h"
 #import "OSInAppMessageAction.h"
 #import <WebKit/WebKit.h>
@@ -36,11 +36,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OSInAppMessageViewControllerDelegate <NSObject>
 
-- (void)messageViewDidSelectAction:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action;
-- (void)messageViewDidDisplayPage:(OSInAppMessage *)message withPageId:(NSString *)pageId;
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
+- (void)messageViewDidDisplayPage:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
 - (void)messageViewControllerWasDismissed;
-- (void)webViewContentFinishedLoading:(OSInAppMessage *)message;
-- (void)messageIsNotActive:(OSInAppMessage *)message;
+- (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message;
+- (void)messageIsNotActive:(OSInAppMessageInternal *)message;
 
 @end
 
@@ -48,10 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OSInAppMessageViewController : UIViewController <OSInAppMessageViewDelegate, WKScriptMessageHandler>
 
 @property (weak, nonatomic, nullable) id<OSInAppMessageViewControllerDelegate> delegate;
-@property (strong, nonatomic, nonnull) OSInAppMessage *message;
+@property (strong, nonatomic, nonnull) OSInAppMessageInternal *message;
 @property (nonatomic) BOOL waitForTags;
 
-- (instancetype _Nonnull)initWithMessage:(OSInAppMessage *)inAppMessage delegate:(id<OSInAppMessageViewControllerDelegate>)delegate;
+- (instancetype _Nonnull)initWithMessage:(OSInAppMessageInternal *)inAppMessage delegate:(id<OSInAppMessageViewControllerDelegate>)delegate;
 - (void)dismissCurrentInAppMessage;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
 - (void)messageViewDidDisplayPage:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
+- (void)messageViewControllerDidDisplay:(OSInAppMessageInternal *)message;
 - (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message;
 - (void)messageViewControllerWasDismissed:(OSInAppMessageInternal *)message displayed:(BOOL)displayed;
 - (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -137,9 +137,8 @@
 
 - (void)applicationIsActive:(NSNotification *)notification {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Application Active"];
-
     // Animate the showing of the IAM when opening the app from background
-    [self animateAppearance];
+    [self animateAppearance:NO];
 }
 
 - (void)applicationIsInBackground:(NSNotification *)notification {
@@ -195,7 +194,7 @@
         if (!finished)
             return;
         
-        [self animateAppearance];
+        [self animateAppearance:YES];
     }];
 }
 
@@ -485,13 +484,17 @@
  For banners the initialYConstraint is set to LOW_CONSTRAINT_PRIORITY
  For center modal and full screen, the transform is set to CGAffineTransformIdentity (original scale)
  */
-- (void)animateAppearance {
+- (void)animateAppearance:(BOOL)firstDisplay {
     self.initialYConstraint.priority = LOW_CONSTRAINT_PRIORITY;
     
     [UIView animateWithDuration:0.3f animations:^{
         self.messageView.hidden = false;
         self.messageView.transform = CGAffineTransformIdentity;
         [self.view layoutIfNeeded];
+    } completion:^(BOOL finished) {
+        if (firstDisplay) {
+            [self.delegate messageViewControllerDidDisplay:self.message];
+        }
     }];
 }
 
@@ -749,7 +752,7 @@
             [self addConstraintsForMessage];
             
             // Reanimate and show IAM
-            [self animateAppearance];
+            [self animateAppearance:NO];
         }];
     }];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -97,7 +97,7 @@
 
 @implementation OSInAppMessageViewController
 
-- (instancetype _Nonnull)initWithMessage:(OSInAppMessage *)inAppMessage delegate:(id<OSInAppMessageViewControllerDelegate>)delegate {
+- (instancetype _Nonnull)initWithMessage:(OSInAppMessageInternal *)inAppMessage delegate:(id<OSInAppMessageViewControllerDelegate>)delegate {
     if (self = [super init]) {
         self.message = inAppMessage;
         self.delegate = delegate;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -431,10 +431,12 @@
     // and we should bypass dismissal adjustments and animations and skip straight to the OSMessagingController callback for dismissing
     if (!self.didPageRenderingComplete) {
         [self dismissViewControllerAnimated:false completion:nil];
-        [self.delegate messageViewControllerWasDismissed];
+        [self.delegate messageViewControllerWasDismissed:self.message displayed:NO];
         return;
     }
         
+    [self.delegate messageViewControllerWillDismiss:self.message];
+    
     // Inactivate the current Y constraints
     self.finalYConstraint.active = false;
     self.initialYConstraint.active = false;
@@ -473,7 +475,7 @@
             return;
 
         self.didPageRenderingComplete = false;
-        [self.delegate messageViewControllerWasDismissed];
+        [self.delegate messageViewControllerWasDismissed:self.message displayed:YES];
     }];
 }
 
@@ -754,7 +756,7 @@
 
 #pragma mark OSInAppMessageViewDelegate Methods
 - (void)messageViewFailedToLoadMessageContent {
-    [self.delegate messageViewControllerWasDismissed];
+    [self.delegate messageViewControllerWasDismissed:self.message displayed:NO];
 }
 
 - (void)messageViewDidFailToProcessAction {

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -237,6 +237,7 @@
         if (self.waitForTags) {
             return;
         }
+        //will display
         [self.messageView loadedHtmlContent:self.pendingHTMLContent withBaseURL:baseUrl];
         self.pendingHTMLContent = nil;
     };

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -237,7 +237,7 @@
         if (self.waitForTags) {
             return;
         }
-        //will display
+        [self.delegate messageWillDisplay:self.message];
         [self.messageView loadedHtmlContent:self.pendingHTMLContent withBaseURL:baseUrl];
         self.pendingHTMLContent = nil;
     };

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -26,7 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSInAppMessageViewController.h"
 #import "OneSignal.h"
 #import "OSTriggerController.h"
@@ -49,12 +49,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (OSMessagingController *)sharedInstance;
 + (void)removeInstance;
-- (void)presentInAppMessage:(OSInAppMessage *)message;
-- (void)presentInAppPreviewMessage:(OSInAppMessage *)message;
+- (void)presentInAppMessage:(OSInAppMessageInternal *)message;
+- (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message;
 - (void)updateInAppMessagesFromCache;
-- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessage *> *)newMessages;
-- (void)messageViewImpressionRequest:(OSInAppMessage *)message;
-- (void)messageViewPageImpressionRequest:(OSInAppMessage *)message withPageId:(NSString *)pageId;
+- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessageInternal *> *)newMessages;
+- (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message;
+- (void)messageViewPageImpressionRequest:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
 
 - (BOOL)isInAppMessagingPaused;
 - (void)setInAppMessagingPaused:(BOOL)pause;

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -64,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)getTriggerValueForKey:(NSString *)key;
 
 - (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock;
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate>*)delegate;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)getTriggerValueForKey:(NSString *)key;
 
 - (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock;
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate>*)delegate;
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)getTriggerValueForKey:(NSString *)key;
 
 - (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock;
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate;
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -572,7 +572,7 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 #pragma mark OSInAppMessageViewControllerDelegate Methods
-- (void)messageViewControllerWasDismissed {
+- (void)messageViewControllerWasDismissed:(OSInAppMessageInternal *)message displayed:(BOOL)displayed {
     @synchronized (self.messageDisplayQueue) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Dismissing IAM and preparing to show next IAM"];
         // Remove DIRECT influence due to ClickHandler of ClickAction outcomes
@@ -580,6 +580,9 @@ static BOOL _isInAppMessagingPaused = false;
 
         // Add current dismissed messageId to seenInAppMessages set and save it to NSUserDefaults
         if (self.isInAppMessageShowing) {
+            if (displayed) {
+                [self onDidDismissInAppMessage:message];
+            }
             OSInAppMessageInternal *showingIAM = self.messageDisplayQueue.firstObject;
             [self.seenInAppMessages addObject:showingIAM.messageId];
             [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_SEEN_SET_KEY withValue:self.seenInAppMessages];
@@ -599,6 +602,10 @@ static BOOL _isInAppMessagingPaused = false;
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Stop evaluateMessageDisplayQueue because prompt is currently displayed"];
         }
     }
+}
+
+- (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message {
+    [self onWillDismissInAppMessage:message];
 }
 
 - (void)evaluateMessageDisplayQueue {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -735,6 +735,10 @@ static BOOL _isInAppMessagingPaused = false;
     [self deleteInactiveMessage:message];
 }
 
+- (void)messageWillDisplay:(nonnull OSInAppMessageInternal *)message {
+    [self onWillDisplayInAppMessage:message];
+}
+
 /*
 * Show the developer what will happen with a non IAM preview
  */
@@ -836,7 +840,7 @@ static BOOL _isInAppMessagingPaused = false;
     [self addKeySceneToWindow:self.window];
 
     [self.window makeKeyAndVisible];
-    // Did Display
+    [self onDidDisplayInAppMessage:message];
 }
 
 // Required to display if the app is using a Scene

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -46,15 +46,15 @@
 @interface OSMessagingController ()
 
 @property (strong, nonatomic, nullable) UIWindow *window;
-@property (strong, nonatomic, nonnull) NSArray <OSInAppMessage *> *messages;
+@property (strong, nonatomic, nonnull) NSArray <OSInAppMessageInternal *> *messages;
 @property (strong, nonatomic, nonnull) OSTriggerController *triggerController;
-@property (strong, nonatomic, nonnull) NSMutableArray <OSInAppMessage *> *messageDisplayQueue;
+@property (strong, nonatomic, nonnull) NSMutableArray <OSInAppMessageInternal *> *messageDisplayQueue;
 
 // Tracking already seen IAMs, used to prevent showing an IAM more than once after it has been dismissed
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *seenInAppMessages;
 
 // Tracking IAMs with redisplay, used to enable showing an IAM more than once after it has been dismissed
-@property (strong, nonatomic, nonnull) NSMutableDictionary <NSString *, OSInAppMessage *> *redisplayedInAppMessages;
+@property (strong, nonatomic, nonnull) NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages;
 
 // Tracking for click ids wihtin IAMs so that body, button, and image are only tracked on the dashboard once
 // TODO:We should refactor this to be like redisplay logic, save clickId + IAM or by IAM
@@ -77,7 +77,7 @@
 
 @property (nonatomic, nullable) NSArray<NSObject<OSInAppMessagePrompt> *> *currentPromptActions;
 
-@property (nonatomic, nullable) OSInAppMessage *currentInAppMessage;
+@property (nonatomic, nullable) OSInAppMessageInternal *currentInAppMessage;
 
 @property (nonatomic) BOOL isAppInactive;
 
@@ -135,7 +135,7 @@ static BOOL _isInAppMessagingPaused = false;
             return [[NSDate date] timeIntervalSince1970];
         };
         self.messages = [OneSignalUserDefaults.initStandard getSavedCodeableDataForKey:OS_IAM_MESSAGES_ARRAY
-                                                                                          defaultValue:[NSArray<OSInAppMessage *> new]];
+                                                                                          defaultValue:[NSArray<OSInAppMessageInternal *> new]];
         self.triggerController = [OSTriggerController new];
         self.triggerController.delegate = self;
         self.messageDisplayQueue = [NSMutableArray new];
@@ -163,7 +163,7 @@ static BOOL _isInAppMessagingPaused = false;
     [self evaluateMessages];
 }
 
-- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessage *> *)newMessages {
+- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessageInternal *> *)newMessages {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"updateInAppMessagesFromOnSession"];
     self.messages = newMessages;
     
@@ -186,7 +186,7 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
-- (void)deleteInactiveMessage:(OSInAppMessage *)message {
+- (void)deleteInactiveMessage:(OSInAppMessageInternal *)message {
     let deleteMessage = [NSString stringWithFormat:@"Deleting inactive in-app message from cache: %@", message.messageId];
     [OneSignal onesignal_Log:ONE_S_LL_ERROR message:deleteMessage];
     NSMutableArray *newMessagesArray = [NSMutableArray arrayWithArray:self.messages];
@@ -214,7 +214,7 @@ static BOOL _isInAppMessagingPaused = false;
     }
 
     if ([messagesIdToRemove count] > 0) {
-        NSMutableDictionary <NSString *, OSInAppMessage *> * newRedisplayDictionary = [_redisplayedInAppMessages mutableCopy];
+        NSMutableDictionary <NSString *, OSInAppMessageInternal *> * newRedisplayDictionary = [_redisplayedInAppMessages mutableCopy];
         for (NSString * messageId in messagesIdToRemove) {
             [newRedisplayDictionary removeObjectForKey:messageId];
         }
@@ -227,7 +227,7 @@ static BOOL _isInAppMessagingPaused = false;
     self.actionClickBlock = actionClickBlock;
 }
 
-- (void)presentInAppMessage:(OSInAppMessage *)message {
+- (void)presentInAppMessage:(OSInAppMessageInternal *)message {
     if (!message.variantId) {
         let errorMessage = [NSString stringWithFormat:@"Attempted to display a message with a nil variantId. Current preferred language is %@, supported message variants are %@", NSLocale.preferredLanguages, message.variants];
         [OneSignal onesignal_Log:ONE_S_LL_ERROR message:errorMessage];
@@ -254,7 +254,7 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 - (BOOL)isMessageInDisplayQueue:(NSString *)messageId {
-    for (OSInAppMessage *message in self.messageDisplayQueue) {
+    for (OSInAppMessageInternal *message in self.messageDisplayQueue) {
         if ([message.messageId isEqualToString:messageId]) {
             return true;
         }
@@ -266,7 +266,7 @@ static BOOL _isInAppMessagingPaused = false;
  If an IAM is currently showing add the preview right behind it in the messageDisplayQueue and then dismiss the current IAM
  Otherwise, Add it to the front of the messageDisplayQueue and call displayMessage
  */
-- (void)presentInAppPreviewMessage:(OSInAppMessage *)message {
+- (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message {
     @synchronized (self.messageDisplayQueue) {
         if (self.isInAppMessageShowing) {
             // Add preview second in messageDisplayQueue
@@ -280,7 +280,7 @@ static BOOL _isInAppMessagingPaused = false;
     };
 }
 
-- (void)displayMessage:(OSInAppMessage *)message {
+- (void)displayMessage:(OSInAppMessageInternal *)message {
     // Check if the app disabled IAMs for this device before showing an IAM
     if (_isInAppMessagingPaused) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app messages will not show while paused"];
@@ -290,7 +290,7 @@ static BOOL _isInAppMessagingPaused = false;
     [self showMessage:message];
 }
 
-- (void)showMessage:(OSInAppMessage *)message {
+- (void)showMessage:(OSInAppMessageInternal *)message {
     self.viewController = [[OSInAppMessageViewController alloc] initWithMessage:message delegate:self];
     if (message.hasLiquid && !self.calledLoadTags) {
         self.viewController.waitForTags = YES;
@@ -301,7 +301,7 @@ static BOOL _isInAppMessagingPaused = false;
     });
 }
 
-- (void)sendMessageImpression:(OSInAppMessage *)message {
+- (void)sendMessageImpression:(OSInAppMessageInternal *)message {
     if ([self shouldSendImpression:message]) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self messageViewImpressionRequest:message];
@@ -317,7 +317,7 @@ static BOOL _isInAppMessagingPaused = false;
         }
     }];
 }
-- (void)messageViewPageImpressionRequest:(OSInAppMessage *)message withPageId:(NSString *)pageId {
+- (void)messageViewPageImpressionRequest:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId {
     if (message.isPreview) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Not sending page impression for preview message. ID: %@",pageId]];
         return;
@@ -361,7 +361,7 @@ static BOOL _isInAppMessagingPaused = false;
                                        }];
 }
 
-- (BOOL)shouldSendImpression:(OSInAppMessage *)message {
+- (BOOL)shouldSendImpression:(OSInAppMessageInternal *)message {
     return !(message.isPreview || [self.impressionedInAppMessages containsObject:message.messageId]);
 }
 
@@ -369,7 +369,7 @@ static BOOL _isInAppMessagingPaused = false;
  Make an impression POST to track that the IAM has been
  Request should only be made for IAMs that are not previews and have not been impressioned yet
  */
-- (void)messageViewImpressionRequest:(OSInAppMessage *)message {
+- (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message {
     // Make sure no tracking is performed for previewed IAMs
     // If the messageId exists in cached impressionedInAppMessages return early so the impression is not tracked again
     if (![self shouldSendImpression:message])
@@ -406,7 +406,7 @@ static BOOL _isInAppMessagingPaused = false;
  */
 - (void)evaluateMessages {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Evaluating in app messages"];
-    for (OSInAppMessage *message in self.messages) {
+    for (OSInAppMessageInternal *message in self.messages) {
         if ([self.triggerController messageMatchesTriggers:message]) {
             // Make changes to IAM if redisplay available
             [self setDataForRedisplay:message];
@@ -430,7 +430,7 @@ static BOOL _isInAppMessagingPaused = false;
  For redisplay, the message need to be removed from the arrays that track the display/impression
  For click counting, every message has it click id array
 */
-- (void)setDataForRedisplay:(OSInAppMessage *)message {
+- (void)setDataForRedisplay:(OSInAppMessageInternal *)message {
     if (!message.displayStats.isRedisplayEnabled) {
         return;
     }
@@ -465,7 +465,7 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
-- (BOOL)hasMessageTriggerChanged:(OSInAppMessage *)message {
+- (BOOL)hasMessageTriggerChanged:(OSInAppMessageInternal *)message {
     // Message that only have dynamic trigger should display only once per session
     BOOL messageHasOnlyDynamicTrigger = [self.triggerController messageHasOnlyDynamicTriggers:message];
     if (messageHasOnlyDynamicTrigger)
@@ -481,7 +481,7 @@ static BOOL _isInAppMessagingPaused = false;
  Method to check whether or not to show an IAM
  Checks if the IAM matches any triggers or if it exists in cached seenInAppMessages set
  */
-- (BOOL)shouldShowInAppMessage:(OSInAppMessage *)message {
+- (BOOL)shouldShowInAppMessage:(OSInAppMessageInternal *)message {
     return ![self.seenInAppMessages containsObject:message.messageId] &&
            [self.triggerController messageMatchesTriggers:message] &&
            ![message isFinished] &&
@@ -510,7 +510,7 @@ static BOOL _isInAppMessagingPaused = false;
  *   - At least one Trigger has changed
  */
 - (void)evaluateRedisplayedInAppMessages:(NSArray<NSString *> *)newTriggersKeys {
-    for (OSInAppMessage *message in _messages) {
+    for (OSInAppMessageInternal *message in _messages) {
         if ([_redisplayedInAppMessages objectForKey:message.messageId] &&
             [self.triggerController hasSharedTriggers:message newTriggersKeys:newTriggersKeys]) {
               message.isTriggerChanged = true;
@@ -546,7 +546,7 @@ static BOOL _isInAppMessagingPaused = false;
 
         // Add current dismissed messageId to seenInAppMessages set and save it to NSUserDefaults
         if (self.isInAppMessageShowing) {
-            OSInAppMessage *showingIAM = self.messageDisplayQueue.firstObject;
+            OSInAppMessageInternal *showingIAM = self.messageDisplayQueue.firstObject;
             [self.seenInAppMessages addObject:showingIAM.messageId];
             [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_SEEN_SET_KEY withValue:self.seenInAppMessages];
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Dismissing IAM save seenInAppMessages: %@", _seenInAppMessages]];
@@ -592,7 +592,7 @@ static BOOL _isInAppMessagingPaused = false;
     self.window.hidden = true;
 }
 
-- (void)persistInAppMessageForRedisplay:(OSInAppMessage *)message {
+- (void)persistInAppMessageForRedisplay:(OSInAppMessageInternal *)message {
     // If the IAM doesn't have the re display prop or is a preview IAM there is no need to save it
     if (![message.displayStats isRedisplayEnabled] || message.isPreview) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"not persisting %@",message.displayStats]];
@@ -620,7 +620,7 @@ static BOOL _isInAppMessagingPaused = false;
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"persistInAppMessageForRedisplay saved redisplayedInAppMessages: %@", [redisplayedInAppMessages description]]];
 }
 
-- (void)handlePromptActions:(NSArray<NSObject<OSInAppMessagePrompt> *> *)promptActions withMessage:(OSInAppMessage *)inAppMessage {
+- (void)handlePromptActions:(NSArray<NSObject<OSInAppMessagePrompt> *> *)promptActions withMessage:(OSInAppMessageInternal *)inAppMessage {
     _currentPromptAction = nil;
     for (NSObject<OSInAppMessagePrompt> *promptAction in promptActions) {
         // Don't show prompt twice
@@ -649,7 +649,7 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
-- (void)showAlertDialogMessage:(OSInAppMessage *)inAppMessage
+- (void)showAlertDialogMessage:(OSInAppMessageInternal *)inAppMessage
                  promptActions:(NSArray<NSObject<OSInAppMessagePrompt> *> *)promptActions  {
     _currentInAppMessage = inAppMessage;
     _currentPromptActions = promptActions;
@@ -663,7 +663,7 @@ static BOOL _isInAppMessagingPaused = false;
     }];
 }
 
-- (void)messageViewDidSelectAction:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action {
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
     // Assign firstClick BOOL based on message being clicked previously or not
     action.firstClick = [message takeActionAsUnique];
     
@@ -691,20 +691,20 @@ static BOOL _isInAppMessagingPaused = false;
     [self sendOutcomes:action.outcomes forMessageId:message.messageId];
 }
 
-- (void)messageViewDidDisplayPage:(OSInAppMessage *)message withPageId:(NSString *)pageId {
+- (void)messageViewDidDisplayPage:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId {
     dispatch_async(dispatch_get_main_queue(), ^{
            [self messageViewPageImpressionRequest:message withPageId:pageId];
     });
 }
 
-- (void)messageIsNotActive:(OSInAppMessage *)message {
+- (void)messageIsNotActive:(OSInAppMessageInternal *)message {
     [self deleteInactiveMessage:message];
 }
 
 /*
 * Show the developer what will happen with a non IAM preview
  */
-- (void)processPreviewInAppMessage:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action {
+- (void)processPreviewInAppMessage:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
      if (action.tags)
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Tags detected inside of the action click payload, ignoring because action came from IAM preview\nTags: %@", action.tags.jsonRepresentation]];
 
@@ -718,12 +718,12 @@ static BOOL _isInAppMessagingPaused = false;
 * 1. Redisplay is enabled and click is available within message
 * 2. Click clickId should not be inside of the clickedClickIds set
 */
-- (BOOL)isClickAvailable:(OSInAppMessage *)message withClickId:(NSString *)clickId {
+- (BOOL)isClickAvailable:(OSInAppMessageInternal *)message withClickId:(NSString *)clickId {
     // If IAM has redisplay the clickId may be available
     return ([message.displayStats isRedisplayEnabled] && [message isClickAvailable:clickId]) || ![_clickedClickIds containsObject:clickId];
 }
 
-- (void)sendClickRESTCall:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action {
+- (void)sendClickRESTCall:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
     let clickId = action.clickId;
     // If the IAM clickId exists within the cached clickedClickIds return early so the click is not tracked
     // unless that click is from an IAM with redisplay
@@ -778,7 +778,7 @@ static BOOL _isInAppMessagingPaused = false;
 /*
  This method must be called on the Main thread
  */
-- (void)webViewContentFinishedLoading:(OSInAppMessage *)message {
+- (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message {
     if (!self.viewController) {
         [self evaluateMessages];
         return;
@@ -822,7 +822,7 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 - (void)makeRedisplayMessagesAvailableWithTriggers:(NSArray<NSString *> *)triggerIds {
-    for (OSInAppMessage *message in self.messages) {
+    for (OSInAppMessageInternal *message in self.messages) {
         if ([self.redisplayedInAppMessages objectForKey:message.messageId]
             && [_triggerController hasSharedTriggers:message newTriggersKeys:triggerIds]) {
             message.isTriggerChanged = YES;
@@ -856,14 +856,14 @@ static BOOL _isInAppMessagingPaused = false;
 - (instancetype)init { self = [super init]; return self; }
 - (BOOL)isInAppMessagingPaused { return false; }
 - (void)setInAppMessagingPaused:(BOOL)pause {}
-- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessage *> *)newMessages {}
+- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessageInternal *> *)newMessages {}
 - (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {}
-- (void)presentInAppMessage:(OSInAppMessage *)message {}
-- (void)presentInAppPreviewMessage:(OSInAppMessage *)message {}
-- (void)displayMessage:(OSInAppMessage *)message {}
-- (void)messageViewImpressionRequest:(OSInAppMessage *)message {}
+- (void)presentInAppMessage:(OSInAppMessageInternal *)message {}
+- (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message {}
+- (void)displayMessage:(OSInAppMessageInternal *)message {}
+- (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message {}
 - (void)evaluateMessages {}
-- (BOOL)shouldShowInAppMessage:(OSInAppMessage *)message { return false; }
+- (BOOL)shouldShowInAppMessage:(OSInAppMessageInternal *)message { return false; }
 - (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {}
 #pragma mark Trigger Methods
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers {}
@@ -872,8 +872,8 @@ static BOOL _isInAppMessagingPaused = false;
 - (id)getTriggerValueForKey:(NSString *)key { return 0; }
 #pragma mark OSInAppMessageViewControllerDelegate Methods
 - (void)messageViewControllerWasDismissed {}
-- (void)messageViewDidSelectAction:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action {}
-- (void)webViewContentFinishedLoading:(OSInAppMessage *)message {}
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {}
+- (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message {}
 #pragma mark OSTriggerControllerDelegate Methods
 - (void)triggerConditionChanged {}
 - (void)dynamicTriggerCompleted:(NSString *)triggerId {}

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -233,6 +233,34 @@ static BOOL _isInAppMessagingPaused = false;
     self.inAppMessageDelegate = delegate;
 }
 
+- (void)onWillDisplayInAppMessage:(OSInAppMessageInternal *)message {
+    if (self.inAppMessageDelegate &&
+        [self.inAppMessageDelegate respondsToSelector:@selector(onWillDisplayInAppMessage:)]) {
+        [self.inAppMessageDelegate onWillDisplayInAppMessage:message];
+    }
+}
+
+- (void)onDidDisplayInAppMessage:(OSInAppMessageInternal *)message {
+    if (self.inAppMessageDelegate &&
+        [self.inAppMessageDelegate respondsToSelector:@selector(onDidDisplayInAppMessage:)]) {
+        [self.inAppMessageDelegate onDidDisplayInAppMessage:message];
+    }
+}
+
+- (void)onWillDismissInAppMessage:(OSInAppMessageInternal *)message {
+    if (self.inAppMessageDelegate &&
+        [self.inAppMessageDelegate respondsToSelector:@selector(onWillDismissInAppMessage:)]) {
+        [self.inAppMessageDelegate onWillDismissInAppMessage:message];
+    }
+}
+
+- (void)onDidDismissInAppMessage:(OSInAppMessageInternal *)message {
+    if (self.inAppMessageDelegate &&
+        [self.inAppMessageDelegate respondsToSelector:@selector(onDidDismissInAppMessage:)]) {
+        [self.inAppMessageDelegate onDidDismissInAppMessage:message];
+    }
+}
+
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message {
     if (!message.variantId) {
         let errorMessage = [NSString stringWithFormat:@"Attempted to display a message with a nil variantId. Current preferred language is %@, supported message variants are %@", NSLocale.preferredLanguages, message.variants];

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -572,6 +572,14 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 #pragma mark OSInAppMessageViewControllerDelegate Methods
+- (void)messageViewControllerDidDisplay:(OSInAppMessageInternal *)message {
+    [self onDidDisplayInAppMessage:message];
+}
+
+- (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message {
+    [self onWillDismissInAppMessage:message];
+}
+
 - (void)messageViewControllerWasDismissed:(OSInAppMessageInternal *)message displayed:(BOOL)displayed {
     @synchronized (self.messageDisplayQueue) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Dismissing IAM and preparing to show next IAM"];
@@ -602,10 +610,6 @@ static BOOL _isInAppMessagingPaused = false;
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Stop evaluateMessageDisplayQueue because prompt is currently displayed"];
         }
     }
-}
-
-- (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message {
-    [self onWillDismissInAppMessage:message];
 }
 
 - (void)evaluateMessageDisplayQueue {
@@ -847,7 +851,6 @@ static BOOL _isInAppMessagingPaused = false;
     [self addKeySceneToWindow:self.window];
 
     [self.window makeKeyAndVisible];
-    [self onDidDisplayInAppMessage:message];
 }
 
 // Required to display if the app is using a Scene

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -229,8 +229,8 @@ static BOOL _isInAppMessagingPaused = false;
     self.actionClickBlock = actionClickBlock;
 }
 
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate>*)delegate {
-    self.inAppMessageDelegate = delegate;
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate {
+    _inAppMessageDelegate = delegate;
 }
 
 - (void)onWillDisplayInAppMessage:(OSInAppMessageInternal *)message {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -69,7 +69,7 @@
 // Click action block to allow overridden behavior when clicking an IAM
 @property (strong, nonatomic, nullable) OSInAppMessageClickBlock actionClickBlock;
 
-@property (weak, nonatomic, nullable) NSObject<OSInAppMessageDelegate> *inAppMessageDelegate;
+@property (weak, nonatomic, nullable) NSObject<OSInAppMessageLifecycleHandler> *inAppMessageDelegate;
 
 @property (strong, nullable) OSInAppMessageViewController *viewController;
 
@@ -229,7 +229,7 @@ static BOOL _isInAppMessagingPaused = false;
     self.actionClickBlock = actionClickBlock;
 }
 
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate {
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate {
     _inAppMessageDelegate = delegate;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -69,11 +69,13 @@
 // Click action block to allow overridden behavior when clicking an IAM
 @property (strong, nonatomic, nullable) OSInAppMessageClickBlock actionClickBlock;
 
+@property (weak, nonatomic, nullable) NSObject<OSInAppMessageDelegate> *inAppMessageDelegate;
+
 @property (strong, nullable) OSInAppMessageViewController *viewController;
 
 @property (nonatomic, readwrite) NSTimeInterval (^dateGenerator)(void);
 
-@property (nonatomic, nullable) NSObject<OSInAppMessagePrompt>*currentPromptAction;
+@property (nonatomic, nullable) NSObject<OSInAppMessagePrompt> *currentPromptAction;
 
 @property (nonatomic, nullable) NSArray<NSObject<OSInAppMessagePrompt> *> *currentPromptActions;
 
@@ -225,6 +227,10 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {
     self.actionClickBlock = actionClickBlock;
+}
+
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate>*)delegate {
+    self.inAppMessageDelegate = delegate;
 }
 
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message {
@@ -802,6 +808,7 @@ static BOOL _isInAppMessagingPaused = false;
     [self addKeySceneToWindow:self.window];
 
     [self.window makeKeyAndVisible];
+    // Did Display
 }
 
 // Required to display if the app is using a Scene

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -48,6 +48,7 @@ THE SOFTWARE.
 - (void)migrate {
     [self migrateToVersion_02_14_00_AndGreater];
     [self migrateIAMRedisplayCache];
+    [self migrateToOSInAppMessageInternal];
     [self saveCurrentSDKVersion];
 }
 
@@ -124,15 +125,19 @@ THE SOFTWARE.
         // Messages Array
         NSArray<OSInAppMessageInternal *> *messages = [OneSignalUserDefaults.initStandard getSavedCodeableDataForKey:OS_IAM_MESSAGES_ARRAY
                                                                                           defaultValue:[NSArray<OSInAppMessageInternal *> new]];
-        if (messages) {
+        if (messages && messages.count) {
             [NSKeyedArchiver setClassName:@"OSInAppMessageInternal" forClass:[OSInAppMessageInternal class]];
             [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_MESSAGES_ARRAY withValue:messages];
+        } else {
+            [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_MESSAGES_ARRAY withValue:nil];
         }
         
         // Redisplay Messages Dict
         NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages = [[NSMutableDictionary alloc] initWithDictionary:[OneSignalUserDefaults.initStandard getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:[NSMutableDictionary new]]];
-        if (redisplayedInAppMessages) {
+        if (redisplayedInAppMessages && redisplayedInAppMessages.count) {
             [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+        } else {
+            [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:nil];
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #import "OneSignalCommonDefines.h"
 #import "OSInAppMessagingDefines.h"
 #import "OneSignalHelper.h"
+#import "OSInAppMessageInternal.h"
 
 @interface OneSignal ()
 + (OSInfluenceDataRepository *)influenceDataRepository;
@@ -106,6 +107,32 @@ THE SOFTWARE.
             //Clear the cached redisplay dictionary of bad data
             [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY
                                                                     withValue:nil];
+        }
+    }
+}
+
+// OSInAppMessage has been made public
+// The old class has been renamed to OSInAppMessageInternal
+// We must set the new class name to the unarchiver to avoid crashing
+- (void)migrateToOSInAppMessageInternal {
+    let nameChangeVersion = 30700;
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    if (sdkVersion < nameChangeVersion) {
+        [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSInAppMessage from version: %ld", sdkVersion]];
+
+        [NSKeyedUnarchiver setClass:[OSInAppMessageInternal class] forClassName:@"OSInAppMessage"];
+        // Messages Array
+        NSArray<OSInAppMessageInternal *> *messages = [OneSignalUserDefaults.initStandard getSavedCodeableDataForKey:OS_IAM_MESSAGES_ARRAY
+                                                                                          defaultValue:[NSArray<OSInAppMessageInternal *> new]];
+        if (messages) {
+            [NSKeyedArchiver setClassName:@"OSInAppMessageInternal" forClass:[OSInAppMessageInternal class]];
+            [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_MESSAGES_ARRAY withValue:messages];
+        }
+        
+        // Redisplay Messages Dict
+        NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages = [[NSMutableDictionary alloc] initWithDictionary:[OneSignalUserDefaults.initStandard getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:[NSMutableDictionary new]]];
+        if (redisplayedInAppMessages) {
+            [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.h
@@ -26,7 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSDynamicTriggerController.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -46,9 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nonatomic) id<OSTriggerControllerDelegate> delegate;
 
-- (BOOL)messageMatchesTriggers:(OSInAppMessage *)message;
-- (BOOL)hasSharedTriggers:(OSInAppMessage *)message newTriggersKeys:(NSArray<NSString *> *)newTriggersKeys;
-- (BOOL)messageHasOnlyDynamicTriggers:(OSInAppMessage *)message;
+- (BOOL)messageMatchesTriggers:(OSInAppMessageInternal *)message;
+- (BOOL)hasSharedTriggers:(OSInAppMessageInternal *)message newTriggersKeys:(NSArray<NSString *> *)newTriggersKeys;
+- (BOOL)messageHasOnlyDynamicTriggers:(OSInAppMessageInternal *)message;
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers;
 - (void)removeTriggersForKeys:(NSArray<NSString *> *)keys;
 - (NSDictionary<NSString *, id> *)getTriggers;

--- a/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSTriggerController.m
@@ -81,7 +81,7 @@
  *
  * If trigger key is part of message triggers, then return true, otherwise false
  */
-- (BOOL)hasSharedTriggers:(OSInAppMessage *)message newTriggersKeys:(NSArray<NSString *> *)newTriggersKeys {
+- (BOOL)hasSharedTriggers:(OSInAppMessageInternal *)message newTriggersKeys:(NSArray<NSString *> *)newTriggersKeys {
     for (NSString *triggerKey in newTriggersKeys) {
         for (NSArray <OSTrigger *> *andConditions in message.triggers) {
             for (OSTrigger *trigger in andConditions) {
@@ -102,7 +102,7 @@
  *
  * If message has only dynamic trigger return true, otherwise false
  */
-- (BOOL)messageHasOnlyDynamicTriggers:(OSInAppMessage *)message {
+- (BOOL)messageHasOnlyDynamicTriggers:(OSInAppMessageInternal *)message {
     if (message.triggers == nil || message.triggers.count == 0)
         return false;
 
@@ -136,7 +136,7 @@
 
  Supports both String and Numeric value types & comparisons
  */
-- (BOOL)messageMatchesTriggers:(OSInAppMessage *)message {
+- (BOOL)messageMatchesTriggers:(OSInAppMessageInternal *)message {
     if (message.triggers.count == 0)
         return true;
     for (NSArray <OSTrigger *> *conditions in message.triggers) {
@@ -181,7 +181,7 @@
     return false;
 }
 
-- (BOOL)evaluateTrigger:(OSTrigger *)trigger forMessage:(OSInAppMessage *)message {
+- (BOOL)evaluateTrigger:(OSTrigger *)trigger forMessage:(OSInAppMessageInternal *)message {
     if (!self.triggers[trigger.property] && [trigger.kind isEqualToString:OS_DYNAMIC_TRIGGER_KIND_CUSTOM]) {
         // The value doesn't exist
         

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -208,6 +208,10 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 @protocol OSInAppMessageDelegate <NSObject>
 @optional
 - (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
+- (void)onWillDisplayInAppMessage:(NSString *)message;
+- (void)onDidDisplayInAppMessage:(NSString *)message;
+- (void)onWillDismissInAppMessage:(NSString *)message;
+- (void)onDidDismissInAppMessage:(NSString *)message;
 @end
 
 // Pass in nil means a notification will not display
@@ -472,6 +476,7 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
 + (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
 + (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
++ (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate;
 
 #pragma mark Post Notification
 + (void)postNotification:(NSDictionary* _Nonnull)jsonData;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -214,6 +214,10 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 @protocol OSInAppMessageDelegate <NSObject>
 @optional
 - (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
+@end
+
+@protocol OSInAppMessageLifecycleHandler <NSObject>
+@optional
 - (void)onWillDisplayInAppMessage:(OSInAppMessage *)message;
 - (void)onDidDisplayInAppMessage:(OSInAppMessage *)message;
 - (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
@@ -482,7 +486,7 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
 + (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
 + (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
-+ (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate;
++ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
 
 #pragma mark Post Notification
 + (void)postNotification:(NSDictionary* _Nonnull)jsonData;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -156,6 +156,12 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 
 @end;
 
+@interface OSInAppMessage : NSObject
+
+@property (strong, nonatomic, nonnull) NSString *messageId;
+
+@end
+
 @interface OSInAppMessageOutcome : NSObject
 
 @property (strong, nonatomic, nonnull) NSString *name;
@@ -208,10 +214,10 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 @protocol OSInAppMessageDelegate <NSObject>
 @optional
 - (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
-- (void)onWillDisplayInAppMessage:(NSString *)message;
-- (void)onDidDisplayInAppMessage:(NSString *)message;
-- (void)onWillDismissInAppMessage:(NSString *)message;
-- (void)onDidDismissInAppMessage:(NSString *)message;
+- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message;
+- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message;
+- (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
+- (void)onDidDismissInAppMessage:(OSInAppMessage *)message;
 @end
 
 // Pass in nil means a notification will not display

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -723,6 +723,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 
 + (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate; {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
+    [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -83,7 +83,7 @@
 #import "OSTrackerFactory.h"
 #import "OSMessagingController.h"
 #import "OSInAppMessageAction.h"
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 
 #import "OSUserState.h"
 #import "OSLocationState.h"
@@ -1974,7 +1974,7 @@ static dispatch_queue_t serialQueue;
 
     if (messagesJson) {
         for (NSDictionary *messageJson in messagesJson) {
-            let message = [OSInAppMessage instanceWithJson:messageJson];
+            let message = [OSInAppMessageInternal instanceWithJson:messageJson];
             if (message) {
                 [messages addObject:message];
             }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -3019,6 +3019,7 @@ static NSString *_lastnonActiveMessageId;
     injectToProperClass(@selector(onesignalSetApplicationIconBadgeNumber:), @selector(setApplicationIconBadgeNumber:), @[], [OneSignalAppDelegate class], [UIApplication class]);
     
     [self setupUNUserNotificationCenterDelegate];
+    [[OSMigrationController new] migrate];
     sessionLaunchTime = [NSDate date];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -721,6 +721,10 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
 }
 
++ (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate; {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
+}
+
 /*
  Called after setAppId and setLaunchOptions, depending on which one is called last (order does not matter)
  */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -721,7 +721,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
 }
 
-+ (void)setInAppMessageDelegate:(NSObject<OSInAppMessageDelegate> *_Nullable)delegate; {
++ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate; {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
     [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -402,7 +402,7 @@ OneSignalWebView *webVC;
     if (uuid) {
 
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"IAM Preview Detected, Begin Handling"];
-        OSInAppMessage *message = [OSInAppMessage instancePreviewFromNotification:notification];
+        OSInAppMessageInternal *message = [OSInAppMessageInternal instancePreviewFromNotification:notification];
         [[OSMessagingController sharedInstance] presentInAppPreviewMessage:message];
         return YES;
     }

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -29,7 +29,7 @@
 #import "OneSignal.h"
 #import "OneSignalUserDefaults.h"
 #import "OneSignalHelper.h"
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSTrigger.h"
 #import "OSTriggerController.h"
 #import "OSInAppMessagingDefines.h"
@@ -404,7 +404,7 @@
     [OneSignalClientOverrider reset:self];
 
     XCTAssertNotNil([[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId]);
-    OSInAppMessage *dismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
+    OSInAppMessageInternal *dismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
     let lastDisplayTime = dismissedMessage.displayStats.lastDisplayTime;
     XCTAssertEqual(1, dismissedMessage.displayStats.displayQuantity);
     XCTAssertEqual(firstInterval, lastDisplayTime);
@@ -432,7 +432,7 @@
     [OSMessagingControllerOverrider dismissCurrentMessage];
 
     XCTAssertNotNil([[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId]);
-    OSInAppMessage *secondDismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
+    OSInAppMessageInternal *secondDismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
     let secondLastDisplayTime = secondDismissedMessage.displayStats.lastDisplayTime;
     XCTAssertEqual(2, secondDismissedMessage.displayStats.displayQuantity);
     XCTAssertEqual(secondInterval, secondLastDisplayTime);
@@ -586,7 +586,7 @@
     NSCalendar* calendar = [NSCalendar currentCalendar];
     NSDate* date = [calendar dateFromComponents:comps];
     NSTimeInterval firstInterval = [date timeIntervalSince1970];
-    NSMutableDictionary <NSString *, OSInAppMessage *> *redisplayedInAppMessages = [NSMutableDictionary new];
+    NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages = [NSMutableDictionary new];
     [redisplayedInAppMessages setObject:message forKey:message.messageId];
     NSMutableSet <NSString *> *seenMessages = [NSMutableSet new];
     [seenMessages addObject:message.messageId];
@@ -664,7 +664,7 @@
 
     XCTAssertEqual(1, OSMessagingControllerOverrider.messagesForRedisplay.count);
 
-    OSInAppMessage *dismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
+    OSInAppMessageInternal *dismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
     let lastDisplayTime = dismissedMessage.displayStats.lastDisplayTime;
     XCTAssertEqual(1, dismissedMessage.displayStats.displayQuantity);
     XCTAssertEqual(firstInterval, lastDisplayTime);
@@ -686,7 +686,7 @@
     [OSMessagingControllerOverrider dismissCurrentMessage];
 
     XCTAssertNotNil([[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId]);
-    OSInAppMessage *secondDismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
+    OSInAppMessageInternal *secondDismissedMessage = [[OSMessagingControllerOverrider messagesForRedisplay] objectForKey:message.messageId];
     let secondLastDisplayTime = secondDismissedMessage.displayStats.lastDisplayTime;
     XCTAssertEqual(2, secondDismissedMessage.displayStats.displayQuantity);
     XCTAssertEqual(secondInterval, secondLastDisplayTime);
@@ -724,7 +724,7 @@
     let message2 = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]] withRedisplayLimit:limit delay:@(delay)];
     message2.displayStats.lastDisplayTime = firstInterval - maxCacheTime - 1;
 
-    NSMutableDictionary <NSString *, OSInAppMessage *> * redisplayedInAppMessages = [NSMutableDictionary new];
+    NSMutableDictionary <NSString *, OSInAppMessageInternal *> * redisplayedInAppMessages = [NSMutableDictionary new];
     [redisplayedInAppMessages setObject:message1 forKey:message1.messageId];
     [redisplayedInAppMessages setObject:message2 forKey:message2.messageId];
 
@@ -823,7 +823,7 @@
     action.clickType = @"button";
     action.clickId = @"test_action_id";
     
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "opened" API request
@@ -854,7 +854,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://api.onesignal.com/outcomes/measure");
@@ -889,7 +889,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://api.onesignal.com/outcomes/measure_sources");
@@ -929,7 +929,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestSendOutcomesV1ToServer class]));
@@ -964,7 +964,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://api.onesignal.com/outcomes/measure_sources");
@@ -984,7 +984,7 @@
 
     let firstTrigger = [OSTrigger customTriggerWithProperty:@"testProp" withOperator:OSTriggerOperatorTypeExists withValue:nil];
 
-    OSInAppMessage * message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
+    OSInAppMessageInternal * message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
 
     [self initOneSignalWithInAppMessage:message];
 
@@ -1027,7 +1027,7 @@
 
     let firstTrigger = [OSTrigger customTriggerWithProperty:@"testProp" withOperator:OSTriggerOperatorTypeExists withValue:nil];
 
-    OSInAppMessage * message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
+    OSInAppMessageInternal * message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
 
     [self initOneSignalWithInAppMessage:message];
 
@@ -1099,7 +1099,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestSendOutcomesV1ToServer class]));
@@ -1139,7 +1139,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // With unattributed outcomes disable no outcome request should happen
     XCTAssertNotEqual(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestSendOutcomesV1ToServer class]));
@@ -1167,7 +1167,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestSendOutcomesV1ToServer class]));
@@ -1203,7 +1203,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // The action should cause an "outcome" API request
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, @"https://api.onesignal.com/outcomes/measure_sources");
@@ -1246,7 +1246,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
 
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
      // Make sure all 3 sets of tags where send in 1 network call.
@@ -1277,7 +1277,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
      // Make sure all 3 sets of tags where send in 1 network call.
     [NSObjectOverrider runPendingSelectors];
@@ -1312,7 +1312,7 @@
     // the message should now be displayed
     // simulate a button press (action) on the inapp message
     let action = [OSInAppMessageAction instanceWithJson: actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
     [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
     // Make sure all 3 sets of tags where send in 1 network call.
     [NSObjectOverrider runPendingSelectors];
@@ -1337,7 +1337,7 @@
     NSMutableDictionary *actionJson = [OSInAppMessageTestHelper.testActionJson mutableCopy];
     actionJson[@"prompts"] = @[@"push"];
     let action = [OSInAppMessageAction instanceWithJson:actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
 
     XCTAssertEqual(1, action.promptActions.count);
     XCTAssertFalse(action.promptActions[0].hasPrompted);
@@ -1359,7 +1359,7 @@
     NSMutableDictionary *actionJson = [OSInAppMessageTestHelper.testActionJson mutableCopy];
     actionJson[@"prompts"] = @[@"location"];
     let action = [OSInAppMessageAction instanceWithJson:actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
 
     XCTAssertEqual(1, action.promptActions.count);
     XCTAssertFalse(action.promptActions[0].hasPrompted);
@@ -1381,7 +1381,7 @@
     NSMutableDictionary *actionJson = [OSInAppMessageTestHelper.testActionJson mutableCopy];
     actionJson[@"prompts"] = @[@"push", @"location"];
     let action = [OSInAppMessageAction instanceWithJson:actionJson];
-    let testMessage = [OSInAppMessage instanceWithJson:message];
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
 
     XCTAssertEqual(2, action.promptActions.count);
     XCTAssertFalse(action.promptActions[0].hasPrompted);
@@ -1452,7 +1452,7 @@
     
     let messageJson = [OSInAppMessageTestHelper testMessageJsonWithTriggerPropertyName:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withId:@"test_id1" withOperator:OSTriggerOperatorTypeLessThan withValue:@10.0];
     
-    let message = [OSInAppMessage instanceWithJson:messageJson];
+    let message = [OSInAppMessageInternal instanceWithJson:messageJson];
     
     [NSLocaleOverrider setPreferredLanguagesArray:@[@"es", @"en"]];
     
@@ -1497,7 +1497,7 @@
     
     let messageJson = [OSInAppMessageTestHelper testMessageJsonWithTriggerPropertyName:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withId:@"test_id1" withOperator:OSTriggerOperatorTypeLessThan withValue:@10.0];
     
-    let message = [OSInAppMessage instanceWithJson:messageJson];
+    let message = [OSInAppMessageInternal instanceWithJson:messageJson];
     
     [NSLocaleOverrider setPreferredLanguagesArray:@[@"kl"]]; //kl = klingon
 
@@ -1597,7 +1597,7 @@
  Helper method that adds an OSInAppMessage to the IAM messageDisplayQueue
  Mock response JSON and initializes the OneSignal SDK
  */
-- (void)initOneSignalWithInAppMessage:(OSInAppMessage *)message {
+- (void)initOneSignalWithInAppMessage:(OSInAppMessageInternal *)message {
     let registrationJson = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message.jsonRepresentation]];
     [self initOneSignalWithRegistrationJSON:registrationJson];
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -1601,7 +1601,7 @@
     [self initOneSignalWithInAppMessage:message];
     
     OSInAppMessageTestDelegate *iamDelegate = [OSInAppMessageTestDelegate new];
-    [OneSignal setInAppMessageDelegate:iamDelegate];
+    [OneSignal setInAppMessageLifecycleHandler:iamDelegate];
 
     XCTAssertEqual(0, OSMessagingControllerOverrider.messageDisplayQueue.count);
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -984,7 +984,7 @@
 
     let firstTrigger = [OSTrigger customTriggerWithProperty:@"testProp" withOperator:OSTriggerOperatorTypeExists withValue:nil];
 
-    OSInAppMessageInternal * message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
+    OSInAppMessageInternal *message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
 
     [self initOneSignalWithInAppMessage:message];
 
@@ -1027,7 +1027,7 @@
 
     let firstTrigger = [OSTrigger customTriggerWithProperty:@"testProp" withOperator:OSTriggerOperatorTypeExists withValue:nil];
 
-    OSInAppMessageInternal * message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
+    OSInAppMessageInternal *message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
 
     [self initOneSignalWithInAppMessage:message];
 
@@ -1591,6 +1591,50 @@
     XCTAssertEqual(OSMessagingControllerOverrider.messagesForRedisplay.count, 1);
     let secondDisplayQuantity = OSMessagingControllerOverrider.messagesForRedisplay.allValues[0].displayStats.displayQuantity;
     XCTAssertEqual(secondDisplayQuantity, 2);
+}
+
+- (void)testIAMLifecyleEventsFired {
+    let firstTrigger = [OSTrigger customTriggerWithProperty:@"testProp" withOperator:OSTriggerOperatorTypeExists withValue:nil];
+
+    OSInAppMessageInternal *message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]]];
+
+    [self initOneSignalWithInAppMessage:message];
+    
+    OSInAppMessageTestDelegate *iamDelegate = [OSInAppMessageTestDelegate new];
+    [OneSignal setInAppMessageDelegate:iamDelegate];
+
+    XCTAssertEqual(0, OSMessagingControllerOverrider.messageDisplayQueue.count);
+
+    XCTAssertNil(iamDelegate->lastMessageWillDisplay);
+    XCTAssertNil(iamDelegate->lastMessageDidDisplay);
+    XCTAssertNil(iamDelegate->lastMessageWillDismiss);
+    XCTAssertNil(iamDelegate->lastMessageDidDismiss);
+    [OneSignal addTrigger:@"testProp" withValue:@2];
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    [OSMessagingController.sharedInstance onWillDisplayInAppMessage:message];
+    XCTAssertNotNil(iamDelegate->lastMessageWillDisplay);
+    XCTAssertNil(iamDelegate->lastMessageDidDisplay);
+    XCTAssertNil(iamDelegate->lastMessageWillDismiss);
+    XCTAssertNil(iamDelegate->lastMessageDidDismiss);
+    
+    [OSMessagingController.sharedInstance onDidDisplayInAppMessage:message];
+    XCTAssertNotNil(iamDelegate->lastMessageWillDisplay);
+    XCTAssertNotNil(iamDelegate->lastMessageDidDisplay);
+    XCTAssertNil(iamDelegate->lastMessageWillDismiss);
+    XCTAssertNil(iamDelegate->lastMessageDidDismiss);
+    
+    [OSMessagingController.sharedInstance onWillDismissInAppMessage:message];
+    XCTAssertNotNil(iamDelegate->lastMessageWillDisplay);
+    XCTAssertNotNil(iamDelegate->lastMessageDidDisplay);
+    XCTAssertNotNil(iamDelegate->lastMessageWillDismiss);
+    XCTAssertNil(iamDelegate->lastMessageDidDismiss);
+    
+    [OSMessagingController.sharedInstance onDidDismissInAppMessage:message];
+    XCTAssertNotNil(iamDelegate->lastMessageWillDisplay);
+    XCTAssertNotNil(iamDelegate->lastMessageDidDisplay);
+    XCTAssertNotNil(iamDelegate->lastMessageWillDismiss);
+    XCTAssertNotNil(iamDelegate->lastMessageDidDismiss);
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingTests.m
@@ -29,7 +29,7 @@
 #import <XCTest/XCTest.h>
 #import "OneSignal.h"
 #import "OneSignalHelper.h"
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSTrigger.h"
 #import "OSTriggerController.h"
 #import "OSInAppMessagingDefines.h"
@@ -54,8 +54,8 @@
 @end
 
 @implementation InAppMessagingTests {
-    OSInAppMessage *testMessage;
-    OSInAppMessage *testMessageRedisplay;
+    OSInAppMessageInternal *testMessage;
+    OSInAppMessageInternal *testMessageRedisplay;
     OSInAppMessageAction *testAction;
     OSInAppMessageBridgeEvent *testBridgeEvent;
     OSInAppMessageBridgeEvent *testPageChangeEvent;
@@ -215,9 +215,9 @@ NSInteger const DELAY = 60;
 }
 
 - (void)testCorrectlyParsedHasLiquid {
-    OSInAppMessage *hasLiquidMessage = [OSInAppMessageTestHelper testMessageWithLiquid];
+    OSInAppMessageInternal *hasLiquidMessage = [OSInAppMessageTestHelper testMessageWithLiquid];
     XCTAssertTrue(hasLiquidMessage.hasLiquid);
-    OSInAppMessage *noLiquidMessage = [OSInAppMessageTestHelper testMessage];
+    OSInAppMessageInternal *noLiquidMessage = [OSInAppMessageTestHelper testMessage];
     XCTAssertFalse(noLiquidMessage.hasLiquid);
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
@@ -288,6 +288,40 @@
     XCTAssertNil(retrievedDict);
 }
 
+- (void)testIAMToInternalMigration {
+    let limit = 5;
+    let delay = 60;
+    let message = [OSInAppMessageTestHelper testMessageWithRedisplayLimit:limit delay:@(delay)];
+    message.isDisplayedInSession = true;
+    
+    // Cached Messages
+    NSArray<OSInAppMessageInternal *> *messages = [[NSArray alloc] initWithObjects:message, nil];
+    
+    [NSKeyedArchiver setClassName:@"OSInAppMessage" forClass:[OSInAppMessageInternal class]];
+    
+    [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_MESSAGES_ARRAY withValue:messages];
+    
+    [migrationController migrate];
+    
+    NSArray<OSInAppMessageInternal *>*retrievedArray = [OneSignalUserDefaults.initStandard
+                                                                getSavedCodeableDataForKey:OS_IAM_MESSAGES_ARRAY defaultValue:nil];
+    XCTAssertEqualObjects(messages, retrievedArray);
+    
+    // Cached Redisplay Messages
+    NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages = [NSMutableDictionary new];
+    [redisplayedInAppMessages setObject:message forKey:message.messageId];
+    
+    [NSKeyedArchiver setClassName:@"OSInAppMessage" forClass:[OSInAppMessageInternal class]];
+    
+    [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
+    
+    [migrationController migrate];
+    
+    NSDictionary<NSString *, OSInAppMessageInternal *>*retrievedDict = [OneSignalUserDefaults.initStandard
+                                                                getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
+    XCTAssertEqualObjects(redisplayedInAppMessages, retrievedDict);
+}
+
 
 
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
@@ -39,7 +39,7 @@
 #import "OneSignalCommonDefines.h"
 #import "OSInAppMessagingDefines.h"
 #import "OneSignalUserDefaults.h"
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSInAppMessagingHelpers.h"
 #import "CommonAsserts.h"
   
@@ -242,20 +242,20 @@
 }
 
 - (void)testIAMCachedEmptyDictionaryToCachedCodeableMigration {
-    NSDictionary<NSString *, OSInAppMessage *>*emptyDict = [NSMutableDictionary new];
+    NSDictionary<NSString *, OSInAppMessageInternal *>*emptyDict = [NSMutableDictionary new];
     [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:emptyDict];
     
     [migrationController migrate];
 }
 
 - (void)testIAMCachedDictionaryToCachedCodeableMigration {
-    NSMutableDictionary <NSString *, OSInAppMessage *> *emptyDict = [NSMutableDictionary new];
+    NSMutableDictionary <NSString *, OSInAppMessageInternal *> *emptyDict = [NSMutableDictionary new];
     
     [OneSignalUserDefaults.initStandard saveDictionaryForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:emptyDict];
     
     [migrationController migrate];
     
-    NSDictionary<NSString *, OSInAppMessage *>*retrievedDict = [OneSignalUserDefaults.initStandard
+    NSDictionary<NSString *, OSInAppMessageInternal *>*retrievedDict = [OneSignalUserDefaults.initStandard
                                                                 getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
     XCTAssertEqualObjects(emptyDict, retrievedDict);
 }
@@ -265,14 +265,14 @@
     let delay = 60;
     let message = [OSInAppMessageTestHelper testMessageWithRedisplayLimit:limit delay:@(delay)];
     message.isDisplayedInSession = true;
-    NSMutableDictionary <NSString *, OSInAppMessage *> *redisplayedInAppMessages = [NSMutableDictionary new];
+    NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages = [NSMutableDictionary new];
     [redisplayedInAppMessages setObject:message forKey:message.messageId];
     
     [OneSignalUserDefaults.initStandard saveCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY withValue:redisplayedInAppMessages];
     
     [migrationController migrate];
     
-    NSDictionary<NSString *, OSInAppMessage *>*retrievedDict = [OneSignalUserDefaults.initStandard
+    NSDictionary<NSString *, OSInAppMessageInternal *>*retrievedDict = [OneSignalUserDefaults.initStandard
                                                                 getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
     XCTAssertEqualObjects(redisplayedInAppMessages, retrievedDict);
 }
@@ -283,7 +283,7 @@
     
     [migrationController migrate];
     
-    NSDictionary<NSString *, OSInAppMessage *>*retrievedDict = [OneSignalUserDefaults.initStandard
+    NSDictionary<NSString *, OSInAppMessageInternal *>*retrievedDict = [OneSignalUserDefaults.initStandard
                                                                 getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
     XCTAssertNil(retrievedDict);
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import "OSTrigger.h"
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSMessagingController.h"
 
 #define OS_TEST_MESSAGE_ID @"a4b3gj7f-d8cc-11e4-bed1-df8f05be55ba"
@@ -53,14 +53,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OSInAppMessageTestHelper : NSObject
 + (NSDictionary *)testActionJson;
-+ (OSInAppMessage *)testMessageWithTriggersJson:(NSArray<NSDictionary *> *)triggers;
-+ (OSInAppMessage *)testMessageWithTriggersJson:(NSArray *)triggers redisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
-+ (OSInAppMessage *)testMessage;
-+ (OSInAppMessage *)testMessageWithLiquid;
-+ (OSInAppMessage *)testMessageWithRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
-+ (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers;
-+ (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
-+ (OSInAppMessage *)testMessageWithPastEndTime:(BOOL)pastEndTime;
++ (OSInAppMessageInternal *)testMessageWithTriggersJson:(NSArray<NSDictionary *> *)triggers;
++ (OSInAppMessageInternal *)testMessageWithTriggersJson:(NSArray *)triggers redisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
++ (OSInAppMessageInternal *)testMessage;
++ (OSInAppMessageInternal *)testMessageWithLiquid;
++ (OSInAppMessageInternal *)testMessageWithRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
++ (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers;
++ (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
++ (OSInAppMessageInternal *)testMessageWithPastEndTime:(BOOL)pastEndTime;
 + (NSDictionary *)testRegistrationJsonWithMessages:(NSArray<NSDictionary *> *)messages;
 + (NSDictionary *)testMessageJsonWithTriggerPropertyName:(NSString *)property withId:(NSString *)triggerId withOperator:(OSTriggerOperatorType)type withValue:(id)value;
 + (NSDictionary*)testInAppMessageGetContainsWithHTML:(NSString *)html;

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
@@ -151,17 +151,17 @@ int messageIdIncrementer = 0;
     };
 }
 
-+ (OSInAppMessage *)testMessageWithTriggersJson:(NSArray *)triggers {
++ (OSInAppMessageInternal *)testMessageWithTriggersJson:(NSArray *)triggers {
     let messageJson = (NSMutableDictionary *)[self.testMessageJson mutableCopy];
     
     messageJson[@"triggers"] = triggers;
     
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
     
-    return [OSInAppMessage instanceWithData:data];
+    return [OSInAppMessageInternal instanceWithData:data];
 }
 
-+ (OSInAppMessage *)testMessageWithTriggersJson:(NSArray *)triggers redisplayLimit:(NSInteger)limit delay:(NSNumber *)delay {
++ (OSInAppMessageInternal *)testMessageWithTriggersJson:(NSArray *)triggers redisplayLimit:(NSInteger)limit delay:(NSNumber *)delay {
     let messageJson = (NSMutableDictionary *)[self.testMessageJson mutableCopy];
 
     messageJson[@"triggers"] = triggers;
@@ -173,26 +173,26 @@ int messageIdIncrementer = 0;
 
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
 
-    return [OSInAppMessage instanceWithData:data];
+    return [OSInAppMessageInternal instanceWithData:data];
 }
 
-+ (OSInAppMessage *)testMessage {
++ (OSInAppMessageInternal *)testMessage {
     let messageJson = self.testMessageJson;
     
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
 
-    return [OSInAppMessage instanceWithData:data];
+    return [OSInAppMessageInternal instanceWithData:data];
 }
 
-+ (OSInAppMessage *)testMessageWithLiquid {
++ (OSInAppMessageInternal *)testMessageWithLiquid {
     let messageJson = self.testMessageJsonLiquid;
     
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
 
-    return [OSInAppMessage instanceWithData:data];
+    return [OSInAppMessageInternal instanceWithData:data];
 }
 
-+ (OSInAppMessage *)testMessageWithPastEndTime:(BOOL)pastEndTime {
++ (OSInAppMessageInternal *)testMessageWithPastEndTime:(BOOL)pastEndTime {
     let messageJson = self.testMessageJson;
     
     NSMutableDictionary *messageJsonWithEndTime = [[NSMutableDictionary alloc] initWithDictionary:messageJson];
@@ -203,15 +203,15 @@ int messageIdIncrementer = 0;
     }
     let data = [NSJSONSerialization dataWithJSONObject:messageJsonWithEndTime options:0 error:nil];
 
-    return [OSInAppMessage instanceWithData:data];
+    return [OSInAppMessageInternal instanceWithData:data];
 }
 
-+ (OSInAppMessage *)testMessageWithRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay {
++ (OSInAppMessageInternal *)testMessageWithRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay {
      let messageJson = self.testMessageJsonRedisplay;
 
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
 
-    let message = [OSInAppMessage instanceWithData:data];
+    let message = [OSInAppMessageInternal instanceWithData:data];
 
     message.displayStats.displayLimit = limit;
     message.displayStats.displayDelay = [delay doubleValue];
@@ -219,24 +219,24 @@ int messageIdIncrementer = 0;
     return message;
 }
 
-+ (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers {
++ (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers {
     let messageJson = self.testMessageJson;
     
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
     
-    let message = [OSInAppMessage instanceWithData:data];
+    let message = [OSInAppMessageInternal instanceWithData:data];
     
     message.triggers = triggers;
     
     return message;
 }
 
-+ (OSInAppMessage *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay {
++ (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay {
     let messageJson = self.testMessageJsonRedisplay;
 
     let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
 
-    let message = [OSInAppMessage instanceWithData:data];
+    let message = [OSInAppMessageInternal instanceWithData:data];
 
     message.displayStats.displayLimit = limit;
     message.displayStats.displayDelay = [delay doubleValue];
@@ -286,8 +286,8 @@ int messageIdIncrementer = 0;
 // which is normally private
 @interface OSMessagingController (Testing)
 @property (strong, nonatomic, nonnull) OSTriggerController *triggerController;
-@property (strong, nonatomic, nonnull) NSArray <OSInAppMessage *> *messages;
-@property (strong, nonatomic, nonnull) NSMutableArray <OSInAppMessage *> *messageDisplayQueue;
+@property (strong, nonatomic, nonnull) NSArray <OSInAppMessageInternal *> *messages;
+@property (strong, nonatomic, nonnull) NSMutableArray <OSInAppMessageInternal *> *messageDisplayQueue;
 @end
 
 @implementation OSMessagingController (Testing)

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
@@ -26,7 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessage.h"
+#import "OSInAppMessageInternal.h"
 #import "OSMessagingController.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -34,25 +34,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OSMessagingControllerOverrider : NSObject
 
 + (void)dismissCurrentMessage;
-+ (void)setMessagesForRedisplay:(NSMutableDictionary <NSString *, OSInAppMessage *> *)messagesForRedisplay;
++ (void)setMessagesForRedisplay:(NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)messagesForRedisplay;
 + (void)setSeenMessages:(NSMutableSet <NSString *> *)seenMessages;
 + (void)setMockDateGenerator:(NSTimeInterval(^)(void))testDateGenerator;
 + (BOOL)isInAppMessageShowing;
-+ (NSArray <OSInAppMessage *> *)messageDisplayQueue;
-+ (NSMutableDictionary <NSString *, OSInAppMessage *> *)messagesForRedisplay;
++ (NSArray <OSInAppMessageInternal *> *)messageDisplayQueue;
++ (NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)messagesForRedisplay;
 
 @end
 
 @interface OSMessagingController (Tests)
 
 - (void)resetState;
-- (void)messageViewDidSelectAction:(OSInAppMessage *)message withAction:(OSInAppMessageAction *)action;
-- (void)persistInAppMessageForRedisplay:(OSInAppMessage *)message;
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
+- (void)persistInAppMessageForRedisplay:(OSInAppMessageInternal *)message;
 - (void)messageViewControllerWasDismissed;
 - (void)setLastTimeGenerator:(NSTimeInterval(^)(void))dateGenerator;
-- (NSArray<OSInAppMessage *> *)getInAppMessages;
-- (NSMutableDictionary <NSString *, OSInAppMessage *> *)getRedisplayedInAppMessages;
-- (NSMutableArray<OSInAppMessage *> *)getDisplayedMessages;
+- (NSArray<OSInAppMessageInternal *> *)getInAppMessages;
+- (NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)getRedisplayedInAppMessages;
+- (NSMutableArray<OSInAppMessageInternal *> *)getDisplayedMessages;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
@@ -53,7 +53,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<OSInAppMessageInternal *> *)getInAppMessages;
 - (NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)getRedisplayedInAppMessages;
 - (NSMutableArray<OSInAppMessageInternal *> *)getDisplayedMessages;
-
+- (void)onWillDisplayInAppMessage:(OSInAppMessageInternal *)message;
+- (void)onDidDisplayInAppMessage:(OSInAppMessageInternal *)message;
+- (void)onWillDismissInAppMessage:(OSInAppMessageInternal *)message;
+- (void)onDidDismissInAppMessage:(OSInAppMessageInternal *)message;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
@@ -38,11 +38,11 @@
 
 // The displayMessage method is private, we'll expose it here
 @interface OSMessagingController ()
-@property (strong, nonatomic, nonnull) NSArray <OSInAppMessage *> *messages;
+@property (strong, nonatomic, nonnull) NSArray <OSInAppMessageInternal *> *messages;
 @property (strong, nonatomic, nonnull) OSTriggerController *triggerController;
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *seenInAppMessages;
-@property (strong, nonatomic, nonnull) NSMutableArray <OSInAppMessage *> *messageDisplayQueue;
-@property (strong, nonatomic, nonnull) NSMutableDictionary <NSString *, OSInAppMessage *> *redisplayedInAppMessages;
+@property (strong, nonatomic, nonnull) NSMutableArray <OSInAppMessageInternal *> *messageDisplayQueue;
+@property (strong, nonatomic, nonnull) NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages;
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *clickedClickIds;
 @property (nonatomic, readwrite) NSTimeInterval (^dateGenerator)(void);
 @property (nonatomic, nullable) NSObject<OSInAppMessagePrompt>*currentPromptAction;
@@ -68,15 +68,15 @@
     self.dateGenerator = dateGenerator;
 }
 
-- (NSArray<OSInAppMessage *> *)getInAppMessages {
+- (NSArray<OSInAppMessageInternal *> *)getInAppMessages {
     return self.messages;
 }
 
-- (NSMutableDictionary <NSString *, OSInAppMessage *> *)getRedisplayedInAppMessages {
+- (NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)getRedisplayedInAppMessages {
     return self.redisplayedInAppMessages;
 }
 
-- (NSMutableArray<OSInAppMessage *> *)getDisplayedMessages {
+- (NSMutableArray<OSInAppMessageInternal *> *)getDisplayedMessages {
     return self.messageDisplayQueue;
 }
 
@@ -92,7 +92,7 @@
     #pragma clang diagnostic pop
 }
 
-- (void)overrideShowMessage:(OSInAppMessage *)message {
+- (void)overrideShowMessage:(OSInAppMessageInternal *)message {
     dispatch_async(dispatch_get_main_queue(), ^{
         let viewController = [[OSInAppMessageViewController alloc] initWithMessage:message delegate:OSMessagingController.self];
         [viewController viewDidLoad];
@@ -100,7 +100,7 @@
     });
 }
 
-- (void)overrideWebViewContentFinishedLoading:(OSInAppMessage *)message {
+- (void)overrideWebViewContentFinishedLoading:(OSInAppMessageInternal *)message {
     if (message) {
         [OSMessagingController.sharedInstance messageViewImpressionRequest:message];
     }
@@ -118,11 +118,11 @@
     return [OSMessagingController.sharedInstance getDisplayedMessages];
 }
 
-+ (NSMutableDictionary <NSString *, OSInAppMessage *> *)messagesForRedisplay {
++ (NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)messagesForRedisplay {
     return [OSMessagingController.sharedInstance getRedisplayedInAppMessages];
 }
 
-+ (void)setMessagesForRedisplay:(NSMutableDictionary <NSString *, OSInAppMessage *> *)messagesForRedisplay {
++ (void)setMessagesForRedisplay:(NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)messagesForRedisplay {
     [OSMessagingController.sharedInstance setRedisplayedInAppMessages:messagesForRedisplay];
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -123,4 +123,12 @@ withNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundB
 - (void)onOSSMSSubscriptionChanged:(OSSMSSubscriptionStateChanges *)stateChanges;
 @end
 
+@interface OSInAppMessageTestDelegate : NSObject<OSInAppMessageDelegate> {
+    @package OSInAppMessage *lastMessageWillDisplay;
+    @package OSInAppMessage *lastMessageDidDisplay;
+    @package OSInAppMessage *lastMessageWillDismiss;
+    @package OSInAppMessage *lastMessageDidDismiss;
+}
+@end
+
 // END - Observers

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -123,7 +123,7 @@ withNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundB
 - (void)onOSSMSSubscriptionChanged:(OSSMSSubscriptionStateChanges *)stateChanges;
 @end
 
-@interface OSInAppMessageTestDelegate : NSObject<OSInAppMessageDelegate> {
+@interface OSInAppMessageTestDelegate : NSObject<OSInAppMessageLifecycleHandler> {
     @package OSInAppMessage *lastMessageWillDisplay;
     @package OSInAppMessage *lastMessageDidDisplay;
     @package OSInAppMessage *lastMessageWillDismiss;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -480,3 +480,21 @@ static XCTestCase* _currentXCTestCase;
     fireCount++;
 }
 @end
+
+@implementation OSInAppMessageTestDelegate
+- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message {
+    lastMessageWillDisplay = message;
+}
+
+- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message {
+    lastMessageDidDisplay = message;
+}
+
+- (void)onWillDismissInAppMessage:(OSInAppMessage *)message {
+    lastMessageWillDismiss = message;
+}
+
+- (void)onDidDismissInAppMessage:(OSInAppMessage *)message {
+    lastMessageDidDismiss = message;
+}
+@end


### PR DESCRIPTION
This PR adds the `OSInAppMessageLifecycleHandler` protocol with the following lifecycle methods:
```
- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message;
- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message;
- (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
- (void)onDidDismissInAppMessage:(OSInAppMessage *)message;
```

And adds the public setter method `setInAppMessageLifecycleHandler`

These methods should each be called once per display of an In App Message.

The InAppMessageDelegate was exposed in the public header with the method 
`- (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action`
But it appears to never be called. I am leaving it in case it is erroneously being used by a consumer application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/977)
<!-- Reviewable:end -->
