### PR TITLE
Fix OSInAppMessageInternal migration crash

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -118,6 +118,7 @@ THE SOFTWARE.
 - (void)migrateToOSInAppMessageInternal {
     let nameChangeVersion = 30700;
     long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    [NSKeyedUnarchiver setClass:[OSInAppMessageInternal class] forClassName:@"OSInAppMessage"];
     if (sdkVersion < nameChangeVersion) {
         [OneSignal onesignal_Log:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSInAppMessage from version: %ld", sdkVersion]];
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/MigrationTests.m
@@ -288,7 +288,7 @@
     XCTAssertNil(retrievedDict);
 }
 
-- (void)testIAMToInternalMigration {
+- (void)testIAMMessagesToInternalMigration {
     let limit = 5;
     let delay = 60;
     let message = [OSInAppMessageTestHelper testMessageWithRedisplayLimit:limit delay:@(delay)];
@@ -306,7 +306,13 @@
     NSArray<OSInAppMessageInternal *>*retrievedArray = [OneSignalUserDefaults.initStandard
                                                                 getSavedCodeableDataForKey:OS_IAM_MESSAGES_ARRAY defaultValue:nil];
     XCTAssertEqualObjects(messages, retrievedArray);
-    
+}
+
+- (void)testIAMRedisplayToInternalMigration {
+    let limit = 5;
+    let delay = 60;
+    let message = [OSInAppMessageTestHelper testMessageWithRedisplayLimit:limit delay:@(delay)];
+    message.isDisplayedInSession = true;
     // Cached Redisplay Messages
     NSMutableDictionary <NSString *, OSInAppMessageInternal *> *redisplayedInAppMessages = [NSMutableDictionary new];
     [redisplayedInAppMessages setObject:message forKey:message.messageId];
@@ -321,9 +327,6 @@
                                                                 getSavedCodeableDataForKey:OS_IAM_REDISPLAY_DICTIONARY defaultValue:nil];
     XCTAssertEqualObjects(redisplayedInAppMessages, retrievedDict);
 }
-
-
-
 
 
 @end


### PR DESCRIPTION
I am still not able to reproduce the crash, but it is always happening in our LifecycleObserver's applicationDidBecomeActive method. We only register our lifecycleObserver after migrations have been run so for some reason it is not running successfully. It could be that our version checking is causing the issue so this PR sets the unarchiver class for OSInAppMessage to OSInAppMessageInternal regardless of the cached SDK version.  

Any ideas about what the root cause of the issue could be, or how to more safely fix it are welcome.

Fixes #996 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/997)
<!-- Reviewable:end -->
