### PR TITLE
Fix forwarding notification opens from non onesignal notifs

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UNUserNotificationCenter+OneSignal.m
@@ -301,37 +301,13 @@ void finishProcessingNotification(UNNotification *notification,
     completionHandler(completionHandlerOptions);
 }
 
-// Apple's docs - Called to let your app know which action was selected by the user for a given notification.
-- (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
-         didReceiveNotificationResponse:(UNNotificationResponse *)response
-                  withCompletionHandler:(void(^)())completionHandler {
-    [OneSignalUNUserNotificationCenter traceCall:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"];
-    // return if the user has not granted privacy permissions or if not a OneSignal payload
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil] || ![OneSignalHelper isOneSignalPayload:response.notification.request.content.userInfo]) {
-        SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
-            initWithTarget:self
-            withYourSelector:@selector(
-                onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
-            )
-            withOriginalSelector:@selector(
-                userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
-            )
-        ];
-        if (forwarder.hasReceiver) {
-            [forwarder invokeWithArgs:@[center, response, completionHandler]];
-        } else {
-            completionHandler();
-        }
-        return;
-    }
-    
-    [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: Fired!"];
-    
-    [OneSignalUNUserNotificationCenter processiOS10Open:response];
-    
-    // Call orginal selector if one was set.
++ (void)forwardReceivedNotificationResponseWithCenter:(UNUserNotificationCenter *)center
+                       didReceiveNotificationResponse:(UNNotificationResponse *)response
+                                      OneSignalCenter:(id)instance
+                                withCompletionHandler:(void(^)())completionHandler {
+    // Call original selector if one was set.
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
-        initWithTarget:self
+        initWithTarget:instance
         withYourSelector:@selector(
             onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
         )
@@ -356,6 +332,22 @@ void finishProcessingNotification(UNNotification *notification,
     }
     else
         completionHandler();
+}
+
+
+// Apple's docs - Called to let your app know which action was selected by the user for a given notification.
+- (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
+         didReceiveNotificationResponse:(UNNotificationResponse *)response
+                  withCompletionHandler:(void(^)())completionHandler {
+    [OneSignalUNUserNotificationCenter traceCall:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"];
+    
+    if (![OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil] && [OneSignalHelper isOneSignalPayload:response.notification.request.content.userInfo]) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: Fired!"];
+        
+        [OneSignalUNUserNotificationCenter processiOS10Open:response];
+    }
+    
+    [OneSignalUNUserNotificationCenter forwardReceivedNotificationResponseWithCenter:center didReceiveNotificationResponse:response OneSignalCenter:self withCompletionHandler:completionHandler];
 }
 
 + (BOOL)isDismissEvent:(UNNotificationResponse *)response {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UIApplicationDelegateSwizzlingTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UIApplicationDelegateSwizzlingTests.m
@@ -501,6 +501,51 @@ static id<UIApplicationDelegate> orignalDelegate;
     XCTAssertTrue(myAppDelegate->selectorCalled);
 }
 
+- (UNNotificationResponse*)createOneSignalNotificationResponse {
+  id userInfo = @{@"custom":
+                       @{ @"i": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba" }
+                };
+  
+  return [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:userInfo];
+}
+
+- (UNNotificationResponse*)createNonOneSignalNotificationResponse {
+    return [UnitTestCommonMethods createBasiciOSNotificationResponseWithPayload:@{}];
+}
+
+- (void)testNotificationOpenForwardsToLegacySelector {
+    
+    AppDelegateForExistingSelectorsTest* myAppDelegate = [AppDelegateForExistingSelectorsTest new];
+    UIApplication.sharedApplication.delegate = myAppDelegate;
+
+    id notifResponse = [self createOneSignalNotificationResponse];
+    UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    id notifCenterDelegate = notifCenter.delegate;
+    // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    XCTAssertTrue([myAppDelegate->selectorCallsDict
+        objectForKey:NSStringFromSelector(
+            @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)
+        )
+    ]);
+    XCTAssertEqual([OneSignalAppDelegateOverrider callCountForSelector:@"oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:"], 1);
+    
+    
+    
+    notifResponse = [self createNonOneSignalNotificationResponse];
+    notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    notifCenterDelegate = notifCenter.delegate;
+    // UNUserNotificationCenterDelegate method iOS 10 calls directly when a notification is opened.
+    [notifCenterDelegate userNotificationCenter:notifCenter didReceiveNotificationResponse:notifResponse withCompletionHandler:^() {}];
+    XCTAssertTrue([myAppDelegate->selectorCallsDict
+        objectForKey:NSStringFromSelector(
+            @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)
+        )
+    ]);
+    XCTAssertEqual([OneSignalAppDelegateOverrider callCountForSelector:@"oneSignalReceiveRemoteNotification:UserInfo:fetchCompletionHandler:"], 2);
+    
+}
+
 - (void)testAppDelegateInheritsFromBaseMissingSelectors {
     id myAppDelegate = [AppDelegateInheritsFromBaseMissingSelectorsTest new];
     UIApplication.sharedApplication.delegate = myAppDelegate;


### PR DESCRIPTION
# Description
## One Line Summary
Fixing a swizzling issue where for non OneSignal notifications we were not forwarding notification opens to the app delegate remoteNotificationReceive.

## Details
We were doing this properly for OneSignal notifs but not properly for non OneSignal notifications. Now the behavior will be the same regardless of notification content/source.

When a notification is opened our swizzled implementation of UserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: is called. We need to forward this call to other implementations of this method (which we were doing correctly). However if there are no other implementers of the UNUserNotificationCenter method then we also need to try forwarding to the old app delegate selector in case there are listeners to the legacy method but not the new one. 

### Motivation
swizzling bug

### Scope
notification opens


# Testing
## Unit testing
Added a unit test that tests forwarding opens to the app delegate selector for both OneSignal and non OneSignal payloads.

## Manual testing
tested against firebase messaging on a physical iOS device

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1131)
<!-- Reviewable:end -->
