### PR TITLE
Display test IAMs when IAMs are paused 

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageInternal.m
@@ -126,6 +126,10 @@
         message.hasLiquid = YES;
     }
 
+    if (json[@"is_preview"]) {
+        message.isPreview = YES;
+    }
+
     if (json[@"triggers"] && [json[@"triggers"] isKindOfClass:[NSArray class]]) {
         let triggers = [NSMutableArray new];
         
@@ -188,6 +192,10 @@
     
     if (self.hasLiquid) {
         json[@"has_liquid"] = @true;
+    }
+
+    if (self.isPreview) {
+        json[@"is_preview"] = @true;
     }
     
     return json;

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -316,7 +316,7 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)displayMessage:(OSInAppMessageInternal *)message {
     // Check if the app disabled IAMs for this device before showing an IAM
-    if (_isInAppMessagingPaused) {
+    if (_isInAppMessagingPaused && !message.isPreview) {
         [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"In app messages will not show while paused"];
         return;
     }

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -1411,6 +1411,19 @@
     XCTAssertEqual(OSMessagingControllerOverrider.messageDisplayQueue.count, 1);
 }
 
+/*
+ Test IAMs should display even when IAMs are paused
+*/
+- (void)testPreviewIAMIsDisplayedOnPause {
+    [OneSignal pauseInAppMessages:true];
+    
+    let message = [OSInAppMessageTestHelper testMessageWithPreview];
+    
+    [self initOneSignalWithInAppMessage:message];
+
+    XCTAssertTrue(OSMessagingControllerOverrider.isInAppMessageShowing);
+}
+
 - (void)testInAppMessageIdTracked {
     [OneSignal pauseInAppMessages:false];
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (OSInAppMessageInternal *)testMessageWithTriggersJson:(NSArray *)triggers redisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
 + (OSInAppMessageInternal *)testMessage;
 + (OSInAppMessageInternal *)testMessageWithLiquid;
++ (OSInAppMessageInternal *)testMessageWithPreview;
 + (OSInAppMessageInternal *)testMessageWithRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;
 + (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers;
 + (OSInAppMessageInternal *)testMessageWithTriggers:(NSArray <NSArray<OSTrigger *> *> *)triggers withRedisplayLimit:(NSInteger)limit delay:(NSNumber *)delay;

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
@@ -110,6 +110,24 @@ int messageIdIncrementer = 0;
     };
 }
 
++ (NSDictionary * _Nonnull)testMessageJsonPreview {
+    return @{
+        @"type" : @"centered_modal", // Prevents issues with the "os_viewed_message" count trigger that lets us prevent a message from being shown > than X times
+        @"id" : [NSString stringWithFormat:@"%@_%i", OS_TEST_MESSAGE_ID, ++messageIdIncrementer],
+        @"variants" : @{
+            @"ios" : @{
+                @"default" : OS_TEST_MESSAGE_VARIANT_ID,
+                @"en" : OS_TEST_ENGLISH_VARIANT_ID
+            },
+            @"all" : @{
+                @"default" : @"should_never_be_used_by_any_test"
+            }
+        },
+        @"triggers" : @[],
+        @"is_preview" : @true,
+    };
+}
+
 + (NSDictionary * _Nonnull)testMessageJsonRedisplay {
     return @{
         @"type" : @"centered_modal", // Prevents issues with the "os_viewed_message" count trigger that lets us prevent a message from being shown > than X times
@@ -202,6 +220,14 @@ int messageIdIncrementer = 0;
         messageJsonWithEndTime[@"end_time"] = @"2200-01-01T00:00:00.000Z";
     }
     let data = [NSJSONSerialization dataWithJSONObject:messageJsonWithEndTime options:0 error:nil];
+
+    return [OSInAppMessageInternal instanceWithData:data];
+}
+
++ (OSInAppMessageInternal *)testMessageWithPreview {
+    let messageJson = self.testMessageJsonPreview;
+    
+    let data = [NSJSONSerialization dataWithJSONObject:messageJson options:0 error:nil];
 
     return [OSInAppMessageInternal instanceWithData:data];
 }


### PR DESCRIPTION
# Description
## One Line Summary
Displays test in app messages even when in app messages are paused.

## Details

### Motivation
Test IAMs should ignore `pauseInAppMessages` because it does not follow a normal trigger flow and is used for testing purposes.

# Testing
## Manual testing
Tested sending a test IAM while `pauseInAppMessages` is enabled, app built with Xcode with the OneSignal Dev App from the latest iOS SDK release (3.10.1) on an iPad7 (14.5.1).

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1050)
<!-- Reviewable:end -->
