### PR TITLE
[user model] adding the operations layer

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -65,7 +65,6 @@
 		3C11518D289AF5E800565C41 /* OSModelChangedHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C11518C289AF5E800565C41 /* OSModelChangedHandler.swift */; };
 		3C11518E289AF83600565C41 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		3C11518F289AF83600565C41 /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		3C115192289AF85400565C41 /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
 		3C115197289AF86C00565C41 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		3C2C7DC4288E007E0020F9AE /* UserModelSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */; };
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
@@ -381,7 +380,6 @@
 		CACBAAAC218A662B000ACAA5 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CACBAAAB218A662B000ACAA5 /* WebKit.framework */; };
 		CACBAAB4218A7113000ACAA5 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CACBAAAB218A662B000ACAA5 /* WebKit.framework */; };
 		CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = CA810FCF202BA97300A60FED /* OSEmailSubscription.h */; };
-		DE12F3F2289B28C4002F63AA /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */; };
@@ -405,7 +403,6 @@
 		DE69E19F282ED8060090BB3D /* OneSignalUser.docc in Sources */ = {isa = PBXBuildFile; fileRef = DE69E19E282ED8060090BB3D /* OneSignalUser.docc */; };
 		DE69E1A0282ED8060090BB3D /* OneSignalUser.h in Headers */ = {isa = PBXBuildFile; fileRef = DE69E19D282ED8060090BB3D /* OneSignalUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE69E1AC282ED87A0090BB3D /* OneSignalUserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69E1AA282ED8790090BB3D /* OneSignalUserManager.swift */; };
-		DE69E1AD282ED8F20090BB3D /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
 		DE69E1B2282ED9430090BB3D /* OneSignalUser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; };
 		DE7D17EA27026B95002D3A5D /* OneSignalCore.docc in Sources */ = {isa = PBXBuildFile; fileRef = DE7D17E927026B95002D3A5D /* OneSignalCore.docc */; };
 		DE7D17EB27026B95002D3A5D /* OneSignalCore.h in Headers */ = {isa = PBXBuildFile; fileRef = DE7D17E827026B95002D3A5D /* OneSignalCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -535,6 +532,9 @@
 		DEA4B4652888C59100E9FE12 /* OneSignalExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17F927026BA3002D3A5D /* OneSignalExtension.framework */; };
 		DEA4B4662888C59E00E9FE12 /* OneSignalExtension.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17F927026BA3002D3A5D /* OneSignalExtension.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DEA4B4672888C5F200E9FE12 /* OneSignalExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17F927026BA3002D3A5D /* OneSignalExtension.framework */; };
+		DEA98C1928C90EE5000C6856 /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
+		DEA98C1C28C90EE6000C6856 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
+		DEA98C1E28C90EE9000C6856 /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
 		DECE6F5B28C90821007058EE /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */; };
 		DEF5CCF52539321A0003E9CC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF5CCF42539321A0003E9CC /* AppDelegate.m */; };
@@ -1069,7 +1069,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3C115192289AF85400565C41 /* OneSignalCore.framework in Frameworks */,
+				DEA98C1E28C90EE9000C6856 /* OneSignalCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1112,8 +1112,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DE12F3F2289B28C4002F63AA /* OneSignalOSCore.framework in Frameworks */,
-				DE69E1AD282ED8F20090BB3D /* OneSignalCore.framework in Frameworks */,
+				DEA98C1C28C90EE6000C6856 /* OneSignalOSCore.framework in Frameworks */,
+				DEA98C1928C90EE5000C6856 /* OneSignalCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -4371,6 +4371,7 @@
 		DECE6F5A28C903D7007058EE /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = OneSignalOSCoreFramework/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalOSCore;
 				PRODUCT_NAME = OneSignalOSCore;

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
 		3C2C7DC8288F3C020020F9AE /* OSPushSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */; };
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
+		3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */; };
+		3C8E6DFF28AB09AE0031E48A /* OSPropertyOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */; };
+		3C8E6E0128AC0BA10031E48A /* OSIdentityOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */; };
 		3CE5F9E3289D88DC004A156E /* OSModelStoreChangedHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5F9E2289D88DC004A156E /* OSModelStoreChangedHandler.swift */; };
 		3CE5F9E5289D9AA3004A156E /* OSOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5F9E4289D9AA3004A156E /* OSOperation.swift */; };
 		3CE9227A289FA88B001B1062 /* OSIdentityModelStoreListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */; };
@@ -741,6 +744,9 @@
 		3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserModelObjcTests.m; sourceTree = "<group>"; };
 		3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPushSubscriptionModel.swift; sourceTree = "<group>"; };
 		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
+		3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationExecutor.swift; sourceTree = "<group>"; };
+		3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertyOperationExecutor.swift; sourceTree = "<group>"; };
+		3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityOperationExecutor.swift; sourceTree = "<group>"; };
 		3CE5F9E2289D88DC004A156E /* OSModelStoreChangedHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSModelStoreChangedHandler.swift; sourceTree = "<group>"; };
 		3CE5F9E4289D9AA3004A156E /* OSOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperation.swift; sourceTree = "<group>"; };
 		3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModelStoreListener.swift; sourceTree = "<group>"; };
@@ -1280,14 +1286,15 @@
 			isa = PBXGroup;
 			children = (
 				3C115163289A259500565C41 /* OneSignalOSCore.h */,
-				3C115184289ADE4F00565C41 /* OSModel.swift */,
 				3C115188289ADEA300565C41 /* OSModelStore.swift */,
 				3C115186289ADE7700565C41 /* OSModelStoreListener.swift */,
+				3C115184289ADE4F00565C41 /* OSModel.swift */,
 				3C11518A289ADEEB00565C41 /* OSEventProducer.swift */,
 				3C11518C289AF5E800565C41 /* OSModelChangedHandler.swift */,
 				3CE5F9E2289D88DC004A156E /* OSModelStoreChangedHandler.swift */,
 				3CE5F9E4289D9AA3004A156E /* OSOperation.swift */,
 				3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */,
+				3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1684,6 +1691,8 @@
 				3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */,
 				3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */,
 				3CF862A128A197D200776CA4 /* OSPropertiesModelStoreListener.swift */,
+				3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */,
+				3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -2604,6 +2613,7 @@
 				3C115187289ADE7700565C41 /* OSModelStoreListener.swift in Sources */,
 				3CE5F9E3289D88DC004A156E /* OSModelStoreChangedHandler.swift in Sources */,
 				3C11518D289AF5E800565C41 /* OSModelChangedHandler.swift in Sources */,
+				3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */,
 				3CE5F9E5289D9AA3004A156E /* OSOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2826,8 +2836,10 @@
 			files = (
 				DE69E1AC282ED87A0090BB3D /* OneSignalUserManager.swift in Sources */,
 				3CF862A028A1964F00776CA4 /* OSPropertiesModel.swift in Sources */,
+				3C8E6E0128AC0BA10031E48A /* OSIdentityOperationExecutor.swift in Sources */,
 				3CF862A228A197D200776CA4 /* OSPropertiesModelStoreListener.swift in Sources */,
 				3C0EF49E28A1DBCB00E5434B /* OSUserInternal.swift in Sources */,
+				3C8E6DFF28AB09AE0031E48A /* OSPropertyOperationExecutor.swift in Sources */,
 				3C2C7DC8288F3C020020F9AE /* OSPushSubscriptionModel.swift in Sources */,
 				3CF8629E28A183F900776CA4 /* OSIdentityModel.swift in Sources */,
 				3CE9227A289FA88B001B1062 /* OSIdentityModelStoreListener.swift in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		3C2C7DC4288E007E0020F9AE /* UserModelSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */; };
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
 		3C2C7DC8288F3C020020F9AE /* OSPushSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */; };
+		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
 		3CE5F9E3289D88DC004A156E /* OSModelStoreChangedHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5F9E2289D88DC004A156E /* OSModelStoreChangedHandler.swift */; };
 		3CE5F9E5289D9AA3004A156E /* OSOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5F9E4289D9AA3004A156E /* OSOperation.swift */; };
 		3CE9227A289FA88B001B1062 /* OSIdentityModelStoreListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */; };
@@ -739,6 +740,7 @@
 		3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModelSwiftTests.swift; sourceTree = "<group>"; };
 		3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserModelObjcTests.m; sourceTree = "<group>"; };
 		3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPushSubscriptionModel.swift; sourceTree = "<group>"; };
+		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
 		3CE5F9E2289D88DC004A156E /* OSModelStoreChangedHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSModelStoreChangedHandler.swift; sourceTree = "<group>"; };
 		3CE5F9E4289D9AA3004A156E /* OSOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperation.swift; sourceTree = "<group>"; };
 		3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModelStoreListener.swift; sourceTree = "<group>"; };
@@ -1285,6 +1287,7 @@
 				3C11518C289AF5E800565C41 /* OSModelChangedHandler.swift */,
 				3CE5F9E2289D88DC004A156E /* OSModelStoreChangedHandler.swift */,
 				3CE5F9E4289D9AA3004A156E /* OSOperation.swift */,
+				3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -2593,6 +2596,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */,
 				3C11518B289ADEEB00565C41 /* OSEventProducer.swift in Sources */,
 				3C115165289A259500565C41 /* OneSignalOSCore.docc in Sources */,
 				3C115189289ADEA300565C41 /* OSModelStore.swift in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -1036,6 +1036,8 @@
 		DE9A5DB225D1FD8000FCEC21 /* OSPlayerTags.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSPlayerTags.m; sourceTree = "<group>"; };
 		DEA4B44C2888AF8900E9FE12 /* OneSignalUNUserNotificationCenterOverrider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OneSignalUNUserNotificationCenterOverrider.m; sourceTree = "<group>"; };
 		DEA4B44D2888AF8900E9FE12 /* OneSignalUNUserNotificationCenterOverrider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalUNUserNotificationCenterOverrider.h; sourceTree = "<group>"; };
+		DEA98C1428C90C74000C6856 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DEA98C1628C90C87000C6856 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEB843A127C0245B00D7E943 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEB843A327C0246A00D7E943 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEB843A527C0247700D7E943 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1181,6 +1183,8 @@
 		37747F8A19147D6400558FAD = {
 			isa = PBXGroup;
 			children = (
+				DEA98C1528C90C87000C6856 /* OneSignalOSCoreFramework */,
+				DEA98C1328C90C74000C6856 /* OneSignalUserFramework */,
 				DE97175C275597E600FC409E /* OneSignalExtensionFramework */,
 				DE97175B275597DA00FC409E /* OneSignalOutcomesFramework */,
 				DE97175A275597D100FC409E /* OneSignalCoreFramework */,
@@ -1916,6 +1920,22 @@
 				DEB843A527C0247700D7E943 /* Info.plist */,
 			);
 			path = OneSignalExtensionFramework;
+			sourceTree = "<group>";
+		};
+		DEA98C1328C90C74000C6856 /* OneSignalUserFramework */ = {
+			isa = PBXGroup;
+			children = (
+				DEA98C1428C90C74000C6856 /* Info.plist */,
+			);
+			path = OneSignalUserFramework;
+			sourceTree = "<group>";
+		};
+		DEA98C1528C90C87000C6856 /* OneSignalOSCoreFramework */ = {
+			isa = PBXGroup;
+			children = (
+				DEA98C1628C90C87000C6856 /* Info.plist */,
+			);
+			path = OneSignalOSCoreFramework;
 			sourceTree = "<group>";
 		};
 		DEF5CCF22539321A0003E9CC /* UnitTestApp */ = {
@@ -2996,6 +3016,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OneSignalOSCoreFramework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -3054,6 +3075,7 @@
 					"$(inherited)",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OneSignalOSCoreFramework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -3835,6 +3857,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = OS_TEST;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OneSignalUserFramework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -3890,6 +3913,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OneSignalUserFramework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -3948,6 +3972,7 @@
 					"$(inherited)",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OneSignalUserFramework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -4346,6 +4371,8 @@
 		DECE6F5A28C903D7007058EE /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				INFOPLIST_FILE = OneSignalOSCoreFramework/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalOSCore;
 				PRODUCT_NAME = OneSignalOSCore;
 				SWIFT_VERSION = 5.0;
 			};

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -66,9 +66,7 @@
 		3C11518E289AF83600565C41 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		3C11518F289AF83600565C41 /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C115192289AF85400565C41 /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
-		3C115193289AF85400565C41 /* OneSignalCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C115197289AF86C00565C41 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
-		3C115198289AF86C00565C41 /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C2C7DC4288E007E0020F9AE /* UserModelSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */; };
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
 		3C2C7DC8288F3C020020F9AE /* OSPushSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */; };
@@ -384,7 +382,6 @@
 		CACBAAB4218A7113000ACAA5 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CACBAAAB218A662B000ACAA5 /* WebKit.framework */; };
 		CAEA1C66202BB3C600FBFE9E /* OSEmailSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = CA810FCF202BA97300A60FED /* OSEmailSubscription.h */; };
 		DE12F3F2289B28C4002F63AA /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
-		DE12F3F3289B28C4002F63AA /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE16C14424D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14524D3724700670EFA /* OneSignalLifecycleObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16C14324D3724700670EFA /* OneSignalLifecycleObserver.m */; };
 		DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = DE16C14624D3727200670EFA /* OneSignalLifecycleObserver.h */; };
@@ -409,9 +406,7 @@
 		DE69E1A0282ED8060090BB3D /* OneSignalUser.h in Headers */ = {isa = PBXBuildFile; fileRef = DE69E19D282ED8060090BB3D /* OneSignalUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE69E1AC282ED87A0090BB3D /* OneSignalUserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69E1AA282ED8790090BB3D /* OneSignalUserManager.swift */; };
 		DE69E1AD282ED8F20090BB3D /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
-		DE69E1AE282ED8F20090BB3D /* OneSignalCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE69E1B2282ED9430090BB3D /* OneSignalUser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; };
-		DE69E1B3282ED9430090BB3D /* OneSignalUser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE7D17EA27026B95002D3A5D /* OneSignalCore.docc in Sources */ = {isa = PBXBuildFile; fileRef = DE7D17E927026B95002D3A5D /* OneSignalCore.docc */; };
 		DE7D17EB27026B95002D3A5D /* OneSignalCore.h in Headers */ = {isa = PBXBuildFile; fileRef = DE7D17E827026B95002D3A5D /* OneSignalCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE7D17FD27026BA3002D3A5D /* OneSignalExtension.docc in Sources */ = {isa = PBXBuildFile; fileRef = DE7D17FC27026BA3002D3A5D /* OneSignalExtension.docc */; };
@@ -540,6 +535,7 @@
 		DEA4B4652888C59100E9FE12 /* OneSignalExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17F927026BA3002D3A5D /* OneSignalExtension.framework */; };
 		DEA4B4662888C59E00E9FE12 /* OneSignalExtension.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17F927026BA3002D3A5D /* OneSignalExtension.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DEA4B4672888C5F200E9FE12 /* OneSignalExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17F927026BA3002D3A5D /* OneSignalExtension.framework */; };
+		DECE6F5B28C90821007058EE /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DE20425C24E21C1500350E4F /* UIApplication+OneSignal.h */; };
 		DEF5CCF52539321A0003E9CC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF5CCF42539321A0003E9CC /* AppDelegate.m */; };
 		DEF5CCFB2539321A0003E9CC /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF5CCFA2539321A0003E9CC /* ViewController.m */; };
@@ -553,13 +549,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3C115190289AF83600565C41 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 37747F8B19147D6400558FAD /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3C115160289A259500565C41;
-			remoteInfo = OneSignalOSCore;
-		};
 		3C115194289AF85400565C41 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 37747F8B19147D6400558FAD /* Project object */;
@@ -655,41 +644,6 @@
 			files = (
 				918CB0301E73388E0067130F /* OneSignal.h in CopyFiles */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3C115196289AF85400565C41 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				3C115193289AF85400565C41 /* OneSignalCore.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DE69E1B1282ED8F30090BB3D /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				DE12F3F3289B28C4002F63AA /* OneSignalOSCore.framework in Embed Frameworks */,
-				DE69E1AE282ED8F20090BB3D /* OneSignalCore.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DE69E1B6282ED9430090BB3D /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				3C115198289AF86C00565C41 /* OneSignalOSCore.framework in Embed Frameworks */,
-				DE69E1B3282ED9430090BB3D /* OneSignalUser.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DEA4B45E2888C1D000E9FE12 /* Embed Frameworks */ = {
@@ -1138,6 +1092,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DECE6F5B28C90821007058EE /* OneSignalOSCore.framework in Frameworks */,
 				DE3784842888CFF900453A8E /* OneSignalUser.framework in Frameworks */,
 				DEA4B4672888C5F200E9FE12 /* OneSignalExtension.framework in Frameworks */,
 				DEA4B4642888C4E200E9FE12 /* OneSignalOutcomes.framework in Frameworks */,
@@ -2170,7 +2125,6 @@
 				3C11515D289A259500565C41 /* Sources */,
 				3C11515E289A259500565C41 /* Frameworks */,
 				3C11515F289A259500565C41 /* Resources */,
-				3C115196289AF85400565C41 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2190,7 +2144,6 @@
 				3E2400341D4FFC31008BDE70 /* Frameworks */,
 				3E2400351D4FFC31008BDE70 /* Headers */,
 				3E2400361D4FFC31008BDE70 /* Resources */,
-				DE69E1B6282ED9430090BB3D /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2232,7 +2185,6 @@
 				DE69E197282ED8060090BB3D /* Sources */,
 				DE69E198282ED8060090BB3D /* Frameworks */,
 				DE69E199282ED8060090BB3D /* Resources */,
-				DE69E1B1282ED8F30090BB3D /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2314,7 +2266,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				3C115191289AF83600565C41 /* PBXTargetDependency */,
 			);
 			name = UnitTestApp;
 			productName = UnitTestApp;
@@ -2930,11 +2881,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		3C115191289AF83600565C41 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 3C115160289A259500565C41 /* OneSignalOSCore */;
-			targetProxy = 3C115190289AF83600565C41 /* PBXContainerItemProxy */;
-		};
 		3C115195289AF85400565C41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DE7D17E527026B95002D3A5D /* OneSignalCore */;
@@ -3912,63 +3858,6 @@
 			};
 			name = Test;
 		};
-		DE3D8F4428C15839008C2BBF /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 99SW8E36CT;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = OS_TEST;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalOSCore;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Test;
-		};
 		DE69E1A5282ED8070090BB3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4454,6 +4343,14 @@
 			};
 			name = Debug;
 		};
+		DECE6F5A28C903D7007058EE /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = OneSignalOSCore;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Test;
+		};
 		DEF5CD082539321D0003E9CC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4580,16 +4477,7 @@
 			buildConfigurations = (
 				3C115173289A259500565C41 /* Release */,
 				3C115174289A259500565C41 /* Debug */,
-				DE3D8F4428C15839008C2BBF /* Test */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		3C115172289A259500565C41 /* Build configuration list for PBXNativeTarget "OneSignalOSCore" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3C115173289A259500565C41 /* Release */,
-				3C115174289A259500565C41 /* Debug */,
+				DECE6F5A28C903D7007058EE /* Test */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		3C2C7DC4288E007E0020F9AE /* UserModelSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */; };
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
 		3C2C7DC8288F3C020020F9AE /* OSPushSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */; };
+		3C2D8A5928B4C4E300BE41F6 /* OSDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */; };
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
 		3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */; };
 		3C8E6DFF28AB09AE0031E48A /* OSPropertyOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */; };
@@ -743,6 +744,7 @@
 		3C2C7DC3288E007E0020F9AE /* UserModelSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModelSwiftTests.swift; sourceTree = "<group>"; };
 		3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserModelObjcTests.m; sourceTree = "<group>"; };
 		3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPushSubscriptionModel.swift; sourceTree = "<group>"; };
+		3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDelta.swift; sourceTree = "<group>"; };
 		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
 		3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationExecutor.swift; sourceTree = "<group>"; };
 		3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertyOperationExecutor.swift; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 				3CE5F9E4289D9AA3004A156E /* OSOperation.swift */,
 				3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */,
 				3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */,
+				3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1689,8 +1692,8 @@
 				3C2C7DC7288F3C020020F9AE /* OSPushSubscriptionModel.swift */,
 				3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */,
 				3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */,
-				3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */,
 				3CF862A128A197D200776CA4 /* OSPropertiesModelStoreListener.swift */,
+				3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */,
 				3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */,
 				3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */,
 			);
@@ -2612,6 +2615,7 @@
 				3C115185289ADE4F00565C41 /* OSModel.swift in Sources */,
 				3C115187289ADE7700565C41 /* OSModelStoreListener.swift in Sources */,
 				3CE5F9E3289D88DC004A156E /* OSModelStoreChangedHandler.swift in Sources */,
+				3C2D8A5928B4C4E300BE41F6 /* OSDelta.swift in Sources */,
 				3C11518D289AF5E800565C41 /* OSModelChangedHandler.swift in Sources */,
 				3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */,
 				3CE5F9E5289D9AA3004A156E /* OSOperation.swift in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -55,11 +55,13 @@ open class OSDelta: NSObject, NSCoding {
     }
 
     public required init?(coder: NSCoder) {
+        // swiftlint:disable force_cast
         name = coder.decodeObject(forKey: "name") as! String
         deltaId = coder.decodeObject(forKey: "deltaId") as! UUID
         timestamp = coder.decodeObject(forKey: "timestamp") as! Date
         model = coder.decodeObject(forKey: "model") as! OSModel
         property = coder.decodeObject(forKey: "property") as! String
         value = coder.decodeObject(forKey: "value")
+        // swiftlint:enable force_cast
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -55,15 +55,22 @@ open class OSDelta: NSObject, NSCoding {
     }
 
     public required init?(coder: NSCoder) {
-        // swiftlint:disable force_cast
-        // TODO: Discuss how to handle this case.
-        name = coder.decodeObject(forKey: "name") as! String
-        deltaId = coder.decodeObject(forKey: "deltaId") as! UUID
-        timestamp = coder.decodeObject(forKey: "timestamp") as! Date
-        model = coder.decodeObject(forKey: "model") as! OSModel
-        property = coder.decodeObject(forKey: "property") as! String
-        value = coder.decodeObject(forKey: "value")
-        // swiftlint:enable force_cast
-        // TODO: essentially guard let every one of these properties ^ to return nil
+        guard let name = coder.decodeObject(forKey: "name") as? String,
+              let deltaId = coder.decodeObject(forKey: "deltaId") as? UUID,
+              let timestamp = coder.decodeObject(forKey: "timestamp") as? Date,
+              let model = coder.decodeObject(forKey: "model") as? OSModel,
+              let property = coder.decodeObject(forKey: "property") as? String,
+              let value = coder.decodeObject(forKey: "value")
+        else {
+            // TODO: Log error
+            return nil
+        }
+
+        self.name = name
+        self.deltaId = deltaId
+        self.timestamp = timestamp
+        self.model = model
+        self.property = property
+        self.value = value
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -56,6 +56,7 @@ open class OSDelta: NSObject, NSCoding {
 
     public required init?(coder: NSCoder) {
         // swiftlint:disable force_cast
+        // TODO: Discuss how to handle this case.
         name = coder.decodeObject(forKey: "name") as! String
         deltaId = coder.decodeObject(forKey: "deltaId") as! UUID
         timestamp = coder.decodeObject(forKey: "timestamp") as! Date
@@ -63,5 +64,6 @@ open class OSDelta: NSObject, NSCoding {
         property = coder.decodeObject(forKey: "property") as! String
         value = coder.decodeObject(forKey: "value")
         // swiftlint:enable force_cast
+        // TODO: essentially guard let every one of these properties ^ to return nil
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -35,7 +35,7 @@ open class OSDelta: NSObject, NSCoding {
     let model: OSModel
     let property: String
     let value: Any?
-    
+
     public init(name: String, model: OSModel, property: String, value: Any?) {
         self.name = name
         self.deltaId = UUID()
@@ -44,7 +44,7 @@ open class OSDelta: NSObject, NSCoding {
         self.property = property
         self.value = value
     }
-    
+
     public func encode(with coder: NSCoder) {
         coder.encode(name, forKey: "name")
         coder.encode(deltaId, forKey: "deltaId")
@@ -53,7 +53,7 @@ open class OSDelta: NSObject, NSCoding {
         coder.encode(property, forKey: "property")
         coder.encode(value, forKey: "value")
     }
-    
+
     public required init?(coder: NSCoder) {
         name = coder.decodeObject(forKey: "name") as! String
         deltaId = coder.decodeObject(forKey: "deltaId") as! UUID

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -27,15 +27,13 @@
 
 import Foundation
 
-public protocol OSOperationExecutor {
-    var supportedDeltas: [String] { get }
-    var deltaQueue: [OSDelta] { get }
-    var operationQueue: [OSOperation] { get }
+public protocol OSDelta: NSCoding {
+    var name: String { get }
+    var deltaId: UUID { get }
+    var timestamp: Date { get }
     
-    func enqueueDelta(_ delta: OSDelta)
-    func processDeltaQueue()
+    var model: OSModel { get }
     
-    func enqueueOperation(_ operation: OSOperation)
-    func processOperationQueue()
-    func executeOperation(_ operation: OSOperation)
+    // define how to respond to operation and get hydrated
+    // like operation.complete()
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -27,13 +27,38 @@
 
 import Foundation
 
-public protocol OSDelta: NSCoding {
-    var name: String { get }
-    var deltaId: UUID { get }
-    var timestamp: Date { get }
+open class OSDelta: NSCoding {
+    let name: String
+    public let deltaId: UUID
+    let timestamp: Date
+    let model: OSModel
+    let property: String
+    let value: Any?
     
-    var model: OSModel { get }
+    public init(name: String, model: OSModel, property: String, value: Any?) {
+        self.name = name
+        self.deltaId = UUID()
+        self.timestamp = Date()
+        self.model = model
+        self.property = property
+        self.value = value
+    }
     
-    // define how to respond to operation and get hydrated
-    // like operation.complete()
+    public func encode(with coder: NSCoder) {
+        coder.encode(name, forKey: "name")
+        coder.encode(deltaId, forKey: "deltaId")
+        coder.encode(timestamp, forKey: "timestamp")
+        coder.encode(model, forKey: "model")
+        coder.encode(property, forKey: "property")
+        coder.encode(value, forKey: "value")
+    }
+    
+    public required init?(coder: NSCoder) {
+        name = coder.decodeObject(forKey: "name") as! String
+        deltaId = coder.decodeObject(forKey: "deltaId") as! UUID
+        timestamp = coder.decodeObject(forKey: "timestamp") as! Date
+        model = coder.decodeObject(forKey: "model") as! OSModel
+        property = coder.decodeObject(forKey: "property") as! String
+        value = coder.decodeObject(forKey: "value")
+    }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSEventProducer.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSEventProducer.swift
@@ -45,7 +45,7 @@ public class OSEventProducer<THandler>: NSObject {
 
     public func fire(callback: (THandler) -> Void) {
         print("🔥 OSEventProducer.fire() called with the following subscribers:")
-        dump(subscribers)
+        // dump(subscribers) -> uncomment for more verbose log during testing
         for subscriber in subscribers {
             callback(subscriber)
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSEventProducer.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSEventProducer.swift
@@ -28,9 +28,9 @@
 import Foundation
 
 public class OSEventProducer<THandler>: NSObject {
-    
+
     var subscribers: [THandler] = []
-    
+
     public func subscribe(_ handler: THandler) {
         print("🔥 OSEventProducer.subscribe() called with handler: \(handler)")
         // TODO: UM do we want to synchronize on subscribers

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSEventProducer.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSEventProducer.swift
@@ -39,7 +39,6 @@ public class OSEventProducer<THandler>: NSObject {
 
     public func unsubscribe(_ handler: THandler) {
         print("🔥 OSEventProducer.unsubscribe() called with handler: \(handler)")
-
         // TODO: UM do we want to synchronize on subscribers
         // subscribers.removeAll(where: { $0 === handler})
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -39,7 +39,7 @@ open class OSModel: NSObject {
     var data: [String : AnyObject?] = [:]
     let changeNotifier: OSEventProducer<OSModelChangedHandler>
 
-    public init(_ changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+    public init(changeNotifier: OSEventProducer<OSModelChangedHandler>) {
         self.changeNotifier = changeNotifier
     }
     

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -61,6 +61,7 @@ open class OSModel: NSObject, NSCoding {
      This function receives a server response and updates the model's properties.
      */
     public func hydrate(_ response: [String: String]) {
+        // TODO: Thread safety when processing server responses to hydrate models.
         self.hydrating = true
         hydrateModel(response) // Calls model-specific hydration logic
         self.hydrating = false

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -37,15 +37,15 @@ open class OSModel: NSObject, NSCoding {
         self.id = id
         self.changeNotifier = changeNotifier
     }
-    
+
     open func encode(with coder: NSCoder) {
         coder.encode(id, forKey: "id")
     }
-    
+
     public required init?(coder: NSCoder) {
         id = coder.decodeObject(forKey: "id") as! String
     }
-    
+
     // We can add operation name to this... , such as enum of "updated", "deleted", "added"
     public func set<T>(property: String, oldValue: T, newValue: T) {
         guard let changeNotifier = self.changeNotifier else {
@@ -53,26 +53,25 @@ open class OSModel: NSObject, NSCoding {
             print("🔥 OSModel changeNotifier is not set!")
             return
         }
-        
+
         let changeArgs = OSModelChangedArgs(model: self, property: property, oldValue: oldValue, newValue: newValue)
-        
+
         changeNotifier.fire { modelChangeHandler in
             modelChangeHandler.onModelUpdated(args: changeArgs, hydrating: self.hydrating)
         }
     }
-    
+
     /**
      This function receives a server response and updates the model's properties.
      */
-    public func hydrate(_ response: [String : String]) {
+    public func hydrate(_ response: [String: String]) {
         self.hydrating = true
         hydrateModel(response) // Calls model-specific hydration logic
         self.hydrating = false
     }
-    
-    open func hydrateModel(_ response: [String : String]) {
+
+    open func hydrateModel(_ response: [String: String]) {
         // TODO: Log as an error.
         print("Error: Function must be overridden.")
     }
 }
-

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -29,22 +29,17 @@ import Foundation
 
 @objc
 open class OSModel: NSObject, NSCoding {
-    public let id: String
     public var changeNotifier: OSEventProducer<OSModelChangedHandler>? // MUST set after initWithCoder
     private var hydrating = false // TODO: Starts out false?
 
-    public init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
-        self.id = id
+    public init(changeNotifier: OSEventProducer<OSModelChangedHandler>) {
         self.changeNotifier = changeNotifier
     }
 
     open func encode(with coder: NSCoder) {
-        coder.encode(id, forKey: "id")
     }
 
     public required init?(coder: NSCoder) {
-        // swiftlint:disable:next force_cast
-        id = coder.decodeObject(forKey: "id") as! String
     }
 
     // We can add operation name to this... , such as enum of "updated", "deleted", "added"

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -43,6 +43,7 @@ open class OSModel: NSObject, NSCoding {
     }
 
     public required init?(coder: NSCoder) {
+        // swiftlint:disable:next force_cast
         id = coder.decodeObject(forKey: "id") as! String
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -26,11 +26,12 @@
  */
 
 import Foundation
+import OneSignalExtension
 
 @objc
 open class OSModel: NSObject {
     public var id: String
-    var data: [String : AnyObject?] = [:]
+    public var hydrating = false // TODO: Starts out false?
     let changeNotifier: OSEventProducer<OSModelChangedHandler>
 
     public init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
@@ -38,26 +39,28 @@ open class OSModel: NSObject {
         self.changeNotifier = changeNotifier
     }
     
-    public func set<T>(name: String, value: T) {
-        
-        let oldValue = data[name] as AnyObject // Error encountered: Argument type 'AnyObject?' expected to be an instance of a class or class-constrained type
-        
-        let newValue = value as AnyObject // Error encountered: Cannot assign value of type 'T' to subscript of type 'AnyObject??'
-        
-        if (oldValue === newValue) { return }
-            
-        data[name] = newValue
-
-        let changeArgs = OSModelChangedArgs(model: self, property: name, oldValue: oldValue, newValue: newValue)
+    public func set<T>(property: String, oldValue: T, newValue: T) {
+        let changeArgs = OSModelChangedArgs(model: self, property: property, oldValue: oldValue, newValue: newValue)
         self.changeNotifier.fire { modelChangeHandler in
             modelChangeHandler.onChanged(args: changeArgs)
         }
     }
 
+    /*
     public func get<T>(_ name: String) -> T {
         return data[name] as! T
     }
+    */
 
     // TODO: Other get function which creates if not found
+    
+    /**
+     This function receives a server response and updates the model's properties. It must be implemented by every OSModel class.
+     */
+    open func hydrate(_ response: [String : String]) {
+        // TODO: Modify the Error that is thrown?
+        // throw NSError(domain: "OneSignalError", code: 0, userInfo: ["error": "Function must be overridden."])
+        print("Error: Function must be overridden.")
+    }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -29,17 +29,12 @@ import Foundation
 
 @objc
 open class OSModel: NSObject {
-    
-    public var id: String? {
-        didSet  {
-            print("🔥 didSet OSModel.id from \(oldValue) to \(id).")
-            self.set(name: "id", value: id)
-        }
-    }
+    public var id: String
     var data: [String : AnyObject?] = [:]
     let changeNotifier: OSEventProducer<OSModelChangedHandler>
 
-    public init(changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+    public init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+        self.id = id
         self.changeNotifier = changeNotifier
     }
     

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelChangedHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelChangedHandler.swift
@@ -56,6 +56,7 @@ public class OSModelChangedArgs: NSObject {
     }
 }
 
+
 public protocol OSModelChangedHandler {
     func onChanged(args: OSModelChangedArgs)
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelChangedHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelChangedHandler.swift
@@ -41,14 +41,14 @@ public class OSModelChangedArgs: NSObject {
     /**
      The old value of the property, prior to it being changed.
      */
-    public let oldValue: AnyObject?
+    public let oldValue: Any?
 
     /**
      The new value of the property, after it has been changed.
      */
-    public let newValue: AnyObject?
+    public let newValue: Any?
     
-    init(model: OSModel, property: String, oldValue: AnyObject?, newValue: AnyObject?) {
+    init(model: OSModel, property: String, oldValue: Any?, newValue: Any?) {
         self.model = model
         self.property = property
         self.oldValue = oldValue

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelChangedHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelChangedHandler.swift
@@ -47,7 +47,7 @@ public class OSModelChangedArgs: NSObject {
      The new value of the property, after it has been changed.
      */
     public let newValue: Any?
-    
+
     init(model: OSModel, property: String, oldValue: Any?, newValue: Any?) {
         self.model = model
         self.property = property

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -31,36 +31,36 @@ import OneSignalCore
 open class OSModelStore<TModel: OSModel>: NSObject {
     let storeKey: String
     let changeSubscription: OSEventProducer<OSModelStoreChangedHandler>
-    var models: [String : TModel]
-    
+    var models: [String: TModel]
+
     public init(changeSubscription: OSEventProducer<OSModelStoreChangedHandler>, storeKey: String) {
         self.storeKey = storeKey
         self.changeSubscription = changeSubscription
-        
+
         // read models from cache, if any
-        self.models = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: self.storeKey, defaultValue: [:]) as! [String : TModel]
+        self.models = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: self.storeKey, defaultValue: [:]) as! [String: TModel]
     }
-    
+
     public func getModels() -> [String: TModel] {
         return self.models
     }
-    
+
     public func add(id: String, model: TModel) {
         print("🔥 OSModelStore add with model \(model)")
 
         models[id] = model
-        
+
         // persist the models (including new model) to storage
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: self.storeKey, withValue: self.models)
-        
+
         // listen for changes to this model
         model.changeNotifier?.subscribe(self)
-        
+
         self.changeSubscription.fire { modelStoreListener in
             modelStoreListener.onAdded(model)
         }
     }
-    
+
     func remove(_ id: String) {
         print("🔥 OSModelStore remove with model \(id)")
         if let model = models[id] {
@@ -71,7 +71,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
 
             // no longer listen for changes to this model
             model.changeNotifier?.unsubscribe(self)
-            
+
             self.changeSubscription.fire { modelStoreListener in
                 modelStoreListener.onRemoved(model)
             }
@@ -82,7 +82,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
 extension OSModelStore: OSModelChangedHandler {
     public func onModelUpdated(args: OSModelChangedArgs, hydrating: Bool) {
         print("🔥 OSModelStore.onChanged() with args \(args)")
-        
+
         // persist the changed models to storage
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: self.storeKey, withValue: self.models)
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -26,6 +26,7 @@
  */
 
 import Foundation
+import OneSignalCore
 
 
 open class OSModelStore<TModel: OSModel>: NSObject {
@@ -38,8 +39,11 @@ open class OSModelStore<TModel: OSModel>: NSObject {
     
     public func add(id: String, model: TModel) {
         print("🔥 OSModelStore add with model \(model)")
-        // TODO: UM persist the new model to storage.
+
         models[id] = model
+        
+        // TODO: Persist the new model to storage.
+        // OneSignalUserDefaults.initStandard().saveCodeableData(forKey: model.id, withValue: model)
         
         // listen for changes to this model
         model.changeNotifier.subscribe(self)
@@ -52,9 +56,13 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         print("🔥 OSModelStore remove with model \(id)")
         if let model = models[id] {
             models.removeValue(forKey: id)
+
+            // Remove the model from storage
+            OneSignalUserDefaults.initShared().removeValue(forKey: model.id)
+            
             // no longer listen for changes to this model
             model.changeNotifier.unsubscribe(self)
-            // TODO: Remove the model from storage
+            
             self.changeSubscription.fire { modelStoreListener in
                 modelStoreListener.onRemoved(model)
             }
@@ -65,7 +73,9 @@ open class OSModelStore<TModel: OSModel>: NSObject {
 extension OSModelStore: OSModelChangedHandler {
     public func onChanged(args: OSModelChangedArgs) {
         print("🔥 OSModelStore.onChanged() with args \(args)")
-        // TODO: Persist the changed model to storage. Consider batching.
+        
+        // TODO: Persist the changed model to storage. TODO: Consider batching.
+        // OneSignalUserDefaults.initStandard().saveCodeableData(forKey: args.model.id, withValue: args.model)
 
         self.changeSubscription.fire { modelStoreListener in
             modelStoreListener.onUpdated(args)

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -38,7 +38,11 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         self.changeSubscription = changeSubscription
 
         // read models from cache, if any
-        self.models = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: self.storeKey, defaultValue: [:]) as! [String: TModel]
+        guard let models = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: self.storeKey, defaultValue: [:]) as? [String: TModel] else {
+            self.models = [:]
+            return
+        }
+        self.models = models
     }
 
     public func getModels() -> [String: TModel] {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -27,6 +27,7 @@
 
 import Foundation
 
+
 open class OSModelStore<TModel: OSModel>: NSObject {
     let changeSubscription: OSEventProducer<OSModelStoreChangedHandler>
     var models: [String : TModel] = [:]
@@ -46,7 +47,6 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         self.changeSubscription.fire { modelStoreListener in
             modelStoreListener.added(model)
         }
-    }
     
     func remove(_ id: String) {
         print("🔥 OSModelStore remove with model \(id)")

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -81,6 +81,10 @@ open class OSModelStore<TModel: OSModel>: NSObject {
             }
         }
     }
+    
+    func clear() { // TODO: Prefer to use an observer pattern like `onUserChanged`
+        // remove models from the cache
+    }
 }
 
 extension OSModelStore: OSModelChangedHandler {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -82,7 +82,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
             }
         }
     }
-    
+
     func clear() { // TODO: Prefer to use an observer pattern like `onUserChanged`
         // remove models from the cache
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -45,7 +45,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         model.changeNotifier.subscribe(self)
         
         self.changeSubscription.fire { modelStoreListener in
-            modelStoreListener.added(model)
+            modelStoreListener.onAdded(model)
         }
     
     func remove(_ id: String) {
@@ -56,7 +56,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
             model.changeNotifier.unsubscribe(self)
             // TODO: Remove the model from storage
             self.changeSubscription.fire { modelStoreListener in
-                modelStoreListener.removed(model)
+                modelStoreListener.onRemoved(model)
             }
         }
     }
@@ -68,7 +68,7 @@ extension OSModelStore: OSModelChangedHandler {
         // TODO: Persist the changed model to storage. Consider batching.
 
         self.changeSubscription.fire { modelStoreListener in
-            modelStoreListener.updated(args)
+            modelStoreListener.onUpdated(args)
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -38,11 +38,12 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         self.changeSubscription = changeSubscription
 
         // read models from cache, if any
-        guard let models = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: self.storeKey, defaultValue: [:]) as? [String: TModel] else {
+        if let models = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: self.storeKey, defaultValue: [:]) as? [String: TModel] {
+            self.models = models
+        } else {
+            // log error
             self.models = [:]
-            return
         }
-        self.models = models
     }
 
     public func getModels() -> [String: TModel] {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreChangedHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreChangedHandler.swift
@@ -35,15 +35,15 @@ public protocol OSModelStoreChangedHandler {
     /**
      Called when a model has been added to the model store.
      */
-    func added(_ model: OSModel)
+    func onAdded(_ model: OSModel)
     
     /**
      Called when a model has been updated.
      */
-    func updated(_ args: OSModelChangedArgs)
+    func onUpdated(_ args: OSModelChangedArgs)
     
     /**
      Called when a model has been removed from the model store.
      */
-    func removed(_ model: OSModel)
+    func onRemoved(_ model: OSModel)
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreChangedHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreChangedHandler.swift
@@ -36,12 +36,12 @@ public protocol OSModelStoreChangedHandler {
      Called when a model has been added to the model store.
      */
     func onAdded(_ model: OSModel)
-    
+
     /**
      Called when a model has been updated.
      */
     func onUpdated(_ args: OSModelChangedArgs)
-    
+
     /**
      Called when a model has been removed from the model store.
      */

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -52,6 +52,7 @@ extension OSModelStoreListener {
 
     public func onAdded(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onAdded() with model \(model)")
+        // swiftlint:disable:next force_cast
         if let delta = getAddModelDelta(model as! Self.TModel) {
             OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
@@ -66,6 +67,7 @@ extension OSModelStoreListener {
 
     public func onRemoved(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
+        // swiftlint:disable:next force_cast
         if let delta = getRemoveModelDelta(model as! Self.TModel) {
             OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -31,10 +31,9 @@ public protocol OSModelStoreListener: OSModelStoreChangedHandler {
     associatedtype TModel: OSModel
     
     var store: OSModelStore<TModel> { get }
-    // TODO: UM Operation Repo
-    // var opRepo: OSOperationRepo {get}
+    var opRepo: OSOperationRepo { get }
     
-    init(_ store: OSModelStore<TModel>)
+    init(store: OSModelStore<TModel>, opRepo: OSOperationRepo)
     
     func getAddOperation(_ model: TModel) -> OSOperation?
     
@@ -55,21 +54,21 @@ extension OSModelStoreListener {
     public func onAdded(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onAdded() with model \(model)")
         if let operation = getAddOperation(model as! Self.TModel) {
-            // opRepo.enqueue(operation)
+            opRepo.enqueue(operation)
         }
     }
 
     public func onUpdated(_ args: OSModelChangedArgs) {
         print("🔥 OSModelStoreListener.onUpdated() with args \(args)")
         if let operation = getUpdateOperation(args) {
-            // opRepo.enqueue(operation)
+            opRepo.enqueue(operation)
         }
     }
     
     public func onRemoved(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
         if let operation = getRemoveOperation(model as! Self.TModel) {
-            // opRepo.enqueue(operation)
+            opRepo.enqueue(operation)
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -52,8 +52,11 @@ extension OSModelStoreListener {
 
     public func onAdded(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onAdded() with model \(model)")
-        // swiftlint:disable:next force_cast
-        if let delta = getAddModelDelta(model as! Self.TModel) {
+        guard let addedModel = model as? Self.TModel else {
+            // TODO: log error
+            return
+        }
+        if let delta = getAddModelDelta(addedModel) {
             OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
     }
@@ -67,8 +70,11 @@ extension OSModelStoreListener {
 
     public func onRemoved(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
-        // swiftlint:disable:next force_cast
-        if let delta = getRemoveModelDelta(model as! Self.TModel) {
+        guard let removedModel = model as? Self.TModel else {
+            // TODO: log error
+            return
+        }
+        if let delta = getRemoveModelDelta(removedModel) {
             OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -34,11 +34,11 @@ public protocol OSModelStoreListener: OSModelStoreChangedHandler {
     
     init(store: OSModelStore<TModel>)
     
-    func getAddOperation(_ model: TModel) -> OSOperation?
+    func getAddDelta(_ model: TModel) -> OSDelta?
     
-    func getRemoveOperation(_ model: TModel) -> OSOperation?
+    func getRemoveDelta(_ model: TModel) -> OSDelta?
     
-    func getUpdateOperation(_ args: OSModelChangedArgs) -> OSOperation?
+    func getUpdateDelta(_ args: OSModelChangedArgs) -> OSDelta?
 }
 
 extension OSModelStoreListener {
@@ -52,22 +52,22 @@ extension OSModelStoreListener {
 
     public func onAdded(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onAdded() with model \(model)")
-        if let operation = getAddOperation(model as! Self.TModel) {
-            OSOperationRepo.sharedInstance.enqueue(operation)
+        if let delta = getAddDelta(model as! Self.TModel) {
+            OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
     }
 
     public func onUpdated(_ args: OSModelChangedArgs) {
         print("🔥 OSModelStoreListener.onUpdated() with args \(args)")
-        if let operation = getUpdateOperation(args) {
-            OSOperationRepo.sharedInstance.enqueue(operation)
+        if let delta = getUpdateDelta(args) {
+            OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
     }
     
     public func onRemoved(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
-        if let operation = getRemoveOperation(model as! Self.TModel) {
-            OSOperationRepo.sharedInstance.enqueue(operation)
+        if let delta = getRemoveDelta(model as! Self.TModel) {
+            OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -29,15 +29,15 @@ import Foundation
 
 public protocol OSModelStoreListener: OSModelStoreChangedHandler {
     associatedtype TModel: OSModel
-    
+
     var store: OSModelStore<TModel> { get }
-    
+
     init(store: OSModelStore<TModel>)
-    
+
     func getAddModelDelta(_ model: TModel) -> OSDelta?
-    
+
     func getRemoveModelDelta(_ model: TModel) -> OSDelta?
-    
+
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta?
 }
 
@@ -45,7 +45,7 @@ extension OSModelStoreListener {
     public func start() {
         store.changeSubscription.subscribe(self)
     }
-    
+
     func close() {
         store.changeSubscription.unsubscribe(self)
     }
@@ -63,7 +63,7 @@ extension OSModelStoreListener {
             OSOperationRepo.sharedInstance.enqueueDelta(delta)
         }
     }
-    
+
     public func onRemoved(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
         if let delta = getRemoveModelDelta(model as! Self.TModel) {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -52,22 +52,22 @@ extension OSModelStoreListener {
         store.changeSubscription.unsubscribe(self)
     }
 
-    public func added(_ model: OSModel) {
-        print("🔥 OSModelStoreListener.added() with model \(model)")
+    public func onAdded(_ model: OSModel) {
+        print("🔥 OSModelStoreListener.onAdded() with model \(model)")
         if let operation = getAddOperation(model as! Self.TModel) {
             // opRepo.enqueue(operation)
         }
     }
 
-    public func updated(_ args: OSModelChangedArgs) {
-        print("🔥 OSModelStoreListener.updated() with args \(args)")
+    public func onUpdated(_ args: OSModelChangedArgs) {
+        print("🔥 OSModelStoreListener.onUpdated() with args \(args)")
         if let operation = getUpdateOperation(args) {
             // opRepo.enqueue(operation)
         }
     }
     
-    public func removed(_ model: OSModel) {
-        print("🔥 OSModelStoreListener.removed() with model \(model)")
+    public func onRemoved(_ model: OSModel) {
+        print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
         if let operation = getRemoveOperation(model as! Self.TModel) {
             // opRepo.enqueue(operation)
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStoreListener.swift
@@ -31,9 +31,8 @@ public protocol OSModelStoreListener: OSModelStoreChangedHandler {
     associatedtype TModel: OSModel
     
     var store: OSModelStore<TModel> { get }
-    var opRepo: OSOperationRepo { get }
     
-    init(store: OSModelStore<TModel>, opRepo: OSOperationRepo)
+    init(store: OSModelStore<TModel>)
     
     func getAddOperation(_ model: TModel) -> OSOperation?
     
@@ -54,21 +53,21 @@ extension OSModelStoreListener {
     public func onAdded(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onAdded() with model \(model)")
         if let operation = getAddOperation(model as! Self.TModel) {
-            opRepo.enqueue(operation)
+            OSOperationRepo.sharedInstance.enqueue(operation)
         }
     }
 
     public func onUpdated(_ args: OSModelChangedArgs) {
         print("🔥 OSModelStoreListener.onUpdated() with args \(args)")
         if let operation = getUpdateOperation(args) {
-            opRepo.enqueue(operation)
+            OSOperationRepo.sharedInstance.enqueue(operation)
         }
     }
     
     public func onRemoved(_ model: OSModel) {
         print("🔥 OSModelStoreListener.onRemoved() with model \(model)")
         if let operation = getRemoveOperation(model as! Self.TModel) {
-            opRepo.enqueue(operation)
+            OSOperationRepo.sharedInstance.enqueue(operation)
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperation.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperation.swift
@@ -27,8 +27,14 @@
 
 import Foundation
 
-public class OSOperation {
-    public init() {
-        print("🔥 OSOperation created.")
-    }
+public protocol OSOperation: NSCoding {
+    var name: String { get }
+    var operationId: UUID { get }
+    var timestamp: Date { get }
+    
+    // OSOperation has an OSModel property to hydrate it after a successful request
+    var model: OSModel { get }
+    
+    // define how to respond to operation and get hydrated
+    // like operation.complete()
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperation.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperation.swift
@@ -32,10 +32,10 @@ public protocol OSOperation: NSCoding {
     var name: String { get }
     var operationId: UUID { get }
     var timestamp: Date { get }
-    
+
     // OSOperation has an OSModel property to hydrate it after a successful request
     var model: OSModel { get }
-    
+
     // define how to respond to operation and get hydrated
     // like operation.complete()
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperation.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperation.swift
@@ -27,6 +27,7 @@
 
 import Foundation
 
+// TODO: Remove class? Modify? Since we are enqueing OSDeltas instead now.
 public protocol OSOperation: NSCoding {
     var name: String { get }
     var operationId: UUID { get }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
@@ -1,0 +1,36 @@
+/*
+ Modified MIT License
+
+ Copyright 2022 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+import Foundation
+
+public protocol OSOperationExecutor {
+    var supportedOperations: [String] { get }
+    var queue: [OSOperation] { get }
+    
+    func enqueue(_ operation: OSOperation)
+    func execute()
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
@@ -31,11 +31,11 @@ public protocol OSOperationExecutor {
     var supportedDeltas: [String] { get }
     var deltaQueue: [OSDelta] { get }
     var operationQueue: [OSOperation] { get }
-    
+
     func start()
     func enqueueDelta(_ delta: OSDelta)
     func processDeltaQueue()
-    
+
     func enqueueOperation(_ operation: OSOperation)
     func processOperationQueue()
     func executeOperation(_ operation: OSOperation)

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
@@ -34,6 +34,7 @@ public protocol OSOperationExecutor {
 
     func start()
     func enqueueDelta(_ delta: OSDelta)
+    func cacheDeltaQueue()
     func processDeltaQueue()
 
     func enqueueOperation(_ operation: OSOperation)

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -98,8 +98,3 @@ public class OSOperationRepo: NSObject {
         }
     }
 }
-
-// how to implement every 5 seconds flush, some background service callign every 5 seconds,
-// blocking queue, sync queue - many threads are manipulating the same queue, think about lock it when flush
-// can't use async keyword bc ios 13+
-// https://developer.apple.com/documentation/dispatch/dispatchqueue

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -50,7 +50,11 @@ public class OSOperationRepo: NSObject {
      */
     func start() -> OSOperationRepo {
         // Read the Deltas from cache, if any... TODO: Don't hardcode key value
-        self.deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", defaultValue: []) as! [OSDelta]
+        guard let deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", defaultValue: []) as? [OSDelta] else {
+            // log error
+            return self
+        }
+        self.deltaQueue = deltaQueue
         return self
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -88,11 +88,6 @@ public class OSOperationRepo: NSObject {
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", withValue: self.deltaQueue)
     }
 
-    public func removeDeltaFromCache(_ delta: OSDelta) {
-        // Persist the deltas (including removed delta) to storage
-        OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", withValue: self.deltaQueue)
-    }
-
     func flushDeltaQueue() {
         print("🔥 OSOperationRepo flushDeltaQueue")
         if deltaQueue.isEmpty {
@@ -108,6 +103,13 @@ public class OSOperationRepo: NSObject {
                 // keep in queue if no executor matches, we may not have the executor available yet
                 index += 1
             }
+        }
+
+        // Persist the deltas (including removed deltas) to storage after they are divvy'd up to executors.
+        OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", withValue: self.deltaQueue)
+
+        for executor in executors {
+            executor.cacheDeltaQueue()
         }
 
         for executor in executors {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -50,11 +50,11 @@ public class OSOperationRepo: NSObject {
      */
     func start() -> OSOperationRepo {
         // Read the Deltas from cache, if any... TODO: Don't hardcode key value
-        guard let deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", defaultValue: []) as? [OSDelta] else {
+        if let deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", defaultValue: []) as? [OSDelta] {
+            self.deltaQueue = deltaQueue
+        } else {
             // log error
-            return self
         }
-        self.deltaQueue = deltaQueue
         return self
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -24,32 +24,13 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
-
 import Foundation
-import OneSignalOSCore
 
-class OSIdentityModelStoreListener: OSModelStoreListener {
-    var store: OSModelStore<OSIdentityModel>
-    var opRepo: OSOperationRepo
-
-    required init(store: OSModelStore<OSIdentityModel>, opRepo: OSOperationRepo) {
-        self.store = store
-        self.opRepo = opRepo
-    }
+public class OSOperationRepo: NSObject {
+    var queue: Array<OSOperation> = Array() // change to a some kind of Queue
     
-    func getAddOperation(_ model: OSIdentityModel) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
+    func enqueue(_ operation: OSOperation) {
+        print("🔥 OSOperationRepo enqueue \(operation)")
+        queue.append(operation)
     }
-    
-    func getRemoveOperation(_ model: OSIdentityModel) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
-    }
-    
-    func getUpdateOperation(_ args: OSModelChangedArgs) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
-    }
-    
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -34,9 +34,9 @@ import OneSignalCore
  */
 public class OSOperationRepo: NSObject {
     public static let sharedInstance = OSOperationRepo().start()
-    
+
     // Maps delta names to the interfaces for the operation executors
-    var deltasToExecutorMap: [String : OSOperationExecutor] = [:]
+    var deltasToExecutorMap: [String: OSOperationExecutor] = [:]
     var executors: [OSOperationExecutor] = []
     var deltaQueue: [OSDelta] = []
 
@@ -53,7 +53,7 @@ public class OSOperationRepo: NSObject {
         self.deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", defaultValue: []) as! [OSDelta]
         return self
     }
-    
+
     /**
      Add and start an executor.
      */
@@ -64,7 +64,7 @@ public class OSOperationRepo: NSObject {
             executor.start()
         }
     }
-    
+
     func enqueueDelta(_ delta: OSDelta) {
         print("🔥 OSOperationRepo enqueueDelta: \(delta)")
         deltaQueue.append(delta)
@@ -72,12 +72,12 @@ public class OSOperationRepo: NSObject {
         // Persist the deltas (including new delta) to storage
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", withValue: self.deltaQueue)
     }
-    
+
     public func removeDeltaFromCache(_ delta: OSDelta) {
         // Persist the deltas (including removed delta) to storage
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_OPERATION_REPO_DELTA_QUEUE", withValue: self.deltaQueue)
     }
-    
+
     func flushDeltaQueue() {
         if deltaQueue.isEmpty {
             return
@@ -88,7 +88,7 @@ public class OSOperationRepo: NSObject {
             }
             // keep in queue if no executor matches, we may not have the executor available yet
         }
-        
+
         for executor in executors {
             executor.processDeltaQueue()
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -56,11 +56,11 @@ public class OSOperationRepo: NSObject {
         } else {
             // log error
         }
-        
+
         pollFlushQueue()
         return self
     }
-    
+
     private func pollFlushQueue() {
         DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(pollIntervalSeconds)) { [weak self] in
             print("🔥 OSOperationRepo pollFlushQueue: begin flush")
@@ -68,7 +68,7 @@ public class OSOperationRepo: NSObject {
             self?.pollFlushQueue()
         }
     }
-    
+
     /**
      Add and start an executor.
      */
@@ -98,7 +98,7 @@ public class OSOperationRepo: NSObject {
         if deltaQueue.isEmpty {
             return
         }
-        
+
         var index = 0
         for delta in deltaQueue {
             if let executor = deltasToExecutorMap[delta.name] {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreFramework/Info.plist
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreFramework/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2022 Hiptic. All rights reserved.</string>
+</dict>
+</plist>

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -29,9 +29,9 @@ import Foundation
 import OneSignalOSCore
 
 class OSIdentityModel: OSModel {
-    var onesignalId: UUID?
+    var onesignalId: UUID? // let? optional?
 
-    var externalId: String? {
+    var externalId: String? { // let? optional?
         didSet  {
             guard self.hydrating else {
                 print("🔥 didSet OSIdentityModel.externalId from \(oldValue) to \(externalId!).")
@@ -40,7 +40,29 @@ class OSIdentityModel: OSModel {
             }
         }
     }
+    
     var aliases: [String : String] = [:]
+    
+    // MARK: - Initialization
+    
+    // We seem to lose access to this init() in superclass after adding init?(coder: NSCoder)
+    override init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+        super.init(id: id, changeNotifier: changeNotifier)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(onesignalId, forKey: "onesignalId")
+        coder.encode(externalId, forKey: "externalId")
+        coder.encode(aliases, forKey: "aliases")
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        onesignalId = coder.decodeObject(forKey: "onesignalId") as? UUID
+        externalId = coder.decodeObject(forKey: "externalId") as? String
+        aliases = coder.decodeObject(forKey: "aliases") as! [String : String]
+    }
     
     func setAlias(label: String, id: String) {
         guard self.hydrating else {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -43,8 +43,8 @@ class OSIdentityModel: OSModel {
     // MARK: - Initialization
 
     // We seem to lose access to this init() in superclass after adding init?(coder: NSCoder)
-    override init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
-        super.init(id: id, changeNotifier: changeNotifier)
+    override init(changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+        super.init(changeNotifier: changeNotifier)
     }
 
     override func encode(with coder: NSCoder) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -64,12 +64,16 @@ class OSIdentityModel: OSModel {
         aliases = coder.decodeObject(forKey: "aliases") as! [String : String]
     }
     
+    // MARK: - Alias Methods
+    
     func setAlias(label: String, id: String) {
+        // Don't let them use `onesignal_id` as an alias label
+        // Don't let them use `external_id` either?
         guard self.hydrating else {
             print("🔥 OSIdentityModel.setAlias \(label) : \(id).")
             let oldValue: String? = aliases[label]
             aliases[label] = id
-            self.set(property: label, oldValue: oldValue, newValue: id)
+            self.set(property: "aliases", oldValue: (label: label, id: oldValue), newValue: (label: label, id: id))
             return
         }
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -78,6 +78,7 @@ class OSIdentityModel: OSModel {
 
     func removeAlias(_ label: String) {
         print("🔥 OSIdentityModel.removeAlias \(label).")
+        // TODO: create a delta even if this alias does not exist locally.
         if let oldValue = aliases.removeValue(forKey: label) {
             // Cannot encode a nil value
             self.set(property: label, oldValue: oldValue, newValue: "")

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -32,37 +32,37 @@ class OSIdentityModel: OSModel {
     var onesignalId: UUID? // let? optional?
 
     var externalId: String? { // let? optional?
-        didSet  {
+        didSet {
             print("🔥 didSet OSIdentityModel.externalId from \(oldValue) to \(externalId!).")
             self.set(property: "externalId", oldValue: oldValue, newValue: externalId)
         }
     }
-    
-    var aliases: [String : String] = [:]
-    
+
+    var aliases: [String: String] = [:]
+
     // MARK: - Initialization
-    
+
     // We seem to lose access to this init() in superclass after adding init?(coder: NSCoder)
     override init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
         super.init(id: id, changeNotifier: changeNotifier)
     }
-    
+
     override func encode(with coder: NSCoder) {
         super.encode(with: coder)
         coder.encode(onesignalId, forKey: "onesignalId")
         coder.encode(externalId, forKey: "externalId")
         coder.encode(aliases, forKey: "aliases")
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         onesignalId = coder.decodeObject(forKey: "onesignalId") as? UUID
         externalId = coder.decodeObject(forKey: "externalId") as? String
-        aliases = coder.decodeObject(forKey: "aliases") as! [String : String]
+        aliases = coder.decodeObject(forKey: "aliases") as! [String: String]
     }
-    
+
     // MARK: - Alias Methods
-    
+
     func setAlias(label: String, id: String) {
         // Don't let them use `onesignal_id` as an alias label
         // Don't let them use `external_id` either?
@@ -71,7 +71,7 @@ class OSIdentityModel: OSModel {
         aliases[label] = id
         self.set(property: "aliases", oldValue: ["label": label, "id": oldValue], newValue: ["label": label, "id": id])
     }
-    
+
     func removeAlias(_ label: String) {
         print("🔥 OSIdentityModel.removeAlias \(label).")
         if let oldValue = aliases.removeValue(forKey: label) {
@@ -79,8 +79,8 @@ class OSIdentityModel: OSModel {
             self.set(property: label, oldValue: oldValue, newValue: "")
         }
     }
-    
-    public override func hydrateModel(_ response: [String : String]) {
+
+    public override func hydrateModel(_ response: [String: String]) {
         print("🔥 OSIdentityModel hydrateModel()")
         // TODO: Update Model properties with the response
         // Flesh out implementation and how to parse the response, deleted aliases...

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -58,7 +58,11 @@ class OSIdentityModel: OSModel {
         super.init(coder: coder)
         onesignalId = coder.decodeObject(forKey: "onesignalId") as? UUID
         externalId = coder.decodeObject(forKey: "externalId") as? String
-        aliases = coder.decodeObject(forKey: "aliases") as! [String: String]
+        guard let aliases = coder.decodeObject(forKey: "aliases") as? [String: String] else {
+            // log error
+            return
+        }
+        self.aliases = aliases
     }
 
     // MARK: - Alias Methods

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
@@ -32,19 +32,19 @@ import OneSignalOSCore
 
 class OSIdentityModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSIdentityModel>
-    
+
     required init(store: OSModelStore<OSIdentityModel>) {
         self.store = store
     }
-    
+
     func getAddModelDelta(_ model: OSIdentityModel) -> OSDelta? {
         return nil
     }
-    
+
     func getRemoveModelDelta(_ model: OSIdentityModel) -> OSDelta? {
         return nil
     }
-    
+
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta? {
         return OSDelta(
             name: "OSUpdateIdentityDelta", // TODO: Don't hardcode.

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
@@ -28,6 +28,42 @@
 import Foundation
 import OneSignalOSCore
 
+// MARK: - Identity Operations
+
+/**
+ An OSUpdateIdentityOperation includes operations for adding, removing, and updating an alias.
+ It may also include adding, removing, and updating an external_id.
+ */
+class OSUpdateIdentityOperation: OSOperation {
+    // Operation Information
+    let name = "OSUpdateIdentityOperation"
+    let operationId = UUID()
+    let timestamp = Date()
+
+    // Model Information
+    var model: OSModel = OSIdentityModel(id: "testtest", changeNotifier: OSEventProducer()) // TODO: Implement NSCoding for OSModel
+    let property: String
+    let value: Any?
+    
+    init(model: OSIdentityModel, property: String, value: Any?) {
+        self.model = model
+        self.property = property
+        self.value = value
+    }
+    
+    func encode(with coder: NSCoder) {
+        //
+    }
+    
+    required init?(coder: NSCoder) {
+        // model = coder.decodeObject(forKey: "model") as! String
+        property = coder.decodeObject(forKey: "property") as! String
+        value = coder.decodeObject(forKey: "value")
+    }
+}
+
+// MARK: - Model Store Listener
+
 class OSIdentityModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSIdentityModel>
     
@@ -36,18 +72,19 @@ class OSIdentityModelStoreListener: OSModelStoreListener {
     }
     
     func getAddOperation(_ model: OSIdentityModel) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
+        return nil
     }
     
     func getRemoveOperation(_ model: OSIdentityModel) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
+        return nil
     }
     
     func getUpdateOperation(_ args: OSModelChangedArgs) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
+        return OSUpdateIdentityOperation(
+            model: args.model as! OSIdentityModel,
+            property: args.property,
+            value: args.newValue
+        )
     }
     
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
@@ -48,7 +48,7 @@ class OSIdentityModelStoreListener: OSModelStoreListener {
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta? {
         return OSDelta(
             name: "OSUpdateIdentityDelta", // TODO: Don't hardcode.
-            model: args.model as! OSIdentityModel,
+            model: args.model,
             property: args.property,
             value: args.newValue
         )

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
@@ -35,37 +35,13 @@ import OneSignalOSCore
  It may also include adding, removing, and updating an external_id (??? need to confirm).
  */
 class OSUpdateIdentityDelta: OSDelta {
-    let name = "OSUpdateIdentityDelta"
-    // TODO: Extract these same properties out to the protocol/superclass:
-    let deltaId: UUID
-    let timestamp: Date
-    let model: OSModel
-    let property: String
-    let value: Any?
-    
-    // TODO: Extract these same init()'s across OSDeltas to a superclass:
-    init(model: OSIdentityModel, property: String, value: Any?) {
-        self.deltaId = UUID()
-        self.timestamp = Date()
-        self.model = model
-        self.property = property
-        self.value = value
-    }
-    
-    func encode(with coder: NSCoder) {
-        coder.encode(deltaId, forKey: "deltaId")
-        coder.encode(timestamp, forKey: "timestamp")
-        coder.encode(model, forKey: "model")
-        coder.encode(property, forKey: "property")
-        coder.encode(value, forKey: "value")
+    // TODO: Best practice for overriding a stored property in subclass?
+    init(model: OSModel, property: String, value: Any?) {
+        super.init(name: "OSUpdateIdentityDelta", model: model, property: property, value: value)
     }
     
     required init?(coder: NSCoder) {
-        deltaId = coder.decodeObject(forKey: "deltaId") as! UUID
-        timestamp = coder.decodeObject(forKey: "timestamp") as! Date
-        model = coder.decodeObject(forKey: "model") as! OSModel
-        property = coder.decodeObject(forKey: "property") as! String
-        value = coder.decodeObject(forKey: "value")
+        super.init(coder: coder)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelStoreListener.swift
@@ -30,11 +30,9 @@ import OneSignalOSCore
 
 class OSIdentityModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSIdentityModel>
-    var opRepo: OSOperationRepo
-
-    required init(store: OSModelStore<OSIdentityModel>, opRepo: OSOperationRepo) {
+    
+    required init(store: OSModelStore<OSIdentityModel>) {
         self.store = store
-        self.opRepo = opRepo
     }
     
     func getAddOperation(_ model: OSIdentityModel) -> OSOperation? {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -36,7 +36,11 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
 
     func start() {
         // Read unfinished operations from cache, if any... TODO: Don't hardcode
-        self.operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as! [OSOperation]
+        guard let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] else {
+            //log error
+            return
+        }
+        self.operationQueue = operationQueue
     }
 
     func enqueueDelta(_ delta: OSDelta) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -36,11 +36,11 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
 
     func start() {
         // Read unfinished operations from cache, if any... TODO: Don't hardcode
-        guard let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] else {
-            //log error
-            return
+        if let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] {
+            self.operationQueue = operationQueue
+        } else {
+            // log error
         }
-        self.operationQueue = operationQueue
     }
 
     func enqueueDelta(_ delta: OSDelta) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -58,6 +58,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
             OSOperationRepo.sharedInstance.removeDeltaFromCache(delta)
             // enqueueOperation(operation)
         }
+        self.deltaQueue = [] // TODO: Check that we can simply clear all the deltas in the deltaQueue
         processOperationQueue()
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -35,7 +35,14 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
     var operationQueue: [OSOperation] = []
 
     func start() {
-        // Read unfinished operations from cache, if any... TODO: Don't hardcode
+        // Read unfinished deltas and operations from cache, if any... TODO: Don't hardcode
+
+        if let deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_DELTA_QUEUE", defaultValue: []) as? [OSDelta] {
+            self.deltaQueue = deltaQueue
+        } else {
+            // log error
+        }
+
         if let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] {
             self.operationQueue = operationQueue
         } else {
@@ -48,6 +55,10 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         deltaQueue.append(delta)
     }
 
+    func cacheDeltaQueue() {
+        OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_DELTA_QUEUE", withValue: self.deltaQueue)
+    }
+
     func processDeltaQueue() {
         if deltaQueue.isEmpty {
             return
@@ -55,7 +66,8 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         // TODO: Implementation
         for delta in deltaQueue {
             // Remove the delta from the cache when it becomes an Operation
-            OSOperationRepo.sharedInstance.removeDeltaFromCache(delta)
+            // Optimize when it is cached.
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_DELTA_QUEUE", withValue: self.deltaQueue)
             // enqueueOperation(operation)
         }
         self.deltaQueue = [] // TODO: Check that we can simply clear all the deltas in the deltaQueue
@@ -77,6 +89,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         for operation in operationQueue {
             executeOperation(operation)
         }
+        self.operationQueue = [] // TODO: Check that we can simply clear all the operations in the operationQueue
     }
 
     func executeOperation(_ operation: OSOperation) {
@@ -85,6 +98,8 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         let response = ["onesignalId": UUID().uuidString, "label01": "id01"]
 
         // On success, remove operation from cache, and hydrate model
+        // TODO: May need to remove this operation from the operationQueue too
+        // For example, if app restarts and we read in operations between sending this off and getting the response
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", withValue: self.operationQueue)
 
         operation.model.hydrate(response)

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -30,33 +30,48 @@ import OneSignalOSCore
 import OneSignalCore
 
 class OSIdentityOperationExecutor: OSOperationExecutor {
-    var supportedOperations: [String] = ["OSUpdateIdentityOperation"] // TODO: Don't hardcode
-    var queue: [OSOperation] = []
+    var supportedDeltas: [String] = ["OSUpdateIdentityDelta"] // TODO: Don't hardcode
+    var deltaQueue: [OSDelta] = []
+    var operationQueue: [OSOperation] = []
     
-    /**
-     For the Identity Model change requests, we enqueue each operation as a separate request.
-     */
-    func enqueue(_ operation: OSOperation) {
-        print("🔥 OSIdentityOperationExecutor enqueue \(operation)")
-        // Cache the operation
-        OneSignalUserDefaults.initShared().saveObject(forKey: operation.operationId.uuidString, withValue: operation)
-        queue.append(operation)
+    func enqueueDelta(_ delta: OSDelta) {
+        print("🔥 OSIdentityOperationExecutor enqueueDelta: \(delta)")
+        deltaQueue.append(delta)
     }
     
-
-
-    
-    func execute() {
-        if queue.isEmpty {
+    func processDeltaQueue() {
+        if deltaQueue.isEmpty {
             return
         }
-            
-        let operation = queue.removeFirst()
+        // TODO: Implementation
+        for delta in deltaQueue {
+            // Remove the delta from the cache when it becomes an Operation
+            OneSignalUserDefaults.initShared().removeValue(forKey: delta.deltaId.uuidString)
+            // enqueueOperation(operation)
+        }
+        processOperationQueue()
+    }
+   
+    func enqueueOperation(_ operation: OSOperation) {
+        print("🔥 OSIdentityOperationExecutor enqueueOperation: \(operation)")
+        // Cache the Operation
+        OneSignalUserDefaults.initShared().saveObject(forKey: operation.operationId.uuidString, withValue: operation)
+        operationQueue.append(operation)
+    }
+    
+    func processOperationQueue() {
+        if operationQueue.isEmpty {
+            return
+        }
+        for operation in operationQueue {
+            executeOperation(operation)
+        }
+    }
+    
+    func executeOperation(_ operation: OSOperation) {
         // Execute the operation
-        
         // Mock a response
-        
-        let response = ["language": "en"]
+        let response = ["onesignalId": UUID().uuidString, "label01": "id01"]
         
         // On success, remove operation from cache, and hydrate model
         OneSignalUserDefaults.initShared().removeValue(forKey: operation.operationId.uuidString)
@@ -64,5 +79,4 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         operation.model.hydrate(response)
         // On failure, retry logic, but order of operations matters
     }
-    
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -33,17 +33,17 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
     var supportedDeltas: [String] = ["OSUpdateIdentityDelta"] // TODO: Don't hardcode
     var deltaQueue: [OSDelta] = []
     var operationQueue: [OSOperation] = []
-    
+
     func start() {
         // Read unfinished operations from cache, if any... TODO: Don't hardcode
         self.operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as! [OSOperation]
     }
-    
+
     func enqueueDelta(_ delta: OSDelta) {
         print("🔥 OSIdentityOperationExecutor enqueueDelta: \(delta)")
         deltaQueue.append(delta)
     }
-    
+
     func processDeltaQueue() {
         if deltaQueue.isEmpty {
             return
@@ -56,7 +56,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         }
         processOperationQueue()
     }
-   
+
     func enqueueOperation(_ operation: OSOperation) {
         print("🔥 OSIdentityOperationExecutor enqueueOperation: \(operation)")
         operationQueue.append(operation)
@@ -64,7 +64,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         // persist executor's operations (including new operation) to storage
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", withValue: self.operationQueue)
     }
-    
+
     func processOperationQueue() {
         if operationQueue.isEmpty {
             return
@@ -73,12 +73,12 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
             executeOperation(operation)
         }
     }
-    
+
     func executeOperation(_ operation: OSOperation) {
         // Execute the operation
         // Mock a response
         let response = ["onesignalId": UUID().uuidString, "label01": "id01"]
-        
+
         // On success, remove operation from cache, and hydrate model
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_IDENTITY_OPERATION_EXECUTOR_OPERATIONS", withValue: self.operationQueue)
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityOperationExecutor.swift
@@ -1,0 +1,68 @@
+/*
+ Modified MIT License
+
+ Copyright 2022 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+import Foundation
+import OneSignalOSCore
+import OneSignalCore
+
+class OSIdentityOperationExecutor: OSOperationExecutor {
+    var supportedOperations: [String] = ["OSUpdateIdentityOperation"] // TODO: Don't hardcode
+    var queue: [OSOperation] = []
+    
+    /**
+     For the Identity Model change requests, we enqueue each operation as a separate request.
+     */
+    func enqueue(_ operation: OSOperation) {
+        print("🔥 OSIdentityOperationExecutor enqueue \(operation)")
+        // Cache the operation
+        OneSignalUserDefaults.initShared().saveObject(forKey: operation.operationId.uuidString, withValue: operation)
+        queue.append(operation)
+    }
+    
+
+
+    
+    func execute() {
+        if queue.isEmpty {
+            return
+        }
+            
+        let operation = queue.removeFirst()
+        // Execute the operation
+        
+        // Mock a response
+        
+        let response = ["language": "en"]
+        
+        // On success, remove operation from cache, and hydrate model
+        OneSignalUserDefaults.initShared().removeValue(forKey: operation.operationId.uuidString)
+
+        operation.model.hydrate(response)
+        // On failure, retry logic, but order of operations matters
+    }
+    
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -47,8 +47,8 @@ class OSPropertiesModel: OSModel {
     // MARK: - Initialization
 
     // We seem to lose access to this init() in superclass after adding init?(coder: NSCoder)
-    override init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
-        super.init(id: id, changeNotifier: changeNotifier)
+    override init(changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+        super.init(changeNotifier: changeNotifier)
     }
 
     override func encode(with coder: NSCoder) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -49,5 +49,26 @@ class OSPropertiesModel: OSModel {
     }
     
     // ... and more ...
+    
+    // MARK: - Initialization
+    
+    // We seem to lose access to this init() in superclass after adding init?(coder: NSCoder)
+    override init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
+        super.init(id: id, changeNotifier: changeNotifier)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(language, forKey: "language")
+        coder.encode(tags, forKey: "tags")
+        // ... and more
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        language = coder.decodeObject(forKey: "language") as? String
+        tags = coder.decodeObject(forKey: "tags") as! [String : String]
+        // ... and more
+    }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -66,7 +66,7 @@ class OSPropertiesModel: OSModel {
             return
         }
         self.tags = tags
-        
+
         // ... and more
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -30,44 +30,43 @@ import OneSignalOSCore
 
 class OSPropertiesModel: OSModel {
     var language: String? {
-        didSet  {
+        didSet {
             print("🔥 didSet OSPropertiesModel.language from \(oldValue) to \(language).")
             self.set(property: "language", oldValue: oldValue, newValue: language)
         }
     }
-    var tags: [String : String] = [:] {
-        didSet  {
+    var tags: [String: String] = [:] {
+        didSet {
             print("🔥 didSet OSPropertiesModel.tags from \(oldValue) to \(tags).")
             self.set(property: "tags", oldValue: oldValue, newValue: tags)
         }
     }
-    
+
     // ... and more ...
-    
+
     // MARK: - Initialization
-    
+
     // We seem to lose access to this init() in superclass after adding init?(coder: NSCoder)
     override init(id: String, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
         super.init(id: id, changeNotifier: changeNotifier)
     }
-    
+
     override func encode(with coder: NSCoder) {
         super.encode(with: coder)
         coder.encode(language, forKey: "language")
         coder.encode(tags, forKey: "tags")
         // ... and more
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         language = coder.decodeObject(forKey: "language") as? String
-        tags = coder.decodeObject(forKey: "tags") as! [String : String]
+        tags = coder.decodeObject(forKey: "tags") as! [String: String]
         // ... and more
     }
-    
-    public override func hydrateModel(_ response: [String : String]) {
+
+    public override func hydrateModel(_ response: [String: String]) {
         print("🔥 OSPropertiesModel hydrateModel()")
         // TODO: Update Model properties with the response
     }
 }
-

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -31,14 +31,20 @@ import OneSignalOSCore
 class OSPropertiesModel: OSModel {
     var language: String? {
         didSet  {
-            print("🔥 didSet OSPropertiesModel.language from \(oldValue) to \(language).")
-            self.set(name: "language", value: language)
+            guard self.hydrating else {
+                print("🔥 didSet OSPropertiesModel.language from \(oldValue) to \(language).")
+                self.set(property: "language", oldValue: oldValue, newValue: language)
+                return
+            }
         }
     }
     var tags: [String : String] = [:] {
         didSet  {
-            print("🔥 didSet OSPropertiesModel.tags from \(oldValue) to \(tags).")
-            self.set(name: "tags", value: tags)
+            guard self.hydrating else {
+                print("🔥 didSet OSPropertiesModel.tags from \(oldValue) to \(tags).")
+                self.set(property: "tags", oldValue: oldValue, newValue: tags)
+                return
+            }
         }
     }
     

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -61,7 +61,12 @@ class OSPropertiesModel: OSModel {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         language = coder.decodeObject(forKey: "language") as? String
-        tags = coder.decodeObject(forKey: "tags") as! [String: String]
+        guard let tags = coder.decodeObject(forKey: "tags") as? [String: String] else {
+            // log error
+            return
+        }
+        self.tags = tags
+        
         // ... and more
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -30,9 +30,11 @@ import OneSignalOSCore
 
 class OSPropertiesModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSPropertiesModel>
+    var opRepo: OSOperationRepo
  
-    required init(_ store: OSModelStore<OSPropertiesModel>) {
+    required init(store: OSModelStore<OSPropertiesModel>, opRepo: OSOperationRepo) {
         self.store = store
+        self.opRepo = opRepo
     }
     
     func getAddOperation(_ model: OSPropertiesModel) -> OSOperation? {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -30,11 +30,9 @@ import OneSignalOSCore
 
 class OSPropertiesModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSPropertiesModel>
-    var opRepo: OSOperationRepo
  
-    required init(store: OSModelStore<OSPropertiesModel>, opRepo: OSOperationRepo) {
+    required init(store: OSModelStore<OSPropertiesModel>) {
         self.store = store
-        self.opRepo = opRepo
     }
     
     func getAddOperation(_ model: OSPropertiesModel) -> OSOperation? {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -31,36 +31,13 @@ import OneSignalOSCore
 // MARK: - Property Operations
 
 class OSUpdatePropertyDelta: OSDelta {
-    let name = "OSUpdatePropertyDelta"
-    let deltaId: UUID
-    let timestamp: Date
-    let model: OSModel
-    let property: String
-    let value: Any?
-    
-    // TODO: Extract these same init()'s across OSOperations to a superclass:
-    init(model: OSPropertiesModel, property: String, value: Any?) {
-        self.deltaId = UUID()
-        self.timestamp = Date()
-        self.model = model
-        self.property = property
-        self.value = value
-    }
-    
-    func encode(with coder: NSCoder) {
-        coder.encode(deltaId, forKey: "operationId")
-        coder.encode(timestamp, forKey: "timestamp")
-        coder.encode(model, forKey: "model")
-        coder.encode(property, forKey: "property")
-        coder.encode(value, forKey: "value")
+    // TODO: Best practice for overriding a stored property in subclass?
+    init(model: OSModel, property: String, value: Any?) {
+        super.init(name: "OSUpdatePropertyDelta", model: model, property: property, value: value)
     }
     
     required init?(coder: NSCoder) {
-        deltaId = coder.decodeObject(forKey: "operationId") as! UUID
-        timestamp = coder.decodeObject(forKey: "timestamp") as! Date
-        model = coder.decodeObject(forKey: "model") as! OSModel
-        property = coder.decodeObject(forKey: "property") as! String
-        value = coder.decodeObject(forKey: "value")
+        super.init(coder: coder)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -30,45 +30,41 @@ import OneSignalOSCore
 
 // MARK: - Property Operations
 
-class OSUpdatePropertyOperation: OSOperation {
-    
-    let name = "OSUpdatePropertyOperation"
-    // TODO: Extract this out to the protocol have these same properties:
-    var operationId = UUID()
-    let timestamp = Date()
-    
-    var model: OSModel = OSPropertiesModel(id: "testtest", changeNotifier: OSEventProducer()) // TODO: Implement NSCoding for OSModel
-
-    let modelId: String
+class OSUpdatePropertyDelta: OSDelta {
+    let name = "OSUpdatePropertyDelta"
+    let deltaId: UUID
+    let timestamp: Date
+    let model: OSModel
     let property: String
     let value: Any?
     
-    func encode(with coder: NSCoder) {
-        coder.encode(name, forKey: "name")
-        coder.encode(operationId, forKey: "operationId")
-        coder.encode(timestamp, forKey: "timestamp")
-        coder.encode(modelId, forKey: "modelId")
-        coder.encode(property, forKey: "property")
-        coder.encode(value, forKey: "value")
-        // TODO: Encode the model
-    }
-    
-    required init?(coder: NSCoder) {
-        modelId = coder.decodeObject(forKey: "modelId") as! String
-        property = coder.decodeObject(forKey: "property") as! String
-        value = coder.decodeObject(forKey: "value")
-        // ...
-    }
-    
+    // TODO: Extract these same init()'s across OSOperations to a superclass:
     init(model: OSPropertiesModel, property: String, value: Any?) {
+        self.deltaId = UUID()
+        self.timestamp = Date()
         self.model = model
-        self.modelId = model.id
         self.property = property
         self.value = value
     }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(deltaId, forKey: "operationId")
+        coder.encode(timestamp, forKey: "timestamp")
+        coder.encode(model, forKey: "model")
+        coder.encode(property, forKey: "property")
+        coder.encode(value, forKey: "value")
+    }
+    
+    required init?(coder: NSCoder) {
+        deltaId = coder.decodeObject(forKey: "operationId") as! UUID
+        timestamp = coder.decodeObject(forKey: "timestamp") as! Date
+        model = coder.decodeObject(forKey: "model") as! OSModel
+        property = coder.decodeObject(forKey: "property") as! String
+        value = coder.decodeObject(forKey: "value")
+    }
 }
 
-// MARK: - Model Store Listener
+// MARK: - Properties Model Store Listener
 
 class OSPropertiesModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSPropertiesModel>
@@ -77,21 +73,20 @@ class OSPropertiesModelStoreListener: OSModelStoreListener {
         self.store = store
     }
     
-    func getAddOperation(_ model: OSPropertiesModel) -> OSOperation? {
+    func getAddDelta(_ model: OSPropertiesModel) -> OSDelta? {
         return nil
     }
     
-    func getRemoveOperation(_ model: OSPropertiesModel) -> OSOperation? {
+    func getRemoveDelta(_ model: OSPropertiesModel) -> OSDelta? {
         return nil
     }
     
-    func getUpdateOperation(_ args: OSModelChangedArgs) -> OSOperation? {
+    func getUpdateDelta(_ args: OSModelChangedArgs) -> OSDelta? {
         // TODO: Implementation
-        return OSUpdatePropertyOperation(
+        return OSUpdatePropertyDelta(
             model: args.model as! OSPropertiesModel,
             property: args.property,
             value: args.newValue
         )
     }
-    
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -28,6 +28,48 @@
 import Foundation
 import OneSignalOSCore
 
+// MARK: - Property Operations
+
+class OSUpdatePropertyOperation: OSOperation {
+    
+    let name = "OSUpdatePropertyOperation"
+    // TODO: Extract this out to the protocol have these same properties:
+    var operationId = UUID()
+    let timestamp = Date()
+    
+    var model: OSModel = OSPropertiesModel(id: "testtest", changeNotifier: OSEventProducer()) // TODO: Implement NSCoding for OSModel
+
+    let modelId: String
+    let property: String
+    let value: Any?
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(name, forKey: "name")
+        coder.encode(operationId, forKey: "operationId")
+        coder.encode(timestamp, forKey: "timestamp")
+        coder.encode(modelId, forKey: "modelId")
+        coder.encode(property, forKey: "property")
+        coder.encode(value, forKey: "value")
+        // TODO: Encode the model
+    }
+    
+    required init?(coder: NSCoder) {
+        modelId = coder.decodeObject(forKey: "modelId") as! String
+        property = coder.decodeObject(forKey: "property") as! String
+        value = coder.decodeObject(forKey: "value")
+        // ...
+    }
+    
+    init(model: OSPropertiesModel, property: String, value: Any?) {
+        self.model = model
+        self.modelId = model.id
+        self.property = property
+        self.value = value
+    }
+}
+
+// MARK: - Model Store Listener
+
 class OSPropertiesModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSPropertiesModel>
  
@@ -36,18 +78,20 @@ class OSPropertiesModelStoreListener: OSModelStoreListener {
     }
     
     func getAddOperation(_ model: OSPropertiesModel) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
+        return nil
     }
     
     func getRemoveOperation(_ model: OSPropertiesModel) -> OSOperation? {
-        // TODO: Implementation
-        return OSOperation()
+        return nil
     }
     
     func getUpdateOperation(_ args: OSModelChangedArgs) -> OSOperation? {
         // TODO: Implementation
-        return OSOperation()
+        return OSUpdatePropertyOperation(
+            model: args.model as! OSPropertiesModel,
+            property: args.property,
+            value: args.newValue
+        )
     }
     
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -32,19 +32,19 @@ import OneSignalOSCore
 
 class OSPropertiesModelStoreListener: OSModelStoreListener {
     var store: OSModelStore<OSPropertiesModel>
- 
+
     required init(store: OSModelStore<OSPropertiesModel>) {
         self.store = store
     }
-    
+
     func getAddModelDelta(_ model: OSPropertiesModel) -> OSDelta? {
         return nil
     }
-    
+
     func getRemoveModelDelta(_ model: OSPropertiesModel) -> OSDelta? {
         return nil
     }
-    
+
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta? {
         return OSDelta(
             name: "OSUpdatePropertyDelta", // TODO: Don't hardcode

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -48,7 +48,7 @@ class OSPropertiesModelStoreListener: OSModelStoreListener {
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta? {
         return OSDelta(
             name: "OSUpdatePropertyDelta", // TODO: Don't hardcode
-            model: args.model as! OSPropertiesModel,
+            model: args.model,
             property: args.property,
             value: args.newValue
         )

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -1,0 +1,68 @@
+/*
+ Modified MIT License
+
+ Copyright 2022 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+import Foundation
+import OneSignalOSCore
+import OneSignalCore
+
+class OSPropertyOperationExecutor: OSOperationExecutor {
+    var supportedOperations: [String] = ["OSUpdatePropertyOperation"] // TODO: Don't hardcode
+    var queue: [OSOperation] = []
+
+    /**
+     For the Properties Model change requests, we only keep the latest OSOperation with the snapshot of the Model.
+     */
+    func enqueue(_ operation: OSOperation) {
+        print("🔥 OSPropertyOperationExecutor enqueue \(operation)")
+        OneSignalUserDefaults.initShared().saveObject(forKey: operation.operationId.uuidString, withValue: operation)
+        if !queue.isEmpty {
+            let prevOperation = queue.removeFirst()
+            OneSignalUserDefaults.initShared().removeValue(forKey: prevOperation.operationId.uuidString)
+        }
+        queue = [operation]
+    }
+
+    func execute() {
+        if queue.isEmpty {
+            return
+        }
+            
+        let operation = queue.removeFirst()
+        // Execute the operation
+        
+        // Mock a response
+        
+        let response = ["language": "en"]
+
+        // On success, remove operation from cache, and hydrate model
+        OneSignalUserDefaults.initShared().removeValue(forKey: operation.operationId.uuidString)
+        operation.model.hydrate(response)
+        
+        // On failure, retry logic
+        // Consider if newer properties request has been made that has the more updated model
+    }
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -36,10 +36,11 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
 
     func start() {
         // Read unfinished operations from cache, if any... TODO: Don't hardcode
-        guard let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] else {
-            return
+        if let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] {
+            self.operationQueue = operationQueue
+        } else {
+            // log error
         }
-        self.operationQueue = operationQueue
     }
 
     func enqueueDelta(_ delta: OSDelta) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -30,39 +30,55 @@ import OneSignalOSCore
 import OneSignalCore
 
 class OSPropertyOperationExecutor: OSOperationExecutor {
-    var supportedOperations: [String] = ["OSUpdatePropertyOperation"] // TODO: Don't hardcode
-    var queue: [OSOperation] = []
+    var supportedDeltas: [String] = ["OSUpdatePropertyOperation"] // TODO: Don't hardcode
+    var deltaQueue: [OSDelta] = []
+    var operationQueue: [OSOperation] = []
 
-    /**
-     For the Properties Model change requests, we only keep the latest OSOperation with the snapshot of the Model.
-     */
-    func enqueue(_ operation: OSOperation) {
-        print("🔥 OSPropertyOperationExecutor enqueue \(operation)")
-        OneSignalUserDefaults.initShared().saveObject(forKey: operation.operationId.uuidString, withValue: operation)
-        if !queue.isEmpty {
-            let prevOperation = queue.removeFirst()
-            OneSignalUserDefaults.initShared().removeValue(forKey: prevOperation.operationId.uuidString)
-        }
-        queue = [operation]
+    func enqueueDelta(_ delta: OSDelta) {
+        print("🔥 OSPropertyOperationExecutor enqueue delta\(delta)")
+        deltaQueue.append(delta)
     }
 
-    func execute() {
-        if queue.isEmpty {
+    func processDeltaQueue() {
+        if deltaQueue.isEmpty {
             return
         }
-            
-        let operation = queue.removeFirst()
+        // TODO: Implementation
+        for delta in deltaQueue {
+            // Remove the delta from the cache when it becomes an Operation
+            OneSignalUserDefaults.initShared().removeValue(forKey: delta.deltaId.uuidString)
+            // enqueueOperation(operation)
+        }
+        processOperationQueue()
+    }
+    
+    func enqueueOperation(_ operation: OSOperation) {
+        print("🔥 OSPropertyOperationExecutor enqueueOperation: \(operation)")
+        // Cache the Operation
+        OneSignalUserDefaults.initShared().saveObject(forKey: operation.operationId.uuidString, withValue: operation)
+        operationQueue.append(operation)
+    }
+    
+    func processOperationQueue() {
+        if operationQueue.isEmpty {
+            return
+        }
+        for operation in operationQueue {
+            executeOperation(operation)
+        }
+    }
+    
+    func executeOperation(_ operation: OSOperation) {
         // Execute the operation
-        
         // Mock a response
         
         let response = ["language": "en"]
 
         // On success, remove operation from cache, and hydrate model
         OneSignalUserDefaults.initShared().removeValue(forKey: operation.operationId.uuidString)
+        
         operation.model.hydrate(response)
         
         // On failure, retry logic
-        // Consider if newer properties request has been made that has the more updated model
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -58,6 +58,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
             OSOperationRepo.sharedInstance.removeDeltaFromCache(delta)
             // enqueueOperation(operation)
         }
+        self.deltaQueue = [] // TODO: Check that we can simply clear all the deltas in the deltaQueue
         processOperationQueue()
     }
 
@@ -76,6 +77,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         for operation in self.operationQueue {
             executeOperation(operation)
         }
+        self.operationQueue = [] // TODO: Check that we can simply clear all the ops in the operationQueue
     }
 
     func executeOperation(_ operation: OSOperation) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -38,7 +38,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         // Read unfinished operations from cache, if any... TODO: Don't hardcode
         self.operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as! [OSOperation]
     }
-    
+
     func enqueueDelta(_ delta: OSDelta) {
         print("🔥 OSPropertyOperationExecutor enqueue delta\(delta)")
         deltaQueue.append(delta)
@@ -56,7 +56,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         }
         processOperationQueue()
     }
-    
+
     func enqueueOperation(_ operation: OSOperation) {
         print("🔥 OSPropertyOperationExecutor enqueueOperation: \(operation)")
         operationQueue.append(operation)
@@ -64,7 +64,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         // persist executor's operations (including new operation) to storage
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", withValue: self.operationQueue)
     }
-    
+
     func processOperationQueue() {
         if operationQueue.isEmpty {
             return
@@ -73,18 +73,18 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
             executeOperation(operation)
         }
     }
-    
+
     func executeOperation(_ operation: OSOperation) {
         // Execute the operation
         // Mock a response
-        
+
         let response = ["language": "en"]
 
         // On success, remove operation from cache, and hydrate model
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", withValue: self.operationQueue)
-        
+
         operation.model.hydrate(response)
-        
+
         // On failure, retry logic
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -30,7 +30,7 @@ import OneSignalOSCore
 import OneSignalCore
 
 class OSPropertyOperationExecutor: OSOperationExecutor {
-    var supportedDeltas: [String] = ["OSUpdatePropertyOperation"] // TODO: Don't hardcode
+    var supportedDeltas: [String] = ["OSUpdatePropertyDelta"] // TODO: Don't hardcode
     var deltaQueue: [OSDelta] = []
     var operationQueue: [OSOperation] = []
 
@@ -69,10 +69,10 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
     }
 
     func processOperationQueue() {
-        if operationQueue.isEmpty {
+        if self.operationQueue.isEmpty {
             return
         }
-        for operation in operationQueue {
+        for operation in self.operationQueue {
             executeOperation(operation)
         }
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -36,7 +36,10 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
 
     func start() {
         // Read unfinished operations from cache, if any... TODO: Don't hardcode
-        self.operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as! [OSOperation]
+        guard let operationQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: "OS_PROPERTY_OPERATION_EXECUTOR_OPERATIONS", defaultValue: []) as? [OSOperation] else {
+            return
+        }
+        self.operationQueue = operationQueue
     }
 
     func enqueueDelta(_ delta: OSDelta) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
@@ -82,6 +82,6 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         self.subscriptionId = subscriptionId
         self.token = token
         self.enabled = enabled ?? false
-        super.init(changeNotifier: OSEventProducer())
+        super.init(OSEventProducer())
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
@@ -38,7 +38,7 @@ public class OSPushSubscriptionState: NSObject {
     @objc public let subscriptionId: UUID?
     @objc public let token: UUID?
     @objc public let enabled: Bool
-    
+
     init(subscriptionId: UUID?, token: UUID?, enabled: Bool) {
         self.subscriptionId = subscriptionId
         self.token = token
@@ -70,15 +70,15 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
     func didSetEnabledHelper(oldValue: Bool, newValue: Bool) {
         // TODO: UM name and scope of function
         // TODO: UM update model, add operation to backend
-        let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: oldValue)
-        let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: newValue)
-        
+        _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: oldValue)
+        _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: newValue)
+
         // use hydrating bool to determine calling self.set
         self.set(property: "enabled", oldValue: oldValue, newValue: newValue)
         // TODO: UM trigger observers.onOSPushSubscriptionChanged(previous: oldState, current: newState)
         print("🔥 didSet pushSubscription.enabled from \(oldValue) to \(newValue)")
     }
-    
+
     // When this PushSubscription is initialized, it will not have a subscriptionId until a request to the backend is made.
     init(token: UUID?, enabled: Bool?) {
         self.token = token
@@ -86,14 +86,14 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         // TODO: What should be the id of this model?
         super.init(id: UUID().uuidString, changeNotifier: OSEventProducer())
     }
-    
+
     override func encode(with coder: NSCoder) {
         super.encode(with: coder)
         coder.encode(subscriptionId, forKey: "subscriptionId")
         coder.encode(token, forKey: "token")
         coder.encode(enabled, forKey: "enabled")
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         subscriptionId = coder.decodeObject(forKey: "subscriptionId") as? UUID

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
@@ -84,7 +84,7 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         self.token = token
         self.enabled = enabled ?? false
         // TODO: What should be the id of this model?
-        super.init(id: UUID().uuidString, changeNotifier: OSEventProducer())
+        super.init(changeNotifier: OSEventProducer())
     }
 
     override func encode(with coder: NSCoder) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
@@ -73,7 +73,8 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: oldValue)
         let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: newValue)
         
-        self.set(name: "enabled", value: newValue)
+        // use hydrating bool to determine calling self.set
+        self.set(property: "enabled", oldValue: oldValue, newValue: newValue)
         // TODO: UM trigger observers.onOSPushSubscriptionChanged(previous: oldState, current: newState)
         print("🔥 didSet pushSubscription.enabled from \(oldValue) to \(newValue)")
     }
@@ -82,6 +83,6 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         self.subscriptionId = subscriptionId
         self.token = token
         self.enabled = enabled ?? false
-        super.init(OSEventProducer())
+        super.init(id: subscriptionId.uuidString, changeNotifier: OSEventProducer())
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
@@ -70,9 +70,8 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
     func didSetEnabledHelper(oldValue: Bool, newValue: Bool) {
         // TODO: UM name and scope of function
         // TODO: UM update model, add operation to backend
-
-        _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: oldValue)
-        _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: newValue)
+        let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: oldValue)
+        let _ = OSPushSubscriptionState(subscriptionId: self.subscriptionId, token: self.token, enabled: newValue)
         
         self.set(name: "enabled", value: newValue)
         // TODO: UM trigger observers.onOSPushSubscriptionChanged(previous: oldState, current: newState)
@@ -83,6 +82,6 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         self.subscriptionId = subscriptionId
         self.token = token
         self.enabled = enabled ?? false
-        super.init(OSEventProducer())
+        super.init(changeNotifier: OSEventProducer())
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPushSubscriptionModel.swift
@@ -35,11 +35,11 @@ import OneSignalOSCore
 
 @objc
 public class OSPushSubscriptionState: NSObject {
-    @objc public let subscriptionId: UUID
+    @objc public let subscriptionId: UUID?
     @objc public let token: UUID?
     @objc public let enabled: Bool
 
-    init(subscriptionId: UUID, token: UUID?, enabled: Bool) {
+    init(subscriptionId: UUID?, token: UUID?, enabled: Bool) {
         self.subscriptionId = subscriptionId
         self.token = token
         self.enabled = enabled
@@ -50,7 +50,7 @@ public class OSPushSubscriptionState: NSObject {
  This is the push subscription interface exposed to the public.
  */
 @objc public protocol OSPushSubscriptionInterface {
-    var subscriptionId: UUID { get }
+    var subscriptionId: UUID? { get }
     var token: UUID? { get }
     var enabled: Bool { get set }
 }
@@ -59,7 +59,7 @@ public class OSPushSubscriptionState: NSObject {
  Internal push subscription model that implements the public-facing OSUser protocol.
  */
 class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
-    @objc public let subscriptionId: UUID
+    @objc public private(set) var subscriptionId: UUID?
     @objc public private(set) var token: UUID?
     @objc public var enabled = false { // this should default to false when first created
         didSet {
@@ -78,11 +78,26 @@ class OSPushSubscriptionModel: OSModel, OSPushSubscriptionInterface {
         // TODO: UM trigger observers.onOSPushSubscriptionChanged(previous: oldState, current: newState)
         print("🔥 didSet pushSubscription.enabled from \(oldValue) to \(newValue)")
     }
-
-    init(subscriptionId: UUID, token: UUID?, enabled: Bool?) {
-        self.subscriptionId = subscriptionId
+    
+    // When this PushSubscription is initialized, it will not have a subscriptionId until a request to the backend is made.
+    init(token: UUID?, enabled: Bool?) {
         self.token = token
         self.enabled = enabled ?? false
-        super.init(id: subscriptionId.uuidString, changeNotifier: OSEventProducer())
+        // TODO: What should be the id of this model?
+        super.init(id: UUID().uuidString, changeNotifier: OSEventProducer())
+    }
+    
+    override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(subscriptionId, forKey: "subscriptionId")
+        coder.encode(token, forKey: "token")
+        coder.encode(enabled, forKey: "enabled")
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        subscriptionId = coder.decodeObject(forKey: "subscriptionId") as? UUID
+        token = coder.decodeObject(forKey: "token") as? UUID
+        enabled = (coder.decodeObject(forKey: "enabled") != nil) // TODO: Not correct!
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
@@ -98,31 +98,34 @@ public class OSUserInternal: NSObject, OSUser {
         // workaround for didSet: call initializeProperties(...)
     }
     
-    // Aliases
+    // MARK: - Aliases
     
     @objc
     public func addAlias(label: String, id: String) -> Void {
         print("🔥 OSUser addAlias() called")
-        // Alt1: update alias list, and fire, observer sees entire list as changed, listener can figure out delta
-        // or Operation can figure it out,  etc depends how Delta is figured out
-        // confirm didSet for appending, see if new object
-        // since it is a struct, it changes, diff if its a class
-        self.identityModel.aliases[label] = id
+        self.identityModel.setAlias(label: label, id: id)
     }
 
     @objc
     public func addAliases(_ aliases: [String : String]) -> Void {
         print("🔥 OSUser addAliases() called")
+        for alias in aliases {
+            addAlias(label: alias.key, id: alias.value)
+        }
     }
     
     @objc
     public func removeAlias(_ label: String) -> Void {
         print("🔥 OSUser removeAlias() called")
+        self.identityModel.removeAlias(label)
     }
     
     @objc
     public func removeAliases(_ labels: [String]) -> Void {
         print("🔥 OSUser removeAliases() called")
+        for label in labels {
+            removeAlias(label)
+        }
     }
 
     // Tags
@@ -130,21 +133,25 @@ public class OSUserInternal: NSObject, OSUser {
     @objc
     public func setTag(key: String, value: String) -> Void {
         print("🔥 OSUser sendTag() called")
+        self.propertiesModel.tags[key] = value
     }
     
     @objc
     public func setTags(_ tags: [String : String]) -> Void {
         print("🔥 OSUser sendTags() called")
+        // TODO: Implementation
     }
     
     @objc
     public func removeTag(_ tag: String) -> Void {
         print("🔥 OSUser removeTag() called")
+        // TODO: Implementation
     }
     
     @objc
     public func removeTags(_ tags: [String]) -> Void {
         print("🔥 OSUser removeTags() called")
+        // TODO: Implementation
     }
     
     @objc

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
@@ -86,7 +86,7 @@ public class OSUserInternal: NSObject, OSUser {
     
     // TODO: UM This is a temporary function to create a push subscription for testing
     @objc public func testCreatePushSubscription(subscriptionId: UUID, token: UUID, enabled: Bool) {
-        self.pushSubscription = OSPushSubscriptionModel(subscriptionId: subscriptionId, token: token, enabled: enabled)
+        self.pushSubscription = OSPushSubscriptionModel(token: token, enabled: enabled)
         print("🔥 OSUser has set pushSubcription for testing")
     }
         

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
@@ -35,32 +35,32 @@ import OneSignalOSCore
 @objc public protocol OSUser {
     var pushSubscription: OSPushSubscriptionInterface { get }
     // Aliases
-    func addAlias(label: String, id: String) -> Void
-    func addAliases(_ aliases: [String : String]) -> Void
-    func removeAlias(_ label: String) -> Void
-    func removeAliases(_ labels: [String]) -> Void
+    func addAlias(label: String, id: String)
+    func addAliases(_ aliases: [String: String])
+    func removeAlias(_ label: String)
+    func removeAliases(_ labels: [String])
     // Tags
-    func setTag(key: String, value: String) -> Void
-    func setTags(_ tags: [String : String]) -> Void
-    func removeTag(_ tag: String) -> Void
-    func removeTags(_ tags: [String]) -> Void
-    func getTag(_ tag: String) -> Void
+    func setTag(key: String, value: String)
+    func setTags(_ tags: [String: String])
+    func removeTag(_ tag: String)
+    func removeTags(_ tags: [String])
+    func getTag(_ tag: String)
     // Outcomes
-    func setOutcome(_ name: String) -> Void
-    func setUniqueOutcome(_ name: String) -> Void
-    func setOutcome(name: String, value: Float) -> Void
+    func setOutcome(_ name: String)
+    func setUniqueOutcome(_ name: String)
+    func setOutcome(name: String, value: Float)
     // Email
-    func addEmail(_ email: String) -> Void
-    func removeEmail(_ email: String) -> Void
+    func addEmail(_ email: String)
+    func removeEmail(_ email: String)
     // SMS
-    func addSmsNumber(_ number: String) -> Void
-    func removeSmsNumber(_ number: String) -> Void
+    func addSmsNumber(_ number: String)
+    func removeSmsNumber(_ number: String)
     // Triggers
-    func setTrigger(key: String, value: String) -> Void
-    func setTriggers(_ triggers: [String : String]) -> Void
-    func removeTrigger(_ trigger: String) -> Void
-    func removeTriggers(_ triggers: [String]) -> Void
-    
+    func setTrigger(key: String, value: String)
+    func setTriggers(_ triggers: [String: String])
+    func removeTrigger(_ trigger: String)
+    func removeTriggers(_ triggers: [String])
+
     // TODO: UM This is a temporary function to create a push subscription for testing
     func testCreatePushSubscription(subscriptionId: UUID, token: UUID, enabled: Bool)
 }
@@ -70,36 +70,36 @@ import OneSignalOSCore
  Class made public because it is used in OneSignalUserManager which is public.
  */
 public class OSUserInternal: NSObject, OSUser {
-    
-    var triggers: [String : String] = [:] // update to include bool, number
-    
+
+    var triggers: [String: String] = [:] // update to include bool, number
+
     // email, sms, subscriptions todo
-    
+
     @objc public var pushSubscription: OSPushSubscriptionInterface
 
     // Sessions will be outside this?
-    
+
     // Owns an Identity Model and Properties Model
     var identityModel: OSIdentityModel
     var propertiesModel: OSPropertiesModel
-    
+
     // TODO: UM This is a temporary function to create a push subscription for testing
     @objc public func testCreatePushSubscription(subscriptionId: UUID, token: UUID, enabled: Bool) {
         self.pushSubscription = OSPushSubscriptionModel(token: token, enabled: enabled)
         print("🔥 OSUser has set pushSubcription for testing")
     }
-        
+
     init(pushSubscription: OSPushSubscriptionModel, identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel) {
         self.pushSubscription = pushSubscription
         self.identityModel = identityModel
         self.propertiesModel = propertiesModel
         // workaround for didSet: call initializeProperties(...)
     }
-    
+
     // MARK: - Aliases
-    
+
     @objc
-    public func addAlias(label: String, id: String) -> Void {
+    public func addAlias(label: String, id: String) {
         // Don't let them use `onesignal_id` as an alias label
         // Don't let them use `external_id` either??
         print("🔥 OSUser addAlias() called")
@@ -107,7 +107,7 @@ public class OSUserInternal: NSObject, OSUser {
     }
 
     @objc
-    public func addAliases(_ aliases: [String : String]) -> Void {
+    public func addAliases(_ aliases: [String: String]) {
         // Don't let them use `onesignal_id` as an alias label
         // Don't let them use `external_id` either??
         print("🔥 OSUser addAliases() called")
@@ -116,15 +116,15 @@ public class OSUserInternal: NSObject, OSUser {
             addAlias(label: alias.key, id: alias.value)
         }
     }
-    
+
     @objc
-    public func removeAlias(_ label: String) -> Void {
+    public func removeAlias(_ label: String) {
         print("🔥 OSUser removeAlias() called")
         self.identityModel.removeAlias(label)
     }
-    
+
     @objc
-    public func removeAliases(_ labels: [String]) -> Void {
+    public func removeAliases(_ labels: [String]) {
         print("🔥 OSUser removeAliases() called")
         for label in labels {
             removeAlias(label)
@@ -132,98 +132,98 @@ public class OSUserInternal: NSObject, OSUser {
     }
 
     // Tags
-    
+
     @objc
-    public func setTag(key: String, value: String) -> Void {
+    public func setTag(key: String, value: String) {
         print("🔥 OSUser sendTag() called")
         self.propertiesModel.tags[key] = value
     }
-    
+
     @objc
-    public func setTags(_ tags: [String : String]) -> Void {
+    public func setTags(_ tags: [String: String]) {
         print("🔥 OSUser sendTags() called")
         // TODO: Implementation
     }
-    
+
     @objc
-    public func removeTag(_ tag: String) -> Void {
+    public func removeTag(_ tag: String) {
         print("🔥 OSUser removeTag() called")
         // TODO: Implementation
     }
-    
+
     @objc
-    public func removeTags(_ tags: [String]) -> Void {
+    public func removeTags(_ tags: [String]) {
         print("🔥 OSUser removeTags() called")
         // TODO: Implementation
     }
-    
+
     @objc
-    public func getTag(_ tag: String) -> Void {
+    public func getTag(_ tag: String) {
         print("🔥 OSUser getTag() called")
     }
-    
+
     // Outcomes
-    
+
     @objc
-    public func setOutcome(_ name: String) -> Void {
+    public func setOutcome(_ name: String) {
         print("🔥 OSUser sendOutcome() called")
     }
-    
+
     @objc
-    public func setUniqueOutcome(_ name: String) -> Void {
+    public func setUniqueOutcome(_ name: String) {
         print("🔥 OSUser setUniqueOutcome() called")
     }
-    
+
     @objc
-    public func setOutcome(name: String, value: Float) -> Void {
+    public func setOutcome(name: String, value: Float) {
         print("🔥 OSUser setOutcomeWithValue() called")
     }
-    
+
     // Email
-    
+
     @objc
-    public func addEmail(_ email: String) -> Void {
+    public func addEmail(_ email: String) {
         print("🔥 OSUser addEmail() called")
     }
-    
+
     @objc
-    public func removeEmail(_ email: String) -> Void {
+    public func removeEmail(_ email: String) {
         print("🔥 OSUser removeEmail() called")
     }
-    
+
     // SMS
-    
+
     @objc
-    public func addSmsNumber(_ number: String) -> Void {
+    public func addSmsNumber(_ number: String) {
         print("🔥 OSUser addPhoneNumber() called")
     }
-    
+
     @objc
-    public func removeSmsNumber(_ number: String) -> Void {
+    public func removeSmsNumber(_ number: String) {
         print("🔥 OSUser removePhoneNumber() called")
     }
-    
+
     // Triggers
-    
+
     @objc
-    public func setTrigger(key: String, value: String) -> Void {
+    public func setTrigger(key: String, value: String) {
         // TODO: UM Value for trigger can be non-string
         print("🔥 OSUser setTrigger() called")
     }
-    
+
     @objc
-    public func setTriggers(_ triggers: [String : String]) -> Void {
+    public func setTriggers(_ triggers: [String: String]) {
         print("🔥 OSUser setTriggers() called")
     }
-    
+
     @objc
-    public func removeTrigger(_ trigger: String) -> Void {
+    public func removeTrigger(_ trigger: String) {
         print("🔥 OSUser removeTrigger() called")
     }
-    
+
     @objc
-    public func removeTriggers(_ triggers: [String]) -> Void {
+    public func removeTriggers(_ triggers: [String]) {
         print("🔥 OSUser removeTriggers() called")
     }
-    
+
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
@@ -81,21 +81,15 @@ public class OSUserInternal: NSObject, OSUser {
     // Sessions will be outside this?
     
     // Owns an Identity Model and Properties Model
-    var identityModel: OSIdentityModel = OSIdentityModel(OSEventProducer())
-    var propertiesModel: OSPropertiesModel = OSPropertiesModel(OSEventProducer())
+    var identityModel: OSIdentityModel
+    var propertiesModel: OSPropertiesModel
     
     // TODO: UM This is a temporary function to create a push subscription for testing
     @objc public func testCreatePushSubscription(subscriptionId: UUID, token: UUID, enabled: Bool) {
         self.pushSubscription = OSPushSubscriptionModel(subscriptionId: subscriptionId, token: token, enabled: enabled)
         print("🔥 OSUser has set pushSubcription for testing")
     }
-    
-    init(onesignalId: UUID, pushSubscription: OSPushSubscriptionModel) {
-        self.onesignalId = onesignalId
-        self.pushSubscription = pushSubscription
-        // workaround for didSet: call initializeProperties(...)
-    }
-    
+        
     init(onesignalId: UUID, pushSubscription: OSPushSubscriptionModel, identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel) {
         self.onesignalId = onesignalId
         self.pushSubscription = pushSubscription

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternal.swift
@@ -103,11 +103,11 @@ public class OSUserInternal: NSObject, OSUser {
         self.propertiesModel = propertiesModel
         // workaround for didSet: call initializeProperties(...)
     }
-
+    
     // Aliases
-
+    
     @objc
-    public func addAlias(label: String, id: String) {
+    public func addAlias(label: String, id: String) -> Void {
         print("🔥 OSUser addAlias() called")
         // Alt1: update alias list, and fire, observer sees entire list as changed, listener can figure out delta
         // or Operation can figure it out,  etc depends how Delta is figured out
@@ -117,108 +117,109 @@ public class OSUserInternal: NSObject, OSUser {
     }
 
     @objc
-    public func addAliases(_ aliases: [String: String]) {
+    public func addAliases(_ aliases: [String : String]) -> Void {
         print("🔥 OSUser addAliases() called")
     }
-
+    
     @objc
-    public func removeAlias(_ label: String) {
+    public func removeAlias(_ label: String) -> Void {
         print("🔥 OSUser removeAlias() called")
     }
-
+    
     @objc
-    public func removeAliases(_ labels: [String]) {
+    public func removeAliases(_ labels: [String]) -> Void {
         print("🔥 OSUser removeAliases() called")
     }
 
     // Tags
-
+    
     @objc
-    public func setTag(key: String, value: String) {
+    public func setTag(key: String, value: String) -> Void {
         print("🔥 OSUser sendTag() called")
     }
-
+    
     @objc
-    public func setTags(_ tags: [String: String]) {
+    public func setTags(_ tags: [String : String]) -> Void {
         print("🔥 OSUser sendTags() called")
     }
-
+    
     @objc
-    public func removeTag(_ tag: String) {
+    public func removeTag(_ tag: String) -> Void {
         print("🔥 OSUser removeTag() called")
     }
-
+    
     @objc
-    public func removeTags(_ tags: [String]) {
+    public func removeTags(_ tags: [String]) -> Void {
         print("🔥 OSUser removeTags() called")
     }
-
+    
     @objc
-    public func getTag(_ tag: String) {
+    public func getTag(_ tag: String) -> Void {
         print("🔥 OSUser getTag() called")
     }
-
+    
     // Outcomes
-
+    
     @objc
-    public func setOutcome(_ name: String) {
+    public func setOutcome(_ name: String) -> Void {
         print("🔥 OSUser sendOutcome() called")
     }
-
+    
     @objc
-    public func setUniqueOutcome(_ name: String) {
+    public func setUniqueOutcome(_ name: String) -> Void {
         print("🔥 OSUser setUniqueOutcome() called")
     }
-
+    
     @objc
-    public func setOutcome(name: String, value: Float) {
+    public func setOutcome(name: String, value: Float) -> Void {
         print("🔥 OSUser setOutcomeWithValue() called")
     }
-
+    
     // Email
-
+    
     @objc
-    public func addEmail(_ email: String) {
+    public func addEmail(_ email: String) -> Void {
         print("🔥 OSUser addEmail() called")
     }
-
+    
     @objc
-    public func removeEmail(_ email: String) {
+    public func removeEmail(_ email: String) -> Void {
         print("🔥 OSUser removeEmail() called")
     }
-
+    
     // SMS
-
+    
     @objc
-    public func addSmsNumber(_ number: String) {
+    public func addSmsNumber(_ number: String) -> Void {
         print("🔥 OSUser addPhoneNumber() called")
     }
-
+    
     @objc
-    public func removeSmsNumber(_ number: String) {
+    public func removeSmsNumber(_ number: String) -> Void {
         print("🔥 OSUser removePhoneNumber() called")
     }
-
+    
     // Triggers
-
+    
     @objc
-    public func setTrigger(key: String, value: String) {
+    public func setTrigger(key: String, value: String) -> Void {
         // TODO: UM Value for trigger can be non-string
         print("🔥 OSUser setTrigger() called")
     }
-
+    
     @objc
-    public func setTriggers(_ triggers: [String: String]) {
+    public func setTriggers(_ triggers: [String : String]) -> Void {
         print("🔥 OSUser setTriggers() called")
     }
-
+    
     @objc
-    public func removeTrigger(_ trigger: String) {
+    public func removeTrigger(_ trigger: String) -> Void {
         print("🔥 OSUser removeTrigger() called")
     }
-
+    
     @objc
-    public func removeTriggers(_ triggers: [String]) {
+    public func removeTriggers(_ triggers: [String]) -> Void {
         print("🔥 OSUser removeTriggers() called")
     }
+    
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -45,8 +45,8 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     static var propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer())
     
     // TODO: UM, and Model Store Listeners: where do they live? Here for now.
-    static var identityModelStoreListener = OSIdentityModelStoreListener(store: identityModelStore, opRepo: OSOperationRepo())
-    static var propertiesModelStoreListener = OSPropertiesModelStoreListener(store: propertiesModelStore, opRepo: OSOperationRepo())
+    static var identityModelStoreListener = OSIdentityModelStoreListener(store: identityModelStore)
+    static var propertiesModelStoreListener = OSPropertiesModelStoreListener(store: propertiesModelStore)
     
     static func startModelStoreListeners() {
         // Model store listeners subscribe to their models
@@ -72,7 +72,6 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
 
         propertiesModel = OSPropertiesModel(id: externalId, changeNotifier: OSEventProducer())
         self.propertiesModelStore.add(id: externalId, model: propertiesModel!)
-        propertiesModel!.id = identityModel!.id
 
         return createAndSetUser(identityModel: identityModel!, propertiesModel: propertiesModel!)
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -38,7 +38,6 @@ import OneSignalOSCore
 
 @objc
 public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
-
     @objc public static var user: OSUserInternal?
     
     // has Identity and Properties Model Stores
@@ -49,11 +48,9 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     static var identityModelStoreListener = OSIdentityModelStoreListener(identityModelStore)
     static var propertiesModelStoreListener = OSPropertiesModelStoreListener(propertiesModelStore)
     
+
     static func startModelStoreListeners() {
-        // Model store listeners subscribe to their models
-        // Where should these live?
-        OneSignalUserManager.identityModelStoreListener.start()
-        OneSignalUserManager.propertiesModelStoreListener.start()
+
     }
 
     @objc

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -99,7 +99,7 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         // do stuff
         self.user = OSUserInternal(
             onesignalId: UUID(),
-            pushSubscription: OSPushSubscriptionModel(subscriptionId: UUID(), token: nil, enabled: false),
+            pushSubscription: OSPushSubscriptionModel(token: nil, enabled: false),
             identityModel: identityModel,
             propertiesModel: propertiesModel)
         

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -45,8 +45,8 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     static var propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer())
     
     // TODO: UM, and Model Store Listeners: where do they live? Here for now.
-    static var identityModelStoreListener = OSIdentityModelStoreListener(identityModelStore)
-    static var propertiesModelStoreListener = OSPropertiesModelStoreListener(propertiesModelStore)
+    static var identityModelStoreListener = OSIdentityModelStoreListener(store: identityModelStore, opRepo: OSOperationRepo())
+    static var propertiesModelStoreListener = OSPropertiesModelStoreListener(store: propertiesModelStore, opRepo: OSOperationRepo())
     
     static func startModelStoreListeners() {
         // Model store listeners subscribe to their models

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -48,9 +48,11 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     static var identityModelStoreListener = OSIdentityModelStoreListener(identityModelStore)
     static var propertiesModelStoreListener = OSPropertiesModelStoreListener(propertiesModelStore)
     
-
     static func startModelStoreListeners() {
-
+        // Model store listeners subscribe to their models
+        // Where should these live?
+        OneSignalUserManager.identityModelStoreListener.start()
+        OneSignalUserManager.propertiesModelStoreListener.start()
     }
 
     @objc

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -44,8 +44,8 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     @objc public static var user: OSUserInternal?
 
     // has Identity and Properties Model Stores
-    static var identityModelStore = OSModelStore<OSIdentityModel>(changeSubscription: OSEventProducer(), storeKey: "OS_IDENTITY_MODEL") // TODO: Don't hardcode
-    static var propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer(), storeKey: "OS_PROPERTIES_MODEL") // TODO: Don't hardcode
+    static var identityModelStore = OSModelStore<OSIdentityModel>(changeSubscription: OSEventProducer(), storeKey: "OS_IDENTITY_MODEL_STORE") // TODO: Don't hardcode
+    static var propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer(), storeKey: "OS_PROPERTIES_MODEL_STORE") // TODO: Don't hardcode
 
     // TODO: UM, and Model Store Listeners: where do they live? Here for now.
     static var identityModelStoreListener = OSIdentityModelStoreListener(store: identityModelStore)
@@ -91,11 +91,12 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
 
         // 3. Create new user
         // TODO: Remove/take care of the old user's information.
-        let identityModel = OSIdentityModel(id: externalId, changeNotifier: OSEventProducer()) // TODO: Change id?
+        
+        let identityModel = OSIdentityModel(changeNotifier: OSEventProducer())
         self.identityModelStore.add(id: externalId, model: identityModel)
         identityModel.externalId = externalId // TODO: Don't fire this change.
 
-        let propertiesModel = OSPropertiesModel(id: externalId, changeNotifier: OSEventProducer()) // TODO: Change id?
+        let propertiesModel = OSPropertiesModel(changeNotifier: OSEventProducer())
         self.propertiesModelStore.add(id: externalId, model: propertiesModel)
 
         let pushSubscription = OSPushSubscriptionModel(token: nil, enabled: false)
@@ -120,8 +121,8 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         // TODO: Another user in cache? Remove old user's info?
 
         // TODO: model logic for guest users
-        let identityModel = OSIdentityModel(id: UUID().uuidString, changeNotifier: OSEventProducer())
-        let propertiesModel = OSPropertiesModel(id: identityModel.id, changeNotifier: OSEventProducer())
+        let identityModel = OSIdentityModel(changeNotifier: OSEventProducer())
+        let propertiesModel = OSPropertiesModel(changeNotifier: OSEventProducer())
         let pushSubscription = OSPushSubscriptionModel(token: nil, enabled: false)
 
         let user = createUser(identityModel: identityModel, propertiesModel: propertiesModel, pushSubscription: pushSubscription)

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -66,12 +66,11 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         // 2. Attempt to retrieve user from cache or stores?
         
         // 3. Create new user
-        identityModel = OSIdentityModel(OSEventProducer())
+        identityModel = OSIdentityModel(id: externalId, changeNotifier: OSEventProducer())
         self.identityModelStore.add(id: externalId, model: identityModel!)
-        identityModel!.id = UUID().uuidString
         identityModel!.externalId = externalId
 
-        propertiesModel = OSPropertiesModel(OSEventProducer())
+        propertiesModel = OSPropertiesModel(id: externalId, changeNotifier: OSEventProducer())
         self.propertiesModelStore.add(id: externalId, model: propertiesModel!)
         propertiesModel!.id = identityModel!.id
 
@@ -89,9 +88,11 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     public static func loginGuest() -> OSUserInternal {
         print("🔥 OneSignalUserManager loginGuest() called")
         startModelStoreListeners()
-        let identityModel = OSIdentityModel(OSEventProducer())
-        let propertiesModel = OSPropertiesModel(OSEventProducer())
+        
         // TODO: model logic for guest users
+        let identityModel = OSIdentityModel(id: UUID().uuidString, changeNotifier: OSEventProducer())
+        let propertiesModel = OSPropertiesModel(id: identityModel.id, changeNotifier: OSEventProducer())
+
         return createAndSetUser(identityModel: identityModel, propertiesModel: propertiesModel)
     }
     

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -29,6 +29,9 @@ import Foundation
 import OneSignalCore
 import OneSignalOSCore
 
+/**
+ Public-facing API to access the User Manager.
+ */
 @objc protocol OneSignalUserManagerInterface {
     static var user: OSUserInternal? { get set }
     static func login(_ externalId: String) -> OSUserInternal
@@ -48,17 +51,30 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     static var identityModelStoreListener = OSIdentityModelStoreListener(store: identityModelStore)
     static var propertiesModelStoreListener = OSPropertiesModelStoreListener(store: propertiesModelStore)
     
-    static func startModelStoreListeners() {
-        // Model store listeners subscribe to their models
-        // Where should these live?
+    // has Property and Identity operation executors
+    static let propertyExecutor = OSPropertyOperationExecutor()
+    static let identityExecutor = OSIdentityOperationExecutor()
+
+    // OneSignalUserManager start() or initialize() method
+    // Read from cache, set stuff up
+    static func start() { // initialize() is existing method
+        // To implement
+    }
+    
+    static func startModelStoreListenersAndExecutors() {
+        // Model store listeners subscribe to their models. TODO: Where should these live?
         OneSignalUserManager.identityModelStoreListener.start()
         OneSignalUserManager.propertiesModelStoreListener.start()
+        
+        // Setup the executors
+        OSOperationRepo.sharedInstance.addExecutor(identityExecutor)
+        OSOperationRepo.sharedInstance.addExecutor(propertyExecutor)
     }
 
     @objc
     public static func login(_ externalId: String) -> OSUserInternal {
         print("🔥 OneSignalUserManager login() called")
-        startModelStoreListeners()
+        startModelStoreListenersAndExecutors()
         var identityModel: OSIdentityModel?
         var propertiesModel: OSPropertiesModel?
         
@@ -73,7 +89,7 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         propertiesModel = OSPropertiesModel(id: externalId, changeNotifier: OSEventProducer())
         self.propertiesModelStore.add(id: externalId, model: propertiesModel!)
 
-        return createAndSetUser(identityModel: identityModel!, propertiesModel: propertiesModel!)
+        return createAndSetUserForTesting(identityModel: identityModel!, propertiesModel: propertiesModel!)
     }
     
     @objc
@@ -86,16 +102,16 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     @objc
     public static func loginGuest() -> OSUserInternal {
         print("🔥 OneSignalUserManager loginGuest() called")
-        startModelStoreListeners()
+        startModelStoreListenersAndExecutors()
         
         // TODO: model logic for guest users
         let identityModel = OSIdentityModel(id: UUID().uuidString, changeNotifier: OSEventProducer())
         let propertiesModel = OSPropertiesModel(id: identityModel.id, changeNotifier: OSEventProducer())
 
-        return createAndSetUser(identityModel: identityModel, propertiesModel: propertiesModel)
+        return createAndSetUserForTesting(identityModel: identityModel, propertiesModel: propertiesModel)
     }
     
-    static func createAndSetUser(identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel) -> OSUserInternal {
+    static func createAndSetUserForTesting(identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel) -> OSUserInternal {
         // do stuff
         self.user = OSUserInternal(
             onesignalId: UUID(),

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -42,15 +42,15 @@ import OneSignalOSCore
 @objc
 public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     @objc public static var user: OSUserInternal?
-    
+
     // has Identity and Properties Model Stores
     static var identityModelStore = OSModelStore<OSIdentityModel>(changeSubscription: OSEventProducer(), storeKey: "OS_IDENTITY_MODEL") // TODO: Don't hardcode
     static var propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer(), storeKey: "OS_PROPERTIES_MODEL") // TODO: Don't hardcode
-    
+
     // TODO: UM, and Model Store Listeners: where do they live? Here for now.
     static var identityModelStoreListener = OSIdentityModelStoreListener(store: identityModelStore)
     static var propertiesModelStoreListener = OSPropertiesModelStoreListener(store: propertiesModelStore)
-    
+
     // has Property and Identity operation executors
     static let propertyExecutor = OSPropertyOperationExecutor()
     static let identityExecutor = OSIdentityOperationExecutor()
@@ -59,21 +59,21 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         // TODO: Finish implementation
         // Read from cache, set stuff up
         // Read the models from User Defaults
-        
+
         // startModelStoreListenersAndExecutors() moves here after this start() method is hooked up.
         self.user = loadUserFromCache() // TODO: Revisit when to load user from the cache.
     }
-    
+
     static func startModelStoreListenersAndExecutors() {
         // Model store listeners subscribe to their models. TODO: Where should these live?
         OneSignalUserManager.identityModelStoreListener.start()
         OneSignalUserManager.propertiesModelStoreListener.start()
-        
+
         // Setup the executors
         OSOperationRepo.sharedInstance.addExecutor(identityExecutor)
         OSOperationRepo.sharedInstance.addExecutor(propertyExecutor)
     }
-    
+
     @objc
     public static func login(_ externalId: String) -> OSUserInternal {
         print("🔥 OneSignalUserManager login() called")
@@ -85,10 +85,10 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
                 return user
             }
         }
-        
+
         // 1. Attempt to retrieve user from backend?
         // 2. Attempt to retrieve user from cache or stores? (No, done in start() method for now)
-        
+
         // 3. Create new user
         // TODO: Remove/take care of the old user's information.
         let identityModel = OSIdentityModel(id: externalId, changeNotifier: OSEventProducer()) // TODO: Change id?
@@ -99,12 +99,12 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         self.propertiesModelStore.add(id: externalId, model: propertiesModel)
 
         let pushSubscription = OSPushSubscriptionModel(token: nil, enabled: false)
-        
+
         let user = createUser(identityModel: identityModel, propertiesModel: propertiesModel, pushSubscription: pushSubscription)
         self.user = user
         return user
     }
-    
+
     @objc
     public static func login(externalId: String, withToken: String) -> OSUserInternal {
         print("🔥 OneSignalUser loginwithBearerToken() called")
@@ -116,19 +116,19 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
     public static func loginGuest() -> OSUserInternal {
         print("🔥 OneSignalUserManager loginGuest() called")
         startModelStoreListenersAndExecutors()
-        
+
         // TODO: Another user in cache? Remove old user's info?
-        
+
         // TODO: model logic for guest users
         let identityModel = OSIdentityModel(id: UUID().uuidString, changeNotifier: OSEventProducer())
         let propertiesModel = OSPropertiesModel(id: identityModel.id, changeNotifier: OSEventProducer())
         let pushSubscription = OSPushSubscriptionModel(token: nil, enabled: false)
-        
+
         let user = createUser(identityModel: identityModel, propertiesModel: propertiesModel, pushSubscription: pushSubscription)
         self.user = user
         return user
     }
-    
+
     static func loadUserFromCache() -> OSUserInternal? {
         // Corrupted state if one exists without the other.
         guard !identityModelStore.getModels().isEmpty &&
@@ -136,9 +136,9 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
         else {
             return nil
         }
-        
+
         // TODO: Need to load any SMS and emails subs too
-        
+
         // There is a user in the cache
         let identityModel = identityModelStore.getModels().first!.value
         let propertiesModel = propertiesModelStore.getModels().first!.value
@@ -148,10 +148,10 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
             pushSubscription: pushSubscription,
             identityModel: identityModel,
             propertiesModel: propertiesModel)
-        
+
         return user
     }
-    
+
     static func createUser(identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel, pushSubscription: OSPushSubscriptionModel) -> OSUserInternal {
         let user = OSUserInternal(
             pushSubscription: pushSubscription,

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManager.swift
@@ -91,7 +91,7 @@ public class OneSignalUserManager: NSObject, OneSignalUserManagerInterface {
 
         // 3. Create new user
         // TODO: Remove/take care of the old user's information.
-        
+
         let identityModel = OSIdentityModel(changeNotifier: OSEventProducer())
         self.identityModelStore.add(id: externalId, model: identityModel)
         identityModel.externalId = externalId // TODO: Don't fire this change.

--- a/iOS_SDK/OneSignalSDK/OneSignalUserFramework/Info.plist
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserFramework/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2022 Hiptic. All rights reserved.</string>
+</dict>
+</plist>

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -292,10 +292,10 @@ typedef void (^OSFailureBlock)(NSError* error);
 #pragma mark User Model 🔥
 
 #pragma mark User Model - User Identity 🔥
-typedef void (^OSUserLoginBlock)(id<OSUser> _Nonnull user);
+typedef void (^OSUserLoginBlock)(id<OSUser> _Nullable user);
 
 // TODO: Confirm nullabilities
-+ (id<OSUser> _Nonnull)user NS_REFINED_FOR_SWIFT;
++ (id<OSUser> _Nullable)user NS_REFINED_FOR_SWIFT;
 + (void)login:(NSString * _Nonnull)externalId withResult:(OSUserLoginBlock _Nonnull)block;
 + (void)login:(NSString * _Nonnull)externalId withToken:(NSString * _Nonnull)token withResult:(OSUserLoginBlock _Nonnull)block;
 + (void)loginGuest:(OSUserLoginBlock _Nonnull)block;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -583,11 +583,8 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 #pragma mark User Model - User Identity 🔥
 // TODO: UM Actual implementations
 
-+ (id<OSUser> _Nonnull)user {
++ (id<OSUser> _Nullable)user {
     OSUserInternal *user = [OneSignalUserManager user];
-    if (!user) {
-        user = [OneSignalUserManager loginGuest];
-    }
     return user;
 }
 
@@ -601,6 +598,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     block(user);
 }
 
+// treat this like "device model"
 + (void)loginGuest:(OSUserLoginBlock)block {
     OSUserInternal *user = [OneSignalUserManager loginGuest];
     block(user);

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -172,27 +172,4 @@
     [user setTagWithKey:@"foo" value:@"bar"];
 }
 
-/**
- Test the model repo hook up via a login with external ID and setting alias.
- */
-- (void)testModelRepositoryHookUpWithLoginAndSetAlias {
-    // login an user with external ID
-    [OneSignal login:@"user01" withResult:^(id<OSUser> _Nonnull user) {
-       NSLog(@"🔥 Unit Tests: logged in user is %@", user);
-    }];
-    
-    id<OSUser> user = OneSignal.user;
-    
-    // Check that deltas for alias (Identity) are created correctly and enqueued.
-    NSLog(@"🔥 Unit Tests adding alias label_01: user_01");
-    [user addAliasWithLabel:@"label_01" id:@"user_01"];
-    [user removeAlias:@"nonexistent"];
-    [user removeAlias:@"label_01"];
-    [user addAliasWithLabel:@"label_02" id:@"user_02"];
-    [user addAliases:@{@"test1": @"user1", @"test2": @"user2", @"test3": @"user3"}];
-    [user removeAliases:@[@"test1", @"label_01", @"test2"]];
-    
-    [user setTagWithKey:@"foo" value:@"bar"];
-}
-
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -118,6 +118,7 @@
     
     // Should not be accessible
     id<OSUser> user = OneSignalUserManager.user;
+
     
     // Should not be settable
     // OneSignal.user.pushSubscription.token = [NSUUID new]; // <- Confirmed that users can't set token

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -161,8 +161,7 @@
     
     id<OSUser> user = OneSignal.user;
     
-    // Check that operations for alias (Identity) are created correctly and enqueued.
-    // Removing a non-existent alias does not create an operation
+    // Check that deltas for alias (Identity) are created correctly and enqueued.
     NSLog(@"🔥 Unit Tests adding alias label_01: user_01");
     [user addAliasWithLabel:@"label_01" id:@"user_01"];
     [user removeAlias:@"nonexistent"];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -161,11 +161,17 @@
     
     id<OSUser> user = OneSignal.user;
     
+    // Check that operations for alias (Identity) are created correctly and enqueued.
+    // Removing a non-existent alias does not create an operation
     NSLog(@"🔥 Unit Tests adding alias label_01: user_01");
     [user addAliasWithLabel:@"label_01" id:@"user_01"];
-    
-    NSLog(@"🔥 Unit Tests adding alias label_02: user_02");
+    [user removeAlias:@"nonexistent"];
+    [user removeAlias:@"label_01"];
     [user addAliasWithLabel:@"label_02" id:@"user_02"];
+    [user addAliases:@{@"test1": @"user1", @"test2": @"user2", @"test3": @"user3"}];
+    [user removeAliases:@[@"test1", @"label_01", @"test2"]];
+    
+    [user setTagWithKey:@"foo" value:@"bar"];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -151,8 +151,9 @@
 
 /**
  Test the model repo hook up via a login with external ID and setting alias.
+ Test the operation repo hookup as well and check the deltas being enqueued and flushed.
  */
-- (void)testModelRepositoryHookUpWithLoginAndSetAlias {
+- (void)testModelAndOperationRepositoryHookUpWithLoginAndSetAlias {
     // login an user with external ID
     [OneSignal login:@"user01" withResult:^(id<OSUser> _Nonnull user) {
        NSLog(@"🔥 Unit Tests: logged in user is %@", user);
@@ -170,6 +171,9 @@
     [user removeAliases:@[@"test1", @"label_01", @"test2"]];
     
     [user setTagWithKey:@"foo" value:@"bar"];
+    
+    // Sleep to allow the flush to be called 1 time.
+    [NSThread sleepForTimeInterval:6.0f];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -117,8 +117,8 @@ class UserModelSwiftTests: XCTestCase {
      */
     func testTheseShouldNotWork() throws {
         // Should not be accessible
-        let _ = OneSignalUserManager.user;
-        
+        _ = OneSignalUserManager.user
+
         // Should not be settable
         // OneSignal.user.pushSubscription.token = UUID() // <- Confirmed that users can't set token
         // OneSignal.user.pushSubscription.subscriptionId = UUID() // <- Confirmed that users can't set subscriptionId
@@ -148,7 +148,7 @@ class UserModelSwiftTests: XCTestCase {
         // OneSignal.addSubscriptionObserver(observer)
         // OneSignal.removeSubscriptionObserver(observer)
     }
-    
+
     /**
      Test the model repo hook up via a login with external ID and setting alias.
      */
@@ -157,9 +157,9 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.login("user01", withResult: { user in
             print("🔥 Unit Tests: logged in user is \(user)")
         })
-        
+
         let user = OneSignal.user
-        
+
         // Check that deltas for alias (Identity) are created correctly and enqueued.
         print("🔥 Unit Tests adding alias label_01: user_01")
         user.addAlias(label: "label_01", id: "user_01")
@@ -168,7 +168,7 @@ class UserModelSwiftTests: XCTestCase {
         user.addAlias(label: "label_02", id: "user_02")
         user.addAliases(["test1": "user1", "test2": "user2", "test3": "user3"])
         user.removeAliases(["test1", "label_01", "test2"])
-        
+
         user.setTag(key: "foo", value: "bar")
     }
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -119,6 +119,7 @@ class UserModelSwiftTests: XCTestCase {
         // Should not be accessible
         _ = OneSignalUserManager.user; // This shouldn't be accessible to the public
 
+        let _ = OneSignalUserManager.user;
         
         // Should not be settable
         // OneSignal.user.pushSubscription.token = UUID() // <- Confirmed that users can't set token

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -162,8 +162,7 @@ class UserModelSwiftTests: XCTestCase {
         
         let user = OneSignal.user
         
-        // Check that operations for alias (Identity) are created correctly and enqueued.
-        // Removing a non-existent alias does not create an operation
+        // Check that deltas for alias (Identity) are created correctly and enqueued.
         print("🔥 Unit Tests adding alias label_01: user_01")
         user.addAlias(label: "label_01", id: "user_01")
         user.removeAlias("nonexistent")

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -40,8 +40,8 @@ extension OneSignal {
 class OSPushSubscriptionTestObserver: OSPushSubscriptionObserver {
     func onOSPushSubscriptionChanged(previous: OSPushSubscriptionState, current: OSPushSubscriptionState) {
         print("🔥 onOSPushSubscriptionChanged \(previous) -> \(current)")
-        dump(previous)
-        dump(current)
+        // dump(previous) -> uncomment for more verbose log during testing
+        // dump(current) -> uncomment for more verbose log during testing
     }
 }
 
@@ -151,8 +151,9 @@ class UserModelSwiftTests: XCTestCase {
 
     /**
      Test the model repo hook up via a login with external ID and setting alias.
+     Test the operation repo hookup as well and check the deltas being enqueued and flushed.
      */
-    func testModelRepositoryHookUpWithLoginAndSetAlias() throws {
+    func testModelAndOperationRepositoryHookUpWithLoginAndSetAlias() throws {
         // login an user with external ID
         OneSignal.login("user01", withResult: { user in
             print("🔥 Unit Tests: logged in user is \(user)")
@@ -170,5 +171,8 @@ class UserModelSwiftTests: XCTestCase {
         user.removeAliases(["test1", "label_01", "test2"])
 
         user.setTag(key: "foo", value: "bar")
+        
+        // Sleep to allow the flush to be called 1 time.
+        Thread.sleep(forTimeInterval: 6)
     }
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -162,10 +162,16 @@ class UserModelSwiftTests: XCTestCase {
         
         let user = OneSignal.user
         
+        // Check that operations for alias (Identity) are created correctly and enqueued.
+        // Removing a non-existent alias does not create an operation
         print("🔥 Unit Tests adding alias label_01: user_01")
         user.addAlias(label: "label_01", id: "user_01")
-        
-        print("🔥 Unit Tests adding alias label_02: user_02")
+        user.removeAlias("nonexistent")
+        user.removeAlias("label_01")
         user.addAlias(label: "label_02", id: "user_02")
+        user.addAliases(["test1": "user1", "test2": "user2", "test3": "user3"])
+        user.removeAliases(["test1", "label_01", "test2"])
+        
+        user.setTag(key: "foo", value: "bar")
     }
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -171,7 +171,7 @@ class UserModelSwiftTests: XCTestCase {
         user.removeAliases(["test1", "label_01", "test2"])
 
         user.setTag(key: "foo", value: "bar")
-        
+
         // Sleep to allow the flush to be called 1 time.
         Thread.sleep(forTimeInterval: 6)
     }


### PR DESCRIPTION
# Description
## One Line Summary
Add the base layer for the operation repo and set up some functionality on top of it.

## Details
* Sorry, commit history is not nice.

### Motivation
We need the to implement the operations for the user model.

### Details
**The `OSOperationRepo`:**
- A static singleton class that maintains a queue of OSDeltas, which are divvy'd up at intervals to concrete executors.
- We cache and load operations and deltas in the `OSOperationRepo` and the concrete executors

**Caching deltas and operations:**

1. When `OSOperationRepo` is initialized, read its deltas from cache, if any.
2. When executors are started, read its deltas and operations from cache, if any.
3. When a delta is enqueued into the `OSOperationRepo`, we snapshot the entire deltaQueue and cache.
4. When the operation repo is flushed, we snapshot the deltas remaining in the operation repo, and snapshot the deltas in the executors.
5. When concrete executors' deltas are processed into operations and enqueued, the entire operationQueue is cached after adding. The deltas are snapshotted as well. The details of this isn't fleshed out and will depend on the implementation.
6. When an operation executes, remove it from the operation queue, but not from cache until it returns successfully.
7. When operation returns successfully, remove this operation from cache (and remove from queue if it still exists). This can happen if the app restarts before an operation returns successfully - we will have loaded all the incomplete operations into the operation queue, including the one that just returned successfully.

# Testing
Unit testing done is just for checking method and property access, and relying on printed statements and debug stop points to see what is happening.

* use existing test that is renamed `testModelAndOperationRepositoryHookUpWithLoginAndSetAlias`
* call various adding and removing aliases methods for testing the deltas/operations logic and hookup

## Manual testing
Not implemented enough to test manually properly.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes
   - [x] User Model changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1118)
<!-- Reviewable:end -->
