### PR TITLE
Track cold restarts with track endpoint

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1709,6 +1709,12 @@ static BOOL _registerUserSuccessful = false;
     // Make sure last time we closed app was more than 30 secs ago
     const int minTimeThreshold = 30;
     NSTimeInterval delta = now - lastTimeClosed;
+    if (delta < minTimeThreshold && appId) {
+        // https://api.onesignal.com/api/v1/track
+        // do track here
+        // OS-Usage-Data
+        NSLog(@"ECM tracking restart appId: %@", appId);
+    }
     return delta >= minTimeThreshold;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1715,21 +1715,25 @@ static BOOL _trackedColdRestart = false;
     // Depending on the results of our tracking we will change this case
     // from a tracking request to return true
     if (delta < minTimeThreshold && appId && !_registerUserFinished && !_trackedColdRestart) {
-        [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"shouldRegisterNow:coldRestart"];
-        // Set to true even if it doesn't pass the sample check
-        _trackedColdRestart = true;
-        // Sample /track calls to avoid hitting our endpoint too hard
-        int randomSample = arc4random_uniform(100);
-        if (randomSample == 99) {
-            NSString *osUsageData = [NSString stringWithFormat:@"lib-name=OneSignal-iOS-SDK,lib-version=%@,lib-event=cold_restart", ONESIGNAL_VERSION];
-            [[OneSignalClient sharedClient] executeRequest:[OSRequestTrackV1 trackUsageData:osUsageData appId:appId] onSuccess:^(NSDictionary *result) {
-                [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"shouldRegisterNow:trackColdRestart: successfully tracked cold restart"];
-            } onFailure:^(NSError *error) {
-                [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"shouldRegisterNow:trackColdRestart: Failed to track cold restart: %@", error.localizedDescription]];
-            }];
-        }
+        [OneSignal trackColdRestart];
     }
     return delta >= minTimeThreshold;
+}
+
++ (void)trackColdRestart {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"trackColdRestart"];
+    // Set to true even if it doesn't pass the sample check
+    _trackedColdRestart = true;
+    // Sample /track calls to avoid hitting our endpoint too hard
+    int randomSample = arc4random_uniform(100);
+    if (randomSample == 99) {
+        NSString *osUsageData = [NSString stringWithFormat:@"kind=sdk, version=%@, source=iOS_SDK, name=cold_restart, lockScreenApp=false", ONESIGNAL_VERSION];
+        [[OneSignalClient sharedClient] executeRequest:[OSRequestTrackV1 trackUsageData:osUsageData appId:appId] onSuccess:^(NSDictionary *result) {
+            [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"trackColdRestart: successfully tracked cold restart"];
+        } onFailure:^(NSError *error) {
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"trackColdRestart: Failed to track cold restart: %@", error.localizedDescription]];
+        }];
+    }
 }
 
 + (void)registerUserAfterDelay {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.h
@@ -38,6 +38,7 @@
 @property (nonatomic) HTTPMethod method;
 @property (strong, nonatomic, nonnull) NSString *path;
 @property (strong, nonatomic, nullable) NSDictionary *parameters;
+@property (strong, nonatomic, nullable) NSDictionary<NSString *, NSString *> *additionalHeaders;
 @property (nonatomic) int reattemptCount;
 @property (nonatomic) BOOL dataRequest; //false for JSON based requests
 -(BOOL)missingAppId; //for requests that don't require an appId parameter, the subclass should override this method and return false

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalRequest.m
@@ -60,6 +60,10 @@
     
     let request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
     
+    for (NSString *key in self.additionalHeaders) {
+        [request setValue:self.additionalHeaders[key] forHTTPHeaderField:key];
+    }
+    
     if (!self.dataRequest)
         [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     

--- a/iOS_SDK/OneSignalSDK/Source/Requests.h
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.h
@@ -203,5 +203,9 @@ NS_ASSUME_NONNULL_END
 + (instancetype _Nonnull)withPlayerId:(NSString * _Nullable)playerId notificationId:(NSString * _Nonnull)notificationId appId:(NSString * _Nonnull)appId;
 @end
 
+@interface OSRequestTrackV1 : OneSignalRequest
++ (instancetype _Nonnull)trackUsageData:(NSString * _Nonnull)osUsageData
+                                     appId:(NSString * _Nonnull)appId;
+@end
 #endif /* Requests_h */
 

--- a/iOS_SDK/OneSignalSDK/Source/Requests.m
+++ b/iOS_SDK/OneSignalSDK/Source/Requests.m
@@ -749,3 +749,20 @@ NSString * const OUTCOME_SOURCE = @"source";
     return request;
 }
 @end
+
+@implementation OSRequestTrackV1
+NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
++ (instancetype)trackUsageData:(NSString *)osUsageData appId:(NSString *)appId {
+    let request = [OSRequestTrackV1 new];
+    let params = [NSMutableDictionary new];
+    let headers = [NSMutableDictionary new];
+    params[APP_ID] = appId;
+    headers[APP_ID] = appId;
+    headers[OS_USAGE_DATA] = osUsageData;
+    request.method = POST;
+    request.path = @"v1/track";
+    request.parameters = params;
+    request.additionalHeaders = headers;
+    return request;
+}
+@end


### PR DESCRIPTION
# Description
## One Line Summary
Tracking cold starts after previous sessions ended within 30 seconds. 

## Details

- Added a new property to `OneSignalRequest` called `additionalHeaders` that adds headers to the URLRequest. This is needed because the /track endpoint request app_id and Os-Usage-Data to be added as headers instead of body content.
- Added `OSTrackUsageData` request that sends a POST request to v1/track with a usage data string that contains the data to be stored.
- Uses the `OSTrackUsageData` request in `shouldRegisterNow` if the following is true
  - we don't have an inflight register request
  - not `isImmediatePlayerCreateOrOnSession`
  - not `isOnSessionSuccessfulForCurrentState`
  -  it is less than 30 seconds since `lastTimeClosed` 
  - appId isn't nil
  - registerUserFinished is false
  - we haven't already tried to trackColdRestart

This scenario arises if we do not currently have a valid session, but since it was 30 seconds since our last close `shouldRegisterNow` will return false. This scenario occurs in practice when the app was closed and relaunched within 30 seconds (I am calling this scenario cold restarts). It will not trigger if that app was just backgrounded and reopened.

Additionally in order to avoid potentially overloading the /track endpoint we only send the request every 1/100 times. This will still allow us to get data on the potential impact of adding `on_session` requests here.

The string being sent to track is in the following format:
**`kind=sdk, version=<SDK_VERSION>, source=iOS_SDK, name=cold_restart, lockScreenApp=false`**
[os-usage-data conventions are described here](https://paper.dropbox.com/doc/2021-09-Feature-Adoption-Usage-Tracking--BWe4hJMFhunIznoFxa2CNlJrAg-9TySpmHdvepfRDNjUFd8t)


### Motivation
We currently don't call on_session for cold restarts. We want to measure the potential performance impact of adding on_session requests to this scenario. By using the new /track endpoint we can measure cold restarts and make a decision about support on_session in this case. If the impact will be manageable then this code will be removed and replaced by 'return true' for the cold restart conditions causing us to immediately call on_session

### Scope
This change involves iOS SDK changes that 1/100 times will send a POST request to the new turbine endpoint v1/track.
Added a new property to `OneSignalRequest` called `additionalHeaders` that adds headers to the URLRequest.

# Testing
## Unit testing
✅  All tests pass after the below modifications
Added testing for the new `additionalHeaders` property on `OneSignalRequest` as well as a test for the track POST request


## Manual testing
✅  Tested on iOS simulators and a physical device. Tested cold starts, cold restarts, and backgrounds both with and without a valid session. 

### Example of the Result
a post request sent to v1/track to be measured

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1022)
<!-- Reviewable:end -->
