### PR TITLE
Register User Thread Safety Improvement - For 2.x.x branch

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1610,12 +1610,6 @@ static BOOL isOnSessionSuccessfulForCurrentState = false;
     [OneSignalHelper performSelector:@selector(registerUser) onMainThreadOnObject:self withObject:nil afterDelay:reattemptRegistrationInterval];
 }
 
-static dispatch_queue_t serialQueue;
-
-+ (dispatch_queue_t) getRegisterQueue {
-    return serialQueue;
-}
-
 + (void)registerUser {
     // return if the user has not granted privacy permissions
     if ([self shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
@@ -1631,13 +1625,12 @@ static dispatch_queue_t serialQueue;
 
 +(void)registerUserNow {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"registerUserNow"];
-
-    if (!serialQueue)
-        serialQueue = dispatch_queue_create("com.onesignal.regiseruser", DISPATCH_QUEUE_SERIAL);
     
-    dispatch_async(serialQueue, ^{
+    // Run on the main queue as it is possible for this to be called from multiple queues.
+    // Also some of the code in the method is not thread safe such as _outcomeEventsController.
+    [OneSignalHelper dispatch_async_on_main_queue:^{
         [self registerUserInternal];
-     });
+    }];
 }
 
 // We should delay registration if we are waiting on APNS

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -62,7 +62,6 @@ NSString * serverUrlWithPath(NSString *path);
 
 // Expose OneSignal test methods
 @interface OneSignal (UN_extra)
-+ (dispatch_queue_t) getRegisterQueue;
 + (void)setDelayIntervals:(NSTimeInterval)apnsMaxWait withRegistrationDelay:(NSTimeInterval)registrationDelay;
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -88,10 +88,6 @@ static XCTestCase* _currentXCTestCase;
         if (notifSettingsQueue)
             dispatch_sync(notifSettingsQueue, ^{});
         
-        registerUserQueue = [OneSignal getRegisterQueue];
-        if (registerUserQueue)
-            dispatch_sync(registerUserQueue, ^{});
-        
         [OneSignalClientOverrider runBackgroundThreads];
         
         [UNUserNotificationCenterOverrider runBackgroundThreads];


### PR DESCRIPTION
## Summary
`registerUserInternal is called from a different dispatch queue that does not run on the main thread. From the queue we access objects that can have a race condition with pointer changing, resulting in a dangling pointer which results in crashes with accessing deallocated memory. See [Apple's Investigating Crashes for Zombie Objects](https://developer.apple.com/documentation/xcode/investigating-crashes-for-zombie-objects) docs for more details on this concept.

This queue has been in the iOS SDK for a number of years, however more things have been added to `registerUserInternal` over the years which adds to surface area of race condition issues.

## Changes
The background queue named "com.onesignal.regiseruser" has been removed since there is a number of objects that are accessed in `registerUserInternal` that are not completely thread safe, such as `_outcomeEventsController`. Instead we enforce `registerUserNow` to call `registerUserInternal` on the main thread as `registerUserNow` has multiple entries points, some from other background dispatch queues.

## Crash Stacktrace
This crash isn't reproducible but a received crash report that this PR is expecting to fix.
```
Crashed: com.onesignal.regiseruser
0  libobjc.A.dylib                0x1a97721c8 objc_msgSend + 8
1  UnityFramework                 0x105f10c68 -[OSOutcomeEventsFactory checkVersionChanged] + 62 (OSOutcomeEventsFactory.m:62)
2  UnityFramework                 0x105f10bcc -[OSOutcomeEventsFactory repository] + 56 (OSOutcomeEventsFactory.m:56)
3  UnityFramework                 0x105f1e97c -[OneSignalOutcomeEventsController saveUnattributedUniqueOutcomeEvents] + 287 (OneSignalOutcomeEventsController.m:287)
4  UnityFramework                 0x105efae0c +[OneSignal registerUserInternal] + 1672 (OneSignal.m:1672)
5  libdispatch.dylib              0x194879a84 _dispatch_call_block_and_release + 32
6  libdispatch.dylib              0x19487b81c _dispatch_client_callout + 20
7  libdispatch.dylib              0x194883004 _dispatch_lane_serial_drain + 620
8  libdispatch.dylib              0x194883c00 _dispatch_lane_invoke + 404
9  libdispatch.dylib              0x19488e4bc _dispatch_workloop_worker_thread + 764
10 libsystem_pthread.dylib        0x1e08fe7a4 _pthread_wqthread + 276
11 libsystem_pthread.dylib        0x1e090574c start_wqthread + 8
```


## Testing
* Ensured unit tests passed locally on a 12.4 simulator
* Tested on a iOS 14.14.1 on an iPhone 6s, tested offline and online both clean installs and app restarts with new sessions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/979)
<!-- Reviewable:end -->
