### PR TITLE
Register User Thread Safety Improvement

### DIFF
--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.h
@@ -83,7 +83,6 @@ withNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundB
 
 // Expose OneSignal test methods
 @interface OneSignal (UN_extra)
-+ (dispatch_queue_t) getRegisterQueue;
 + (void)setDelayIntervals:(NSTimeInterval)apnsMaxWait withRegistrationDelay:(NSTimeInterval)registrationDelay;
 @end
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -182,17 +182,13 @@ static XCTestCase* _currentXCTestCase;
 
 + (void)runThreadsOnEachQueue {
     // the httpQueue makes sure all HTTP request mocks are sync'ed
-    dispatch_queue_t registerUserQueue, notifSettingsQueue;
+    dispatch_queue_t notifSettingsQueue;
     
     [OneSignalHelperOverrider runBackgroundThreads];
     
     notifSettingsQueue = [OneSignalNotificationSettingsIOS10 getQueue];
     if (notifSettingsQueue)
         dispatch_sync(notifSettingsQueue, ^{});
-    
-    registerUserQueue = [OneSignal getRegisterQueue];
-    if (registerUserQueue)
-        dispatch_sync(registerUserQueue, ^{});
     
     [OneSignalClientOverrider runBackgroundThreads];
     


### PR DESCRIPTION
## Summary
`registerUserInternal` is called from a different dispatch queue that does not run on the main thread. From the queue we access objects that can have a race condition with pointer changing, resulting in a dangling pointer which results in crashes with accessing deallocated memory. See [Apple's Investigating Crashes for Zombie Objects](https://developer.apple.com/documentation/xcode/investigating-crashes-for-zombie-objects) docs for more details on this concept.

This queue has been in the iOS SDK for a number of years, however more things have been added to `registerUserInternal` over the years which adds to surface area of race condition issues.

## Changes
The background queue named "com.onesignal.regiseruser" has been removed since there is a number of objects that are accessed in `registerUserInternal` that are not completely thread safe, such as `_outcomeEventsController`. Instead we enforce `registerUserNow` to call `registerUserInternal` on the main thread as `registerUserNow` has multiple entries points, some from other background dispatch queues.

## Crash Stacktrace
This crash isn't reproducible but a received crash report that this PR is expecting to fix.
```
Crashed: com.onesignal.regiseruser
0  libobjc.A.dylib                0x1a97721c8 objc_msgSend + 8
1  UnityFramework                 0x105f10c68 -[OSOutcomeEventsFactory checkVersionChanged] + 62 (OSOutcomeEventsFactory.m:62)
2  UnityFramework                 0x105f10bcc -[OSOutcomeEventsFactory repository] + 56 (OSOutcomeEventsFactory.m:56)
3  UnityFramework                 0x105f1e97c -[OneSignalOutcomeEventsController saveUnattributedUniqueOutcomeEvents] + 287 (OneSignalOutcomeEventsController.m:287)
4  UnityFramework                 0x105efae0c +[OneSignal registerUserInternal] + 1672 (OneSignal.m:1672)
5  libdispatch.dylib              0x194879a84 _dispatch_call_block_and_release + 32
6  libdispatch.dylib              0x19487b81c _dispatch_client_callout + 20
7  libdispatch.dylib              0x194883004 _dispatch_lane_serial_drain + 620
8  libdispatch.dylib              0x194883c00 _dispatch_lane_invoke + 404
9  libdispatch.dylib              0x19488e4bc _dispatch_workloop_worker_thread + 764
10 libsystem_pthread.dylib        0x1e08fe7a4 _pthread_wqthread + 276
11 libsystem_pthread.dylib        0x1e090574c start_wqthread + 8
```


## Testing
* Ran unit tests locally with iOS 14.5 on Xcode 12.5.1
* Tested on a iOS 14.14.1 on an iPhone 6s, tested offline and online both clean installs and app restarts with new sessions.

## Related
Same as PR #979 but for main instead of a backport.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/981)
<!-- Reviewable:end -->
