### PR TITLE
iOS 15 Feature Notification action icons

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -169,10 +169,20 @@
             continue;
         }
         
-        [buttonArray addObject: @{
-            @"text" : button[@"n"],
-            @"id" : (button[@"i"] ?: button[@"n"])
-        }];
+        NSMutableDictionary *actionDict = [NSMutableDictionary new];
+        actionDict[@"text"] = button[@"n"];
+        actionDict[@"id"] = button[@"i"] ?: button[@"n"];
+        
+        // Parse Action Icon into system or template icon
+        if (button[@"icon_type"] && button[@"path"]) {
+            if ([button[@"icon_type"] isEqualToString:@"system"]) {
+                actionDict[@"systemIcon"] = button[@"path"];
+            } else if ([button[@"icon_type"] isEqualToString:@"custom"]) {
+                actionDict[@"templateIcon"] = button[@"path"];
+            }
+        }
+        
+        [buttonArray addObject: actionDict];
     }
     
     _actionButtons = buttonArray;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -566,6 +566,25 @@ static OneSignal* singleInstance = nil;
     return [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
 }
 
++ (UNNotificationAction *)createActionForButton:(NSDictionary *)button {
+    if (@available(iOS 15.0, *)) {
+        UNNotificationActionIcon *icon;
+        if (button[@"systemIcon"]) {
+            icon = [UNNotificationActionIcon iconWithSystemImageName:button[@"systemIcon"]];
+        } else if (button[@"templateIcon"]) {
+            icon = [UNNotificationActionIcon iconWithTemplateImageName:button[@"templateIcon"]];
+        }
+        return [UNNotificationAction actionWithIdentifier:button[@"id"]
+                                                    title:button[@"text"]
+                                                  options:UNNotificationActionOptionForeground
+                                                     icon:icon];
+    } else {
+        return [UNNotificationAction actionWithIdentifier:button[@"id"]
+                                                    title:button[@"text"]
+                                                  options:UNNotificationActionOptionForeground];
+    }
+}
+
 + (void)addActionButtons:(OSNotification*)notification
    toNotificationContent:(UNMutableNotificationContent*)content {
     if (!notification.actionButtons || notification.actionButtons.count == 0)
@@ -573,9 +592,7 @@ static OneSignal* singleInstance = nil;
     
     let actionArray = [NSMutableArray new];
     for(NSDictionary* button in notification.actionButtons) {
-        let action = [UNNotificationAction actionWithIdentifier:button[@"id"]
-                                                          title:button[@"text"]
-                                                        options:UNNotificationActionOptionForeground];
+        let action = [self createActionForButton:button];
         [actionArray addObject:action];
     }
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalHelperOverrider.h
@@ -28,6 +28,11 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "OneSignalHelper.h"
+
+@interface OneSignalHelper (Tests)
++ (UNNotificationAction *)createActionForButton:(NSDictionary *)button;
+@end
 
 @interface OneSignalHelperOverrider : NSObject
 + (void)reset;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3150,11 +3150,76 @@ didReceiveRemoteNotification:userInfo
                                 @"i": @"id1",
                                 @"n": @"text1",
                                 @"path": @"myImage/thumbsup",
-                                @"icon_type": @"template"
+                                @"icon_type": @"custom"
                             }]
                         }};
     OSNotification *notification = [OSNotification parseWithApns:aps];
     XCTAssertEqualObjects(notification.actionButtons[0][@"templateIcon"], @"myImage/thumbsup");
+}
+
+- (void)testCreateActionForButtonsWithIcon {
+    if (@available(iOS 15.0, *)) {
+        NSDictionary *aps = @{
+                            @"aps": @{
+                                @"content-available": @1,
+                                @"mutable-content": @1,
+                                @"alert": @"Message Body",
+                            },
+                            @"os_data": @{
+                                @"i": @"notif id",
+                                @"ti": @"templateId123",
+                                @"tn": @"Template name",
+                                @"buttons": @[@{
+                                    @"i": @"id1",
+                                    @"n": @"text1",
+                                    @"path": @"myImage/thumbsup",
+                                    @"icon_type": @"custom"
+                                }]
+                            }};
+        OSNotification *notification = [OSNotification parseWithApns:aps];
+        UNNotificationAction *action = [OneSignalHelper createActionForButton:notification.actionButtons[0]];
+        XCTAssertNotNil(action.icon);
+        
+        aps = @{
+                @"aps": @{
+                    @"content-available": @1,
+                    @"mutable-content": @1,
+                    @"alert": @"Message Body",
+                },
+                @"os_data": @{
+                    @"i": @"notif id",
+                    @"ti": @"templateId123",
+                    @"tn": @"Template name",
+                    @"buttons": @[@{
+                        @"i": @"id1",
+                        @"n": @"text1",
+                        @"path": @"hand.thumbsup",
+                        @"icon_type": @"system"
+                    }]
+                }};
+        notification = [OSNotification parseWithApns:aps];
+        action = [OneSignalHelper createActionForButton:notification.actionButtons[0]];
+        XCTAssertNotNil(action.icon);
+        
+        aps = @{
+                @"aps": @{
+                    @"content-available": @1,
+                    @"mutable-content": @1,
+                    @"alert": @"Message Body",
+                },
+                @"os_data": @{
+                    @"i": @"notif id",
+                    @"ti": @"templateId123",
+                    @"tn": @"Template name",
+                    @"buttons": @[@{
+                        @"i": @"id1",
+                        @"n": @"text1"
+                    }]
+                }};
+        notification = [OSNotification parseWithApns:aps];
+        action = [OneSignalHelper createActionForButton:notification.actionButtons[0]];
+        XCTAssertNil(action.icon);
+    }
 }
 
 - (void)testNotificationJson {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3113,6 +3113,50 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(json[@"isSMSSubscribed"], @1);
 }
 
+- (void)testParseNotificationSystemActionIconJson {
+    NSDictionary *aps = @{
+                        @"aps": @{
+                            @"content-available": @1,
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body",
+                        },
+                        @"os_data": @{
+                            @"i": @"notif id",
+                            @"ti": @"templateId123",
+                            @"tn": @"Template name",
+                            @"buttons": @[@{
+                                @"i": @"id1",
+                                @"n": @"text1",
+                                @"path": @"hand.thumbsup",
+                                @"icon_type": @"system"
+                            }]
+                        }};
+    OSNotification *notification = [OSNotification parseWithApns:aps];
+    XCTAssertEqualObjects(notification.actionButtons[0][@"systemIcon"], @"hand.thumbsup");
+}
+
+- (void)testParseNotificationTemplateActionIconJson {
+    NSDictionary *aps = @{
+                        @"aps": @{
+                            @"content-available": @1,
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body",
+                        },
+                        @"os_data": @{
+                            @"i": @"notif id",
+                            @"ti": @"templateId123",
+                            @"tn": @"Template name",
+                            @"buttons": @[@{
+                                @"i": @"id1",
+                                @"n": @"text1",
+                                @"path": @"myImage/thumbsup",
+                                @"icon_type": @"template"
+                            }]
+                        }};
+    OSNotification *notification = [OSNotification parseWithApns:aps];
+    XCTAssertEqualObjects(notification.actionButtons[0][@"templateIcon"], @"myImage/thumbsup");
+}
+
 - (void)testNotificationJson {
     NSDictionary *aps = @{
                         @"aps": @{


### PR DESCRIPTION
This is branched off of main which currently has some broken IAM unit tests (already fixed in another PR).

iOS 15 introduced UNNotificationActionIcons ([read about them here](https://onesignal.com/blog/ios-notification-changes-updates-from-apples-wwdc-21/)). This PR supports adding action icons from OneSignal notification payloads.

There are 2 types of icons:
1. System icons which are [SF Symbols](https://developer.apple.com/sf-symbols/) included in all iOS Apps.
2. Template icons which are icon resources included by developers in their app bundles.

Icons can be added to notification actions through a new initializer method, and can themselves be initialized as either system or template icons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/991)
<!-- Reviewable:end -->
