### PR TITLE
[user model] refactor login API, clearing old user's models

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -303,6 +303,7 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 
 #pragma mark User Model
 
+#define OS_ONESIGNAL_ID                                                     @"onesignal_id"
 #define OS_EXTERNAL_ID                                                      @"external_id"
 #define OS_IDENTITY_MODEL_KEY                                               @"OS_IDENTITY_MODEL_KEY"
 #define OS_IDENTITY_MODEL_STORE_KEY                                         @"OS_IDENTITY_MODEL_STORE_KEY"

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -318,4 +318,6 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 #define OS_PROPERTIES_EXECUTOR_DELTA_QUEUE_KEY                              @"OS_PROPERTIES_EXECUTOR_DELTA_QUEUE_KEY"
 #define OS_PROPERTIES_EXECUTOR_OPERATION_QUEUE_KEY                          @"OS_PROPERTIES_EXECUTOR_OPERATION_QUEUE_KEY"
 
+#define OS_ON_USER_WILL_CHANGE                                              @"OS_ON_USER_WILL_CHANGE"
+
 #endif /* OneSignalCommonDefines_h */

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -303,6 +303,7 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE} HTTPMethod;
 
 #pragma mark User Model
 
+#define OS_EXTERNAL_ID                                                      @"external_id"
 #define OS_IDENTITY_MODEL_KEY                                               @"OS_IDENTITY_MODEL_KEY"
 #define OS_IDENTITY_MODEL_STORE_KEY                                         @"OS_IDENTITY_MODEL_STORE_KEY"
 #define OS_PROPERTIES_MODEL_KEY                                             @"OS_PROPERTIES_MODEL_KEY"

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -44,6 +44,15 @@ open class OSModelStore<TModel: OSModel>: NSObject {
             // log error
             self.models = [:]
         }
+        super.init()
+
+        // register as user observer
+        NotificationCenter.default.addObserver(self, selector: #selector(self.clearModelsFromCache),
+                                               name: Notification.Name(OS_ON_USER_WILL_CHANGE), object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: Notification.Name(OS_ON_USER_WILL_CHANGE), object: nil)
     }
 
     public func getModels() -> [String: TModel] {
@@ -83,8 +92,10 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         }
     }
 
-    func clear() { // TODO: Prefer to use an observer pattern like `onUserChanged`
-        // remove models from the cache
+    @objc func clearModelsFromCache() {
+        print("🔥 OSModelStore \(self.storeKey): clearModelsFromCache() called.")
+        // Clear the models cache when ON_OS_USER_WILL_CHANGE
+        OneSignalUserDefaults.initShared().removeValue(forKey: self.storeKey)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -47,11 +47,6 @@ class OSIdentityModel: OSModel {
         super.init(changeNotifier: changeNotifier)
     }
 
-    init(externalId: String?, changeNotifier: OSEventProducer<OSModelChangedHandler>) {
-        self.externalId = externalId // TODO: check didSet is not called
-        super.init(changeNotifier: changeNotifier)
-    }
-
     override func encode(with coder: NSCoder) {
         super.encode(with: coder)
         coder.encode(onesignalId, forKey: "onesignalId")

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -26,16 +26,16 @@
  */
 
 import Foundation
+import OneSignalCore
 import OneSignalOSCore
 
 class OSIdentityModel: OSModel {
-    var onesignalId: UUID? // let? optional?
+    var onesignalId: String? {
+        return aliases[OS_ONESIGNAL_ID]
+    }
 
-    var externalId: String? { // let? optional?
-        didSet {
-            print("🔥 didSet OSIdentityModel.externalId from \(oldValue) to \(externalId!).")
-            self.set(property: "externalId", oldValue: oldValue, newValue: externalId)
-        }
+    var externalId: String? {
+        return aliases[OS_EXTERNAL_ID]
     }
 
     var aliases: [String: String] = [:]
@@ -56,8 +56,6 @@ class OSIdentityModel: OSModel {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        onesignalId = coder.decodeObject(forKey: "onesignalId") as? UUID
-        externalId = coder.decodeObject(forKey: "externalId") as? String
         guard let aliases = coder.decodeObject(forKey: "aliases") as? [String: String] else {
             // log error
             return

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -46,7 +46,6 @@ protocol OSUserInternal {
     func setTags(_ tags: [String: String])
     func removeTag(_ tag: String)
     func removeTags(_ tags: [String])
-    func getTag(_ tag: String)
     // Outcomes
     func setOutcome(_ name: String)
     func setUniqueOutcome(_ name: String)
@@ -149,10 +148,6 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
     func removeTags(_ tags: [String]) {
         print("🔥 OSUserInternalImpl removeTags() called")
         // TODO: Implementation
-    }
-
-    func getTag(_ tag: String) {
-        print("🔥 OSUserInternalImpl getTag() called")
     }
 
     // MARK: - Outcomes

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -97,6 +97,12 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
     func addAlias(label: String, id: String) {
         // Don't let them use `onesignal_id` as an alias label
         // Don't let them use `external_id` either??
+        guard label != OS_ONESIGNAL_ID else {
+            // log error
+            print("🔥 OSUserInternal addAlias: Cannot use onesignal_id as a label")
+            return
+        }
+
         print("🔥 OSUserInternalImpl addAlias() called")
         identityModel.addAlias(label: label, id: id)
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -137,7 +137,9 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         }
 
         // Create new user
-        // TODO: Remove/take care of the old user's information.
+
+        // Notify that the user will change so model stores, etc can clear their cache.
+        NotificationCenter.default.post(name: Notification.Name(OS_ON_USER_WILL_CHANGE), object: nil)
 
         let identityModel = OSIdentityModel(changeNotifier: OSEventProducer())
         self.identityModelStore.add(id: OS_IDENTITY_MODEL_KEY, model: identityModel)
@@ -154,7 +156,7 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
     @objc
     public static func logout() {
-        // TODO: Clear the models cache
+        NotificationCenter.default.post(name: Notification.Name(OS_ON_USER_WILL_CHANGE), object: nil)
         _user = nil
     }
 
@@ -175,7 +177,6 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
         _user = OSUserInternalImpl(identityModel: identityModel, propertiesModel: propertiesModel, pushSubscription: pushSubscription)
     }
-
 }
 
 extension OneSignalUserManagerImpl: OSUser {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -53,7 +53,6 @@ import OneSignalOSCore
     static func setTags(_ tags: [String: String])
     static func removeTag(_ tag: String)
     static func removeTags(_ tags: [String])
-    static func getTag(_ tag: String)
     // Outcomes
     static func setOutcome(_ name: String)
     static func setUniqueOutcome(_ name: String)
@@ -218,11 +217,6 @@ extension OneSignalUserManagerImpl: OSUser {
 
     public static func removeTags(_ tags: [String]) {
         user.removeTags(tags)
-    }
-
-    // TODO: No tag getter?
-    public static func getTag(_ tag: String) {
-        user.getTag(tag)
     }
 
     public static func setOutcome(_ name: String) {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -294,7 +294,12 @@ typedef void (^OSFailureBlock)(NSError* error);
 #pragma mark User Model - User Identity 🔥
 + (Class<OSUser>)User NS_REFINED_FOR_SWIFT;
 + (void)login:(NSString * _Nonnull)externalId;
-+ (void)login:(NSString * _Nonnull)externalId withToken:(NSString * _Nullable)token;
++ (void)login:(NSString * _Nonnull)externalId withToken:(NSString * _Nullable)token
+NS_SWIFT_NAME(login(externalId:token:));
++ (void)loginWithAliasLabel:(NSString * _Nonnull)aliasLabel withAliasId:(NSString * _Nonnull)aliasId
+NS_SWIFT_NAME(login(aliasLabel:aliasId:));
++ (void)loginWithAliasLabel:(NSString * _Nonnull)aliasLabel withAliasId:(NSString * _Nonnull)aliasId withToken:(NSString * _Nullable)token
+NS_SWIFT_NAME(login(aliasLabel:aliasId:token:));
 + (void)logout;
 
 #pragma mark Initialization

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -581,17 +581,26 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 #pragma mark User Model 🔥
 
 #pragma mark User Model - User Identity 🔥
-// TODO: UM Actual implementations
+
 + (Class<OSUser>)User {
     return [OneSignalUserManagerImpl User];
 }
 
 + (void)login:(NSString * _Nonnull)externalId {
-    [OneSignalUserManagerImpl loginWithExternalId:externalId withToken:nil];
+    [OneSignalUserManagerImpl loginWithAliasLabel:OS_EXTERNAL_ID aliasId:externalId token:nil];
+    // refine Swift name for Obj-C? But doesn't matter as much since this isn't public API
 }
 
 + (void)login:(NSString * _Nonnull)externalId withToken:(NSString * _Nullable)token {
-    [OneSignalUserManagerImpl loginWithExternalId:externalId withToken:token];
+    [OneSignalUserManagerImpl loginWithAliasLabel:OS_EXTERNAL_ID aliasId:externalId token:token];
+}
+
++ (void)loginWithAliasLabel:(NSString * _Nonnull)aliasLabel withAliasId:(NSString * _Nonnull)aliasId {
+    [OneSignalUserManagerImpl loginWithAliasLabel:aliasLabel aliasId:aliasId token:nil];
+}
+
++ (void)loginWithAliasLabel:(NSString * _Nonnull)aliasLabel withAliasId:(NSString * _Nonnull)aliasId withToken:(NSString * _Nullable)token {
+    [OneSignalUserManagerImpl loginWithAliasLabel:aliasLabel aliasId:aliasId token:token];
 }
 
 + (void)logout {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -64,6 +64,11 @@
     // User Identity
     [OneSignal login:@"foo"];
     [OneSignal login:@"foo" withToken:@"someToken"];
+    [OneSignal login:@"foo" withToken:nil];
+    [OneSignal loginWithAliasLabel:@"foo" withAliasId:@"bar"];
+    [OneSignal loginWithAliasLabel:@"foo" withAliasId:@"bar" withToken:@"someToken"];
+    [OneSignal loginWithAliasLabel:@"foo" withAliasId:@"bar" withToken:nil];
+    [OneSignal logout];
 
     // Aliases
     [OneSignal.User addAliasWithLabel:@"foo" id:@"foo1"];
@@ -153,6 +158,16 @@
     
     // Sleep to allow the flush to be called 1 time.
     [NSThread sleepForTimeInterval:6.0f];
+}
+
+/**
+ Test login and logout and creation of guest users.
+ */
+- (void)testLoginLogout {
+    // A guest user is created when OneSignal.User is accessed
+    [OneSignal.User addEmail:@"test@email.com"];
+    
+    // ... and more to be added
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -81,7 +81,6 @@
     [OneSignal.User setTags:@{@"foo": @"foo1", @"bar": @"bar2"}];
     [OneSignal.User removeTag:@"foo"];
     [OneSignal.User removeTags:@[@"foo", @"bar"]];
-    [OneSignal.User getTag:@"foo"];
 
     // Outcomes
     [OneSignal.User setOutcome:@"foo"];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -64,7 +64,12 @@ class UserModelSwiftTests: XCTestCase {
 
         // User Identity
         OneSignal.login("foo")
-        OneSignal.login("foo", withToken: "someToken")
+        OneSignal.login(externalId: "foo", token: "someToken")
+        OneSignal.login(externalId: "foo", token: nil)
+        OneSignal.login(aliasLabel: "foo", aliasId: "bar")
+        OneSignal.login(aliasLabel: "foo", aliasId: "bar", token: "someToken")
+        OneSignal.login(aliasLabel: "foo", aliasId: "bar", token: nil)
+        OneSignal.logout()
 
         // Aliases
         OneSignal.User.addAlias(label: "foo", id: "bar")
@@ -156,5 +161,15 @@ class UserModelSwiftTests: XCTestCase {
 
         // Sleep to allow the flush to be called 1 time.
         Thread.sleep(forTimeInterval: 6)
+    }
+
+    /**
+     Test login and logout and creation of guest users.
+     */
+    func testLoginLogout() throws {
+        // A guest user is created when OneSignal.User is accessed
+        OneSignal.User.addEmail("test@email.com")
+
+        // ... and more to be added
     }
 }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -82,7 +82,6 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.User.setTags(["foo": "foo1", "bar": "bar2"])
         OneSignal.User.removeTag("foo")
         OneSignal.User.removeTags(["foo", "bar"])
-        OneSignal.User.getTag("foo")
 
         // Outcomes
         OneSignal.User.setOutcome("foo")


### PR DESCRIPTION
# Description
## One Line Summary
Refactor the login API by adding `login(aliasLabel, aliasId, token?)` method and delete the old user from device cache.

## Details

### Motivation
- Add login with alias API in addition to the default login with external_id API.
- Refine login API for Swift to remove prepositions in parameter names.
- Make `onesignal_id` and `external_id` computed properties, and treat them as just another alias.
- Remove current/previous user from device cache when the user will change.
- Remove `getTag` since this currently isn't in the API.

# Testing
## Unit testing
Update login API in unit tests with new login methods and refined Swift names.
* Add new login methods to unit tests
* Update name with refined Swift names

## Manual testing
Not implemented enough to test manually properly.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes
   - [x] User Model changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1127)
<!-- Reviewable:end -->
