### PR TITLE
Don't wait for push prompt to register user

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1631,18 +1631,10 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     let isPushTokenDifferent = ![deviceToken isEqualToString:self.currentSubscriptionState.pushToken];
     self.currentSubscriptionState.pushToken = deviceToken;
 
-    // iOS 9+ - We get a token right away but give the user 30 sec to respond notification permission prompt.
-    // The goal is to only have 1 server call.
-    [self.osNotificationSettings getNotificationPermissionState:^(OSPermissionState *status) {
-        if (status.answeredPrompt || status.provisional) {
-            if ([self shouldRegisterNow])
-                [self registerUser];
-            else if (isPushTokenDifferent)
-                [self playerPutForPushTokenAndNotificationTypes];
-        } else {
-            [self registerUserAfterDelay];
-        }
-    }];
+    if ([self shouldRegisterNow])
+        [self registerUser];
+    else if (isPushTokenDifferent)
+        [self playerPutForPushTokenAndNotificationTypes];
 }
 
 + (void)playerPutForPushTokenAndNotificationTypes {

--- a/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
@@ -257,7 +257,7 @@
     
     NSDictionary<NSString *, OSInAppMessageInternal *>*retrievedDict = [OneSignalUserDefaults.initStandard
                                                                 getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
-    XCTAssertEqualObjects(emptyDict, retrievedDict);
+    XCTAssertEqualObjects(nil, retrievedDict);
 }
 
 - (void)testIAMCachedCodeableMigration {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.m
@@ -36,10 +36,15 @@
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wundeclared-selector"
     injectToProperClass(@selector(overrideAnimateAppearance), @selector(animateAppearance), @[], [OSInAppMessageViewControllerOverrider class], [OSInAppMessageViewController class]);
+    injectToProperClass(@selector(overrideAnimateAppearance:), @selector(animateAppearance:), @[], [OSInAppMessageViewControllerOverrider class], [OSInAppMessageViewController class]);
     #pragma clang diagnostic pop
 }
 
 - (void)overrideAnimateAppearance {
+    
+}
+
+- (void)overrideAnimateAppearance:(BOOL)firstDisplay {
     
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resetState;
 - (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
 - (void)persistInAppMessageForRedisplay:(OSInAppMessageInternal *)message;
-- (void)messageViewControllerWasDismissed;
+- (void)messageViewControllerWasDismissed:(OSInAppMessageInternal *)message displayed:(BOOL)displayed;
 - (void)setLastTimeGenerator:(NSTimeInterval(^)(void))dateGenerator;
 - (NSArray<OSInAppMessageInternal *> *)getInAppMessages;
 - (NSMutableDictionary <NSString *, OSInAppMessageInternal *> *)getRedisplayedInAppMessages;

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
@@ -94,7 +94,7 @@
 
 - (void)overrideShowMessage:(OSInAppMessageInternal *)message {
     dispatch_async(dispatch_get_main_queue(), ^{
-        let viewController = [[OSInAppMessageViewController alloc] initWithMessage:message delegate:OSMessagingController.self];
+        let viewController = [[OSInAppMessageViewController alloc] initWithMessage:message delegate:OSMessagingController.sharedInstance];
         [viewController viewDidLoad];
         [OSMessagingController.sharedInstance webViewContentFinishedLoading:message];
     });
@@ -107,7 +107,7 @@
 }
 
 + (void)dismissCurrentMessage {
-    [OSMessagingController.sharedInstance messageViewControllerWasDismissed];
+    [OSMessagingController.sharedInstance messageViewControllerWasDismissed: self.messageDisplayQueue.firstObject displayed:YES];
 }
 
 + (BOOL)isInAppMessageShowing {


### PR DESCRIPTION
Previously we would call registerUserAfterDelay if the user has not completed the push prompt or they don't have provisional auth. We want to register right away so that we can get IAMs for the session (which might include a push prompt IAM). 

I believe this was intended to be an optimization to wait for an answer to the push prompt **if the prompt is currently being display** but that was not the behavior, and I don't think we need to try to achieve that optimization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/990)
<!-- Reviewable:end -->
