### PR TITLE
Option to provide AppDelegate for SwiftUI lifecycle etc

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -42,6 +42,7 @@
 */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import <UserNotifications/UserNotifications.h>
 
 #pragma clang diagnostic push
@@ -443,6 +444,8 @@ typedef void (^OSSendOutcomeSuccess)(OSOutcomeEvent* outcome);
 @interface OneSignal : NSObject
 
 extern NSString* const ONESIGNAL_VERSION;
+
++ (id<UIApplicationDelegate>)appDelegate;
 
 + (NSString*)appId;
 + (NSString* _Nonnull)sdkVersionRaw;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -445,8 +445,6 @@ typedef void (^OSSendOutcomeSuccess)(OSOutcomeEvent* outcome);
 
 extern NSString* const ONESIGNAL_VERSION;
 
-+ (id<UIApplicationDelegate>)appDelegate;
-
 + (NSString*)appId;
 + (NSString* _Nonnull)sdkVersionRaw;
 + (NSString* _Nonnull)sdkSemanticVersion;
@@ -492,11 +490,13 @@ typedef void(^OSUserResponseBlock)(BOOL accepted);
 
 #pragma mark Public Handlers
 
+typedef void (^OSNotificationReceivedBlock)(OSNotification * _Nonnull notification);
 // If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired.
 typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull notification, OSNotificationDisplayResponse _Nonnull completion);
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull result);
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
 
++ (void)setNotificationReceivedHandler:(OSNotificationReceivedBlock _Nullable)block;
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
 + (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
 + (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -445,6 +445,8 @@ typedef void (^OSSendOutcomeSuccess)(OSOutcomeEvent* outcome);
 
 extern NSString* const ONESIGNAL_VERSION;
 
++ (id<UIApplicationDelegate>)appDelegate;
+
 + (NSString*)appId;
 + (NSString* _Nonnull)sdkVersionRaw;
 + (NSString* _Nonnull)sdkSemanticVersion;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -172,6 +172,8 @@ DelayedConsentInitializationParameters *_delayedInitParameters;
     return _delayedInitParameters;
 }
 
+static id<UIApplicationDelegate> appDelegate;
+
 static NSString* appId;
 static NSDictionary* launchOptions;
 static NSDictionary* appSettings;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.h
@@ -44,6 +44,9 @@
 + (NSMutableDictionary*) formatApsPayloadIntoStandard:(NSDictionary*)remoteUserInfo identifier:(NSString*)identifier;
 + (void)lastMessageReceived:(NSDictionary*)message;
 
++ (void)setNotificationReceivedBlock:(OSNotificationReceivedBlock)block;
++ (void)handleReceivedNotification:(OSNotification *)notification;
+
 + (void)setNotificationOpenedBlock:(OSNotificationOpenedBlock)block;
 + (void)setNotificationWillShowInForegroundBlock:(OSNotificationWillShowInForegroundBlock)block;
 + (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -251,10 +251,16 @@ static NSMutableArray<OSNotificationOpenedResult*> *unprocessedOpenedNotifis;
     _lastMessageIdFromAction = nil;
     lastMessageID = @"";
 
+    notificationReceivedHandler = nil;
     notificationWillShowInForegroundHandler = nil;
     notificationOpenedHandler = nil;
     
     unprocessedOpenedNotifis = nil;
+}
+
+OSNotificationReceivedBlock notificationReceivedHandler;
++ (void)setNotificationReceivedBlock:(OSNotificationReceivedBlock)block {
+    notificationReceivedHandler = block;
 }
 
 OSNotificationWillShowInForegroundBlock notificationWillShowInForegroundHandler;
@@ -386,6 +392,13 @@ OneSignalWebView *webVC;
     }
     
     return userInfo;
+}
+
++ (void)handleReceivedNotification:(OSNotification *)notification {
+    if (notificationReceivedHandler) {
+        [notification startTimeoutTimer];
+        notificationReceivedHandler(notification);
+    }
 }
 
 + (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion {


### PR DESCRIPTION
Should fix https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1045#issuecomment-1032300940 but I've no idea how to build OneSignal XCFramework to test and haven't touched ObjC for ages so might have issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1048)
<!-- Reviewable:end -->
