### PR TITLE
Updating testEnterLiveActivity

### DIFF
--- a/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/RequestTests.m
@@ -777,7 +777,7 @@ BOOL checkHttpHeaders(NSDictionary *additionalHeaders, NSDictionary *correct) {
     let correctUrl = correctUrlWithPath(testEnterLiveActivityUrlPath);
 
     XCTAssertTrue([correctUrl isEqualToString:request.urlRequest.URL.absoluteString]);
-    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"push_token" : testLiveActivityToken, @"subscription_id" : testUserId }));
+    XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{@"push_token" : testLiveActivityToken, @"subscription_id" : testUserId, @"device_type" : @0 }));
     
     XCTAssertEqualObjects(request.urlRequest.HTTPMethod, @"POST");
     XCTAssertEqualObjects(request.urlRequest.allHTTPHeaderFields[@"Accept"], @"application/vnd.onesignal.v1+json");


### PR DESCRIPTION
### Fixing a test not changing any SDK functionality
Updating testEnterLiveActivity in RequestTest.m with the additional `device_type` param

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1161)
<!-- Reviewable:end -->
