### PR TITLE
Enable Transparent IAM backgrounds

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -111,7 +111,8 @@
     
     // Setup WebView, delegates, and disable scrolling inside of the WebView
     self.webView = [[WKWebView alloc] initWithFrame:mainBounds configuration:configuration];
-    
+    self.webView.backgroundColor = [UIColor clearColor];
+    self.webView.opaque = NO;
     [self addSubview:self.webView];
     
     [self layoutIfNeeded];


### PR DESCRIPTION
In order to support transparent IAM backgrounds we must set the WebView to not opaque and set the background color to clear. We are always doing this since the HTML will set its own background color unless it is specified as clear by the IAM's creator (part of new advanced IAM functionality)