### PR TITLE
fixing XCFramework podspec

### DIFF
--- a/OneSignalXCFramework.podspec
+++ b/OneSignalXCFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OneSignalXCFramework"
     s.version          = "3.7.0"
-r    s.summary          = "OneSignal push notification library for mobile apps."
+    s.summary          = "OneSignal push notification library for mobile apps."
     s.homepage         = "https://onesignal.com"
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { "Joseph Kalash" => "joseph@onesignal.com", "Josh Kasten" => "josh@onesignal.com" , "Brad Hesse" => "brad@onesignal.com"}


### PR DESCRIPTION
typo in XCFramework podspec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/988)
<!-- Reviewable:end -->
