### PR TITLE
activity_id index out of bounds check

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalRequest.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalRequest.m
@@ -92,7 +92,7 @@
   if ([self.path containsString:@"apps/"]) {
     NSArray *pathComponents = [self.path componentsSeparatedByString:@"/"];
     NSUInteger x = [pathComponents indexOfObject:@"apps"] + 1; // Find the index that follows "apps" in the path
-    return ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0 || [[pathComponents objectAtIndex:x] isEqual: @"(null)"]);
+    return ([pathComponents count] <= x || [[pathComponents objectAtIndex:x] length] == 0 || [[pathComponents objectAtIndex:x] isEqual: @"(null)"]);
   }
    
   return (self.parameters[@"app_id"] == nil || [self.parameters[@"app_id"] length] == 0);

--- a/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/Shadows/OneSignalClientOverrider.m
@@ -217,7 +217,7 @@ static NSDictionary* remoteParams;
         if ([request.urlRequest.URL.absoluteString containsString:@"apps/"]) {
           NSArray *pathComponents = [request.urlRequest.URL.absoluteString componentsSeparatedByString:@"/"];
           NSUInteger x = [pathComponents indexOfObject:@"apps"] + 1; // Find the index that follows "apps" in the path
-            if ([pathComponents count] < x || [[pathComponents objectAtIndex:x] length] == 0 || [[pathComponents objectAtIndex:x] isEqual: @"(null)"]) {
+            if ([pathComponents count] <= x || [[pathComponents objectAtIndex:x] length] == 0 || [[pathComponents objectAtIndex:x] isEqual: @"(null)"]) {
                 _XCTPrimitiveFail(currentTestInstance, @"All request must include an app_id");
             }
         } else if (!parameters[@"app_id"]) {


### PR DESCRIPTION
# Description
## One Line Summary
After further testing with Nan, we decided that the index out of bounds check should read <= rather than <.
It is unreachable because the code will only be running if there is a slash after apps `apps/` and therefore the path components array will contain something after apps even if it is an empty string. However I believe this change will be helpful to avoid future mistakes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1163)
<!-- Reviewable:end -->
