### PR TITLE
Adding devicetype for enter live activity

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -502,6 +502,7 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
     let params = [NSMutableDictionary new];
     params[@"push_token"] = token;
     params[@"subscription_id"] = userId; // pre-5.X.X subscription_id = player_id = userId
+    params[@"device_type"] = @0;
     request.parameters = params;
     request.method = POST;
     request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token", appId, activityId];


### PR DESCRIPTION
Adding device type for enterLiveActivity


`params[@"device_type"] = @0;`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1155)
<!-- Reviewable:end -->
