### PR TITLE
Fix badge incrementing when cancelling display in foreground

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -27,11 +27,15 @@
 
 #import <Foundation/Foundation.h>
 
+#import <UIKit/UIKit.h>
+
 #import "OSNotification+Internal.h"
 
 #import "OneSignal.h"
 
 #import "OneSignalCommonDefines.h"
+
+#import "OneSignalUserDefaults.h"
 
 @implementation OSNotification
 
@@ -298,6 +302,14 @@
 
  - (OSNotificationDisplayResponse)getCompletionBlock {
      OSNotificationDisplayResponse block = ^(OSNotification *notification){
+         /*
+          If notification is null here then display was cancelled and we need to
+          reset the badge count to the value prior to receipt of this notif
+          */
+         if (!notification) {
+             NSInteger previousBadgeCount = [UIApplication sharedApplication].applicationIconBadgeNumber;
+             [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:previousBadgeCount];
+         }
          [self complete:notification];
      };
      return block;


### PR DESCRIPTION
Fixes https://github.com/OneSignal/react-native-onesignal/issues/1256

When choosing to not display a notification with our foreground handler iOS does not increment the badge count or send the notification to the notification center, but we cache the increased value in OneSignal's user defaults. This cause a subsequent notification to include the cancelled notifications badge increment value.

In order to prevent this we need to reset the cached badge count if the notification is not displayed. In order to fix this for non-incremental badge changes we need to also store the previous badge count value to NSUserDefaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/998)
<!-- Reviewable:end -->
