### PR TITLE
Adding Collapse id to OSNotification

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSNotification.m
@@ -130,6 +130,7 @@
     _templateId = payload[@"ti"];
     _templateName = payload[@"tn"];
     _badgeIncrement = [payload[@"badge_inc"] integerValue];
+    _collapseId = payload[@"collapse_id"];
 }
 
 - (void)parseApnsFields {
@@ -216,7 +217,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat: @"notificationId=%@ templateId=%@ templateName=%@ contentAvailable=%@ mutableContent=%@ category=%@ relevanceScore=%@ interruptionLevel=%@ rawPayload=%@", _notificationId, _templateId, _templateName, _contentAvailable ? @"YES" : @"NO", _mutableContent ? @"YES" : @"NO", _category, _relevanceScore, _interruptionLevel, _rawPayload];
+    return [NSString stringWithFormat: @"notificationId=%@ templateId=%@ templateName=%@ contentAvailable=%@ mutableContent=%@ category=%@ relevanceScore=%@ interruptionLevel=%@ collapseId=%@ rawPayload=%@", _notificationId, _templateId, _templateName, _contentAvailable ? @"YES" : @"NO", _mutableContent ? @"YES" : @"NO", _category, _relevanceScore, _interruptionLevel, _collapseId, _rawPayload];
 }
 
 - (NSDictionary *)jsonRepresentation {
@@ -281,6 +282,9 @@
     
     if (self.interruptionLevel)
         [obj setObject:self.interruptionLevel forKeyedSubscript: @"interruptionLevel"];
+    
+    if (self.collapseId)
+        [obj setObject:self.collapseId forKeyedSubscript: @"collapseId"];
 
     return obj;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -136,6 +136,8 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
 /* iOS 15+ : Interruption Level */
 @property(readonly)NSString *interruptionLevel;
 
+@property(readonly, nullable)NSString *collapseId;
+
 /* Parses an APNS push payload into a OSNotification object.
    Useful to call from your NotificationServiceExtension when the
       didReceiveNotificationRequest:withContentHandler: method fires. */

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -348,6 +348,7 @@ static XCTestCase* _currentXCTestCase;
     UNNotificationRequest *unNotifRequqest = [UNNotificationRequest alloc];
     // Set as remote push type
     [unNotifRequqest setValue:[UNPushNotificationTrigger alloc] forKey:@"trigger"];
+    [unNotifRequqest setValue:@"test_id" forKey:@"identifier"];
     [unNotifContent setValue:userInfo forKey:@"userInfo"];
     [unNotifRequqest setValue:unNotifContent forKeyPath:@"content"];
     [unNotif setValue:unNotifRequqest forKeyPath:@"request"];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3330,4 +3330,92 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"timezone_id"], mockTimezone.name);
     
 }
+
+- (void)testParseCollapseIdInOSData {
+    NSDictionary *apsOsData = @{
+                        @"aps": @{
+                            @"content-available": @1,
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body",
+                            @"relevance-score": @0.15,
+                            @"interruption-level": @"time-sensitive",
+                        },
+                        @"os_data": @{
+                            @"i": @"notif id",
+                            @"ti": @"templateId123",
+                            @"tn": @"Template name",
+                            @"collapse_id" : @"test_id"
+                        }};
+    OSNotification *notification = [OSNotification parseWithApns:apsOsData];
+    XCTAssertEqualObjects(notification.collapseId, @"test_id");
+    NSDictionary *json = [notification jsonRepresentation];
+    XCTAssertEqualObjects(json[@"collapseId"], @"test_id");
+}
+
+- (void)testParseCollapseIdInCustom {
+    NSDictionary *apsCustom = @{
+                        @"aps": @{
+                            @"content-available": @1,
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body",
+                            @"relevance-score": @0.15,
+                            @"interruption-level": @"time-sensitive",
+                        },
+                        @"custom": @{
+                            @"i": @"notif id",
+                            @"ti": @"templateId123",
+                            @"tn": @"Template name",
+                            @"collapse_id" : @"test_id"
+                        }};
+    OSNotification *notification = [OSNotification parseWithApns:apsCustom];
+    XCTAssertEqualObjects(notification.collapseId, @"test_id");
+    NSDictionary *json = [notification jsonRepresentation];
+    XCTAssertEqualObjects(json[@"collapseId"], @"test_id");
+}
+
+- (void) testParseCollapseIdFromNotificationRequestWithCustom {
+    NSDictionary *apsCustom = @{
+                        @"aps": @{
+                            @"content-available": @1,
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body",
+                            @"relevance-score": @0.15,
+                            @"interruption-level": @"time-sensitive",
+                        },
+                        @"custom": @{
+                            @"i": @"notif id",
+                            @"ti": @"templateId123",
+                            @"tn": @"Template name"
+                        }};
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:apsCustom];
+    
+    UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request                                                           withMutableNotificationContent:nil
+                                                                           withContentHandler:nil];
+    
+    XCTAssertEqualObjects(content.userInfo[@"custom"][@"collapse_id"], @"test_id");
+}
+
+- (void) testParseCollapseIdFromNotificationRequestWithOSData {
+    NSDictionary *apsOSData = @{
+                        @"aps": @{
+                            @"content-available": @1,
+                            @"mutable-content": @1,
+                            @"alert": @"Message Body",
+                            @"relevance-score": @0.15,
+                            @"interruption-level": @"time-sensitive",
+                        },
+                        @"os_data": @{
+                            @"i": @"notif id",
+                            @"ti": @"templateId123",
+                            @"tn": @"Template name"
+                        }};
+    id notifResponse = [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:apsOSData];
+
+    UNMutableNotificationContent* content = [OneSignal didReceiveNotificationExtensionRequest:[notifResponse notification].request                                                           withMutableNotificationContent:nil
+                                                                           withContentHandler:nil];
+    
+    
+    XCTAssertEqualObjects(content.userInfo[@"os_data"][@"collapse_id"], @"test_id");
+}
+
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Adding a readonly string property `collapseId` to the public `OSNotification` object and populating it with the collapseId set on a notification.

## Details
The collapse id field is set to the [request.identifier field](https://developer.apple.com/documentation/usernotifications/unnotificationrequest/1649634-identifier?language=objc) when a notification is received.

In order to parse it to OSNotification both inside and outside the service extension I am adding the value of this field to the notification's content.userInfo dictionary from the `OneSignalNotificationServiceExtensionHandler`'s `didReceiveNotificationExtensionRequest: withMutableNotificationContent:` method. 

I am adding the value to the key `collapse_id` to the `custom` or `os_data` dictionary depending on which format the notification is using.


### Motivation
We currently have collapseId on Android's OSNotification object but not on iOS. This field is in the iOS notification request's identifier field so we can add it to OSNotification without any backend changes.

### Scope
This change involves adding a new readonly string field to the **public** OSNotification object called `collapseId`.

# Testing
## Unit testing
✅  All tests pass after the below modifications
Added unit tests for parsing the collapse id from request.identifier and adding it to either os_data or custom depending on which format the notification is using.

## Manual testing
✅  Tested on an iOS device from both send to test user and a real notification.

### Example of the Result
setting the collapse id on the dashboard/api will populate collapseId in the OSNotification object

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1024)
<!-- Reviewable:end -->
