### PR TITLE
2.x.x unity IAM orientation fix

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -656,6 +656,40 @@
 }
 
 /*
+ Unity overrides orientation behavior and enables all orientations in supportedInterfaceOrientations, regardless of
+ the values set in the info.plist. It then uses its own internal logic for restricting the Application's views to
+ the selected orientations. This view controller inherits the behavior of all orientations being allowed so we need
+ to manually set the supported orientations based on the values in the plist.
+ If no values are selected for the orientation key in the plist then we will default to super's behavior.
+*/
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    NSUInteger orientationMask = 0;
+    NSArray *supportedOrientations = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UISupportedInterfaceOrientations"];
+    if (!supportedOrientations) {
+        return [super supportedInterfaceOrientations];
+    }
+    
+    if ([supportedOrientations containsObject:@"UIInterfaceOrientationLandscapeLeft"]) {
+        orientationMask += UIInterfaceOrientationMaskLandscapeLeft;
+    }
+    
+    if ([supportedOrientations containsObject:@"UIInterfaceOrientationLandscapeRight"]) {
+        orientationMask += UIInterfaceOrientationMaskLandscapeRight;
+    }
+    
+    if ([supportedOrientations containsObject:@"UIInterfaceOrientationPortrait"]) {
+        orientationMask += UIInterfaceOrientationMaskPortrait;
+    }
+    
+    if ([supportedOrientations containsObject:@"UIInterfaceOrientationPortraitUpsideDown"]) {
+        orientationMask += UIInterfaceOrientationMaskPortraitUpsideDown;
+    }
+    
+    return orientationMask;
+    
+}
+
+/*
  Override method for handling orientation change within a view controller on iOS 8 or higher
  This specifically handles the resizing and reanimation of a currently showing IAM
  */


### PR DESCRIPTION
Cherry pick of #999 

Unity overrides orientation behavior and enables all orientations in supportedInterfaceOrientations, regardless of the values set in the info.plist. It then uses its own internal logic for restricting the Application's views to the selected orientations.

Our InAppMessageViewController inherits the behavior of all orientations being allowed, so we need to manually set the supported orientations based on the values in the plist.

To do this we can read the values from the supported orientations array in the mainBundle and then return the appropriate UIInterfaceOrientationMask.

If new orientations are released in future iOS versions we will need to update this method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1000)
<!-- Reviewable:end -->
