### PR TITLE
[Change] Omit objc_getClassList calls from swizzling

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		03CCCC8D283624F3004BF794 /* SwizzlingForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03CCCC8B283624F3004BF794 /* SwizzlingForwarder.h */; };
 		03CCCC8E283624F3004BF794 /* SwizzlingForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03CCCC8C283624F3004BF794 /* SwizzlingForwarder.m */; };
 		03CCCC8F283624F3004BF794 /* SwizzlingForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03CCCC8C283624F3004BF794 /* SwizzlingForwarder.m */; };
+		03E56DD328405F4A006AA1DA /* OneSignalAppDelegateOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E56DD228405F4A006AA1DA /* OneSignalAppDelegateOverrider.m */; };
 		16664C4C25DDB195003B8A14 /* NSTimeZoneOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 16664C4B25DDB195003B8A14 /* NSTimeZoneOverrider.m */; };
 		37E6B2BB19D9CAF300D0C601 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		3E464ED71D88ED1F00DCF7E9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; };
@@ -632,6 +633,8 @@
 		03CCCC842835F291004BF794 /* UIApplicationDelegateSwizzlingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIApplicationDelegateSwizzlingTests.m; sourceTree = "<group>"; };
 		03CCCC8B283624F3004BF794 /* SwizzlingForwarder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwizzlingForwarder.h; sourceTree = "<group>"; };
 		03CCCC8C283624F3004BF794 /* SwizzlingForwarder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwizzlingForwarder.m; sourceTree = "<group>"; };
+		03E56DD128405F4A006AA1DA /* OneSignalAppDelegateOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalAppDelegateOverrider.h; sourceTree = "<group>"; };
+		03E56DD228405F4A006AA1DA /* OneSignalAppDelegateOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalAppDelegateOverrider.m; sourceTree = "<group>"; };
 		16664C4B25DDB195003B8A14 /* NSTimeZoneOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSTimeZoneOverrider.m; sourceTree = "<group>"; };
 		16664C5425DDB2CB003B8A14 /* NSTimeZoneOverrider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSTimeZoneOverrider.h; sourceTree = "<group>"; };
 		1AF75EAC1E8567FD0097B315 /* NSString+OneSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+OneSignal.h"; sourceTree = "<group>"; };
@@ -1172,6 +1175,8 @@
 				DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */,
 				16664C4B25DDB195003B8A14 /* NSTimeZoneOverrider.m */,
 				16664C5425DDB2CB003B8A14 /* NSTimeZoneOverrider.h */,
+				03E56DD128405F4A006AA1DA /* OneSignalAppDelegateOverrider.h */,
+				03E56DD228405F4A006AA1DA /* OneSignalAppDelegateOverrider.m */,
 			);
 			path = Shadows;
 			sourceTree = "<group>";
@@ -2394,6 +2399,7 @@
 				91F60F7D1E80E4E400706E60 /* UncaughtExceptionHandler.m in Sources */,
 				CA4743A02190FEA80020DC8C /* OSTrigger.m in Sources */,
 				912412201E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
+				03E56DD328405F4A006AA1DA /* OneSignalAppDelegateOverrider.m in Sources */,
 				7AF9863D2444C43900C36EAE /* OSInAppMessageTracker.m in Sources */,
 				DE9877342591656300DE07D5 /* NSDateFormatter+OneSignal.m in Sources */,
 				DEAD6F98270B829700DE7C67 /* OneSignalLog.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -2949,16 +2949,30 @@ static ONE_S_LOG_LEVEL _visualLogLevel = ONE_S_LL_NONE;
         return;
 
     // Double loading of class detection.
-    BOOL existing = injectSelector([OneSignalAppDelegate class], @selector(oneSignalLoadedTagSelector:), self, @selector(oneSignalLoadedTagSelector:));
+    BOOL existing = injectSelector(
+        self,
+        @selector(oneSignalLoadedTagSelector:),
+        [OneSignalAppDelegate class],
+        @selector(oneSignalLoadedTagSelector:)
+    );
     if (existing) {
         [OneSignal onesignalLog:ONE_S_LL_WARN message:@"Already swizzled UIApplication.setDelegate. Make sure the OneSignal library wasn't loaded into the runtime twice!"];
         return;
     }
 
     // Swizzle - UIApplication delegate
-    injectToProperClass(@selector(setOneSignalDelegate:), @selector(setDelegate:), @[], [OneSignalAppDelegate class], [UIApplication class]);
-    
-    injectToProperClass(@selector(onesignalSetApplicationIconBadgeNumber:), @selector(setApplicationIconBadgeNumber:), @[], [OneSignalAppDelegate class], [UIApplication class]);
+    injectSelector(
+        [UIApplication class],
+        @selector(setDelegate:),
+        [OneSignalAppDelegate class],
+        @selector(setOneSignalDelegate:)
+   );
+    injectSelector(
+        [UIApplication class],
+        @selector(setApplicationIconBadgeNumber:),
+        [OneSignalAppDelegate class],
+        @selector(onesignalSetApplicationIconBadgeNumber:)
+    );
     
     [self setupUNUserNotificationCenterDelegate];
     [[OSMigrationController new] migrate];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
@@ -29,8 +29,6 @@
 #define OneSignalSelectorHelpers_h
 
 // Functions to help sizzle methods.
-
-BOOL injectClassSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);
 BOOL injectSelector(Class targetClass, SEL targetSelector, Class myClass, SEL mySelector);
 
 #endif /* OneSignalSelectorHelpers_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
@@ -30,9 +30,6 @@
 
 // Functions to help sizzle methods.
 
-BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector);
-Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind);
-NSArray* ClassGetSubclasses(Class parentClass);
 void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass);
 BOOL injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);
 BOOL injectClassSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.h
@@ -30,8 +30,7 @@
 
 // Functions to help sizzle methods.
 
-void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass);
-BOOL injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);
 BOOL injectClassSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);
+BOOL injectSelector(Class targetClass, SEL targetSelector, Class myClass, SEL mySelector);
 
 #endif /* OneSignalSelectorHelpers_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
@@ -30,27 +30,6 @@
 
 #import "OneSignalSelectorHelpers.h"
 
-BOOL injectClassSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
-    Method newMeth = class_getClassMethod(newClass, newSel);
-    IMP imp = method_getImplementation(newMeth);
-    
-    const char* methodTypeEncoding = method_getTypeEncoding(newMeth);
-   
-    BOOL existing = class_getClassMethod(addToClass, makeLikeSel) != NULL;
-    
-    if (existing) {
-        class_addMethod(addToClass, newSel, imp, methodTypeEncoding);
-        newMeth = class_getClassMethod(addToClass, newSel);
-       // Method orgMeth = class_getClassMethod(addToClass, makeLikeSel);
-        class_replaceMethod(addToClass, makeLikeSel, imp, methodTypeEncoding);
-        //method_exchangeImplementations(orgMeth, newMeth);
-    }
-    else
-        class_addMethod(addToClass, makeLikeSel, imp, methodTypeEncoding);
-    
-    return existing;
-}
-
 BOOL injectSelector(Class targetClass, SEL targetSelector, Class myClass, SEL mySelector) {
     Method newMeth = class_getInstanceMethod(myClass, mySelector);
     IMP newImp = method_getImplementation(newMeth);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSelectorHelpers.m
@@ -30,24 +30,6 @@
 
 #import "OneSignalSelectorHelpers.h"
 
-BOOL checkIfInstanceOverridesSelector(Class instance, SEL selector) {
-    Class instSuperClass = [instance superclass];
-    return [instance instanceMethodForSelector: selector] != [instSuperClass instanceMethodForSelector: selector];
-}
-
-
-Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind) {
-    if (!class_conformsToProtocol(searchClass, protocolToFind)) {
-        if ([searchClass superclass] == nil)
-            return nil;
-        Class foundClass = getClassWithProtocolInHierarchy([searchClass superclass], protocolToFind);
-        if (foundClass)
-            return foundClass;
-        return searchClass;
-    }
-    return searchClass;
-}
-
 BOOL injectClassSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
     Method newMeth = class_getClassMethod(newClass, newSel);
     IMP imp = method_getImplementation(newMeth);
@@ -104,47 +86,5 @@ BOOL injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSe
 // Try to find out which class to inject to
 void injectToProperClass(SEL newSel, SEL makeLikeSel, NSArray* delegateSubclasses, Class myClass, Class delegateClass) {
     
-    // Find out if we should inject in delegateClass or one of its subclasses.
-    // CANNOT use the respondsToSelector method as it returns TRUE to both implementing and inheriting a method
-    // We need to make sure the class actually implements the method (overrides) and not inherits it to properly perform the call
-    // Start with subclasses then the delegateClass
-    
-    for(Class subclass in delegateSubclasses) {
-        if (checkIfInstanceOverridesSelector(subclass, makeLikeSel)) {
-            injectSelector(myClass, newSel, subclass, makeLikeSel);
-            return;
-        }
-    }
-    
-    // No subclass overrides the method, try to inject in delegate class
     injectSelector(myClass, newSel, delegateClass, makeLikeSel);
-    
-}
-
-NSArray* ClassGetSubclasses(Class parentClass) {
-    int numClasses = objc_getClassList(NULL, 0);
-    int memSize = sizeof(Class) * numClasses;
-    Class *classes = (Class*)malloc(memSize);
-    if (classes == NULL && memSize) {
-        return [NSMutableArray array];
-    }
-    
-    objc_getClassList(classes, numClasses);
-    
-    NSMutableArray *result = [NSMutableArray array];
-    
-    for (NSInteger i = 0; i < numClasses; i++) {
-        Class superClass = classes[i];
-        
-        while(superClass && superClass != parentClass) {
-            superClass = class_getSuperclass(superClass);
-        }
-        
-        if (superClass)
-            [result addObject:classes[i]];
-    }
-    
-    free(classes);
-    
-    return result;
 }

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
@@ -31,6 +31,7 @@
 
 + (void)sizzlePreiOS10MethodsPhase1;
 + (void)sizzlePreiOS10MethodsPhase2;
++ (void)traceCall:(NSString*)selector;
 
 @end
 #endif /* UIApplicationDelegate_OneSignal_h */

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -81,8 +81,8 @@ static NSArray* delegateSubclasses = nil;
     
     Class newClass = [OneSignalAppDelegate class];
     
-    delegateClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
-    delegateSubclasses = ClassGetSubclasses(delegateClass);
+    delegateClass = [delegate class];
+    delegateSubclasses = @[];
     
     // Need to keep this one for iOS 10 for content-available notifiations when the app is not in focus
     //   iOS 10 doesn't fire a selector on UNUserNotificationCenter in this cases most likely becuase

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -71,6 +71,7 @@ static NSArray* delegateSubclasses = nil;
 }
 
 - (void) setOneSignalDelegate:(id<UIApplicationDelegate>)delegate {
+    [OneSignalAppDelegate traceCall:@"setOneSignalDelegate:"];
     [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"ONESIGNAL setOneSignalDelegate CALLED: %@", delegate]];
     
     if ([delegate class] == delegateClass) {
@@ -135,7 +136,7 @@ static NSArray* delegateSubclasses = nil;
 
 
 - (void)oneSignalDidRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken {
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"oneSignalDidRegisterForRemoteNotifications:deviceToken:"];
+    [OneSignalAppDelegate traceCall:@"oneSignalDidRegisterForRemoteNotifications:deviceToken:"];
     
     [OneSignal didRegisterForRemoteNotifications:app deviceToken:inDeviceToken];
     
@@ -152,7 +153,7 @@ static NSArray* delegateSubclasses = nil;
 }
 
 - (void)oneSignalDidFailRegisterForRemoteNotification:(UIApplication*)app error:(NSError*)err {
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"oneSignalDidFailRegisterForRemoteNotification:error:"];
+    [OneSignalAppDelegate traceCall:@"oneSignalDidFailRegisterForRemoteNotification:error:"];
     
     if ([OneSignal appId])
         [OneSignal handleDidFailRegisterForRemoteNotification:err];
@@ -172,7 +173,7 @@ static NSArray* delegateSubclasses = nil;
 #pragma clang diagnostic ignored "-Wdeprecated"
 // iOS 9 Only
 - (void)oneSignalDidRegisterUserNotifications:(UIApplication*)application settings:(UIUserNotificationSettings*)notificationSettings {
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"oneSignalDidRegisterUserNotifications:settings:"];
+    [OneSignalAppDelegate traceCall:@"oneSignalDidRegisterUserNotifications:settings:"];
     
     if ([OneSignal appId])
         [OneSignal updateNotificationTypes:(int)notificationSettings.types];
@@ -188,7 +189,7 @@ static NSArray* delegateSubclasses = nil;
 //          iOS 10 - This crashes the app if it is called twice! Crash will happen when the app is resumed.
 //          iOS 9  - Does not have this issue.
 - (void) oneSignalReceiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:"];
+    [OneSignalAppDelegate traceCall:@"oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:"];
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
         initWithTarget:self
         withYourSelector:@selector(
@@ -257,7 +258,7 @@ static NSArray* delegateSubclasses = nil;
 #pragma clang diagnostic ignored "-Wdeprecated"
 - (void) oneSignalLocalNotificationOpened:(UIApplication*)application handleActionWithIdentifier:(NSString*)identifier forLocalNotification:(UILocalNotification*)notification completionHandler:(void(^)()) completionHandler {
 #pragma clang diagnostic pop
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:"];
+    [OneSignalAppDelegate traceCall:@"oneSignalLocalNotificationOpened:handleActionWithIdentifier:forLocalNotification:completionHandler:"];
     
     if ([OneSignal appId])
         [OneSignal processLocalActionBasedNotification:notification identifier:identifier];
@@ -271,7 +272,7 @@ static NSArray* delegateSubclasses = nil;
 #pragma clang diagnostic ignored "-Wdeprecated"
 - (void)oneSignalLocalNotificationOpened:(UIApplication*)application notification:(UILocalNotification*)notification {
 #pragma clang diagnostic pop
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"oneSignalLocalNotificationOpened:notification:"];
+    [OneSignalAppDelegate traceCall:@"oneSignalLocalNotificationOpened:notification:"];
     
     if ([OneSignal appId])
         [OneSignal processLocalActionBasedNotification:notification identifier:@"__DEFAULT__"];
@@ -295,6 +296,12 @@ static NSArray* delegateSubclasses = nil;
         )
     ];
     [forwarder invokeWithArgs:@[application]];
+}
+
+// Used to log all calls, also used in unit tests to observer
+// the OneSignalAppDelegate selectors get called.
++(void) traceCall:(NSString*)selector {
+    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:selector];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -195,8 +195,8 @@ static UNNotificationSettings* cachedUNNotificationSettings;
 }
 
 + (void)swizzleSelectorsOnDelegate:(id)delegate {
-    delegateUNClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UNUserNotificationCenterDelegate));
-    delegateUNSubclasses = ClassGetSubclasses(delegateUNClass);
+    delegateUNClass = [delegate class];
+    delegateUNSubclasses = @[];
     
     injectToProperClass(@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:),
                         @selector(userNotificationCenter:willPresentNotification:withCompletionHandler:), delegateUNSubclasses, [OneSignalUNUserNotificationCenter class], delegateUNClass);

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -94,16 +94,27 @@ static NSArray* delegateUNSubclasses = nil;
 __weak static id previousDelegate;
 
 + (void)swizzleSelectors {
-    injectToProperClass(@selector(setOneSignalUNDelegate:), @selector(setDelegate:), @[], [OneSignalUNUserNotificationCenter class], [UNUserNotificationCenter class]);
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(setDelegate:),
+        [OneSignalUNUserNotificationCenter class],
+        @selector(setOneSignalUNDelegate:)
+   );
     
     // Overrides to work around 10.2.1 bug where getNotificationSettingsWithCompletionHandler: reports as declined if called before
     //  requestAuthorizationWithOptions:'s completionHandler fires when the user accepts notifications.
-    injectToProperClass(@selector(onesignalRequestAuthorizationWithOptions:completionHandler:),
-                        @selector(requestAuthorizationWithOptions:completionHandler:), @[],
-                        [OneSignalUNUserNotificationCenter class], [UNUserNotificationCenter class]);
-    injectToProperClass(@selector(onesignalGetNotificationSettingsWithCompletionHandler:),
-                        @selector(getNotificationSettingsWithCompletionHandler:), @[],
-                        [OneSignalUNUserNotificationCenter class], [UNUserNotificationCenter class]);
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(requestAuthorizationWithOptions:completionHandler:),
+        [OneSignalUNUserNotificationCenter class],
+        @selector(onesignalRequestAuthorizationWithOptions:completionHandler:)
+    );
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(getNotificationSettingsWithCompletionHandler:),
+        [OneSignalUNUserNotificationCenter class],
+        @selector(onesignalGetNotificationSettingsWithCompletionHandler:)
+   );
 }
 
 + (void)registerDelegate {
@@ -196,13 +207,18 @@ static UNNotificationSettings* cachedUNNotificationSettings;
 
 + (void)swizzleSelectorsOnDelegate:(id)delegate {
     delegateUNClass = [delegate class];
-    delegateUNSubclasses = @[];
-    
-    injectToProperClass(@selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:),
-                        @selector(userNotificationCenter:willPresentNotification:withCompletionHandler:), delegateUNSubclasses, [OneSignalUNUserNotificationCenter class], delegateUNClass);
-    
-    injectToProperClass(@selector(onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:),
-                        @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:), delegateUNSubclasses, [OneSignalUNUserNotificationCenter class], delegateUNClass);
+    injectSelector(
+        delegateUNClass,
+        @selector(userNotificationCenter:willPresentNotification:withCompletionHandler:),
+        [OneSignalUNUserNotificationCenter class],
+        @selector(onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:)
+    );
+    injectSelector(
+        delegateUNClass,
+        @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:),
+        [OneSignalUNUserNotificationCenter class],
+        @selector(onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)
+    );
 }
 
 + (BOOL)forwardNotificationWithCenter:(UNUserNotificationCenter *)center

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSBundleOverrider.m
@@ -42,13 +42,33 @@ static BOOL privacyState = false;
 }
 
 + (void)load {
-    injectToProperClass(@selector(overrideBundleIdentifier), @selector(bundleIdentifier), @[], [NSBundleOverrider class], [NSBundle class]);
+    injectSelector(
+        [NSBundle class],
+        @selector(bundleIdentifier),
+        [NSBundleOverrider class],
+        @selector(overrideBundleIdentifier)
+    );
     
-    injectToProperClass(@selector(overrideObjectForInfoDictionaryKey:), @selector(objectForInfoDictionaryKey:), @[], [NSBundleOverrider class], [NSBundle class]);
-    injectToProperClass(@selector(overrideURLForResource:withExtension:), @selector(URLForResource:withExtension:), @[], [NSBundleOverrider class], [NSBundle class]);
+    injectSelector(
+        [NSBundle class],
+        @selector(objectForInfoDictionaryKey:),
+        [NSBundleOverrider class],
+        @selector(overrideObjectForInfoDictionaryKey:)
+   );
+   injectSelector(
+       [NSBundle class],
+       @selector(URLForResource:withExtension:),
+       [NSBundleOverrider class],
+       @selector(overrideURLForResource:withExtension:)
+    );
     
     // Doesn't work to swizzle for mocking. Both an NSDictionary and NSMutableDictionarys both throw odd selecotor not found errors.
-    // injectToProperClass(@selector(overrideInfoDictionary), @selector(infoDictionary), @[], [NSBundleOverrider class], [NSBundle class]);
+    // injectSelector(
+    //     [NSBundle class],
+    //     @selector(infoDictionary),
+    //     [NSBundleOverrider class],
+    //     @selector(overrideInfoDictionary)
+    // );
 }
 
 +(void) setNsbundleDictionary:(NSDictionary*)value {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDateOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSDateOverrider.m
@@ -60,7 +60,12 @@ static NSTimeInterval _globalTimeOffset;
     swizzleClassMethodWithCategoryImplementation([NSDate class], @selector(date), @selector(overrideDate));
     swizzleClassMethodWithCategoryImplementation([NSDate class], @selector(dateWithTimeIntervalSince1970:), @selector(overrideDateWithTimeIntervalSince1970:));
 
-    injectToProperClass(@selector(overrideTimeIntervalSinceNow), @selector(timeIntervalSinceNow), @[], [NSDateOverrider class], [NSDate class]);
+    injectSelector(
+        [NSDate class],
+        @selector(timeIntervalSinceNow),
+        [NSDateOverrider class],
+        @selector(overrideTimeIntervalSinceNow)
+   );
 }
 
 +(void) reset {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSObjectOverrider.m
@@ -36,7 +36,12 @@ static BOOL instantRunPerformSelectorAfterDelay;
 static NSMutableArray* selectorNamesForInstantOnlyForFirstRun;
 
 + (void)load {
-    injectToProperClass(@selector(overridePerformSelector:withObject:afterDelay:), @selector(performSelector:withObject:afterDelay:), @[], [NSObjectOverrider class], [NSObject class]);
+    injectSelector(
+        [NSObject class],
+        @selector(performSelector:withObject:afterDelay:),
+        [NSObjectOverrider class],
+        @selector(overridePerformSelector:withObject:afterDelay:)
+   );
 }
 
 + (void)reset {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSTimerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSTimerOverrider.m
@@ -76,7 +76,12 @@ static NSMutableArray<NSTimer*>* _pendingNSTimers;
     swizzleClassMethodWithCategoryImplementation(NSTimer.class, @selector(timerWithTimeInterval:target:selector:userInfo:repeats:), @selector(overrideTimerWithTimeInterval:target:selector:userInfo:repeats:));
     swizzleClassMethodWithCategoryImplementation(NSTimer.class, @selector(scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:), @selector(overrideScheduledTimerWithTimeInterval:target:selector:userInfo:repeats:));
     // __NSCFTimer is special here as the implementation of invalidate lives in this private class
-    injectToProperClass(@selector(overrideInvalidate), @selector(invalidate), @[NSClassFromString(@"__NSCFTimer")], NSTimerOverrider.class, NSTimer.class);
+    injectSelector(
+        NSClassFromString(@"__NSCFTimer"),
+        @selector(invalidate),
+        [NSTimerOverrider class],
+        @selector(overrideInvalidate)
+    );
 }
 
 + (void)reset {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/NSURLSessionOverrider.m
@@ -40,7 +40,12 @@
     // Swizzle an injected method defined in OneSignalHelper
     injectStaticSelector([NSURLSessionOverrider class], @selector(overrideDownloadItemAtURL:toFile:error:), [NSURLSession class], @selector(downloadItemAtURL:toFile:error:));
     #pragma clang diagnostic pop
-    injectToProperClass(@selector(overrideDataTaskWithRequest:completionHandler:), @selector(dataTaskWithRequest:completionHandler:), @[], [NSURLSessionOverrider class], [NSURLSession class]);
+    injectSelector(
+        [NSURLSession class],
+        @selector(dataTaskWithRequest:completionHandler:),
+        [NSURLSessionOverrider class],
+        @selector(overrideDataTaskWithRequest:completionHandler:)
+   );
 }
 
 // Override downloading of media attachment

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewControllerOverrider.m
@@ -35,8 +35,18 @@
 + (void)load {
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wundeclared-selector"
-    injectToProperClass(@selector(overrideAnimateAppearance), @selector(animateAppearance), @[], [OSInAppMessageViewControllerOverrider class], [OSInAppMessageViewController class]);
-    injectToProperClass(@selector(overrideAnimateAppearance:), @selector(animateAppearance:), @[], [OSInAppMessageViewControllerOverrider class], [OSInAppMessageViewController class]);
+    injectSelector(
+        [OSInAppMessageViewController class],
+        @selector(animateAppearance),
+        [OSInAppMessageViewControllerOverrider class],
+        @selector(overrideAnimateAppearance)
+    );
+    injectSelector(
+        [OSInAppMessageViewController class],
+        @selector(animateAppearance:),
+        [OSInAppMessageViewControllerOverrider class],
+        @selector(overrideAnimateAppearance:)
+    );
     #pragma clang diagnostic pop
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSInAppMessageViewOverrider.m
@@ -33,7 +33,12 @@
 @implementation OSInAppMessageViewOverrider
 
 + (void)load {
-    injectToProperClass(@selector(overrideLoadedHtmlContent:withBaseURL:), @selector(loadedHtmlContent:withBaseURL:), @[], [OSInAppMessageViewOverrider class], [OSInAppMessageView class]);
+    injectSelector(
+        [OSInAppMessageView class],
+        @selector(loadedHtmlContent:withBaseURL:),
+        [OSInAppMessageViewOverrider class],
+        @selector(overrideLoadedHtmlContent:withBaseURL:)
+   );
 }
 
 - (void)overrideLoadedHtmlContent:(NSString *)html withBaseURL:(NSURL *)url {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OSMessagingControllerOverrider.m
@@ -87,8 +87,18 @@
 + (void)load {
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wundeclared-selector"
-    injectToProperClass(@selector(overrideShowMessage:), @selector(showMessage:), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
-    injectToProperClass(@selector(overrideWebViewContentFinishedLoading:), @selector(webViewContentFinishedLoading:), @[], [OSMessagingControllerOverrider class], [OSMessagingController class]);
+    injectSelector(
+        [OSMessagingController class],
+        @selector(showMessage:),
+        [OSMessagingControllerOverrider class],
+        @selector(overrideShowMessage:)
+    );
+    injectSelector(
+        [OSMessagingController class],
+        @selector(webViewContentFinishedLoading:),
+        [OSMessagingControllerOverrider class],
+        @selector(overrideWebViewContentFinishedLoading:)
+    );
     #pragma clang diagnostic pop
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalAppDelegateOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalAppDelegateOverrider.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OneSignalAppDelegateOverrider : NSObject
++ (int)callCountForSelector:(NSString*)selector;
++ (void)reset;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalAppDelegateOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalAppDelegateOverrider.m
@@ -1,0 +1,35 @@
+#import "OneSignalAppDelegateOverrider.h"
+
+#import "TestHelperFunctions.h"
+
+#import "OneSignalSelectorHelpers.h"
+#import "UIApplicationDelegate+OneSignal.h"
+
+@implementation OneSignalAppDelegateOverrider
+
+static NSMutableDictionary* callCount;
+
++ (void)load {
+    callCount = [NSMutableDictionary new];
+
+    injectStaticSelector(
+        [OneSignalAppDelegateOverrider class],
+        @selector(overrideTraceCall:),
+        [OneSignalAppDelegate class],
+        @selector(traceCall:)
+    );
+}
+
++ (void)reset {
+    callCount = [NSMutableDictionary new];
+}
+
++ (void)overrideTraceCall:(NSString*)selector {
+    NSNumber *value = callCount[selector];
+    callCount[selector] = [NSNumber numberWithInt:[value intValue] + 1];
+}
+
++ (int)callCountForSelector:(NSString*)selector {
+    return [callCount[selector] intValue];
+}
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -67,9 +67,24 @@ static NSDictionary* remoteParams;
     serialMockMainLooper = dispatch_queue_create("com.onesignal.unittest", DISPATCH_QUEUE_SERIAL);
     
     //with refactored networking code, need to replace the implementation of the execute request method so tests don't actually execite HTTP requests
-    injectToProperClass(@selector(overrideExecuteRequest:onSuccess:onFailure:), @selector(executeRequest:onSuccess:onFailure:), @[], [OneSignalClientOverrider class], [OneSignalClient class]);
-    injectToProperClass(@selector(overrideExecuteSimultaneousRequests:withSuccess:onFailure:), @selector(executeSimultaneousRequests:withSuccess:onFailure:), @[], [OneSignalClientOverrider class], [OneSignalClient class]);
-    injectToProperClass(@selector(overrideExecuteDataRequest:onSuccess:onFailure:), @selector(executeDataRequest:onSuccess:onFailure:), @[], [OneSignalClientOverrider class], [OneSignalClient class]);
+    injectSelector(
+        [OneSignalClient class],
+        @selector(executeRequest:onSuccess:onFailure:),
+        [OneSignalClientOverrider class],
+        @selector(overrideExecuteRequest:onSuccess:onFailure:)
+    );
+    injectSelector(
+        [OneSignalClient class],
+        @selector(executeSimultaneousRequests:withSuccess:onFailure:),
+        [OneSignalClientOverrider class],
+        @selector(overrideExecuteSimultaneousRequests:withSuccess:onFailure:)
+    );
+    injectSelector(
+        [OneSignalClient class],
+        @selector(executeDataRequest:onSuccess:onFailure:),
+        [OneSignalClientOverrider class],
+        @selector(overrideExecuteDataRequest:onSuccess:onFailure:)
+    );
 
     executionQueue = dispatch_queue_create("com.onesignal.execution", NULL);
     executedRequests = [NSMutableArray new];

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalDialogControllerOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalDialogControllerOverrider.m
@@ -42,7 +42,12 @@
 static OSDialogRequest *currentDialog;
 
 + (void)load {
-    injectToProperClass(@selector(overrideDisplayDialog:), @selector(displayDialog:), @[], [OneSignalDialogControllerOverrider class], [OneSignalDialogController class]);
+    injectSelector(
+        [OneSignalDialogController class],
+        @selector(displayDialog:),
+        [OneSignalDialogControllerOverrider class],
+        @selector(overrideDisplayDialog:)
+    );
 }
 
 - (void)overrideDisplayDialog:(OSDialogRequest * _Nonnull)request {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalLocationOverrider.m
@@ -54,9 +54,24 @@ NSArray *locations;
     injectStaticSelector([OneSignalLocationOverrider class], @selector(overrideStarted), [OneSignalLocation class], @selector(started));
     injectStaticSelector([OneSignalLocationOverrider class], @selector(overrideAuthorizationStatus), [CLLocationManager class], @selector(authorizationStatus));
     
-    injectSelector([OneSignalLocationOverrider class], @selector(overrideRequestAlwaysAuthorization), [CLLocationManager class], @selector(requestAlwaysAuthorization));
-    injectSelector([OneSignalLocationOverrider class], @selector(overrideRequestWhenInUseAuthorization), [CLLocationManager class], @selector(requestWhenInUseAuthorization));
-    injectSelector([OneSignalLocationOverrider class], @selector(overrideStartUpdatingLocation), [CLLocationManager class], @selector(startUpdatingLocation));
+    injectSelector(
+        [CLLocationManager class],
+        @selector(requestAlwaysAuthorization),
+        [OneSignalLocationOverrider class],
+        @selector(overrideRequestAlwaysAuthorization)
+    );
+    injectSelector(
+        [CLLocationManager class],
+        @selector(requestWhenInUseAuthorization),
+        [OneSignalLocationOverrider class],
+        @selector(overrideRequestWhenInUseAuthorization)
+    );
+    injectSelector(
+        [CLLocationManager class],
+        @selector(startUpdatingLocation),
+        [OneSignalLocationOverrider class],
+        @selector(overrideStartUpdatingLocation)
+   );
     
     // Never asked use for location service permission
     startedMock = false;

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIAlertViewOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIAlertViewOverrider.m
@@ -35,11 +35,19 @@ static NSObject<UIAlertViewDelegate>* lastUIAlertViewDelegate;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
 + (void)load {
-    injectToProperClass(@selector(overrideAddButtonWithTitle:), @selector(addButtonWithTitle:), @[], [UIAlertViewOverrider class], [UIAlertView class]);
+    injectSelector(
+        [UIAlertView class],
+        @selector(addButtonWithTitle:),
+        [UIAlertViewOverrider class],
+        @selector(overrideAddButtonWithTitle:)
+    );
     
-    injectToProperClass(@selector(overrideInitWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:),
-                        @selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:), @[],
-                        [UIAlertViewOverrider class], [UIAlertView class]);
+    injectSelector(
+        [UIAlertView class],
+        @selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:),
+        [UIAlertViewOverrider class],
+        @selector(overrideInitWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:)
+    );
 }
 #pragma GCC diagnostic pop
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIApplicationOverrider.m
@@ -58,13 +58,48 @@ static int apnsTokenLength = 32;
 static UIApplication *sharedApplication;
 
 + (void)load {
-    injectToProperClass(@selector(overrideRegisterForRemoteNotifications), @selector(registerForRemoteNotifications), @[], [UIApplicationOverrider class], [UIApplication class]);
-    injectToProperClass(@selector(overrideCurrentUserNotificationSettings), @selector(currentUserNotificationSettings), @[], [UIApplicationOverrider class], [UIApplication class]);
-    injectToProperClass(@selector(overrideRegisterForRemoteNotificationTypes:), @selector(registerForRemoteNotificationTypes:), @[], [UIApplicationOverrider class], [UIApplication class]);
-    injectToProperClass(@selector(overrideRegisterUserNotificationSettings:), @selector(registerUserNotificationSettings:), @[], [UIApplicationOverrider class], [UIApplication class]);
-    injectToProperClass(@selector(overrideApplicationState), @selector(applicationState), @[], [UIApplicationOverrider class], [UIApplication class]);
-    injectToProperClass(@selector(overrideScheduleLocalNotification:), @selector(scheduleLocalNotification:), @[], [UIApplicationOverrider class], [UIApplication class]);
-    injectToProperClass(@selector(overrideOpenURL:options:completionHandler:), @selector(openURL:options:completionHandler:), @[], [UIApplicationOverrider class], [UIApplication class]);
+    injectSelector(
+        [UIApplication class],
+        @selector(registerForRemoteNotifications),
+        [UIApplicationOverrider class],
+        @selector(overrideRegisterForRemoteNotifications)
+    );
+    injectSelector(
+        [UIApplication class],
+        @selector(currentUserNotificationSettings),
+        [UIApplicationOverrider class],
+        @selector(overrideCurrentUserNotificationSettings)
+    );
+    injectSelector(
+        [UIApplication class],
+        @selector(registerForRemoteNotificationTypes:),
+        [UIApplicationOverrider class],
+        @selector(overrideRegisterForRemoteNotificationTypes:)
+    );
+    injectSelector(
+        [UIApplication class],
+        @selector(registerUserNotificationSettings:),
+        [UIApplicationOverrider class],
+        @selector(overrideRegisterUserNotificationSettings:)
+    );
+    injectSelector(
+        [UIApplication class],
+        @selector(applicationState),
+        [UIApplicationOverrider class],
+        @selector(overrideApplicationState)
+    );
+    injectSelector(
+        [UIApplication class],
+        @selector(scheduleLocalNotification:),
+        [UIApplicationOverrider class],
+        @selector(overrideScheduleLocalNotification:)
+    );
+    injectSelector(
+        [UIApplication class],
+        @selector(openURL:options:completionHandler:),
+        [UIApplicationOverrider class],
+        @selector(overrideOpenURL:options:completionHandler:)
+   );
 }
 
 + (void)reset {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIDeviceOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UIDeviceOverrider.m
@@ -27,8 +27,18 @@ static NSString *_model; // e.g. @"iPhone", @"iPod touch"
 }
 
 + (void)load {
-    injectToProperClass(@selector(overrideSystemName), @selector(systemName), @[], [UIDeviceOverrider class], [UIDevice class]);
-    injectToProperClass(@selector(overrideModel), @selector(model), @[], [UIDeviceOverrider class], [UIDevice class]);
+    injectSelector(
+        [UIDevice class],
+        @selector(systemName),
+        [UIDeviceOverrider class],
+        @selector(overrideSystemName)
+    );
+    injectSelector(
+       [UIDevice class],
+       @selector(model),
+       [UIDeviceOverrider class],
+       @selector(overrideModel)
+   );
 }
 
 + (void)reset {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/UNUserNotificationCenterOverrider.m
@@ -57,26 +57,44 @@ static void (^lastRequestAuthorizationWithOptionsBlock)(BOOL granted, NSError *e
     unNotifiserialQueue = dispatch_queue_create("com.UNNotificationCenter", DISPATCH_QUEUE_SERIAL);
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wundeclared-selector"
-    injectToProperClass(@selector(overrideInitWithBundleProxy:),
-                        @selector(initWithBundleProxy:), @[],
-                        [UNUserNotificationCenterOverrider class], [UNUserNotificationCenter class]);
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(initWithBundleProxy:),
+        [UNUserNotificationCenterOverrider class],
+        @selector(overrideInitWithBundleProxy:)
+    );
     #pragma clang diagnostic pop
     
-    injectToProperClass(@selector(overrideInitWithBundleIdentifier:),
-                        @selector(initWithBundleIdentifier:), @[],
-                        [UNUserNotificationCenterOverrider class], [UNUserNotificationCenter class]);
-    injectToProperClass(@selector(overrideGetNotificationSettingsWithCompletionHandler:),
-                        @selector(getNotificationSettingsWithCompletionHandler:), @[],
-                        [UNUserNotificationCenterOverrider class], [UNUserNotificationCenter class]);
-    injectToProperClass(@selector(overrideSetNotificationCategories:),
-                        @selector(setNotificationCategories:), @[],
-                        [UNUserNotificationCenterOverrider class], [UNUserNotificationCenter class]);
-    injectToProperClass(@selector(overrideGetNotificationCategoriesWithCompletionHandler:),
-                        @selector(getNotificationCategoriesWithCompletionHandler:), @[],
-                        [UNUserNotificationCenterOverrider class], [UNUserNotificationCenter class]);
-    injectToProperClass(@selector(overrideRequestAuthorizationWithOptions:completionHandler:),
-                        @selector(requestAuthorizationWithOptions:completionHandler:), @[],
-                        [UNUserNotificationCenterOverrider class], [UNUserNotificationCenter class]);
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(initWithBundleIdentifier:),
+        [UNUserNotificationCenterOverrider class],
+        @selector(overrideInitWithBundleIdentifier:)
+    );
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(getNotificationSettingsWithCompletionHandler:),
+        [UNUserNotificationCenterOverrider class],
+        @selector(overrideGetNotificationSettingsWithCompletionHandler:)
+    );
+    injectSelector(
+        [UNUserNotificationCenter class],
+        @selector(setNotificationCategories:),
+        [UNUserNotificationCenterOverrider class],
+        @selector(overrideSetNotificationCategories:)
+    );
+    injectSelector(
+       [UNUserNotificationCenter class],
+       @selector(getNotificationCategoriesWithCompletionHandler:),
+       [UNUserNotificationCenterOverrider class],
+       @selector(overrideGetNotificationCategoriesWithCompletionHandler:)
+    );
+    injectSelector(
+       [UNUserNotificationCenter class],
+       @selector(requestAuthorizationWithOptions:completionHandler:),
+       [UNUserNotificationCenterOverrider class],
+       @selector(overrideRequestAuthorizationWithOptions:completionHandler:)
+   );
 }
 
 + (UNAuthorizationOptions)lastRequestedAuthorizationOptions {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UNNotificationCenter/OneSignalUNUserNotificationCenterHelper.m
@@ -17,27 +17,23 @@
 // Why? This way we can setup a senario where someone else's delegate is assigned before OneSignal get loaded.
 + (void)putIntoPreloadedState {
     // Put back original implementation for setDelegat and others first.
-    injectToProperClass(
-        @selector(setDelegate:),
+    injectSelector(
+        [UNUserNotificationCenter class],
         @selector(setOneSignalUNDelegate:),
-        @[],
         [OneSignalUNUserNotificationCenter class],
-        [UNUserNotificationCenter class]
+        @selector(setDelegate:)
     );
-    
-    injectToProperClass(
-        @selector(requestAuthorizationWithOptions:completionHandler:),
+    injectSelector(
+        [UNUserNotificationCenter class],
         @selector(onesignalRequestAuthorizationWithOptions:completionHandler:),
-        @[],
         [OneSignalUNUserNotificationCenter class],
-        [UNUserNotificationCenter class]
+        @selector(requestAuthorizationWithOptions:completionHandler:)
     );
-    injectToProperClass(
-        @selector(getNotificationSettingsWithCompletionHandler:),
+    injectSelector(
+        [UNUserNotificationCenter class],
         @selector(onesignalGetNotificationSettingsWithCompletionHandler:),
-        @[],
         [OneSignalUNUserNotificationCenter class],
-        [UNUserNotificationCenter class]
+        @selector(getNotificationSettingsWithCompletionHandler:)
     );
     
     // Unassign OneSignal as the delegate

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -60,6 +60,7 @@
 #import "OneSignalOverrider.h"
 #import "OneSignalUserDefaults.h"
 #import "OneSignalLog.h"
+#import "OneSignalAppDelegateOverrider.h"
 
 NSString * serverUrlWithPath(NSString *path) {
     return [OS_API_SERVER_URL stringByAppendingString:path];
@@ -233,6 +234,7 @@ static XCTestCase* _currentXCTestCase;
     [OSMessagingController.sharedInstance resetState];
 
     [OneSignalLifecycleObserver removeObserver];
+    [OneSignalAppDelegateOverrider reset];
 }
 
 + (void)beforeAllTest:(XCTestCase *)testCase {


### PR DESCRIPTION
# Description
## One Line Summary
Remove calls to `objc_getClassList` from swizzling code as it creates issues with other libraries as it can trigger `+initialize` to be called before `+load` for some classes.

## Details
### Motivation
Fixes compatibility with Kotlin pre-1.7.0 (issue #1042) as well as fixes[ another similar crash](https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1042#issuecomment-1076448501). This also should improve startup time, by preventing the SDK from loading all classes at once on the main thread, issue #307.

### Scope
This effect which classes are swizzled, implementation has been simplified to swizzle only the class of the instance passed in, instead of trying look at the parent and sub classes.

# Testing
## Unit testing
Added new tests for inheritance cases to ensure the simplified logic can still cover all cases.

## Manual testing
Tested on an iPhone 6s with iOS 14.4.1
Tested the the following projects:
* SwiftUI
* Objective-C
* Some light tests with Flutter with FlutterFire

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [X] Swizzling
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1099)
<!-- Reviewable:end -->
