### PR TITLE
Guarantee that messageView is a subview of OSInAppMessageViewController

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -280,6 +280,11 @@
 - (void)addConstraintsForMessage {
     [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"Setting up In-App Message Constraints"];
     
+    if (![self.view.subviews containsObject:self.messageView]) {
+        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"addConstraintsForMessage: messageView is not a subview of OSInAppMessageViewController"];
+        [self.view addSubview:self.messageView];
+    }
+    
     // Initialize the anchors that describe the edges of the view, such as the top, bottom, etc.
     NSLayoutAnchor *top = self.view.topAnchor,
                    *bottom = self.view.bottomAnchor,


### PR DESCRIPTION
There is swiftUI crash where `addConstraintsForMessage` can be called without `messageView` being a subview of OSInAppMessageViewController's view.  This is likely happening because `viewWillTransitionToSize` is being called before `setupInitialMessageUI`. Neither the crash reporters nor OneSignal have been able to reproduce the crash, but it is safe to always add `messageView` as a subview if it is not already.

Fixes #819 