### PR TITLE
Update OneSignal.podspec to use xcframeworks

### DIFF
--- a/OneSignal.podspec
+++ b/OneSignal.podspec
@@ -7,10 +7,22 @@ Pod::Spec.new do |s|
   s.author           = { "Joseph Kalash" => "joseph@onesignal.com", "Josh Kasten" => "josh@onesignal.com" , "Brad Hesse" => "brad@onesignal.com"}
   
   s.source           = { :git => "https://github.com/OneSignal/OneSignal-iOS-SDK.git", :tag => s.version.to_s }
-  
   s.platform         = :ios, "9.0"
   s.requires_arc     = true
-  
-  s.ios.vendored_frameworks = 'iOS_SDK/OneSignalSDK/Framework/OneSignal.framework'
-  s.framework               = 'SystemConfiguration', 'UIKit', 'UserNotifications', 'WebKit', 'CoreGraphics'
+
+  s.ios.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_XCFramework/OneSignal.xcframework'
+    s.subspec 'OneSignalCore' do |ss|
+      ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_Core/OneSignalCore.xcframework'
+    end
+
+    s.subspec 'OneSignalOutcomes' do |ss|
+      ss.dependency 'OneSignalXCFramework/OneSignalCore'
+      ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_Outcomes/OneSignalOutcomes.xcframework'
+    end
+
+    s.subspec 'OneSignalExtension' do |ss|
+      ss.dependency 'OneSignalXCFramework/OneSignalCore'
+      ss.dependency 'OneSignalXCFramework/OneSignalOutcomes'
+      ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_Extension/OneSignalExtension.xcframework'
+    end
 end

--- a/OneSignalXCFramework.podspec
+++ b/OneSignalXCFramework.podspec
@@ -11,24 +11,20 @@ Pod::Spec.new do |s|
     s.requires_arc     = true
     
     s.ios.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_XCFramework/OneSignal.xcframework'
-    #s.preserve_paths = 'iOS_SDK/OneSignalSDK/OneSignal_XCFramework/OneSignal.xcframework'
 
     s.subspec 'OneSignalCore' do |ss|
       ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_Core/OneSignalCore.xcframework'
-      #ss.preserve_paths = 'iOS_SDK/OneSignalSDK/OneSignal_Core/OneSignalCore.xcframework'
     end
 
     s.subspec 'OneSignalOutcomes' do |ss|
       ss.dependency 'OneSignalXCFramework/OneSignalCore'
       ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_Outcomes/OneSignalOutcomes.xcframework'
-      #ss.preserve_paths = 'iOS_SDK/OneSignalSDK/OneSignal_Outcomes/OneSignalOutcomes.xcframework'
     end
 
     s.subspec 'OneSignalExtension' do |ss|
       ss.dependency 'OneSignalXCFramework/OneSignalCore'
       ss.dependency 'OneSignalXCFramework/OneSignalOutcomes'
       ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_Extension/OneSignalExtension.xcframework'
-      #ss.preserve_paths = 'iOS_SDK/OneSignalSDK/OneSignal_Extension/OneSignalExtension.xcframework'
     end
   end
   


### PR DESCRIPTION
# Description
## One Line Summary
Updating the `OneSignal.podspec` to distribute the modularized xcframeworks identically to `OneSignalXCFramework.podspec`

## Details
We are unable to distribute a fat framework from the modularized branch using Cocoapods, and we should be using XCFrameworks going forward. This PR makes the two podspecs identical. When we do a major release we can sunset one of the two.

### Motivation
required to distribute the modularized branch for customers still using OneSignal.podspec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1072)
<!-- Reviewable:end -->
