### PR TITLE
Log entire `NSError` instead of just `localizedDescription`

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -67,7 +67,7 @@
     NSString *jsonString;
     if (!jsonData) {
         [OneSignal onesignalLog:ONE_S_LL_ERROR message:
-         [NSString stringWithFormat:@"Error parsing tag dictionary to json :%@",error.localizedDescription]];
+         [NSString stringWithFormat:@"Error parsing tag dictionary to json: %@", error]];
     } else {
          jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1733,7 +1733,7 @@ static BOOL _trackedColdRestart = false;
         [[OneSignalClient sharedClient] executeRequest:[OSRequestTrackV1 trackUsageData:osUsageData appId:appId] onSuccess:^(NSDictionary *result) {
             [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:@"trackColdRestart: successfully tracked cold restart"];
         } onFailure:^(NSError *error) {
-            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"trackColdRestart: Failed to track cold restart: %@", error.localizedDescription]];
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"trackColdRestart: Failed to track cold restart: %@", error]];
         }];
     }
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -104,7 +104,7 @@
     }
     
     if (fileHandleError != nil) {
-        [OneSignal onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal Error encountered while downloading attachment: %@", fileHandleError.localizedDescription]];
+        [OneSignal onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal Error encountered while downloading attachment: %@", fileHandleError]];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalNotificationServiceExtensionHandler.m
@@ -157,7 +157,7 @@
                 dispatch_semaphore_signal(semaphore);
             }
         } failureBlock:^(NSError *error) {
-            [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal onNotificationReceived sendReceiveReceipt Failed for playerId: %@ error:%@", playerId, error.localizedDescription]];
+            [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"OneSignal onNotificationReceived sendReceiveReceipt Failed for playerId: %@ error: %@", playerId, error]];
             if (semaphore) {
                 dispatch_semaphore_signal(semaphore);
             }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalWebView.m
@@ -84,7 +84,7 @@ UIViewController *viewControllerForPresentation;
 }
 
 -(void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-    [OneSignal onesignal_Log:ONE_S_LL_ERROR message:error.localizedDescription];
+    [OneSignal onesignal_Log:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"webView: An error occurred during navigation: %@", error]];
 }
 
 - (void)pinSubviewToMarginsWithSubview:(UIView *)subview withSuperview:(UIView *)superview {


### PR DESCRIPTION
# Description
## One Line Summary
Give developers more error details by logging the entire `NSError` instead of just the `localizedDescription`, which many not exist for the error.

## Details

### Motivation
These changes were brought up when a customer was getting failure for sending receive receipts but the error logged was `(Error 0 in OneSignal Error.)`, not so informative. This is because the error's `localizedDescription` was being logged when it didn't have that information set. When missing, a default string is constructed from the domain and code.

### Context
To properly provide `localizedDescription`, we would have to provide a key `NSLocalizedDescriptionKey` in the `userInfo` dictionary. Most of the NSErrors created in the SDK use a key of `"error"` instead, and in a few other cases, a key of `"returned"`. Only 1 error at the time of this PR uses `NSLocalizedDescriptionKey`.

The SDK creates and handles errors in a variety of ways, and the scope of this PR is limited to logging.

I also looked at other error logging that used `error.description` and this does give the full error details as well.

### Example Log
Here is an example of what is logged for `error` or `error.description`:
```
Error Domain=OneSignal Error Code=0 "(null)" UserInfo={error=Attempted to perform an HTTP request (OSRequestReceiveReceipts) before the user provided privacy consent.}
```

The "(null)" is the localized description.

### Scope
Just affects logging only.

## Manual testing
Tested what is logged on different errors using the error object itself, `error. localizedDescription`, and `error.description` (which is used in some other instances).

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1068)
<!-- Reviewable:end -->
