### PR TITLE
Fix xcode 14 warnings and build failure

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -2701,7 +2701,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = (
 					"$(ARCHS_STANDARD)",
-					armv7s,
 					x86_64h,
 					x86_64,
 				);
@@ -2765,6 +2764,11 @@
 		CA2951B82167F4120064227A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					x86_64h,
+					x86_64,
+				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -2859,7 +2863,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = (
 					"$(ARCHS_STANDARD)",
-					armv7s,
 					x86_64h,
 					x86_64,
 				);
@@ -2923,6 +2926,11 @@
 		CA2951C42167FB950064227A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					x86_64h,
+					x86_64,
+				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -3016,6 +3024,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					x86_64h,
+					x86_64,
+				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -3072,6 +3085,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					x86_64h,
+					x86_64,
+				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";

--- a/iOS_SDK/OneSignalSDK/UnitTests/RemoteParamsTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RemoteParamsTests.m
@@ -90,6 +90,7 @@
     [OneSignal setLocationShared:true];
     // Simulate user granting location services
     [OneSignalLocationOverrider grantLocationServices];
+    [UnitTestCommonMethods runLongBackgroundThreads];
     // Last location should exist since we are sharing location
     XCTAssertTrue([OneSignalLocation lastLocation]);
 }
@@ -108,6 +109,7 @@
     XCTAssertFalse([OneSignalLocation lastLocation]);
     // Simulate user granting location services
     [OneSignalLocationOverrider grantLocationServices];
+    [UnitTestCommonMethods runLongBackgroundThreads];
     // Last location should exist since we are sharing location
     XCTAssertTrue([OneSignalLocation lastLocation]);
 }
@@ -144,6 +146,7 @@
     XCTAssertFalse([OneSignalLocation lastLocation]);
     // Simulate user granting location services
     [OneSignalLocationOverrider grantLocationServices];
+    [UnitTestCommonMethods runLongBackgroundThreads];
     // Last location should exist since we are sharing location
     XCTAssertTrue([OneSignalLocation lastLocation]);
 }


### PR DESCRIPTION
# Description
## One Line Summary
fixes #1113 
This PR makes fixes related to using Xcode 14.

## Details
The two fixes in this pr are
1. Fixing build failure due to compiling for the armv7s architecture
  For this fix we will remove the armv7s archicture from builds
3. Fixing a UI thread block warning due to calling locationServicesEnabled on the main thread.
  Running locationServicesEnabled on the main thread causes an Xcode warning in Xcode 14 about a potential UI holdup. 
  However the location manager class needs to be created and run on a thread with a runloop or it's updates won't come 
  through. To handle this we will do locationServicesEnabled on a background thread and location fetch on main thread

### Motivation
Xcode 14 warnings

### Scope
build architecture and location services

# Testing
## Unit testing
Updated location unit tests to account for async location fetch

## Manual testing
tested location services on a physical iOS device

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Location

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1132)
<!-- Reviewable:end -->
