### PR TITLE
[Fix] Prevent re-swizzling when there is another swizzler

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -54,10 +54,6 @@
 + (NSString*)mUserId;
 @end
 
-@interface UIApplication (Swizzling)
-+(Class)delegateClass;
-@end
-
 @implementation OSNotificationAction
 @synthesize type = _type, actionId = _actionId;
 

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
@@ -29,8 +29,6 @@
 #define UIApplicationDelegate_OneSignal_h
 @interface OneSignalAppDelegate : NSObject
 
-+ (void)sizzlePreiOS10MethodsPhase1;
-+ (void)sizzlePreiOS10MethodsPhase2;
 + (void)traceCall:(NSString*)selector;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -60,23 +60,28 @@
 
 + (void) oneSignalLoadedTagSelector {}
 
-static Class delegateClass = nil;
-
-+(Class)delegateClass {
-    return delegateClass;
-}
+// A Set to keep track of which classes we have already swizzled so we only
+// swizzle each one once. If we swizzled more than once then this will create
+// an infinite loop, this includes swizzling with ourselves but also with
+// another SDK that swizzles.
+static NSMutableSet<Class>* swizzledClasses;
 
 - (void) setOneSignalDelegate:(id<UIApplicationDelegate>)delegate {
     [OneSignalAppDelegate traceCall:@"setOneSignalDelegate:"];
     [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"ONESIGNAL setOneSignalDelegate CALLED: %@", delegate]];
     
-    if ([delegate class] == delegateClass) {
+    if (swizzledClasses == nil)
+        swizzledClasses = [NSMutableSet new];
+    
+    Class delegateClass = [delegate class];
+    
+    if (delegate == nil || [swizzledClasses containsObject:delegateClass]) {
         [self setOneSignalDelegate:delegate];
         return;
     }
+    [swizzledClasses addObject:delegateClass];
     
     Class newClass = [OneSignalAppDelegate class];
-    delegateClass = [delegate class];
     
     // Need to keep this one for iOS 10 for content-available notifiations when the app is not in focus
     //   iOS 10 doesn't fire a selector on UNUserNotificationCenter in this cases most likely becuase
@@ -88,7 +93,7 @@ static Class delegateClass = nil;
         @selector(oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:)
     );
     
-    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase1];
+    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase1:delegateClass];
 
     injectSelector(
         delegateClass,
@@ -109,7 +114,7 @@ static Class delegateClass = nil;
         @selector(oneSignalDidRegisterForRemoteNotifications:deviceToken:)
     );
     
-    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase2];
+    [OneSignalAppDelegate sizzlePreiOS10MethodsPhase2:delegateClass];
 
     // Used to track how long the app has been closed
     injectSelector(
@@ -122,7 +127,7 @@ static Class delegateClass = nil;
     [self setOneSignalDelegate:delegate];
 }
 
-+ (void)sizzlePreiOS10MethodsPhase1 {
++ (void)sizzlePreiOS10MethodsPhase1:(Class)delegateClass {
     if ([OneSignalHelper isIOSVersionGreaterThanOrEqual:@"10.0"])
         return;
     
@@ -144,7 +149,7 @@ static Class delegateClass = nil;
    );
 }
 
-+ (void)sizzlePreiOS10MethodsPhase2 {
++ (void)sizzlePreiOS10MethodsPhase2:(Class)delegateClass {
     if ([OneSignalHelper isIOSVersionGreaterThanOrEqual:@"10.0"])
         return;
     

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -304,6 +304,7 @@ static Class delegateClass = nil;
 }
 
 -(void)oneSignalApplicationWillTerminate:(UIApplication *)application {
+    [OneSignalAppDelegate traceCall:@"oneSignalApplicationWillTerminate:"];
     
     if ([OneSignal appId])
         [OneSignalTracker onFocus:YES];

--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.h
@@ -49,6 +49,7 @@
 - (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
          didReceiveNotificationResponse:(UNNotificationResponse *)response
                   withCompletionHandler:(void(^)())completionHandler;
++ (void)traceCall:(NSString*)selector;
 @end
 
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalUNUserNotificationCenterOverrider.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalUNUserNotificationCenterOverrider.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OneSignalUNUserNotificationCenterOverrider : NSObject
++ (int)callCountForSelector:(NSString*)selector;
++ (void)reset;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalUNUserNotificationCenterOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalUNUserNotificationCenterOverrider.m
@@ -1,0 +1,32 @@
+#import "OneSignalUNUserNotificationCenterOverrider.h"
+
+#import "TestHelperFunctions.h"
+#import "UNUserNotificationCenter+OneSignal.h"
+
+@implementation OneSignalUNUserNotificationCenterOverrider
+static NSMutableDictionary* callCount;
+
++ (void)load {
+    callCount = [NSMutableDictionary new];
+
+    injectStaticSelector(
+        [OneSignalUNUserNotificationCenterOverrider class],
+        @selector(overrideTraceCall:),
+        [OneSignalUNUserNotificationCenter class],
+        @selector(traceCall:)
+    );
+}
+
++ (void)reset {
+    callCount = [NSMutableDictionary new];
+}
+
++ (void)overrideTraceCall:(NSString*)selector {
+    NSNumber *value = callCount[selector];
+    callCount[selector] = [NSNumber numberWithInt:[value intValue] + 1];
+}
+
++ (int)callCountForSelector:(NSString*)selector {
+    return [callCount[selector] intValue];
+}
+@end

--- a/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.h
+++ b/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.h
@@ -28,3 +28,4 @@
 void DumpObjcMethods(Class clz);
 BOOL injectStaticSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel);
 void swizzleClassMethodWithCategoryImplementation(Class class, SEL original, SEL new);
+void swizzleExistingSelector(Class targetClass, SEL targetSelector, Class myClass, SEL mySelector);

--- a/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/TestHelperFunctions.m
@@ -90,3 +90,15 @@ void swizzleClassMethodWithCategoryImplementation(Class class, SEL original, SEL
         method_exchangeImplementations(originalMethod, newMethod);
     }
 }
+
+// Use for tests to simulate how another library would swizzle.
+void swizzleExistingSelector(Class targetClass, SEL targetSelector, Class myClass, SEL mySelector) {
+    Method orgMeth = class_getInstanceMethod(targetClass, targetSelector);
+    Method newMeth = class_getInstanceMethod(myClass, mySelector);
+    IMP newImp = method_getImplementation(newMeth);
+    const char* methodTypeEncoding = method_getTypeEncoding(newMeth);
+    
+    class_addMethod(targetClass, mySelector, newImp, methodTypeEncoding);
+    newMeth = class_getInstanceMethod(targetClass, mySelector);
+    method_exchangeImplementations(orgMeth, newMeth);
+}

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -61,6 +61,7 @@
 #import "OneSignalUserDefaults.h"
 #import "OneSignalLog.h"
 #import "OneSignalAppDelegateOverrider.h"
+#import "OneSignalUNUserNotificationCenterOverrider.h"
 
 NSString * serverUrlWithPath(NSString *path) {
     return [OS_API_SERVER_URL stringByAppendingString:path];
@@ -235,6 +236,7 @@ static XCTestCase* _currentXCTestCase;
 
     [OneSignalLifecycleObserver removeObserver];
     [OneSignalAppDelegateOverrider reset];
+    [OneSignalUNUserNotificationCenterOverrider reset];
 }
 
 + (void)beforeAllTest:(XCTestCase *)testCase {


### PR DESCRIPTION
# Description
## One Line Summary
Prevent infinite loops between OneSignal and other SDKs that also swizzle.

## Details
### Motivation
After [a recent swizzling change](https://github.com/OneSignal/OneSignal-iOS-SDK/commit/6e0a68508d544b17bb307bc46cf32b498bbec680#diff-26ad113465fb193fe71d6324ccf71ebc476d87b48a8463b62864c69904c14cfaL75) (commit hasn't gotten into a release yet) it was discovered that it introduced a bug with FlutterFire which causes an infinite loop between the two with the `AppDelegate`. This is due to the fact `FlutterFire` clears the `AppDelegate` and re-assigns it and OneSignal re-swizzles it self back. Then when an `AppDelegate` selector fires from iOS OneSignal and FlutterFire call each other in a loop due to this.

### Scope
Effects swizzling for both `AppDelegate` and `UNUserNotificationCenterDelegate`.

# Testing
## Unit testing
Added a unit test that reproduced the exact FlutterFire issue.

## Manual testing
Ensured issue no longer happens on the Flutter project with FlutterFire and OneSignal. Tested on an iPhone 6s with iOS 14.4.1 and sent a notification while the app was in the foreground, ensured "onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler: Fired!" was printed to the log. 

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [X] Swizzling
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1100)
<!-- Reviewable:end -->
