### PR TITLE
encoding activity_id

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -505,7 +505,10 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
     params[@"device_type"] = @0;
     request.parameters = params;
     request.method = POST;
-    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token", appId, activityId];
+    
+    NSString *urlSafeActivityId = [activityId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLUserAllowedCharacterSet]];
+    
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token", appId, urlSafeActivityId];
     return request;
 }
 @end
@@ -516,7 +519,11 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
                 activityId:(NSString * _Nonnull)activityId {
     let request = [OSRequestLiveActivityExit new];
     request.method = DELETE;
-    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@", appId, activityId, userId];
+    
+    NSString *urlSafeActivityId = [activityId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLUserAllowedCharacterSet]];
+    
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@", appId, urlSafeActivityId, userId];
+    
     return request;
 }
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -3532,6 +3532,61 @@ didReceiveRemoteNotification:userInfo
     XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testExitLiveActivityCorrectURL);
 
 }
+
+- (void)testExitLiveActivityURLUnsafeSpace {
+    
+    NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    NSString *testLiveActivityURLUnsafe = @"onesignal 01012022";
+    NSString *testLiveActivityURLSafe = @"onesignal%2001012022";
+    NSString *testUserId = @"1234";
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    [OneSignal exitLiveActivity:testLiveActivityURLUnsafe
+                    withSuccess:nil
+                    withFailure:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    //check to make sure the OSRequestExitLiveActivity HTTP call was made, and was formatted correctly
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityExit class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);
+    
+    let testExitLiveActivityCorrectURL = [NSString stringWithFormat:@"https://api.onesignal.com/apps/%@/live_activities/%@/token/%@",
+                                          testAppId,
+                                          testLiveActivityURLSafe,
+                                          testUserId];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testExitLiveActivityCorrectURL);
+
+}
+
+- (void)testExitLiveActivityURLUnsafeSlash {
+    
+    NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    NSString *testLiveActivityURLUnsafe = @"onesignal/01012022";
+    NSString *testLiveActivityURLSafe = @"onesignal%2F01012022";
+    NSString *testUserId = @"1234";
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    [OneSignal exitLiveActivity:testLiveActivityURLUnsafe
+                    withSuccess:nil
+                    withFailure:nil];
+    
+    [UnitTestCommonMethods runBackgroundThreads];
+    
+    //check to make sure the OSRequestExitLiveActivity HTTP call was made, and was formatted correctly
+    XCTAssertTrue([NSStringFromClass([OSRequestLiveActivityExit class]) isEqualToString:OneSignalClientOverrider.lastHTTPRequestType]);
+    
+    let testExitLiveActivityCorrectURL = [NSString stringWithFormat:@"https://api.onesignal.com/apps/%@/live_activities/%@/token/%@",
+                                          testAppId,
+                                          testLiveActivityURLSafe,
+                                          testUserId];
+    
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastUrl, testExitLiveActivityCorrectURL);
+
+}
+
 - (void)testExitLiveActivityEarly {
     
     NSString *testAppId = @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba";


### PR DESCRIPTION
# Description
## One Line Summary
Adding URL encoding to `activity_id` which is user defined but will appear in the url when entering or exiting a live activity

# Testing
## Unit testing
added a couple of tests to make sure encoding works properly

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1159)
<!-- Reviewable:end -->
