### PR TITLE
Removing cold restart tracking

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1605,12 +1605,6 @@ static BOOL _trackedColdRestart = false;
     const int minTimeThreshold = 30;
     NSTimeInterval delta = now - lastTimeClosed;
     
-    // Tracking cold starts within 30 seconds of last close.
-    // Depending on the results of our tracking we will change this case
-    // from a tracking request to return true
-    if (delta < minTimeThreshold && appId && !_registerUserFinished && !_trackedColdRestart) {
-        [OneSignal trackColdRestart];
-    }
     return delta >= minTimeThreshold;
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Removing our call to track cold restarts via the /track endpoint

## Details
Once User Model is released we will use a new end point for getting IAMs, and our old SDK versions will still be gathering this data. I am leaving the method to do the tracking in the SDK in case we want to add it back in the future, but it is no longer being called.

### Motivation
We no longer need to be hitting our /track endpoint to track cold restarts. Our existing SDKs will get us data, and with user model we will change when IAMs are pulled down, which was the original reason for wanting to gather this data.

### Scope
no longer hitting /track for cold restarts


# Testing
## Unit testing
no change

## Manual testing
tested on my iPhone

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1103)
<!-- Reviewable:end -->
