### PR TITLE
Find app_id in path if path contains "apps/"

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -72,10 +72,6 @@
     
     return request;
 }
-
--(BOOL)missingAppId {
-    return false; //this request doesn't have an app ID parameter
-}
 @end
 
 @implementation OSRequestSendTagsToServer

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalClient.m
@@ -290,7 +290,7 @@
 }
 
 - (void)handleMissingAppIdError:(OSFailureBlock)failureBlock withRequest:(OneSignalRequest *)request {
-    NSString *errorDescription = [NSString stringWithFormat:@"HTTP Request (%@) must contain app_id parameter", NSStringFromClass([request class])];
+    NSString *errorDescription = [NSString stringWithFormat:@"HTTP Request (%@) must include an app_id", NSStringFromClass([request class])];
     
     [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorDescription];
     

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalRequest.m
@@ -89,7 +89,14 @@
 }
 
 -(BOOL)missingAppId {
-    return self.parameters[@"app_id"] == nil || [self.parameters[@"app_id"] length] == 0;
+
+  if ([self.path containsString:@"apps/"]) {
+    NSArray *pathComponents = [self.path componentsSeparatedByString:@"/"];
+    NSUInteger x = [pathComponents indexOfObject:@"apps"] + 1; // Find the index that follows "apps" in the path
+    return ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0);
+  }
+   
+  return (self.parameters[@"app_id"] == nil || [self.parameters[@"app_id"] length] == 0);
 }
 
 -(void)attachBodyToRequest:(NSMutableURLRequest *)request withParameters:(NSDictionary *)parameters {

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalRequest.m
@@ -89,11 +89,10 @@
 }
 
 -(BOOL)missingAppId {
-
   if ([self.path containsString:@"apps/"]) {
     NSArray *pathComponents = [self.path componentsSeparatedByString:@"/"];
     NSUInteger x = [pathComponents indexOfObject:@"apps"] + 1; // Find the index that follows "apps" in the path
-    return ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0);
+    return ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0 || [[pathComponents objectAtIndex:x] isEqual: @"(null)"]);
   }
    
   return (self.parameters[@"app_id"] == nil || [self.parameters[@"app_id"] length] == 0);

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -214,9 +214,16 @@ static NSDictionary* remoteParams;
         
         NSMutableDictionary *parameters = [request.parameters mutableCopy];
         
-        if (!parameters[@"app_id"] && ![request.urlRequest.URL.absoluteString containsString:@"/apps/"])
-            _XCTPrimitiveFail(currentTestInstance, @"All request should include an app_id");
-        
+        if ([request.urlRequest.URL.absoluteString containsString:@"apps/"]) {
+          NSArray *pathComponents = [request.urlRequest.URL.absoluteString componentsSeparatedByString:@"/"];
+          NSUInteger x = [pathComponents indexOfObject:@"apps"] + 1; // Find the index that follows "apps" in the path
+            if ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0) {
+                _XCTPrimitiveFail(currentTestInstance, @"All request must include an app_id");
+            }
+        } else if (!parameters[@"app_id"]) {
+            _XCTPrimitiveFail(currentTestInstance, @"All request must include an app_id");
+        }
+     
         [self didCompleteRequest:request];
 
         if (successBlock) {

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -217,7 +217,7 @@ static NSDictionary* remoteParams;
         if ([request.urlRequest.URL.absoluteString containsString:@"apps/"]) {
           NSArray *pathComponents = [request.urlRequest.URL.absoluteString componentsSeparatedByString:@"/"];
           NSUInteger x = [pathComponents indexOfObject:@"apps"] + 1; // Find the index that follows "apps" in the path
-            if ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0) {
+            if ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0 || [[pathComponents objectAtIndex:x] isEqual: @"(null)"]) {
                 _XCTPrimitiveFail(currentTestInstance, @"All request must include an app_id");
             }
         } else if (!parameters[@"app_id"]) {


### PR DESCRIPTION
# Description
## One Line Summary
`app_id` must be included with each request. In order to reduce load on the server we fail requests early on the client that we know will fail on the server. Currently the check in OneSignalRequest looks for `app_id` in the body as a param. However there is another valid way to send the `app_id` that is after "/apps" in the path". This was overlooked initially because it functions correctly in the testing harness `OneSignalClientOverrider` by checking the path and the request body. the PR makes the logic the same in OneSignalRequest and OneSignalClientOverrider.

- Find `app_id` in path if path contains "apps/" 
- Update tests

### Motivation
Getting the error when trying to call the new Live Activity endpoint:

`2022-11-22 16:52:01.080841-0800 OneSignalExample[58470:3775197] Error code: -1 and message: Error Domain=OneSignalError Code=-1 "(null)" UserInfo={error=HTTP Request (OSRequestLiveActivityEnter) must contain app_id parameter}`

`app_id` is in the path rather than a param in the body, this fails the request

# Testing
## Unit testing
Modified OneSignalClientOverrider with the same behavior so that in the future people can count on the testing harness to have the same functionality as the real world case.

## Manual testing
Tested manually with many different cases

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1162)
<!-- Reviewable:end -->
