### PR TITLE
Live Activity Support

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.h
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_END
 + (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
                               appId:(NSString * _Nonnull)appId
                          activityId:(NSString * _Nonnull)activityId
-                              token:(NSString * _Nullable)token;
+                              token:(NSString * _Nonnull)token;
 @end
 
 @interface OSRequestLiveActivityExit: OneSignalRequest

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.h
@@ -135,10 +135,22 @@ NS_ASSUME_NONNULL_END
 + (instancetype _Nonnull)withUserId:(NSString * _Nullable)externalId withUserIdHashToken:(NSString * _Nullable)hashToken withOneSignalUserId:(NSString * _Nonnull)userId withSMSHashToken:(NSString * _Nullable)smsHashToken appId:(NSString * _Nonnull)appId;
 @end
 
-
 @interface OSRequestTrackV1 : OneSignalRequest
 + (instancetype _Nonnull)trackUsageData:(NSString * _Nonnull)osUsageData
                                      appId:(NSString * _Nonnull)appId;
+@end
+
+@interface OSRequestLiveActivityEnter: OneSignalRequest
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
+                              appId:(NSString * _Nonnull)appId
+                         activityId:(NSString * _Nonnull)activityId
+                              token:(NSString * _Nullable)token;
+@end
+
+@interface OSRequestLiveActivityExit: OneSignalRequest
++ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
+                              appId:(NSString * _Nonnull)appId
+                         activityId:(NSString * _Nonnull)activityId;
 @end
 #endif /* Requests_h */
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -500,11 +500,11 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
                      token:(NSString * _Nullable)token {
     let request = [OSRequestLiveActivityEnter new];
     let params = [NSMutableDictionary new];
-    params[@"subscription_id"] = appId; // pre-5.X.X
     params[@"push_token"] = token;
+    params[@"subscription_id"] = userId; // pre-5.X.X subscription_id = player_id = userId
     request.parameters = params;
     request.method = POST;
-    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/enter", appId, activityId];
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token", appId, activityId];
     return request;
 }
 @end
@@ -514,11 +514,8 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
                      appId:(NSString * _Nonnull)appId
                 activityId:(NSString * _Nonnull)activityId{
     let request = [OSRequestLiveActivityExit new];
-    let params = [NSMutableDictionary new];
-    params[@"subscription_id"] = appId; // pre-5.X.X
-    request.parameters = params;
-    request.method = POST;
-    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/exit", appId, activityId];
+    request.method = DELETE;
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@", appId, activityId, userId];
     return request;
 }
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -492,3 +492,33 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
     return request;
 }
 @end
+
+@implementation OSRequestLiveActivityEnter
++ (instancetype)withUserId:(NSString * _Nonnull)userId
+                     appId:(NSString * _Nonnull)appId
+                activityId:(NSString * _Nonnull)activityId
+                     token:(NSString * _Nullable)token {
+    let request = [OSRequestLiveActivityEnter new];
+    let params = [NSMutableDictionary new];
+    params[@"subscription_id"] = appId; // pre-5.X.X
+    params[@"push_token"] = token;
+    request.parameters = params;
+    request.method = POST;
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/enter", appId, activityId];
+    return request;
+}
+@end
+
+@implementation OSRequestLiveActivityExit
++ (instancetype)withUserId:(NSString * _Nonnull)userId
+                     appId:(NSString * _Nonnull)appId
+                activityId:(NSString * _Nonnull)activityId{
+    let request = [OSRequestLiveActivityExit new];
+    let params = [NSMutableDictionary new];
+    params[@"subscription_id"] = appId; // pre-5.X.X
+    request.parameters = params;
+    request.method = POST;
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/exit", appId, activityId];
+    return request;
+}
+@end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -512,7 +512,7 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
 @implementation OSRequestLiveActivityExit
 + (instancetype)withUserId:(NSString * _Nonnull)userId
                      appId:(NSString * _Nonnull)appId
-                activityId:(NSString * _Nonnull)activityId{
+                activityId:(NSString * _Nonnull)activityId {
     let request = [OSRequestLiveActivityExit new];
     request.method = DELETE;
     request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@", appId, activityId, userId];

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -497,7 +497,7 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
 + (instancetype)withUserId:(NSString * _Nonnull)userId
                      appId:(NSString * _Nonnull)appId
                 activityId:(NSString * _Nonnull)activityId
-                     token:(NSString * _Nullable)token {
+                     token:(NSString * _Nonnull)token {
     let request = [OSRequestLiveActivityEnter new];
     let params = [NSMutableDictionary new];
     params[@"push_token"] = token;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -293,6 +293,17 @@ typedef void (^OSFailureBlock)(NSError* error);
 + (void)setLaunchURLsInApp:(BOOL)launchInApp;
 + (void)setProvidesNotificationSettingsView:(BOOL)providesView;
 
+
+#pragma mark Live Activity
+typedef void (^OSLiveActivitySuccessBlock)();
+typedef void (^OSLiveActivityFailureBlock)(NSError *error);
+
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token;
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;
+
++ (void)exitLiveActivity:(NSString * _Nonnull)activityId;
++ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;
+
 #pragma mark Logging
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
 + (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -298,8 +298,8 @@ typedef void (^OSFailureBlock)(NSError* error);
 typedef void (^OSLiveActivitySuccessBlock)();
 typedef void (^OSLiveActivityFailureBlock)(NSError *error);
 
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token;
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token;
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;
 
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId;
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -295,14 +295,11 @@ typedef void (^OSFailureBlock)(NSError* error);
 
 
 #pragma mark Live Activity
-typedef void (^OSLiveActivitySuccessBlock)();
-typedef void (^OSLiveActivityFailureBlock)(NSError *error);
-
 + (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token;
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
 
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId;
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock;
++ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
 
 #pragma mark Logging
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -664,6 +664,33 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     appSettings = newSettings;
 }
 
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token {
+    [self enterLiveActivity:activityId withToken:token withSuccess:nil withFailure:nil];
+}
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
+    
+    [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId token:token]
+    onSuccess:^(NSDictionary *result) {
+        [self callSuccessBlockOnMainThread:successBlock];
+    } onFailure:^(NSError *error) {
+        [self callFailureBlockOnMainThread:failureBlock withError:error];
+    }];
+}
+
++ (void)exitLiveActivity:(NSString * _Nonnull)activityId{
+    [self exitLiveActivity:activityId withSuccess:nil withFailure:nil];
+}
+
++ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
+
+    [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId]
+    onSuccess:^(NSDictionary *result) {
+        [self callSuccessBlockOnMainThread:successBlock];
+    } onFailure:^(NSError *error) {
+        [self callFailureBlockOnMainThread:failureBlock withError:error];
+    }];
+}
+
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock)block {
     [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"Notification will show in foreground handler set successfully"];
     [OneSignalHelper setNotificationWillShowInForegroundBlock:block];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -664,10 +664,22 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     appSettings = newSettings;
 }
 
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token {
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token {
+    
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:"])
+        return;
+    
     [self enterLiveActivity:activityId withToken:token withSuccess:nil withFailure:nil];
 }
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nullable)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
+    
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:onSuccess:onFailure:"]) {
+        if (failureBlock) {
+            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called enterLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+            failureBlock(error);
+        }
+        return;
+    }
     
     [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId token:token]
     onSuccess:^(NSDictionary *result) {
@@ -678,11 +690,23 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
 }
 
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId{
+    
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:"])
+        return;
+    
     [self exitLiveActivity:activityId withSuccess:nil withFailure:nil];
 }
 
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
 
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"exitLiveActivity:onSuccess:onFailure:"]) {
+        if (failureBlock) {
+            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called exitLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+            failureBlock(error);
+        }
+        return;
+    }
+    
     [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId]
     onSuccess:^(NSDictionary *result) {
         [self callSuccessBlockOnMainThread:successBlock];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -111,6 +111,34 @@ NSString* const kOSSettingsKeyProvidesAppNotificationSettings = @"kOSSettingsKey
 }
 @end
 
+@interface OSPendingLiveActivityUpdate: NSObject
+    @property NSString* token;
+    @property NSString* activityId;
+    @property BOOL isEnter;
+    @property OSResultSuccessBlock successBlock;
+    @property OSFailureBlock failureBlock;
+    - (id)initWith:(NSString * _Nonnull)activityId
+         withToken:(NSString * _Nonnull)token
+           isEnter:(BOOL)isEnter
+       withSuccess:(OSResultSuccessBlock _Nullable)successBlock
+       withFailure:(OSFailureBlock _Nullable)failureBlock;
+@end
+@implementation OSPendingLiveActivityUpdate
+
+- (id)initWith:(NSString *)activityId
+     withToken:(NSString *)token
+       isEnter:(BOOL)isEnter
+   withSuccess:(OSResultSuccessBlock)successBlock
+   withFailure:(OSFailureBlock)failureBlock {
+    self.token = token;
+    self.activityId = activityId;
+    self.isEnter = isEnter;
+    self.successBlock = successBlock;
+    self.failureBlock = failureBlock;
+    return self;
+};
+@end
+
 @interface OneSignal (SessionStatusDelegate)
 @end
 
@@ -137,6 +165,8 @@ static OneSignalSetLanguageParameters *delayedLanguageParameters;
 static NSMutableArray* pendingSendTagCallbacks;
 static OSResultSuccessBlock pendingGetTagsSuccessBlock;
 static OSFailureBlock pendingGetTagsFailureBlock;
+
+static NSMutableArray* pendingLiveActivityUpdates;
 
 // Has attempted to register for push notifications with Apple since app was installed.
 static BOOL registeredWithApple = NO;
@@ -671,7 +701,52 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     
     [self enterLiveActivity:activityId withToken:token withSuccess:nil withFailure:nil];
 }
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
+
+#pragma mark: LIVE ACTIVITIES
+
+
++ (void)addPendingLiveActivityUpdate:(NSString * _Nonnull)activityId
+                           withToken:(NSString * _Nullable)token
+                             isEnter:(BOOL)isEnter
+                         withSuccess:(OSResultSuccessBlock _Nullable)successBlock
+                         withFailure:(OSFailureBlock _Nullable)failureBlock {
+    OSPendingLiveActivityUpdate *pendingLiveActivityUpdate = [[OSPendingLiveActivityUpdate alloc] initWith:activityId withToken:token isEnter:isEnter withSuccess:successBlock withFailure:failureBlock];
+    
+    if (!pendingLiveActivityUpdates){
+        pendingLiveActivityUpdates = [NSMutableArray new];
+    }
+    [pendingLiveActivityUpdates addObject:pendingLiveActivityUpdate];
+}
+
++ (void)executePendingLiveActivityUpdates{
+    if(pendingLiveActivityUpdates.count <= 0){
+        return;
+    }
+    
+    OSPendingLiveActivityUpdate * updateToProcess = [pendingLiveActivityUpdates objectAtIndex:0];
+    [pendingLiveActivityUpdates removeObjectAtIndex: 0];
+    if (updateToProcess.isEnter) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:self.currentSubscriptionState.userId appId:appId activityId:updateToProcess.activityId token:updateToProcess.token]
+                                           onSuccess:^(NSDictionary *result) {
+            [self callSuccessBlockOnMainThread:updateToProcess.successBlock withResult:result];
+            [self executePendingLiveActivityUpdates];
+        } onFailure:^(NSError *error) {
+            [self callFailureBlockOnMainThread:updateToProcess.failureBlock withError:error];
+            [self executePendingLiveActivityUpdates];
+        }];
+    } else {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:self.currentSubscriptionState.userId appId:appId activityId:updateToProcess.activityId]
+                                           onSuccess:^(NSDictionary *result) {
+            [self callSuccessBlockOnMainThread:updateToProcess.successBlock withResult:result];
+            [self executePendingLiveActivityUpdates];
+        } onFailure:^(NSError *error) {
+            [self callFailureBlockOnMainThread:updateToProcess.failureBlock withError:error];
+            [self executePendingLiveActivityUpdates];
+        }];
+    }
+}
+
++ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
     
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:onSuccess:onFailure:"]) {
         if (failureBlock) {
@@ -680,13 +755,18 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         }
         return;
     }
+
     
-    [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId token:token]
-    onSuccess:^(NSDictionary *result) {
-        [self callSuccessBlockOnMainThread:successBlock];
-    } onFailure:^(NSError *error) {
-        [self callFailureBlockOnMainThread:failureBlock withError:error];
-    }];
+    if(self.currentSubscriptionState.userId) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId token:token]
+                                           onSuccess:^(NSDictionary *result) {
+            [self callSuccessBlockOnMainThread:successBlock withResult:result];
+        } onFailure:^(NSError *error) {
+            [self callFailureBlockOnMainThread:failureBlock withError:error];
+        }];
+    } else {
+        [self addPendingLiveActivityUpdate:activityId withToken:token isEnter:true withSuccess:successBlock withFailure:failureBlock];
+    }
 }
 
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId{
@@ -697,7 +777,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     [self exitLiveActivity:activityId withSuccess:nil withFailure:nil];
 }
 
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSLiveActivitySuccessBlock _Nullable)successBlock withFailure:(OSLiveActivityFailureBlock _Nullable)failureBlock{
++ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
 
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"exitLiveActivity:onSuccess:onFailure:"]) {
         if (failureBlock) {
@@ -706,13 +786,16 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
         }
         return;
     }
-    
-    [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId]
-    onSuccess:^(NSDictionary *result) {
-        [self callSuccessBlockOnMainThread:successBlock];
-    } onFailure:^(NSError *error) {
-        [self callFailureBlockOnMainThread:failureBlock withError:error];
-    }];
+    if(self.currentSubscriptionState.userId) {
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:self.currentSubscriptionState.userId appId:appId activityId:activityId]
+                                           onSuccess:^(NSDictionary *result) {
+            [self callSuccessBlockOnMainThread:successBlock withResult:result];
+        } onFailure:^(NSError *error) {
+            [self callFailureBlockOnMainThread:failureBlock withError:error];
+        }];
+    } else {
+        [self addPendingLiveActivityUpdate:activityId withToken:nil isEnter:false  withSuccess:successBlock withFailure:failureBlock];
+    }
 }
 
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock)block {
@@ -1260,7 +1343,7 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
     
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(sendTagsToServer) object:nil];
     
-    // Can't send tags yet as their isn't a player_id.
+    // Can't send tags yet as there isn't a player_id.
     //   tagsToSend will be sent with the POST create player call later in this case.
     if (self.currentSubscriptionState.userId)
        [OneSignalHelper performSelector:@selector(sendTagsToServer) onMainThreadOnObject:self withObject:nil afterDelay:5];
@@ -1891,7 +1974,7 @@ static BOOL _trackedColdRestart = false;
                 pendingGetTagsSuccessBlock = nil;
                 pendingGetTagsFailureBlock = nil;
             }
-            
+            [self executePendingLiveActivityUpdates];
         }
         
         if (results[@"push"][@"in_app_messages"]) {
@@ -2354,7 +2437,15 @@ static NSString *_lastnonActiveMessageId;
     }
 }
 
-+ (void)callSuccessBlockOnMainThread:(OSEmailSuccessBlock)successBlock {
++ (void)callSuccessBlockOnMainThread:(OSResultSuccessBlock)successBlock withResult:(NSDictionary *)result{
+    if (successBlock) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            successBlock(result);
+        });
+    }
+}
+
++ (void)callEmailSuccessBlockOnMainThread:(OSEmailSuccessBlock)successBlock {
     if (successBlock) {
         dispatch_async(dispatch_get_main_queue(), ^{
             successBlock();
@@ -2437,7 +2528,7 @@ static NSString *_lastnonActiveMessageId;
     // Since developers may be making UI changes when this call finishes, we will call callbacks on the main thread.
     if (self.currentEmailSubscriptionState.emailUserId) {
         [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentEmailSubscriptionState.emailUserId appId:self.appId deviceToken:email withParentId:nil emailAuthToken:emailAuthToken email:nil externalIdAuthToken:[self mExternalIdAuthToken]] onSuccess:^(NSDictionary *result) {
-            [self callSuccessBlockOnMainThread:successBlock];
+            [self callEmailSuccessBlockOnMainThread:successBlock];
         } onFailure:^(NSError *error) {
             [self callFailureBlockOnMainThread:failureBlock withError:error];
         }];
@@ -2449,7 +2540,7 @@ static NSString *_lastnonActiveMessageId;
             if (emailPlayerId) {
                 [OneSignal saveEmailAddress:email withAuthToken:emailAuthToken userId:emailPlayerId];
                 [OneSignalClient.sharedClient executeRequest:[OSRequestUpdateDeviceToken withUserId:self.currentSubscriptionState.userId appId:self.appId deviceToken:nil withParentId:self.currentEmailSubscriptionState.emailUserId emailAuthToken:hashToken email:email externalIdAuthToken:[self mExternalIdAuthToken] ] onSuccess:^(NSDictionary *result) {
-                    [self callSuccessBlockOnMainThread:successBlock];
+                    [self callEmailSuccessBlockOnMainThread:successBlock];
                 } onFailure:^(NSError *error) {
                     [self callFailureBlockOnMainThread:failureBlock withError:error];
                 }];
@@ -2490,7 +2581,7 @@ static NSString *_lastnonActiveMessageId;
         [OneSignalUserDefaults.initStandard removeValueForKey:OSUD_EMAIL_PLAYER_ID];
         [OneSignal saveEmailAddress:nil withAuthToken:nil userId:nil];
         
-        [self callSuccessBlockOnMainThread:successBlock];
+        [self callEmailSuccessBlockOnMainThread:successBlock];
     } onFailure:^(NSError *error) {
         [self callFailureBlockOnMainThread:failureBlock withError:error];
     }];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -712,14 +712,14 @@ static OneSignalOutcomeEventsController *_outcomeEventsController;
                          withFailure:(OSFailureBlock _Nullable)failureBlock {
     OSPendingLiveActivityUpdate *pendingLiveActivityUpdate = [[OSPendingLiveActivityUpdate alloc] initWith:activityId withToken:token isEnter:isEnter withSuccess:successBlock withFailure:failureBlock];
     
-    if (!pendingLiveActivityUpdates){
+    if (!pendingLiveActivityUpdates) {
         pendingLiveActivityUpdates = [NSMutableArray new];
     }
     [pendingLiveActivityUpdates addObject:pendingLiveActivityUpdate];
 }
 
-+ (void)executePendingLiveActivityUpdates{
-    if(pendingLiveActivityUpdates.count <= 0){
++ (void)executePendingLiveActivityUpdates {
+    if(pendingLiveActivityUpdates.count <= 0) {
         return;
     }
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -110,7 +110,6 @@
 
     testAction = testBridgeEvent.userAction;
     testAction.firstClick = true;
-    
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -57,6 +57,8 @@
     NSString *testInAppMessageAppId;
     NSString *testInAppMessageVariantId;
     NSString *testInAppMessagePageId;
+    NSString *testLiveActivityId;
+    NSString *testLiveActivityToken;
     NSString *testNotificationId;
     OSOutcomeEvent *testOutcome;
     NSNumber *testDeviceType;
@@ -84,6 +86,8 @@
     testInAppMessageAppId = @"test_in_app_message_app_id";
     testInAppMessageVariantId = @"test_in_app_message_variant_id";
     testInAppMessagePageId = @"test_in_app_message_page_id";
+    testLiveActivityId = @"test_live_activity_id";
+    testLiveActivityToken = @"test_live_activity_token";
     testNotificationId = @"test_notification_id";
     
     testOutcome = [[OSOutcomeEvent new] initWithSession:UNATTRIBUTED
@@ -106,6 +110,7 @@
 
     testAction = testBridgeEvent.userAction;
     testAction.firstClick = true;
+    
 }
 
 /*
@@ -761,6 +766,39 @@ BOOL checkHttpHeaders(NSDictionary *additionalHeaders, NSDictionary *correct) {
     XCTAssertTrue(checkHttpHeaders(request.additionalHeaders, @{@"app_id" : testAppId,
                                                                 @"OS-Usage-Data" : testUsageData,
                                                               }));
+}
+
+- (void)testEnterLiveActivity {
+    let request = [OSRequestLiveActivityEnter withUserId:testUserId appId:testAppId activityId:testLiveActivityId token:testLiveActivityToken];
+    
+    let testEnterLiveActivityUrlPath = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token",
+                                        testAppId,
+                                        testLiveActivityId];
+    
+    let correctUrl = correctUrlWithPath(testEnterLiveActivityUrlPath);
+
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"push_token" : testLiveActivityToken, @"subscription_id" : testUserId }));
+    
+    XCTAssertEqualObjects(request.urlRequest.HTTPMethod, @"POST");
+    XCTAssertEqualObjects(request.urlRequest.allHTTPHeaderFields[@"Accept"], @"application/vnd.onesignal.v1+json");
+}
+
+- (void)testExitLiveActivity {
+    let request = [OSRequestLiveActivityExit withUserId:testUserId appId:testAppId activityId:testLiveActivityId];
+    
+    let testExitLiveActivityUrlPath = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@",
+                                        testAppId,
+                                        testLiveActivityId,
+                                        testUserId];
+    
+    let correctUrl = correctUrlWithPath(testExitLiveActivityUrlPath);
+
+    XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
+    
+    XCTAssertEqualObjects(request.urlRequest.HTTPBody, nil);
+    XCTAssertEqualObjects(request.urlRequest.HTTPMethod, @"DELETE");
+    XCTAssertEqualObjects(request.urlRequest.allHTTPHeaderFields[@"Accept"], @"application/vnd.onesignal.v1+json");
 }
 
 - (void)testAdditionalHeaders {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3463,6 +3463,50 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testEnterLiveActivityCorrectURL);
 }
 
+- (void)testPendingLiveActivityUpdates {
+    
+    NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    NSString *testLiveActivity = @"onesignal-01012022";
+    NSString *testLiveActivityToken = @"8076f335e7a8f865607949b02e95ba49268cf98a633f3963256e53172c19f299d312f09950d25c4e711260a65157446aba0b47d6120d53d67f6f6946b706f9ce4a0c883d3e0b1391f67fe4a8cc2ca381";
+    NSString *testUserId = @"1234";
+    
+    [OneSignal enterLiveActivity:testLiveActivity
+                       withToken:testLiveActivityToken
+                     withSuccess:nil
+                     withFailure:nil];
+    
+    [OneSignal exitLiveActivity:testLiveActivity
+                    withSuccess:nil
+                    withFailure:nil];
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    //check to make sure the OSRequestEnterLiveActivity HTTP call was made, and was formatted correctly
+    OneSignalRequest *enterRequest = OneSignalClientOverrider.executedRequests[OneSignalClientOverrider.executedRequests.count-2];
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityEnter class]) isEqualToString:NSStringFromClass([enterRequest class])]);
+    XCTAssertEqual(enterRequest.parameters[@"push_token"],testLiveActivityToken);
+    XCTAssertEqual(enterRequest.parameters[@"subscription_id"], testUserId);
+    
+    let testEnterLiveActivityCorrectURL = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token",
+                                           testAppId,
+                                           testLiveActivity];
+    
+    XCTAssertEqualObjects(enterRequest.path, testEnterLiveActivityCorrectURL);
+    
+    //check to make sure the OSRequestExitLiveActivity HTTP call was made, and was formatted correctly
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityExit class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);
+    
+    let testExitLiveActivityCorrectURL = [NSString stringWithFormat:@"https://api.onesignal.com/apps/%@/live_activities/%@/token/%@",
+                                          testAppId,
+                                          testLiveActivity,
+                                          testUserId];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testExitLiveActivityCorrectURL);
+    
+}
+
 - (void)testExitLiveActivity {
     
     NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
@@ -3474,6 +3518,31 @@ didReceiveRemoteNotification:userInfo
     [OneSignal exitLiveActivity:testLiveActivity
                     withSuccess:nil
                     withFailure:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    //check to make sure the OSRequestExitLiveActivity HTTP call was made, and was formatted correctly
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityExit class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);
+    
+    let testExitLiveActivityCorrectURL = [NSString stringWithFormat:@"https://api.onesignal.com/apps/%@/live_activities/%@/token/%@",
+                                          testAppId,
+                                          testLiveActivity,
+                                          testUserId];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testExitLiveActivityCorrectURL);
+
+}
+- (void)testExitLiveActivityEarly {
+    
+    NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    NSString *testLiveActivity = @"onesignal-01012022";
+    NSString *testUserId = @"1234";
+    
+    [OneSignal exitLiveActivity:testLiveActivity
+                    withSuccess:nil
+                    withFailure:nil];
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
     
     [UnitTestCommonMethods runBackgroundThreads];
     

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3435,4 +3435,58 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(content.userInfo[@"os_data"][@"collapse_id"], @"test_id");
 }
 
+- (void)testEnterLiveActivity {
+    
+    NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    NSString *testLiveActivity = @"onesignal-01012022";
+    NSString *testLiveActivityToken = @"8076f335e7a8f865607949b02e95ba49268cf98a633f3963256e53172c19f299d312f09950d25c4e711260a65157446aba0b47d6120d53d67f6f6946b706f9ce4a0c883d3e0b1391f67fe4a8cc2ca381";
+    NSString *testUserId = @"1234";
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    [OneSignal enterLiveActivity:testLiveActivity
+                    withToken:testLiveActivityToken
+                    withSuccess:nil
+                    withFailure:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+  
+    //check to make sure the OSRequestEnterLiveActivity HTTP call was made, and was formatted correctly
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityEnter class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);
+    XCTAssertEqual(OneSignalClientOverrider.lastHTTPRequest[@"push_token"],testLiveActivityToken);
+    XCTAssertEqual(OneSignalClientOverrider.lastHTTPRequest[@"subscription_id"], testUserId);
+    
+    let testEnterLiveActivityCorrectURL = [NSString stringWithFormat:@"https://api.onesignal.com/apps/%@/live_activities/%@/token",
+                                          testAppId,
+                                          testLiveActivity];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testEnterLiveActivityCorrectURL);
+}
+
+- (void)testExitLiveActivity {
+    
+    NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    NSString *testLiveActivity = @"onesignal-01012022";
+    NSString *testUserId = @"1234";
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    [OneSignal exitLiveActivity:testLiveActivity
+                    withSuccess:nil
+                    withFailure:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    //check to make sure the OSRequestExitLiveActivity HTTP call was made, and was formatted correctly
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityExit class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);
+    
+    let testExitLiveActivityCorrectURL = [NSString stringWithFormat:@"https://api.onesignal.com/apps/%@/live_activities/%@/token/%@",
+                                          testAppId,
+                                          testLiveActivity,
+                                          testUserId];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testExitLiveActivityCorrectURL);
+
+}
+
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Adds Live Activity support for the SDK

## Details

### Motivation
Adding 2 sdk methods that allow a customer to register their temporary live activity token with an activity ID on OneSignal's backend

### Scope
Adding two SDK public methods and two corresponding requests

# Testing
## Unit testing
Added several tests to test the requests and the public SDK method

## Manual testing
The backend piece is not available yet so only testing with mock data.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1152)
<!-- Reviewable:end -->
