### PR TITLE
Fix calling setLaunchUrlsInApp after init

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -698,6 +698,8 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     NSMutableDictionary *newSettings = [[NSMutableDictionary alloc] initWithDictionary:appSettings];
     newSettings[kOSSettingsKeyInAppLaunchURL] = launchInApp ? @true : @false;
     appSettings = newSettings;
+    // This allows this method to have an effect after init is called
+    [self enableInAppLaunchURL:launchInApp];
 }
 
 + (void)setProvidesNotificationSettingsView:(BOOL)providesView {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3318,6 +3318,22 @@ didReceiveRemoteNotification:userInfo
     XCTAssertFalse(OneSignalOverrider.launchWebURLWasCalled);
 }
 
+- (void)testsetLaunchURLInAppAfterInit {
+    // 1. setLaunchURLsInApp to false
+    [OneSignal setLaunchURLsInApp:false];
+    
+    // 2. Init OneSignal with app start
+    [UnitTestCommonMethods initOneSignal];
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    XCTAssertFalse([OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL defaultValue:false]);
+    
+    // 3. Change setLaunchURLsInApp to true
+    [OneSignal setLaunchURLsInApp:true];
+    
+    XCTAssertTrue([OneSignalUserDefaults.initStandard getSavedBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL defaultValue:false]);
+}
+
 - (void)testTimezoneId {
        
     let mockTimezone = [NSTimeZone timeZoneWithName:@"Europe/London"];


### PR DESCRIPTION

# Description
## One Line Summary
This allows setLaunchUrlsInApp to have an effect after init has been called

## Details
launchURL behavior used to be a part of the init call in the previous major release. When the init call was split apart in the 3.0.0 major release the setLaunchUrlsInApp logic only worked if it was called prior to init because it set values in the appSettings dictionary instead of calling enableInAppLaunchUrls directly.

# Testing
## Manual testing
Tested setLaunchUrlsInApp true and false before and after init

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [ ] Distribution

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1043)
<!-- Reviewable:end -->
