### PR TITLE
Fix sending tags when rejecting the push permission prompt

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1322,7 +1322,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
 }
 
 + (void)sendTagsOnBackground {
-    if (!self.playerTags.tagsToSend || self.playerTags.tagsToSend.count <= 0)
+    if (!self.playerTags.tagsToSend || self.playerTags.tagsToSend.count <= 0 || !self.currentSubscriptionState.userId)
         return;
     
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(sendTagsToServer) object:nil];


### PR DESCRIPTION
# Description
## One Line Summary
Checking for a playerId before trying to sendTagsOnBackground

## Details
When the push prompt is displayed the application background lifecycle method is called. This results in trying to sendTagsOnBackground but we may not have a playerId yet. This adds a check for playerId so that we don't erroneously try to send tags without a playerId

### Motivation
This PR fixes a customer reported issue regarding sending tags when the push prompt is declined

# Testing
## Manual testing
I have tested on multiple example apps on my iPhone

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [ ] Distribution
   - [x] Tags

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1037)
<!-- Reviewable:end -->
