### PR TITLE
Add `jsonRepresentation` to OSInAppMessage

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
@@ -30,6 +30,13 @@
 #import "OneSignalCommonDefines.h"
 
 @implementation OSInAppMessage
+
+- (NSDictionary *)jsonRepresentation {
+    NSMutableDictionary *json = [NSMutableDictionary new];
+    json[@"messageId"] = self.messageId;
+    return json;
+}
+
 @end
 
 @interface OSInAppMessageInternal ()
@@ -92,6 +99,7 @@
 + (instancetype)instanceWithJson:(NSDictionary * _Nonnull)json {
     let message = [OSInAppMessageInternal new];
     
+    // "id" is expected instead of "messageId" when parsing JSON from the backend
     if (json[@"id"] && [json[@"id"] isKindOfClass:[NSString class]])
         message.messageId = json[@"id"];
     else
@@ -156,7 +164,7 @@
 -(NSDictionary *)jsonRepresentation {
     let json = [NSMutableDictionary new];
     
-    json[@"id"] = self.messageId;
+    json[@"messageId"] = self.messageId;
     json[@"variants"] = self.variants;
     
     let triggers = [NSMutableArray new];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -166,6 +166,9 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 
 @property (strong, nonatomic, nonnull) NSString *messageId;
 
+// Convert the object into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
 @end
 
 @interface OSInAppMessageOutcome : NSObject

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -490,7 +490,8 @@
     let firstTrigger = [OSTrigger customTriggerWithProperty:@"prop1" withOperator:OSTriggerOperatorTypeExists withValue:nil];
 
     let message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[firstTrigger]] withRedisplayLimit:limit delay:@(delay)];
-    let registrationResponse = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message.jsonRepresentation]];
+    NSDictionary* json = [OSInAppMessageTestHelper convertIAMtoJson:message];
+    let registrationResponse = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[json]];
 
     [OneSignalClientOverrider setMockResponseForRequest:NSStringFromClass([OSRequestRegisterUser class]) withResponse:registrationResponse];
 
@@ -1525,7 +1526,8 @@
     [OneSignal pauseInAppMessages:NO];
     let trigger = [OSTrigger dynamicTriggerWithKind:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withOperator:OSTriggerOperatorTypeGreaterThanOrEqualTo withValue:@0];
     let message = [OSInAppMessageTestHelper testMessageWithTriggers:@[@[trigger]] withRedisplayLimit:5 delay:@30];
-    let registrationJson = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message.jsonRepresentation]];
+    NSDictionary* json = [OSInAppMessageTestHelper convertIAMtoJson:message];
+    let registrationJson = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[json]];
 
     //Time interval mock
     NSDateComponents* comps = [[NSDateComponents alloc]init];
@@ -1642,7 +1644,8 @@
  Mock response JSON and initializes the OneSignal SDK
  */
 - (void)initOneSignalWithInAppMessage:(OSInAppMessageInternal *)message {
-    let registrationJson = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message.jsonRepresentation]];
+    NSDictionary* json = [OSInAppMessageTestHelper convertIAMtoJson:message];
+    let registrationJson = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[json]];
     [self initOneSignalWithRegistrationJSON:registrationJson];
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
@@ -61,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers;
 + (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
 + (OSInAppMessageInternal *)testMessageWithPastEndTime:(BOOL)pastEndTime;
++ (NSDictionary *)convertIAMtoJson:(OSInAppMessageInternal *)message;
 + (NSDictionary *)testRegistrationJsonWithMessages:(NSArray<NSDictionary *> *)messages;
 + (NSDictionary *)testMessageJsonWithTriggerPropertyName:(NSString *)property withId:(NSString *)triggerId withOperator:(OSTriggerOperatorType)type withValue:(id)value;
 + (NSDictionary*)testInAppMessageGetContainsWithHTML:(NSString *)html;

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
@@ -245,6 +245,14 @@ int messageIdIncrementer = 0;
     return message;
 }
 
+// jsonRepresentation uses key of "messageId" but we need to use key of "id" for creating IAM, etc.
++ (NSDictionary *)convertIAMtoJson:(OSInAppMessageInternal *)message {
+    NSMutableDictionary *json = [message.jsonRepresentation mutableCopy];
+    json[@"id"] = message.messageId;
+    [json removeObjectForKey:@"messageId"];
+    return json;
+}
+
 + (NSDictionary *)testRegistrationJsonWithMessages:(NSArray<NSDictionary *> *)messages {
     return @{
         @"id" : @"1234",

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3265,6 +3265,32 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(json[@"templateName"], @"Template name");
 }
 
+- (void)testInAppMessageInternalJson {
+    NSDictionary *messageJson = @{
+        @"id" : OS_TEST_MESSAGE_ID,
+        @"variants" : @{
+            @"ios" : @{
+                @"default" : OS_TEST_MESSAGE_VARIANT_ID,
+                @"en" : OS_TEST_ENGLISH_VARIANT_ID
+            },
+            @"all" : @{
+                @"default" : @"some_message_id"
+            }
+        },
+        @"triggers" : @[],
+        @"has_liquid" : @true,
+    };
+    OSInAppMessageInternal *message = [OSInAppMessageInternal instanceWithJson:messageJson];
+    NSDictionary *json = [message jsonRepresentation];
+    
+    XCTAssertEqualObjects(json[@"messageId"], OS_TEST_MESSAGE_ID);
+    XCTAssertNil(json[@"id"]);
+    XCTAssertEqualObjects(json[@"variants"][@"ios"][@"default"], OS_TEST_MESSAGE_VARIANT_ID);
+    XCTAssertEqualObjects(json[@"variants"][@"all"][@"default"], @"some_message_id");
+    XCTAssertEqualObjects(json[@"triggers"], @[]);
+    XCTAssertTrue(json[@"has_liquid"]);
+}
+
 - (void)testLaunchURL {
         
     // 1. Init OneSignal with app start


### PR DESCRIPTION
# Description
## One Line Summary
Add JSON stringifier to the public `OSInAppMessage` class and refactor JSON stringifier for internal `OSInAppMessageInternal` class to return JSON key of `"messageId"` instead of `"id"`.

## Details
### Motivation
We want the public `OSInAppMessage` to have a `jsonRepresentation` method for the wrappers (and others) to use. This Dictionary only has one item of `"messageId"`. Since IAMs have the property `messageId` and our documentation refer to `messageId`, this key was chosen over `"id"`.

The need for this method first arose when adding the InAppMessage Lifecycle Handler to React Native.
We also modified the `OSInAppMessageInternal` class's `jsonRepresentation` to return a key of `"messageId"` instead of `"id"` for clarity and consistency to the public class.

### Background Context
Previously, the current `OSInAppMessageInternal` class was named `OSInAppMessage` before being refactored into an internal InAppMessage class and a public InAppMessage class. 

Worth noting, `"id"` is expected instead of `"messageId"` when parsing JSON from the backend, so "id" is used in the constructor.

### Scope
We didn't use any InAppMessage `jsonRepresentation` in SDK code, except in unit tests (see below). This method was not exposed before and now it is new method to the public.

# Testing
## Unit testing
✅  All tests pass after the below modifications

Some unit tests where using `jsonRepresentation` to stringify the IAM in a mocked server response. However, when working with the backend, "id" is expected. Because of this, some existing tests broke.

#### Added method: 
`convertIAMtoJson(OSInAppMessageInternal message)`
- just replaces key `"messageId"` with `"id"`
- refactored unit test code to use this method instead of `jsonRepresentation`

#### Added test: 
`testInAppMessageInternalJson`
- tests OSInAppMessageInternal jsonRepresentation

## Manual testing
✅  Tested by calling `[message jsonRepresentation]` in demo app:
- [X] iOS 15 Emulator

### Example of the Result
``` 
{
    messageId = "e3483698-3881-4b9b-827f-6c67c5b6c9e4";
    redisplay =     {
        delay = 0;
        limit = 2147483647;
    };
    triggers =     (
    );
    variants =     {
        all =         {
            default = "b30d1163-1d96-4714-b022-f0d46e01964c";
        };
    };
}
```

FYI: Did not test in the wrappers

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes - exposed new method, will update documentation

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1017)
<!-- Reviewable:end -->
