### PR TITLE
Add push subscription basic functionality

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		37E6B2BB19D9CAF300D0C601 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		3C2C7DC4288E007E0020F9AE /* UserModelSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */; };
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
+		3C2C7DC8288F3C020020F9AE /* OSPushSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSPushSubscription.swift */; };
 		3CC10451286A52A600148757 /* OSUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1044F286A52A600148757 /* OSUser.swift */; };
 		3E464ED71D88ED1F00DCF7E9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; };
 		3E66F5821D90A2C600E45A01 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */; };
@@ -667,6 +668,7 @@
 		3C2C7DC2288E007E0020F9AE /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModelSwiftTests.swift; sourceTree = "<group>"; };
 		3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserModelObjcTests.m; sourceTree = "<group>"; };
+		3C2C7DC7288F3C020020F9AE /* OSPushSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPushSubscription.swift; sourceTree = "<group>"; };
 		3CC1044F286A52A600148757 /* OSUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSUser.swift; sourceTree = "<group>"; };
 		3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		3E2400381D4FFC31008BDE70 /* OneSignal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OneSignal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1562,6 +1564,7 @@
 				3CC1044F286A52A600148757 /* OSUser.swift */,
 				DE69E1AA282ED8790090BB3D /* OneSignalUserManager.swift */,
 				DE69E1A9282ED8790090BB3D /* UnitTestApp-Bridging-Header.h */,
+				3C2C7DC7288F3C020020F9AE /* OSPushSubscription.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -2645,6 +2648,7 @@
 			files = (
 				DE69E1AC282ED87A0090BB3D /* OneSignalUserManager.swift in Sources */,
 				3CC10451286A52A600148757 /* OSUser.swift in Sources */,
+				3C2C7DC8288F3C020020F9AE /* OSPushSubscription.swift in Sources */,
 				DE69E19F282ED8060090BB3D /* OneSignalUser.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscription.swift
@@ -34,60 +34,45 @@ import OneSignalCore
 
 @objc
 public class OSPushSubscriptionState: NSObject {
+    @objc public let subscriptionId: UUID
     @objc public let token: UUID?
     @objc public let enabled: Bool
     
-    init(token: UUID?, enabled: Bool) {
+    init(subscriptionId: UUID, token: UUID?, enabled: Bool) {
+        self.subscriptionId = subscriptionId
         self.token = token
         self.enabled = enabled
     }
 }
 
 protocol OSPushSubscriptionInterface {
-    var id: UUID? { get }
+    var subscriptionId: UUID { get }
     var token: UUID? { get }
     var enabled: Bool { get set }
-
-    func addObserver(_ observer: OSPushSubscriptionObserver)
-    func removeObserver(_ observer: OSPushSubscriptionObserver)
 }
 
 @objc
 public class OSPushSubscription: NSObject, OSPushSubscriptionInterface {
-    @objc public let id: UUID?
-    @objc public let token: UUID?
-    @objc public var enabled = true {
+    @objc public let subscriptionId: UUID
+    @objc public private(set) var token: UUID?
+    @objc public var enabled = false { // this should default to false when first created
         didSet {
             didSetEnabledHelper(oldValue: oldValue, newValue: enabled)
         }
     }
     
-    var subscriptionObservers: [OSPushSubscriptionObserver] = []
-
     func didSetEnabledHelper(oldValue: Bool, newValue: Bool) {
         // TODO: UM name and scope of function
         // TODO: UM update model, add operation to backend
+        let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: oldValue)
+        let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: newValue)
+        // TODO: UM trigger observers.onOSPushSubscriptionChanged(previous: oldState, current: newState)
         print("🔥 didSet pushSubscription.enabled from \(oldValue) to \(newValue)")
-        let oldState = OSPushSubscriptionState(token: self.token, enabled: oldValue)
-        let newState = OSPushSubscriptionState(token: self.token, enabled: newValue)
-        for observer in subscriptionObservers {
-            observer.onOSPushSubscriptionChanged(previous: oldState, current: newState)
-        }
     }
     
-    init(id: UUID, token: UUID) {
-        self.id = id
+    init(subscriptionId: UUID, token: UUID?, enabled: Bool?) {
+        self.subscriptionId = subscriptionId
         self.token = token
-    }
-    
-    @objc public func addObserver(_ observer: OSPushSubscriptionObserver) {
-        self.subscriptionObservers.append(observer) // TODO: UM we do want to synchronize on observers
-        print("🔥 OSPushSubscription addObserver(), subscriptionObservers now: \(subscriptionObservers)")
-    }
-    
-    @objc public func removeObserver(_ observer: OSPushSubscriptionObserver) {
-        // TODO: UM we do want to synchronize on observers
-        subscriptionObservers.removeAll(where: { $0 === observer })
-        print("🔥 OSPushSubscription removeObserver(), subscriptionObservers now: \(subscriptionObservers)")
+        self.enabled = enabled ?? false
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscription.swift
@@ -1,0 +1,93 @@
+/*
+ Modified MIT License
+
+ Copyright 2022 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+import Foundation
+import OneSignalCore
+
+@objc public protocol OSPushSubscriptionObserver { //  weak reference?
+    @objc func onOSPushSubscriptionChanged(previous: OSPushSubscriptionState, current: OSPushSubscriptionState)
+}
+
+@objc
+public class OSPushSubscriptionState: NSObject {
+    @objc public let token: UUID?
+    @objc public let enabled: Bool
+    
+    init(token: UUID?, enabled: Bool) {
+        self.token = token
+        self.enabled = enabled
+    }
+}
+
+protocol OSPushSubscriptionInterface {
+    var id: UUID? { get }
+    var token: UUID? { get }
+    var enabled: Bool { get set }
+
+    func addObserver(_ observer: OSPushSubscriptionObserver)
+    func removeObserver(_ observer: OSPushSubscriptionObserver)
+}
+
+@objc
+public class OSPushSubscription: NSObject, OSPushSubscriptionInterface {
+    @objc public let id: UUID?
+    @objc public let token: UUID?
+    @objc public var enabled = true {
+        didSet {
+            didSetEnabledHelper(oldValue: oldValue, newValue: enabled)
+        }
+    }
+    
+    var subscriptionObservers: [OSPushSubscriptionObserver] = []
+
+    func didSetEnabledHelper(oldValue: Bool, newValue: Bool) {
+        // TODO: UM name and scope of function
+        // TODO: UM update model, add operation to backend
+        print("🔥 didSet pushSubscription.enabled from \(oldValue) to \(newValue)")
+        let oldState = OSPushSubscriptionState(token: self.token, enabled: oldValue)
+        let newState = OSPushSubscriptionState(token: self.token, enabled: newValue)
+        for observer in subscriptionObservers {
+            observer.onOSPushSubscriptionChanged(previous: oldState, current: newState)
+        }
+    }
+    
+    init(id: UUID, token: UUID) {
+        self.id = id
+        self.token = token
+    }
+    
+    @objc public func addObserver(_ observer: OSPushSubscriptionObserver) {
+        self.subscriptionObservers.append(observer) // TODO: UM we do want to synchronize on observers
+        print("🔥 OSPushSubscription addObserver(), subscriptionObservers now: \(subscriptionObservers)")
+    }
+    
+    @objc public func removeObserver(_ observer: OSPushSubscriptionObserver) {
+        // TODO: UM we do want to synchronize on observers
+        subscriptionObservers.removeAll(where: { $0 === observer })
+        print("🔥 OSPushSubscription removeObserver(), subscriptionObservers now: \(subscriptionObservers)")
+    }
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUser.swift
@@ -31,7 +31,7 @@ import OneSignalCore
 @objc
 public class OSUser: NSObject {
     
-    var onesignalId: UUID
+    let onesignalId: UUID
     var externalId: String?
     var language: String?
     var aliases: [String : String] = [:]
@@ -40,16 +40,17 @@ public class OSUser: NSObject {
     
     // email, sms, subscriptions todo
     
-    @objc public var pushSubscription: OSPushSubscription?
+    @objc public var pushSubscription: OSPushSubscription
     
-    // TODO: UM This is public for now to create a push subscription for testing
-    @objc public func createPushSubscription(id: UUID, token: UUID) {
-        self.pushSubscription = OSPushSubscription(id: id, token: token)
-        print("🔥 OSUser has set pushSubcription")
+    // TODO: UM This is a temporary function to create a push subscription for testing
+    @objc public func testCreatePushSubscription(subscriptionId: UUID, token: UUID, enabled: Bool) {
+        self.pushSubscription = OSPushSubscription(subscriptionId: subscriptionId, token: token, enabled: enabled)
+        print("🔥 OSUser has set pushSubcription for testing")
     }
     
-    @objc public init(_ onesignalId: UUID) {
+    @objc public init(onesignalId: UUID, pushSubscription: OSPushSubscription) {
         self.onesignalId = onesignalId
+        self.pushSubscription = pushSubscription
     }
     
     // Aliases

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUser.swift
@@ -37,7 +37,10 @@ public class OSUser: NSObject {
     var aliases: [String : String] = [:]
     var tags: [String : String] = [:]
     var triggers: [String : String] = [:] // update to include bool, number
+    
     // email, sms, subscriptions todo
+    
+    @objc public var pushSubscription: OSPushSubscription?
     
     @objc public init(_ onesignalId: UUID) {
         self.onesignalId = onesignalId

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUser.swift
@@ -42,6 +42,12 @@ public class OSUser: NSObject {
     
     @objc public var pushSubscription: OSPushSubscription?
     
+    // TODO: UM This is public for now to create a push subscription for testing
+    @objc public func createPushSubscription(id: UUID, token: UUID) {
+        self.pushSubscription = OSPushSubscription(id: id, token: token)
+        print("🔥 OSUser has set pushSubcription")
+    }
+    
     @objc public init(_ onesignalId: UUID) {
         self.onesignalId = onesignalId
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -29,7 +29,7 @@ import Foundation
 import OneSignalCore
 
 @objc protocol OneSignalUserManagerInterface {
-    static var user: OSUser { get set }
+    static var user: OSUser? { get set }
     static func login(_ externalId: String) -> OSUser
     static func login(externalId: String, withToken: String) -> OSUser
     static func loginGuest() -> OSUser
@@ -37,23 +37,30 @@ import OneSignalCore
 
 @objc
 public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
-    @objc static var user = OSUser(UUID())
+    // TODO: UM temp make public so OneSignal.m can access, but users shouldn't access this directly
+    @objc public static var user: OSUser?
     
     @objc
     public static func login(_ externalId: String) -> OSUser {
         print("🔥 OneSignalUser login() called")
-        return user
+        return createAndSetUser()
     }
     
     @objc
     public static func login(externalId: String, withToken: String) -> OSUser {
         print("🔥 OneSignalUser loginwithBearerToken() called")
-        return user
+        return createAndSetUser()
     }
     
     @objc
     public static func loginGuest() -> OSUser {
         print("🔥 OneSignalUser loginGuest() called")
-        return user
+        return createAndSetUser()
+    }
+    
+    static func createAndSetUser() -> OSUser {
+        // do stuff
+        return OSUser(onesignalId: UUID(),
+                           pushSubscription: OSPushSubscription(subscriptionId: UUID(), token: nil, enabled: false))
     }
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSSubscription.h
@@ -85,7 +85,7 @@ typedef OSObservable<NSObject<OSSubscriptionStateObserver>*, OSSubscriptionState
 @end
 
 
-typedef OSObservable<NSObject<OSSubscriptionObserver>*, OSSubscriptionStateChanges*> ObservableSubscriptionStateChangesType;
+typedef OSObservable<NSObject<OSPushSubscriptionObserver>*, OSSubscriptionStateChanges*> ObservableSubscriptionStateChangesType;
 
 @interface OSSubscriptionChangedInternalObserver : NSObject<OSSubscriptionStateObserver>
 + (void)fireChangesObserver:(OSSubscriptionState*)state;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -371,8 +371,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer;
 
-+ (void)addSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
-+ (void)removeSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer;
++ (void)addSubscriptionObserver:(NSObject<OSPushSubscriptionObserver>*)observer;
++ (void)removeSubscriptionObserver:(NSObject<OSPushSubscriptionObserver>*)observer;
 
 + (void)addEmailSubscriptionObserver:(NSObject<OSEmailSubscriptionObserver>*)observer;
 + (void)removeEmailSubscriptionObserver:(NSObject<OSEmailSubscriptionObserver>*)observer;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1128,14 +1128,15 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 }
 
 // onOSSubscriptionChanged should only fire if something changed.
-+ (void)addSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
+// TODO: UM rename to addPushSubscriptionObserver, and connect functionality
++ (void)addSubscriptionObserver:(NSObject<OSPushSubscriptionObserver>*)observer {
     [self.subscriptionStateChangesObserver addObserver:observer];
     
     if ([self.currentSubscriptionState compare:self.lastSubscriptionState])
         [OSSubscriptionChangedInternalObserver fireChangesObserver:self.currentSubscriptionState];
 }
 
-+ (void)removeSubscriptionObserver:(NSObject<OSSubscriptionObserver>*)observer {
++ (void)removeSubscriptionObserver:(NSObject<OSPushSubscriptionObserver>*)observer {
     [self.subscriptionStateChangesObserver removeObserver:observer];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -584,7 +584,10 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 // TODO: UM Actual implementations
 
 + (OSUser* _Nonnull)user {
-    OSUser *user = [[OSUser alloc] init:[NSUUID new]];
+    OSUser *user = [OneSignalUserManager user];
+    if (!user) {
+        user = [OneSignalUserManager loginGuest];
+    }
     return user;
 }
 

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -56,8 +56,10 @@
     [super tearDown];
 }
 
+/**
+ This test lays out the public APIs of the user model
+ */
 - (void)testUserModelMethodAccess {
-    // this test lays out the public APIs of the user model
 
     // User Identity
     __block OSUser* myUser = OneSignal.user;
@@ -109,38 +111,42 @@
     XCTAssertNotNil(myUser);
 }
 
-- (void)testPushSubscriptionFunctionality {
+/**
+ This is to collect things that should not work, but do for now.
+ */
+- (void)testTheseShouldNotWork {
+    
+    // Should not be accessible
+    OSUser *user = OneSignalUserManager.user; // This shouldn't be accessible to the public
+    
+    // Should not be settable
+    // OneSignal.user.pushSubscription.token = [NSUUID new]; // <- Confirmed that users can't set token
+    // OneSignal.user.pushSubscription.subscriptionId = [NSUUID new]; // <- Confirmed that users can't set subscriptionId
+}
+
+/**
+ Test the access of properties and methods, and setting properties related to the push subscription.
+ */
+- (void)testPushSubscriptionPropertiesAccess {
     
     // Create a user and mock pushSubscription
     OSUser* user = OneSignal.user;
-    [user createPushSubscriptionWithId:[NSUUID new] token:[NSUUID new]];
-    
-    // Add a subscription observer
-    OSPushSubscriptionTestObserver* observer = [OSPushSubscriptionTestObserver new];
-    [user.pushSubscription addObserver:observer];
-    
-    // Check accessing some properties
-    NSLog(@"🔥 token %@", user.pushSubscription.token);
-    NSLog(@"🔥 subscriptionId %@", user.pushSubscription.id);
-    
-    // Check that the observer fires when enabled is set
-    user.pushSubscription.enabled = false;
-    
-    // Remove the observer and check observer is not fired
-    [user.pushSubscription removeObserver:observer];
-    user.pushSubscription.enabled = true;
-}
+    [user testCreatePushSubscriptionWithSubscriptionId:[NSUUID new] token:[NSUUID new] enabled:false];
 
-- (void)testPushSubscriptionMethodsAccess {
-    OSUser* user = OneSignal.user;
-    
-    NSUUID* subscriptionId = user.pushSubscription.id;
+    // Access properties of the pushSubscription
+    NSUUID* subscriptionId = user.pushSubscription.subscriptionId;
     NSUUID* token = user.pushSubscription.token;
     bool enabled = user.pushSubscription.enabled; // BOOL or bool preferred?
     
+    // Set the enabled property of the pushSubscription
+    user.pushSubscription.enabled = true;
+    
+    // Create a push subscription observer
     OSPushSubscriptionTestObserver* observer = [OSPushSubscriptionTestObserver new];
-    [user.pushSubscription addObserver:observer];
-    [user.pushSubscription removeObserver:observer];
+    
+    // Push subscription observers are not user-scoped
+    [OneSignal addSubscriptionObserver:observer];
+    [OneSignal removeSubscriptionObserver:observer];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -32,6 +32,18 @@
 
 @end
 
+
+@interface OSPushSubscriptionTestObserver: NSObject<OSPushSubscriptionObserver>
+- (void)onOSPushSubscriptionChangedWithPrevious:(OSPushSubscription * _Nonnull)previous current:(OSPushSubscription * _Nonnull)current;
+@end
+
+@implementation OSPushSubscriptionTestObserver
+- (void)onOSPushSubscriptionChangedWithPrevious:(OSPushSubscriptionState * _Nonnull)previous current:(OSPushSubscriptionState * _Nonnull)current {
+    NSLog(@"🔥 UnitTest:onOSPushSubscriptionChanged :%@ :%@", previous, current);
+    
+}
+@end
+
 @implementation UserModelObjcTests
 
 - (void)setUp {
@@ -95,6 +107,40 @@
     [OneSignal.user removeTriggers:@[@"foo", @"bar"]];
 
     XCTAssertNotNil(myUser);
+}
+
+- (void)testPushSubscriptionFunctionality {
+    
+    // Create a user and mock pushSubscription
+    OSUser* user = OneSignal.user;
+    [user createPushSubscriptionWithId:[NSUUID new] token:[NSUUID new]];
+    
+    // Add a subscription observer
+    OSPushSubscriptionTestObserver* observer = [OSPushSubscriptionTestObserver new];
+    [user.pushSubscription addObserver:observer];
+    
+    // Check accessing some properties
+    NSLog(@"🔥 token %@", user.pushSubscription.token);
+    NSLog(@"🔥 subscriptionId %@", user.pushSubscription.id);
+    
+    // Check that the observer fires when enabled is set
+    user.pushSubscription.enabled = false;
+    
+    // Remove the observer and check observer is not fired
+    [user.pushSubscription removeObserver:observer];
+    user.pushSubscription.enabled = true;
+}
+
+- (void)testPushSubscriptionMethodsAccess {
+    OSUser* user = OneSignal.user;
+    
+    NSUUID* subscriptionId = user.pushSubscription.id;
+    NSUUID* token = user.pushSubscription.token;
+    bool enabled = user.pushSubscription.enabled; // BOOL or bool preferred?
+    
+    OSPushSubscriptionTestObserver* observer = [OSPushSubscriptionTestObserver new];
+    [user.pushSubscription addObserver:observer];
+    [user.pushSubscription removeObserver:observer];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -58,8 +58,10 @@ class UserModelSwiftTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    /**
+     This test lays out the public APIs of the user model
+     */
     func testUserModelMethodAccess() throws {
-        // this test lays out the public APIs of the user model
         
         // User Identity
         var myUser: OSUser = OneSignal.user
@@ -111,33 +113,42 @@ class UserModelSwiftTests: XCTestCase {
         XCTAssertNotNil(myUser)
     }
     
-    func testPushSubscriptionFunctionality() throws {
+    /**
+     This is to collect things that should not work, but do for now.
+     */
+    func testTheseShouldNotWork() throws {
+        // Should not be accessible
+        let _ = OneSignalUserManager.user; // This shouldn't be accessible to the public
         
-        // Create a user and mock pushSubscription
-        let user = OneSignal.user
-        user.createPushSubscription(id: UUID(), token: UUID())
-        
-        // Add a subscription observer
-        let observer = OSPushSubscriptionTestObserver()
-        user.pushSubscription?.addObserver(observer)
-        
-        // Check accessing some properties
-        print("🔥 token \(user.pushSubscription?.token)")
-        print("🔥 enabled \(user.pushSubscription?.enabled)")
-        
-        // Check that the observer fires when enabled is set
-        user.pushSubscription?.enabled = false;
-        
-        // Remove the observer and check observer is not fired
-        user.pushSubscription?.removeObserver(observer)
-        user.pushSubscription?.enabled = true;
+        // Should not be settable
+        // OneSignal.user.pushSubscription.token = UUID() // <- Confirmed that users can't set token
+        // OneSignal.user.pushSubscription.subscriptionId = UUID() // <- Confirmed that users can't set subscriptionId
     }
     
-
-    func testPushSubscriptionMethodsAccess() throws {
+    /**
+     Test the access of properties and methods, and setting properties related to the push subscription.
+     */
+    func testPushSubscriptionPropertiesAccess() throws {
+        // Create a user and mock pushSubscription
         let user = OneSignal.user
-        let observer = OSPushSubscriptionTestObserver()
-        user.pushSubscription?.addObserver(observer)
-        user.pushSubscription?.removeObserver(observer)
+        user.testCreatePushSubscription(subscriptionId: UUID(), token: UUID(), enabled: false)
+        
+        // Access properties of the pushSubscription
+        let _ = user.pushSubscription.subscriptionId
+        let _ = user.pushSubscription.token
+        let _ = user.pushSubscription.enabled
+        
+        // Set the enabled property of the pushSubscription
+        user.pushSubscription.enabled = true;
+        
+        
+        // Create a push subscription observer
+        let _ = OSPushSubscriptionTestObserver()
+
+        // Push subscription observers are not user-scoped
+        // TODO: UM The following does not build as of now
+        // OneSignal.addSubscriptionObserver(observer)
+        // OneSignal.removeSubscriptionObserver(observer)
+     
     }
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -35,6 +35,17 @@ extension OneSignal {
     }
 }
 
+// Non-class type 'OSPushSubscriptionTestObserver' cannot conform to class protocol 'OSPushSubscriptionObserver'
+// ^ Cannot use a struct for an OSPushSubscriptionObserver
+
+class OSPushSubscriptionTestObserver: OSPushSubscriptionObserver {
+    func onOSPushSubscriptionChanged(previous: OSPushSubscriptionState, current: OSPushSubscriptionState) {
+        print("🔥 onOSPushSubscriptionChanged \(previous) -> \(current)")
+        dump(previous)
+        dump(current)
+    }
+}
+
 class UserModelSwiftTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -98,5 +109,35 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.user.removeTriggers(["foo", "bar"])
 
         XCTAssertNotNil(myUser)
+    }
+    
+    func testPushSubscriptionFunctionality() throws {
+        
+        // Create a user and mock pushSubscription
+        let user = OneSignal.user
+        user.createPushSubscription(id: UUID(), token: UUID())
+        
+        // Add a subscription observer
+        let observer = OSPushSubscriptionTestObserver()
+        user.pushSubscription?.addObserver(observer)
+        
+        // Check accessing some properties
+        print("🔥 token \(user.pushSubscription?.token)")
+        print("🔥 enabled \(user.pushSubscription?.enabled)")
+        
+        // Check that the observer fires when enabled is set
+        user.pushSubscription?.enabled = false;
+        
+        // Remove the observer and check observer is not fired
+        user.pushSubscription?.removeObserver(observer)
+        user.pushSubscription?.enabled = true;
+    }
+    
+
+    func testPushSubscriptionMethodsAccess() throws {
+        let user = OneSignal.user
+        let observer = OSPushSubscriptionTestObserver()
+        user.pushSubscription?.addObserver(observer)
+        user.pushSubscription?.removeObserver(observer)
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Add the basic functionality of push subscriptions.

## Details

### Motivation
The `OSUser` has a `pushSubscription` property called by `OneSignal.user.pushSubscription`. We want to stub out this class.

### Scope
- The `OneSignalUserManager` may or may not have an `OSUser`.
- An `OSUser` will always have an `OSPushSubscription`.
- An `OSPushSubscription` will always have a `subscriptionId` and `enabled` (which is `false` by default if not provided since on iOS we must always prompt first). It may or may not have a `token` (the push token).
- Add `OSPushSubscriptionObserver` protocol to observe subscription state changes, and rename the existing `OSSubscriptionObserver` to this to be clear it is for the **push** subscription, but it hasn't yet been hooked up properly to trigger.
- The push subscription observer has been rescoped away from the user as it is tied to the device instead. 

# Testing
## Unit testing
Unit testing done is just for checking method and property access, and relying on printed statements to see what is happening.
* In order to start testing, added a public `testCreatePushSubscription()` method in `OSUser` so we can test a user's `pushSubscription`. Shouldn't actually be public or maybe even exist.
* Added a test called `testTheseShouldNotWork` to dump things that should't be accessible or settable as they come up, and comment out as they are addressed/changed.

## Manual testing
Not implemented enough to run properly.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and **conform to existing APIs**

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1112)
<!-- Reviewable:end -->
