### PR TITLE
Add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask-question.yml
+++ b/.github/ISSUE_TEMPLATE/ask-question.yml
@@ -21,7 +21,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](#insert-project-code-of-conduct-here)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/main/CONTRIBUTING.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/ask-question.yml
+++ b/.github/ISSUE_TEMPLATE/ask-question.yml
@@ -1,5 +1,5 @@
 name: 🙋‍♂️ Ask a question
-description: How can we help?
+description: Tell us what's on your mind
 title: "[question]: "
 labels: ["question"]
 # assignees:

--- a/.github/ISSUE_TEMPLATE/ask-question.yml
+++ b/.github/ISSUE_TEMPLATE/ask-question.yml
@@ -1,0 +1,27 @@
+name: 🙋‍♂️ Ask a question
+description: How can we help?
+title: "[question]: "
+labels: ["question"]
+# assignees:
+#   - OneSignal/ios-sdk
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Having issues integrating this SDK?
+  - type: textarea
+    id: question
+    attributes:
+      label: How can we help?
+      description: Specific question regarding integrating this SDK.
+      placeholder: How do I...?
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](#insert-project-code-of-conduct-here)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,54 @@
+name: 🪳 Bug report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+# assignees:
+#   - assign your sdk team e.g., onesignal/unity
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Provide a thorough description of whats going on.
+      placeholder: e.g. The latest version of the SDK causes my screen to go blank when I tap on the screen three times.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce?
+      description: Provide as much detail as posible to reproduce the issue.
+      placeholder: |
+        1. Install vX.Y.Z of dependency
+        2. Launch the app on iOS device
+        3. Tap the screen three times
+        4. Note that the app crashes
+      render: Markdown
+    validations:
+      required: true
+  - type: textarea
+    id: what-are-expectations
+    attributes:
+      label: What did you expect to happen?
+      description: Also tell us, what did you expect to happen?
+      placeholder: I expected the app to continue running no matter how many times I tap the screen.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: Shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](#insert-project-code-of-conduct-here)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,6 +38,43 @@ body:
       placeholder: I expected the app to continue running no matter how many times I tap the screen.
     validations:
       required: true
+  - type: input
+    id: ios-sdk-version
+    attributes:
+      label: OneSignal iOS SDK version
+      description: What version of the OneSignal iOS SDK are you using?
+      placeholder: Release 3.10.3
+    validations:
+      required: true
+  - type: dropdown
+    id: ios-major-version
+    attributes:
+      label: iOS version
+      description:  Which versions of iOS are broken for you?
+      multiple: true
+      options:
+        - 15
+        - 14
+        - 13
+        - 12
+        - 11
+        - 10 or below
+      validations:
+        required: true
+   
+  - type: input
+    id: ios-sdk-version
+    attributes:
+      label: Specific iOS version
+      description: What are the specific versions.
+      placeholder: |
+        * iOS 15.4
+        * iOS 13.7
+        * iOS 8.0
+      render: Markdown
+    validations:
+      required: true
+      
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -72,8 +72,8 @@ body:
         * iOS 13.7
         * iOS 8.0
       render: Markdown
-    validations:
-      required: true
+      validations:
+        required: true
       
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -53,17 +53,15 @@ body:
       description:  Which versions of iOS are broken for you?
       multiple: true
       options:
-        - 15
-        - 14
-        - 13
-        - 12
-        - 11
-        - 10 or below
-      validations:
-        required: true
-   
-  - type: input
-    id: ios-sdk-version
+        - "15"
+        - "14"
+        - "13"
+        - "12"
+        - "11 or below"
+    validations:
+      required: true
+  - type: textarea
+    id: ios-specific-version
     attributes:
       label: Specific iOS version
       description: What are the specific versions.
@@ -72,9 +70,9 @@ body:
         * iOS 13.7
         * iOS 8.0
       render: Markdown
-      validations:
+    validations:
         required: true
-      
+
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -81,7 +81,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](#insert-project-code-of-conduct-here)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/main/CONTRIBUTING.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,8 +70,6 @@ body:
         * iOS 13.7
         * iOS 8.0
       render: Markdown
-    validations:
-        required: true
 
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,7 +3,7 @@ description: File a bug report
 title: "[Bug]: "
 labels: ["bug", "triage"]
 # assignees:
-#   - assign your sdk team e.g., onesignal/unity
+#   - OneSignal/ios-sdk
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/general-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/general-feedback.yml
@@ -21,7 +21,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](#insert-project-code-of-conduct-here)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/main/CONTRIBUTING.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/general-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/general-feedback.yml
@@ -1,0 +1,27 @@
+name: 📣 General feedback
+description: Tell us what's on your mind
+title: "[Bug]: "
+labels: ["triage"]
+# assignees:
+#   - OneSignal/ios-sdk
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your valuable feedback!
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What's on your mind?
+      description: Feedback regarding this SDK.
+      placeholder: Share your feedback...
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](#insert-project-code-of-conduct-here)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
I added issue form templates.

* [📝 rendered bug form ](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/b82d0f048676f49fa487a993d95738e590bb6c2d/.github/ISSUE_TEMPLATE/bug-report.yml)
* [📝 rendered question form](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/705506f1ee4aa9308e7b062c1a585733dfe8394a/.github/ISSUE_TEMPLATE/ask-question.yml)
* [📝 rendered general feedback form](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/9ec51008aae3eff78b004add848fa175caf5e621/.github/ISSUE_TEMPLATE/general-feedback.yml)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1080)
<!-- Reviewable:end -->
