### PR TITLE
[user model] Fix xcode 14 warnings and build failure

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -3111,7 +3111,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = (
 					"$(ARCHS_STANDARD)",
-					armv7s,
 					x86_64h,
 					x86_64,
 				);
@@ -3273,7 +3272,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = (
 					"$(ARCHS_STANDARD)",
-					armv7s,
 					x86_64h,
 					x86_64,
 				);
@@ -3436,7 +3434,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = (
 					"$(ARCHS_STANDARD)",
-					armv7s,
 					x86_64h,
 					x86_64,
 				);

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -33,9 +33,9 @@ open class OSDelta: NSObject, NSCoding {
     public let timestamp: Date
     public let model: OSModel
     public let property: String
-    public let value: Any?
+    public let value: Any
 
-    public init(name: String, model: OSModel, property: String, value: Any?) {
+    public init(name: String, model: OSModel, property: String, value: Any) {
         self.name = name
         self.deltaId = UUID().uuidString
         self.timestamp = Date()

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -70,7 +70,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
             }
 
             let request = OSRequestUpdateProperties(
-                properties: [delta.property: delta.value ?? ""], // Sort this out.
+                properties: [delta.property: delta.value],
                 deltas: nil,
                 refreshDeviceMetadata: false, // Sort this out.
                 modelToUpdate: model,

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModelStoreListener.swift
@@ -45,6 +45,9 @@ class OSSubscriptionModelStoreListener: OSModelStoreListener {
         )
     }
 
+    /**
+     The `property` and `value` is not needed for a remove operation, so just pass in some model data as placeholders.
+     */
     func getRemoveModelDelta(_ model: OSSubscriptionModel) -> OSDelta? {
         return OSDelta(
             name: OS_REMOVE_SUBSCRIPTION_DELTA,

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionOperationExecutor.swift
@@ -84,11 +84,8 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                 enqueueRequest(request)
 
             case OS_UPDATE_SUBSCRIPTION_DELTA:
-                guard let value = delta.value else {
-                    continue
-                }
                 let request = OSRequestUpdateSubscription(
-                    subscriptionObject: [delta.property: value],
+                    subscriptionObject: [delta.property: delta.value],
                     subscriptionModel: model
                 )
                 enqueueRequest(request)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -45,6 +45,7 @@
 #import "OneSignalNotificationSettings.h"
 #import "OneSignalNotificationSettingsIOS10.h"
 #import "OneSignalNotificationSettingsIOS9.h"
+// TODO: ^ if no longer support ios 9 + 10 after user model, need to address all stuffs
 
 #import <OneSignalOutcomes/OneSignalOutcomes.h>
 #import "OneSignalExtension/OneSignalExtension.h"

--- a/iOS_SDK/OneSignalSDK/UnitTests/RemoteParamsTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RemoteParamsTests.m
@@ -90,6 +90,7 @@
     [OneSignal setLocationShared:true];
     // Simulate user granting location services
     [OneSignalLocationOverrider grantLocationServices];
+    [UnitTestCommonMethods runLongBackgroundThreads];
     // Last location should exist since we are sharing location
     XCTAssertTrue([OneSignalLocation lastLocation]);
 }
@@ -108,6 +109,7 @@
     XCTAssertFalse([OneSignalLocation lastLocation]);
     // Simulate user granting location services
     [OneSignalLocationOverrider grantLocationServices];
+    [UnitTestCommonMethods runLongBackgroundThreads];
     // Last location should exist since we are sharing location
     XCTAssertTrue([OneSignalLocation lastLocation]);
 }
@@ -144,6 +146,7 @@
     XCTAssertFalse([OneSignalLocation lastLocation]);
     // Simulate user granting location services
     [OneSignalLocationOverrider grantLocationServices];
+    [UnitTestCommonMethods runLongBackgroundThreads];
     // Last location should exist since we are sharing location
     XCTAssertTrue([OneSignalLocation lastLocation]);
 }


### PR DESCRIPTION
# Description
## One Line Summary
This PR makes fixes related to using Xcode 14, and effectively support for iOS 9 and 10.

### Motivation
Xcode 14 warnings related to https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1132.

By the time user model is released, we should be able to drop support for iOS 9 and 10.
However, if not, we can add it back via logic in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1134.

**TODO:** If we do move forward with dropping iOS 9 and 10 support, we need to make more changes to the SDK including minimum deployment and iOS 9 and 10 related code removal. Document requirements change - migration guide.

A commit that didn't make it into the last PR is added here too:
- Making `OSDelta.value` non-optional. Currently, we have no forced need to pass a `nil` value. Examples of usage bordering on nil values:
  - remove alias: `value = ["someAliasLabel: ""]`
  - remove a tag: `value =  ["someTag": ""]`

## Details
_(from original PR)_
The two fixes in this pr are
1. Fixing build failure due to compiling for the armv7s architecture
  For this fix we will remove the armv7s archicture from builds
3. (🍒 cherry picked) Fixing a UI thread block warning due to calling locationServicesEnabled on the main thread.
  Running locationServicesEnabled on the main thread causes an Xcode warning in Xcode 14 about a potential UI holdup. 
  However the location manager class needs to be created and run on a thread with a runloop or it's updates won't come 
  through. To handle this we will do locationServicesEnabled on a background thread and location fetch on main thread

### Scope
_(from original PR)_
build architecture and location services

# Testing
## Unit testing 
_(from original PR)_
Updated location unit tests to account for async location fetch

## Manual testing
_(from original PR)_
tested location services on a physical iOS device

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Location

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1138)
<!-- Reviewable:end -->
