### PR TITLE
WiP: call `failureBlock` during `setExternalUserId` if one or more channels return success of false

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalClient.m
@@ -132,6 +132,8 @@
         // Requests should all be completed at this point, the response NSDictionary will be passed back
         dispatch_async(dispatch_get_main_queue(), ^{
             if (completionBlock)
+                // TODO: we send "success": 0 for example to the completionBlock
+                // TODO: but should we pass the errors too? Like invalid auth hash
                 completionBlock(response);
         });
     });


### PR DESCRIPTION
- we were always calling the `successBlock` after making the request to set external user ID
- which means we call the `successBlock` even when the backend doesn't set it and return the error of invalid auth hath
- now we check if the result has any channels that returned "success" of false and call the `failureBlock`
- (to remove later) I made some comments in the code about what to do for certain things

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1009)
<!-- Reviewable:end -->
