### PR TITLE
[user model] `InAppMessages` namespace

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -74,7 +74,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     };
 
     // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal.InAppMessages setInAppMessageClickHandler:inAppMessagingActionClickBlock];
+    [OneSignal.InAppMessages setClickHandler:inAppMessagingActionClickBlock];
     
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
@@ -85,7 +85,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         NSLog(@"OneSignal Demo App requestPermission: %d", accepted);
     }];
     
-    [OneSignal.InAppMessages setInAppMessageLifecycleHandler:self];
+    [OneSignal.InAppMessages setLifecycleHandler:self];
     [OneSignal.InAppMessages paused:true];
 
     [OneSignal.Notifications setNotificationWillShowInForegroundHandler:notificationReceiverBlock];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -74,7 +74,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     };
 
     // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal setInAppMessageClickHandler:inAppMessagingActionClickBlock];
+    [OneSignal.InAppMessages setInAppMessageClickHandler:inAppMessagingActionClickBlock];
     
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
@@ -85,8 +85,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         NSLog(@"OneSignal Demo App requestPermission: %d", accepted);
     }];
     
-    [OneSignal setInAppMessageLifecycleHandler:self];
-    [OneSignal pauseInAppMessages:true];
+    [OneSignal.InAppMessages setInAppMessageLifecycleHandler:self];
+    [OneSignal.InAppMessages paused:true];
 
     [OneSignal.Notifications setNotificationWillShowInForegroundHandler:notificationReceiverBlock];
     [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -80,67 +80,40 @@
 }
 
 - (IBAction)getTriggersAction:(id)sender {
-    NSString *key = [self.getTriggerKey text];
-    // TODO: No more gets
-//    if (key && [key length]) {
-//        id value = [OneSignal.InAppMessages getTriggerValueForKey:key];
-//        self.infoLabel.text = [NSString stringWithFormat:@"Key: %@ Value: %@", key, value];
-//    }
+    NSLog(@"Getting triggers no longer supported");
 }
 
 - (IBAction)setEmailButton:(id)sender {
-//    NSString *email = self.emailTextField.text;
-//    [OneSignal setEmail:email withSuccess:^{
-//        NSLog(@"Set email successful with email: %@", email);
-//    } withFailure:^(NSError *error) {
-//        NSLog(@"Set email failed with code: %@ and message: %@", @(error.code), error.description);
-//    }];
+    NSString *email = self.emailTextField.text;
+    NSLog(@"Adding email with email: %@", email);
+    [OneSignal.User addEmail:email];
 }
 
 - (IBAction)logoutEmailButton:(id)sender {
-//    [OneSignal logoutEmailWithSuccess:^{
-//        NSLog(@"Email logout successful");
-//    } withFailure:^(NSError *error) {
-//        NSLog(@"Error logging out email with code: %@ and message: %@", @(error.code), error.description);
-//    }];
+    NSString *email = self.emailTextField.text;
+    BOOL canRemove = [OneSignal.User removeEmail:email];
+    NSLog(@"Removing email with email: %@ and canRemove: %d", email, canRemove);
 }
 
 - (IBAction)sendTagButton:(id)sender {
-//    if (self.tagKey.text && self.tagKey.text.length
-//        && self.tagValue.text && self.tagValue.text.length) {
-//        [OneSignal sendTag:self.tagKey.text
-//                     value:self.tagValue.text
-//                 onSuccess:^(NSDictionary *result) {
-//                     static int successes = 0;
-//                     NSLog(@"successes: %d", ++successes);
-//                 }
-//                 onFailure:^(NSError *error) {
-//                     static int failures = 0;
-//                     NSLog(@"failures: %d", ++failures);
-//        }];
-//    }
+    if (self.tagKey.text && self.tagKey.text.length
+        && self.tagValue.text && self.tagValue.text.length) {
+        NSLog(@"Sending tag with key: %@ value: %@", self.tagKey.text, self.tagValue.text);
+        [OneSignal.User setTagWithKey:self.tagKey.text value:self.tagValue.text];
+    }
 }
 
 - (IBAction)getTagsButton:(id)sender {
-//    [OneSignal getTags:^(NSDictionary *result) {
-//        NSLog(@"Tags: %@", result.description);
-//    }];
+    NSLog(@"getTags no longer supported");
 }
 
 - (IBAction)sendTagsButton:(id)sender {
-//    [OneSignal sendTag:@"key1"
-//                 value:@"value1"
-//             onSuccess:^(NSDictionary *result) {
-//                 static int successes = 0;
-//                 NSLog(@"successes: %d", ++successes);
-//             }
-//             onFailure:^(NSError *error) {
-//                 static int failures = 0;
-//                 NSLog(@"failures: %d", ++failures);
-//    }];
+    NSLog(@"Sending tags %@", @{@"key1": @"value1", @"key2": @"value2"});
+    [OneSignal.User setTags:@{@"key1": @"value1", @"key2": @"value2"}];
 }
 
 - (IBAction)promptPushAction:(UIButton *)sender {
+    // This was already commented out pre-5.0.0
     //    [self promptForNotificationsWithNativeiOS10Code];
     [OneSignal.Notifications requestPermission:^(BOOL accepted) {
         NSLog(@"OneSignal Demo App requestPermission: %d", accepted);
@@ -191,18 +164,11 @@
 }
 
 - (IBAction)setExternalUserId:(UIButton *)sender {
-//    NSString* externalUserId = self.externalUserIdTextField.text;
-//    [OneSignal setExternalUserId:externalUserId withSuccess:^(NSDictionary *results) {
-//        NSLog(@"External user id update complete with results: %@", results.description);
-//    } withFailure:^(NSError *error) {
-//    }];
+    NSLog(@"setExternalUserId is no longer supported. Please use login or addAlias.");
 }
 
 - (IBAction)removeExternalUserId:(UIButton *)sender {
-//    [OneSignal removeExternalUserId:^(NSDictionary *results) {
-//        NSLog(@"External user id update complete with results: %@", results.description);
-//    } withFailure:^(NSError *error) {
-//    }];
+    NSLog(@"setExternalUserId is no longer supported. Please use logout or removeAlias.");
 }
 
 #pragma mark UITextFieldDelegate Methods
@@ -212,35 +178,24 @@
 }
 
 - (IBAction)sendTestOutcomeEvent:(UIButton *)sender {
-//    [OneSignal sendOutcome:[_outcomeName text] onSuccess:^(OSOutcomeEvent *outcome) {
-//        dispatch_async(dispatch_get_main_queue(), ^{
-//            _result.text = [NSString stringWithFormat:@"sendTestOutcomeEvent success %@", outcome];
-//            [self.view endEditing:YES];
-//        });
-//    }];
+    NSLog(@"adding Outcome: %@", [_outcomeName text]);
+    [OneSignal.Session addOutcome:[_outcomeName text]];
 }
+
 - (IBAction)sendValueOutcomeEvent:(id)sender {
-//    if ([_outcomeValue text]) {
-//        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-//        formatter.numberStyle = NSNumberFormatterDecimalStyle;
-//        NSNumber *value = [formatter numberFromString:[_outcomeValue text]];
-//
-//        [OneSignal sendOutcomeWithValue:[_outcomeValueName text] value:value onSuccess:^(OSOutcomeEvent *outcome) {
-//            dispatch_async(dispatch_get_main_queue(), ^{
-//                _result.text = [NSString stringWithFormat:@"sendValueOutcomeEvent success %@", outcome];
-//                [self.view endEditing:YES];
-//            });
-//        }];
-//    }
+    if ([_outcomeValue text]) {
+        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+        formatter.numberStyle = NSNumberFormatterDecimalStyle;
+        NSNumber *value = [formatter numberFromString:[_outcomeValue text]];
+        
+        NSLog(@"adding Outcome with name: %@ value: %@", [_outcomeValueName text], value);
+        [OneSignal.Session addOutcomeWithValue:[_outcomeValueName text] value:value];
+    }
 }
 
 - (IBAction)sendUniqueOutcomeEvent:(id)sender {
-//    [OneSignal sendUniqueOutcome:[_outcomeUniqueName text] onSuccess:^(OSOutcomeEvent *outcome) {
-//        dispatch_async(dispatch_get_main_queue(), ^{
-//            _result.text = [NSString stringWithFormat:@"sendUniqueOutcomeEvent success %@", outcome];
-//            [self.view endEditing:YES];
-//        });
-//    }];
+    NSLog(@"adding unique Outcome: %@", [_outcomeUniqueName text]);
+    [OneSignal.Session addUniqueOutcome:[_outcomeUniqueName text]];
 }
 
 @end

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -45,7 +45,7 @@
     
     self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) OneSignal.isLocationShared;
     
-    self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal isInAppMessagingPaused];
+    self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal.InAppMessages paused];
 
     self.appIdTextField.text = [AppDelegate getOneSignalAppId];
 
@@ -67,7 +67,7 @@
     NSString *value = [self.addTriggerValue text];
 
     if (key && value && [key length] && [value length]) {
-        [OneSignal addTrigger:key withValue:value];
+        [OneSignal.InAppMessages addTrigger:key withValue:value];
     }
 }
 
@@ -75,17 +75,17 @@
     NSString *key = [self.removeTriggerKey text];
 
     if (key && [key length]) {
-        [OneSignal removeTriggerForKey:key];
+        [OneSignal.InAppMessages removeTriggerForKey:key];
     }
 }
 
 - (IBAction)getTriggersAction:(id)sender {
     NSString *key = [self.getTriggerKey text];
-
-    if (key && [key length]) {
-        id value = [OneSignal getTriggerValueForKey:key];
-        self.infoLabel.text = [NSString stringWithFormat:@"Key: %@ Value: %@", key, value];
-    }
+    // TODO: No more gets
+//    if (key && [key length]) {
+//        id value = [OneSignal.InAppMessages getTriggerValueForKey:key];
+//        self.infoLabel.text = [NSString stringWithFormat:@"Key: %@ Value: %@", key, value];
+//    }
 }
 
 - (IBAction)setEmailButton:(id)sender {
@@ -183,7 +183,7 @@
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller in app messaging paused: %i", (int) !sender.selectedSegmentIndex);
-    [OneSignal pauseInAppMessages:(bool) !sender.selectedSegmentIndex];
+    [OneSignal.InAppMessages paused:(bool) !sender.selectedSegmentIndex];
 }
 
 - (void)handleMessageAction:(NSString *)actionId {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -69,7 +69,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     };
 
     // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal.InAppMessages setInAppMessageClickHandler:inAppMessagingActionClickBlock];
+    [OneSignal.InAppMessages setClickHandler:inAppMessagingActionClickBlock];
     
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -69,7 +69,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     };
 
     // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal setInAppMessageClickHandler:inAppMessagingActionClickBlock];
+    [OneSignal.InAppMessages setInAppMessageClickHandler:inAppMessagingActionClickBlock];
     
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
@@ -84,7 +84,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
         NSLog(@"OneSignal Demo App requestPermission: %d", accepted);
     }];
     
-    [OneSignal pauseInAppMessages:false];
+    [OneSignal.InAppMessages paused:false];
     
     [OneSignal.Notifications setNotificationWillShowInForegroundHandler:notificationReceiverBlock];
     [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -45,7 +45,7 @@
     
     self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) OneSignal.isLocationShared;
     
-    self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal isInAppMessagingPaused];
+    self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal.InAppMessages paused];
 
     self.appIdTextField.text = [AppDelegate getOneSignalAppId];
 
@@ -67,7 +67,7 @@
     NSString *value = [self.addTriggerValue text];
 
     if (key && value && [key length] && [value length]) {
-        [OneSignal addTrigger:key withValue:value];
+        [OneSignal.InAppMessages addTrigger:key withValue:value];
     }
 }
 
@@ -75,17 +75,18 @@
     NSString *key = [self.removeTriggerKey text];
 
     if (key && [key length]) {
-        [OneSignal removeTriggerForKey:key];
+        [OneSignal.InAppMessages removeTriggerForKey:key];
     }
 }
 
 - (IBAction)getTriggersAction:(id)sender {
     NSString *key = [self.getTriggerKey text];
 
-    if (key && [key length]) {
-        id value = [OneSignal getTriggerValueForKey:key];
-        self.infoLabel.text = [NSString stringWithFormat:@"Key: %@ Value: %@", key, value];
-    }
+    // TODO: no getter for trigger
+//    if (key && [key length]) {
+//        id value = [OneSignal getTriggerValueForKey:key];
+//        self.infoLabel.text = [NSString stringWithFormat:@"Key: %@ Value: %@", key, value];
+//    }
 }
 
 - (IBAction)setEmailButton:(id)sender {
@@ -168,7 +169,7 @@
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller in app messaging paused: %i", (int) !sender.selectedSegmentIndex);
-    [OneSignal pauseInAppMessages:(bool) !sender.selectedSegmentIndex];
+    [OneSignal.InAppMessages paused:(bool) !sender.selectedSegmentIndex];
 }
 
 - (void)handleMessageAction:(NSString *)actionId {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -53,11 +53,6 @@
     self.infoLabel.numberOfLines = 0;
 }
 
-- (void)changeAnimationState:(BOOL)animating {
-    animating ? [self.activityIndicatorView startAnimating] : [self.activityIndicatorView stopAnimating];
-    self.activityIndicatorView.hidden = !animating;
-}
-
 - (IBAction)updateAppId:(id)sender {
     [AppDelegate setOneSignalAppId:self.appIdTextField.text];
 }
@@ -80,52 +75,32 @@
 }
 
 - (IBAction)getTriggersAction:(id)sender {
-    NSString *key = [self.getTriggerKey text];
-
-    // TODO: no getter for trigger
-//    if (key && [key length]) {
-//        id value = [OneSignal getTriggerValueForKey:key];
-//        self.infoLabel.text = [NSString stringWithFormat:@"Key: %@ Value: %@", key, value];
-//    }
+    NSLog(@"Getting triggers no longer supported");
 }
 
 - (IBAction)setEmailButton:(id)sender {
-//    NSString *email = self.emailTextField.text;
-//    [OneSignal setEmail:email withSuccess:^{
-//        NSLog(@"Set email successful with email: %@", email);
-//    } withFailure:^(NSError *error) {
-//        NSLog(@"Set email failed with code: %@ and message: %@", @(error.code), error.description);
-//    }];
+    NSString *email = self.emailTextField.text;
+    NSLog(@"Adding email with email: %@", email);
+    [OneSignal.User addEmail:email];
 }
 
 - (IBAction)logoutEmailButton:(id)sender {
-//    [OneSignal logoutEmailWithSuccess:^{
-//        NSLog(@"Email logout successful");
-//    } withFailure:^(NSError *error) {
-//        NSLog(@"Error logging out email with code: %@ and message: %@", @(error.code), error.description);
-//    }];
+    NSString *email = self.emailTextField.text;
+    BOOL canRemove = [OneSignal.User removeEmail:email];
+    NSLog(@"Removing email with email: %@ and canRemove: %d", email, canRemove);
 }
 
 - (IBAction)getTagsButton:(id)sender {
-//    [OneSignal getTags:^(NSDictionary *result) {
-//        NSLog(@"Tags: %@", result.description);
-//    }];
+    NSLog(@"getTags no longer supported");
 }
 
 - (IBAction)sendTagsButton:(id)sender {
-//    [OneSignal sendTag:@"key1"
-//                 value:@"value1"
-//             onSuccess:^(NSDictionary *result) {
-//                 static int successes = 0;
-//                 NSLog(@"successes: %d", ++successes);
-//             }
-//             onFailure:^(NSError *error) {
-//                 static int failures = 0;
-//                 NSLog(@"failures: %d", ++failures);
-//    }];
+    NSLog(@"Sending tags %@", @{@"key1": @"value1", @"key2": @"value2"});
+    [OneSignal.User setTags:@{@"key1": @"value1", @"key2": @"value2"}];
 }
 
 - (IBAction)promptPushAction:(UIButton *)sender {
+    // This was already commented out pre-5.0.0
     //    [self promptForNotificationsWithNativeiOS10Code];
     [OneSignal.Notifications requestPermission:^(BOOL accepted) {
         NSLog(@"OneSignal Demo App requestPermission: %d", accepted);
@@ -159,7 +134,6 @@
 - (IBAction)subscriptionSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller subscription status: %i", (int) sender.selectedSegmentIndex);
     // [OneSignal disablePush:(bool) !sender.selectedSegmentIndex];
-    // [OneSignal.User.pushSubscription setEnabled:(bool) !sender.selectedSegmentIndex];
 }
 
 - (IBAction)locationSharedSegmentedControlValueChanged:(UISegmentedControl *)sender {
@@ -177,20 +151,11 @@
 }
 
 - (IBAction)setExternalUserId:(UIButton *)sender {
-    NSString* externalUserId = self.externalUserIdTextField.text;
-//    [OneSignal setExternalUserId:externalUserId withSuccess:^(NSDictionary *results) {
-//        NSLog(@"External user id update complete with results: %@", results.description);
-//    } withFailure:^(NSError *error) {
-//        NSLog(@"External user id update failed with error: %@", error);
-//    }];
+    NSLog(@"setExternalUserId is no longer supported. Please use login or addAlias.");
 }
 
 - (IBAction)removeExternalUserId:(UIButton *)sender {
-//    [OneSignal removeExternalUserId:^(NSDictionary *results) {
-//        NSLog(@"External user id update complete with results: %@", results.description);
-//    } withFailure:^(NSError *error) {
-//        NSLog(@"External user id update failed with error: %@", error);
-//    }];
+    NSLog(@"setExternalUserId is no longer supported. Please use logout or removeAlias.");
 }
 
 #pragma mark UITextFieldDelegate Methods
@@ -200,35 +165,24 @@
 }
 
 - (IBAction)sendTestOutcomeEvent:(UIButton *)sender {
-//    [OneSignal sendOutcome:[_outcomeName text] onSuccess:^(OSOutcomeEvent *outcome) {
-//        dispatch_async(dispatch_get_main_queue(), ^{
-//            self->_result.text = [NSString stringWithFormat:@"sendTestOutcomeEvent success %@", outcome];
-//            [self.view endEditing:YES];
-//        });
-//    }];
+    NSLog(@"adding Outcome: %@", [_outcomeName text]);
+    [OneSignal.Session addOutcome:[_outcomeName text]];
 }
+
 - (IBAction)sendValueOutcomeEvent:(id)sender {
     if ([_outcomeValue text]) {
         NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
         formatter.numberStyle = NSNumberFormatterDecimalStyle;
         NSNumber *value = [formatter numberFromString:[_outcomeValue text]];
         
-//        [OneSignal sendOutcomeWithValue:[_outcomeValueName text] value:value onSuccess:^(OSOutcomeEvent *outcome) {
-//            dispatch_async(dispatch_get_main_queue(), ^{
-//                self->_result.text = [NSString stringWithFormat:@"sendValueOutcomeEvent success %@", outcome];
-//                [self.view endEditing:YES];
-//            });
-//        }];
+        NSLog(@"adding Outcome with name: %@ value: %@", [_outcomeValueName text], value);
+        [OneSignal.Session addOutcomeWithValue:[_outcomeValueName text] value:value];
     }
 }
 
 - (IBAction)sendUniqueOutcomeEvent:(id)sender {
-//    [OneSignal sendUniqueOutcome:[_outcomeUniqueName text] onSuccess:^(OSOutcomeEvent *outcome) {
-//        dispatch_async(dispatch_get_main_queue(), ^{
-//            self->_result.text = [NSString stringWithFormat:@"sendUniqueOutcomeEvent success %@", outcome];
-//            [self.view endEditing:YES];
-//        });
-//    }];
+    NSLog(@"adding unique Outcome: %@", [_outcomeUniqueName text]);
+    [OneSignal.Session addUniqueOutcome:[_outcomeUniqueName text]];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
 		3C789DBD293C2206004CF83D /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
 		3C789DBE293D8EAD004CF83D /* OSFocusInfluenceParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C79BEB9293DC88F0034CB10 /* OneSignalInAppMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */; };
+		3C79BEBA293DC88F0034CB10 /* OneSignalInAppMessaging.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C79BEB8293DC88F0034CB10 /* OneSignalInAppMessaging.m */; };
 		3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */; };
 		3C8E6DFF28AB09AE0031E48A /* OSPropertyOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */; };
 		3C8E6E0128AC0BA10031E48A /* OSIdentityOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */; };
@@ -694,6 +696,8 @@
 		3C47A972292642B100312125 /* OneSignalConfigManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalConfigManager.h; sourceTree = "<group>"; };
 		3C47A973292642B100312125 /* OneSignalConfigManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalConfigManager.m; sourceTree = "<group>"; };
 		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
+		3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalInAppMessaging.h; sourceTree = "<group>"; };
+		3C79BEB8293DC88F0034CB10 /* OneSignalInAppMessaging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalInAppMessaging.m; sourceTree = "<group>"; };
 		3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationExecutor.swift; sourceTree = "<group>"; };
 		3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertyOperationExecutor.swift; sourceTree = "<group>"; };
 		3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityOperationExecutor.swift; sourceTree = "<group>"; };
@@ -1557,6 +1561,8 @@
 				CA7FC88F21925253002C4FD9 /* UI */,
 				CA7FC89C21926B6B002C4FD9 /* Controller */,
 				CA6B3CB621B5CF2600AA6A65 /* Model */,
+				3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */,
+				3C79BEB8293DC88F0034CB10 /* OneSignalInAppMessaging.m */,
 			);
 			name = InAppMessaging;
 			sourceTree = "<group>";
@@ -2009,6 +2015,7 @@
 				7AECE59423674AA700537907 /* OSAttributedFocusTimeProcessor.h in Headers */,
 				912412311E73342200E41FD7 /* OneSignalTracker.h in Headers */,
 				A63E9E4026742C1600EA273E /* LanguageProviderAppDefined.h in Headers */,
+				3C79BEB9293DC88F0034CB10 /* OneSignalInAppMessaging.h in Headers */,
 				9124123D1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.h in Headers */,
 				7AF9865324451F3900C36EAE /* OSFocusCallParams.h in Headers */,
 				DE7D18DD2703B44B002D3A5D /* OSFocusRequests.h in Headers */,
@@ -2665,6 +2672,7 @@
 				7AECE59123674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				CACBAA9E218A6243000ACAA5 /* OSInAppMessageView.m in Sources */,
 				CAB269DB21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				3C79BEBA293DC88F0034CB10 /* OneSignalInAppMessaging.m in Sources */,
 				CA1A6E6B20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
 		3C789DBD293C2206004CF83D /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
 		3C789DBE293D8EAD004CF83D /* OSFocusInfluenceParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3C79BEB9293DC88F0034CB10 /* OneSignalInAppMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */; };
+		3C79BEB9293DC88F0034CB10 /* OneSignalInAppMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C79BEBA293DC88F0034CB10 /* OneSignalInAppMessaging.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C79BEB8293DC88F0034CB10 /* OneSignalInAppMessaging.m */; };
 		3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */; };
 		3C8E6DFF28AB09AE0031E48A /* OSPropertyOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */; };
@@ -183,7 +183,6 @@
 		9124121E1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411F91E73342200E41FD7 /* OneSignalJailbreakDetection.m */; };
 		9124121F1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411F91E73342200E41FD7 /* OneSignalJailbreakDetection.m */; };
 		912412201E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411F91E73342200E41FD7 /* OneSignalJailbreakDetection.m */; };
-		912412211E73342200E41FD7 /* OneSignalLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FA1E73342200E41FD7 /* OneSignalLocation.h */; };
 		912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FB1E73342200E41FD7 /* OneSignalLocation.m */; };
 		912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FB1E73342200E41FD7 /* OneSignalLocation.m */; };
 		912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FB1E73342200E41FD7 /* OneSignalLocation.m */; };
@@ -317,6 +316,7 @@
 		DE3784852888D00300453A8E /* OneSignalUser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; };
 		DE3784862888D00B00453A8E /* OneSignalUser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE3CD300270FA9F200A5BECD /* OneSignalOutcomes.m in Sources */ = {isa = PBXBuildFile; fileRef = DE3CD2FE270FA9F200A5BECD /* OneSignalOutcomes.m */; };
+		DE51DDE12941697A0073D5C4 /* OneSignalLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FA1E73342200E41FD7 /* OneSignalLocation.h */; };
 		DE5EFECA24D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */; };
 		DE69E19F282ED8060090BB3D /* OneSignalUser.docc in Sources */ = {isa = PBXBuildFile; fileRef = DE69E19E282ED8060090BB3D /* OneSignalUser.docc */; };
 		DE69E1A0282ED8060090BB3D /* OneSignalUser.h in Headers */ = {isa = PBXBuildFile; fileRef = DE69E19D282ED8060090BB3D /* OneSignalUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1998,13 +1998,13 @@
 				7AF5174524FDC2AA00B076BC /* OSRemoteParamController.h in Headers */,
 				A63E9E3F26742C1400EA273E /* LanguageProvider.h in Headers */,
 				A66239952686612F00D52FD8 /* OneSignal.h in Headers */,
-				912412211E73342200E41FD7 /* OneSignalLocation.h in Headers */,
 				7A93269325AF4E6700BBEC27 /* OSPendingCallbacks.h in Headers */,
 				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
 				A63E9E3E26742C1000EA273E /* LanguageContext.h in Headers */,
 				CA4742E4218B8FF30020DC8C /* OSTriggerController.h in Headers */,
 				DE7D18EC2703B5AA002D3A5D /* OSInAppMessagingRequests.h in Headers */,
 				DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */,
+				DE51DDE12941697A0073D5C4 /* OneSignalLocation.h in Headers */,
 				7A674F192360D813001F9ACD /* OSBaseFocusTimeProcessor.h in Headers */,
 				CA36F35821C33A2500300C77 /* OSInAppMessageController.h in Headers */,
 				CA1A6E6F20DC2E73001C41B9 /* OneSignalDialogRequest.h in Headers */,

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -54,7 +54,8 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 
 
 @protocol OneSignalNotificationsDelegate <NSObject>
-
+// set delegate before user
+// can check responds to selector
 - (void)setNotificationTypes:(int)notificationTypes;
 - (void)setPushToken:(NSString * _Nonnull)pushToken;
 - (void)setAccepted:(BOOL)inAccepted;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -88,8 +88,17 @@
 @end
 
 @implementation OSNotificationsManager
+
 + (Class<OSNotifications>)Notifications {
     return self;
+}
+
+static id<OneSignalNotificationsDelegate> _delegate;
++ (id<OneSignalNotificationsDelegate>)delegate {
+    return _delegate;
+}
++(void)setDelegate:(id<OneSignalNotificationsDelegate>)delegate {
+    _delegate = delegate;
 }
 
 // UIApplication-registerForRemoteNotifications has been called but a success or failure has not triggered yet.

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -366,7 +366,9 @@ static NSString *_pushSubscriptionId;
 }
 
 + (void)sendPushTokenToDelegate {
-    [self.delegate setPushToken:_pushToken];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(setPushToken:)]) {
+        [self.delegate setPushToken:_pushToken];
+    }
 }
 
 + (void)setSubscriptionErrorStatus:(int)errorType {
@@ -402,15 +404,20 @@ static NSString *_pushSubscriptionId;
     
     // TODO: Dropped support, can remove below?
     [self.osNotificationSettings onNotificationPromptResponse:notificationTypes]; // iOS 9 only
-
+    
+    // TODO: This can be called before the User Manager sets itself as the delegate
     [self sendNotificationTypesUpdateToDelegate];
 }
 
 + (void)sendNotificationTypesUpdateToDelegate {
     // We don't delay observer update to wait until the OneSignal server is notified
     // TODO: We can do the above and delay observers until server is updated.
-    [self.delegate setAccepted:[self getNotificationTypes] > 0];
-    [self.delegate setNotificationTypes:[self getNotificationTypes]];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(setAccepted:)]) {
+        [self.delegate setAccepted:[self getNotificationTypes] > 0];
+    }
+    if (self.delegate && [self.delegate respondsToSelector:@selector(setNotificationTypes:)]) {
+        [self.delegate setNotificationTypes:[self getNotificationTypes]];
+    }
 }
 
 // Accounts for manual disabling by the app developer

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -230,7 +230,10 @@
         [OSNotificationsManager.lastPermissionState persistAsFrom];
     }
     // Update the push subscription's _accepted property
-    [OSNotificationsManager.delegate setAccepted:state.accepted];
+    // TODO: This can be called before the User Manager has set itself as the delegate
+    if (OSNotificationsManager.delegate && [OSNotificationsManager.delegate respondsToSelector:@selector(setAccepted:)]) {
+        [OSNotificationsManager.delegate setAccepted:state.accepted];
+    }
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -147,7 +147,7 @@ class OSSubscriptionModel: OSModel {
             self.set(property: "notificationTypes", newValue: notificationTypes)
         }
     }
-
+    // swiftlint:disable identifier_name
     // This is set by the permission state changing
     // Defaults to true for email & SMS, defaults to false for push
     var _accepted: Bool {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -151,6 +151,7 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         self.subscriptionModelStoreListener = OSSubscriptionModelStoreListener(store: subscriptionModelStore)
     }
 
+    // TODO: This method is called A LOT, check if all calls are needed.
     @objc
     public func start() {
         guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: nil) else {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -63,12 +63,6 @@ import OneSignalNotifications
     // SMS
     func addSmsNumber(_ number: String)
     func removeSmsNumber(_ number: String) -> Bool
-    // TODO: Remove triggers from User Module
-    // Triggers
-    func setTrigger(key: String, value: String)
-    func setTriggers(_ triggers: [String: String])
-    func removeTrigger(_ trigger: String)
-    func removeTriggers(_ triggers: [String])
 
     // TODO: UM This is a temporary function to create a push subscription for testing
     func testCreatePushSubscription(subscriptionId: String, token: String, enabled: Bool)
@@ -537,34 +531,6 @@ extension OneSignalUserManagerImpl: OSUser {
         // Check if is valid SMS?
         createUserIfNil()
         return self.subscriptionModelStore.remove(number)
-    }
-
-    public func setTrigger(key: String, value: String) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "setTrigger") else {
-            return
-        }
-        user.setTrigger(key: key, value: value)
-    }
-
-    public func setTriggers(_ triggers: [String: String]) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "setTriggers") else {
-            return
-        }
-        user.setTriggers(triggers)
-    }
-
-    public func removeTrigger(_ trigger: String) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "removeTrigger") else {
-            return
-        }
-        user.removeTrigger(trigger)
-    }
-
-    public func removeTriggers(_ triggers: [String]) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "removeTriggers") else {
-            return
-        }
-        user.removeTriggers(triggers)
     }
 
     public func testCreatePushSubscription(subscriptionId: String, token: String, enabled: Bool) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -33,6 +33,7 @@ import OneSignalNotifications
  Public-facing API to access the User Manager.
  */
 @objc protocol OneSignalUserManager {
+    // swiftlint:disable identifier_name
     var User: OSUser { get }
     func login(externalId: String, token: String?)
     func logout()
@@ -332,14 +333,14 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
     func createDefaultPushSubscription() -> OSSubscriptionModel {
         let sharedUserDefaults = OneSignalUserDefaults.initShared()
-        let _accepted = OSNotificationsManager.currentPermissionState.accepted
+        let accepted = OSNotificationsManager.currentPermissionState.accepted
         let token = sharedUserDefaults.getSavedString(forKey: OSUD_PUSH_TOKEN_TO, defaultValue: nil)
         let subscriptionId = sharedUserDefaults.getSavedString(forKey: OSUD_PLAYER_ID_TO, defaultValue: nil)
 
         return OSSubscriptionModel(type: .push,
                                    address: token,
                                    subscriptionId: subscriptionId,
-                                   accepted: _accepted,
+                                   accepted: accepted,
                                    isDisabled: false,
                                    changeNotifier: OSEventProducer())
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -344,6 +344,14 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
                                    isDisabled: false,
                                    changeNotifier: OSEventProducer())
     }
+    
+    @objc
+    public func getTags() -> [String:String]? {
+        guard let user = _user else {
+            return nil
+        }
+        return user.propertiesModel.tags
+    }
 }
 
 // MARK: - Sessions

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -53,25 +53,23 @@
 }
 
 - (NSString *)getTagsString {
-    // TODO: this
-//    NSError *error;
-//    OSPlayerTags *tags = [OneSignal getPlayerTags];
-//    if (!tags.allTags || tags.allTags.count <= 0 ) {
-//        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"[getTagsString] no tags found for the player"];
-//        return nil;
-//    }
-//    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:tags.allTags
-//                                                       options:NSJSONWritingPrettyPrinted
-//                                                         error:&error];
-//    NSString *jsonString;
-//    if (!jsonData) {
-//        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:
-//         [NSString stringWithFormat:@"Error parsing tag dictionary to json: %@", error]];
-//    } else {
-//         jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-//    }
-//    return jsonString;
-    return @"todo";
+    NSError *error;
+    NSDictionary<NSString *, NSString*> *tags = [OneSignalUserManagerImpl.sharedInstance getTags];
+    if (tags == nil || tags.count <= 0 ) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"[getTagsString] no tags found for the player"];
+        return nil;
+    }
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:tags
+                                                       options:NSJSONWritingPrettyPrinted
+                                                         error:&error];
+    NSString *jsonString;
+    if (!jsonData) {
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:
+         [NSString stringWithFormat:@"Error parsing tag dictionary to json: %@", error]];
+    } else {
+         jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    }
+    return jsonString;
 }
 
 - (NSString *)addTagsToHTML:(NSString *)html {

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.h
@@ -9,6 +9,9 @@
 #import <OneSignalCore/OneSignalCore.h>
 #import "OSInAppMessageAction.h"
 
+@interface OSRequestGetInAppMessages : OneSignalRequest
++ (instancetype _Nonnull)withSubscriptionId:(NSString * _Nonnull)subscriptionId;
+@end
 
 @interface OSRequestInAppMessageViewed : OneSignalRequest
 + (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withPlayerId:(NSString * _Nonnull)playerId withMessageId:(NSString * _Nonnull)messageId forVariantId:(NSString * _Nonnull)variantId;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.m
@@ -9,6 +9,15 @@
 #import <Foundation/Foundation.h>
 #import "OSInAppMessagingRequests.h"
 
+@implementation OSRequestGetInAppMessages
++ (instancetype _Nonnull)withSubscriptionId:(NSString * _Nonnull)subscriptionId {
+    let request = [OSRequestGetInAppMessages new];
+    request.method = GET;
+    request.path = [NSString stringWithFormat:@"subscriptions/%@/iams", subscriptionId];
+    return request;
+}
+@end
+
 @implementation OSRequestInAppMessageViewed
 + (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId
                       withPlayerId:(NSString * _Nonnull)playerId

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -28,8 +28,8 @@
 #import <Foundation/Foundation.h>
 #import "OSInAppMessageInternal.h"
 #import "OSInAppMessageViewController.h"
-#import "OneSignal.h"
 #import "OSTriggerController.h"
+#import <OneSignalUser/OneSignalUser.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface OSMessagingController : NSObject <OSInAppMessageViewControllerDelegate, OSTriggerControllerDelegate, OSMessagingControllerDelegate>
+@interface OSMessagingController : NSObject <OSInAppMessageViewControllerDelegate, OSTriggerControllerDelegate, OSMessagingControllerDelegate, OSPushSubscriptionObserver>
 
 @property (class, readonly) BOOL isInAppMessagingPaused;
 
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL isInAppMessageShowing;
 
 + (OSMessagingController *)sharedInstance;
++ (void)start;
 + (void)removeInstance;
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message;
 - (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message;

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -60,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setInAppMessagingPaused:(BOOL)pause;
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers;
 - (void)removeTriggersForKeys:(NSArray<NSString *> *)keys;
+- (void)clearTriggers;
 - (NSDictionary<NSString *, id> *)getTriggers;
 - (id)getTriggerValueForKey:(NSString *)key;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message;
 - (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message;
 - (void)updateInAppMessagesFromCache;
-- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessageInternal *> *)newMessages;
+- (void)getInAppMessagesFromServer:(NSString * _Nullable)subscriptionId;
 - (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message;
 - (void)messageViewPageImpressionRequest:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -396,6 +396,7 @@ static BOOL _isInAppMessagingPaused = false;
 - (void)loadTags {
     self.calledLoadTags = YES;
     // TODO: getTags
+    self.viewController.waitForTags = NO;
 //    [OneSignal getTags:^(NSDictionary *result) {
 //        if (self.viewController) {
 //            self.viewController.waitForTags = NO;
@@ -569,10 +570,10 @@ static BOOL _isInAppMessagingPaused = false;
  Checks if the IAM matches any triggers or if it exists in cached seenInAppMessages set
  */
 - (BOOL)shouldShowInAppMessage:(OSInAppMessageInternal *)message {
-//    return ![self.seenInAppMessages containsObject:message.messageId] &&
-//           [self.triggerController messageMatchesTriggers:message] &&
-//           ![message isFinished] &&
-//           OneSignal.isRegisterUserFinished; // TODO: this crashes app
+    return ![self.seenInAppMessages containsObject:message.messageId] &&
+           [self.triggerController messageMatchesTriggers:message] &&
+           ![message isFinished] &&
+           OneSignalUserManagerImpl.sharedInstance.pushSubscription.subscriptionId != nil;
     return true;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -172,8 +172,45 @@ static BOOL _isInAppMessagingPaused = false;
     [self evaluateMessages];
 }
 
-- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessageInternal *> *)newMessages {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"updateInAppMessagesFromOnSession"];
+- (void)getInAppMessagesFromServer:(NSString *)subscriptionId {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"getInAppMessagesFromServer"];
+
+    if (!subscriptionId) {
+        [self updateInAppMessagesFromCache];
+        return;
+    }
+    
+    OSRequestGetInAppMessages *request = [OSRequestGetInAppMessages withSubscriptionId:subscriptionId];
+    [OneSignalClient.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"getInAppMessagesFromServer success"];
+        if (result[@"in_app_messages"]) { // when there are no IAMs, will this still be there?
+            let messages = [NSMutableArray new];
+            
+            for (NSDictionary *messageJson in result[@"in_app_messages"]) {
+                let message = [OSInAppMessageInternal instanceWithJson:messageJson];
+                if (message) {
+                    [messages addObject:message];
+                }
+            }
+            
+            [self updateInAppMessagesFromServer:messages];
+            return;
+        }
+        
+        // TODO: Check this request and response. If no IAMs returned, should we really get from cache?
+        // This is the existing implementation but it could mean this user has no IAMs?
+        
+        // Default is using cached IAMs in the messaging controller
+        [self updateInAppMessagesFromCache];
+        
+    } onFailure:^(NSError *error) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"getInAppMessagesFromServer failure"];
+        [self updateInAppMessagesFromCache];
+    }];
+}
+
+- (void)updateInAppMessagesFromServer:(NSArray<OSInAppMessageInternal *> *)newMessages {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"updateInAppMessagesFromServer"];
     self.messages = newMessages;
     
     // Cache if messages passed in are not null, this method is called from on_session for
@@ -926,7 +963,7 @@ static BOOL _isInAppMessagingPaused = false;
 - (instancetype)init { self = [super init]; return self; }
 - (BOOL)isInAppMessagingPaused { return false; }
 - (void)setInAppMessagingPaused:(BOOL)pause {}
-- (void)updateInAppMessagesFromOnSession:(NSArray<OSInAppMessageInternal *> *)newMessages {}
+- (void)getInAppMessagesFromServer {}
 - (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {}
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message {}
 - (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message {}

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -395,13 +395,10 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)loadTags {
     self.calledLoadTags = YES;
-    // TODO: getTags
+    // TODO: should we always pull new tags?
+    // For now we aren't pulling new tags and we are just using what is already on the user
+    // I am leaving the logic for waiting for tags to be pulled in case this changes
     self.viewController.waitForTags = NO;
-//    [OneSignal getTags:^(NSDictionary *result) {
-//        if (self.viewController) {
-//            self.viewController.waitForTags = NO;
-//        }
-//    }];
 }
 - (void)messageViewPageImpressionRequest:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId {
     if (message.isPreview) {
@@ -425,27 +422,26 @@ static BOOL _isInAppMessagingPaused = false;
     
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Page Impression Request page id: %@",pageId]];
     // Create the request and attach a payload to it
-    // TODO: withPlayerId gets ID from proper place
-//    let metricsRequest = [OSRequestInAppMessagePageViewed withAppId:OneSignal.appId
-//                                                       withPlayerId:OneSignal.currentSubscriptionState.userId
-//                                                      withMessageId:message.messageId
-//                                                         withPageId:pageId
-//                                                       forVariantId:message.variantId];
-//
-//    [OneSignalClient.sharedClient executeRequest:metricsRequest
-//                                       onSuccess:^(NSDictionary *result) {
-//        NSString *successMessage = [NSString stringWithFormat:@"In App Message with message id: %@ and page id: %@, successful POST page impression update with result: %@", message.messageId, pageId, result];
-//                                           [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
-//                                            // If the post was successful, save the updated viewedPageIds set
-//                                            [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_PAGE_IMPRESSIONED_SET_KEY withValue:self.viewedPageIDs];
-//                                       }
-//                                       onFailure:^(NSError *error) {
-//        NSString *errorMessage = [NSString stringWithFormat:@"In App Message with message id: %@ and page id: %@, failed POST page impression update with error: %@", message.messageId, pageId, error];
-//                                            [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorMessage];
-//                                            if (message) {
-//                                                [self.viewedPageIDs removeObject:messagePrefixedPageId];
-//                                            }
-//                                       }];
+    let metricsRequest = [OSRequestInAppMessagePageViewed withAppId:OneSignal.appId
+                                                       withPlayerId:OneSignalUserManagerImpl.sharedInstance.pushSubscription.subscriptionId
+                                                      withMessageId:message.messageId
+                                                         withPageId:pageId
+                                                       forVariantId:message.variantId];
+
+    [OneSignalClient.sharedClient executeRequest:metricsRequest
+                                       onSuccess:^(NSDictionary *result) {
+        NSString *successMessage = [NSString stringWithFormat:@"In App Message with message id: %@ and page id: %@, successful POST page impression update with result: %@", message.messageId, pageId, result];
+                                           [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
+                                            // If the post was successful, save the updated viewedPageIds set
+                                            [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_PAGE_IMPRESSIONED_SET_KEY withValue:self.viewedPageIDs];
+                                       }
+                                       onFailure:^(NSError *error) {
+        NSString *errorMessage = [NSString stringWithFormat:@"In App Message with message id: %@ and page id: %@, failed POST page impression update with error: %@", message.messageId, pageId, error];
+                                            [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorMessage];
+                                            if (message) {
+                                                [self.viewedPageIDs removeObject:messagePrefixedPageId];
+                                            }
+                                       }];
 }
 
 - (BOOL)shouldSendImpression:(OSInAppMessageInternal *)message {
@@ -466,27 +462,26 @@ static BOOL _isInAppMessagingPaused = false;
     [self.impressionedInAppMessages addObject:message.messageId];
     
     // Create the request and attach a payload to it
-    // TODO: withPlayerId
-//    let metricsRequest = [OSRequestInAppMessageViewed withAppId:OneSignal.appId
-//                                                   withPlayerId:OneSignal.currentSubscriptionState.userId
-//                                                  withMessageId:message.messageId
-//                                                   forVariantId:message.variantId];
-//    
-//    [OneSignalClient.sharedClient executeRequest:metricsRequest
-//                                       onSuccess:^(NSDictionary *result) {
-//                                           NSString *successMessage = [NSString stringWithFormat:@"In App Message with id: %@, successful POST impression update with result: %@", message.messageId, result];
-//                                           [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
-//                                           
-//                                           // If the post was successful, save the updated impressionedInAppMessages set
-//                                           [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_IMPRESSIONED_SET_KEY withValue:self.impressionedInAppMessages];
-//                                       }
-//                                       onFailure:^(NSError *error) {
-//                                           NSString *errorMessage = [NSString stringWithFormat:@"In App Message with id: %@, failed POST impression update with error: %@", message.messageId, error];
-//                                           [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorMessage];
-//                                           
-//                                           // If the post failed, remove the messageId from the impressionedInAppMessages set
-//                                           [self.impressionedInAppMessages removeObject:message.messageId];
-//                                       }];
+    let metricsRequest = [OSRequestInAppMessageViewed withAppId:OneSignal.appId
+                                                   withPlayerId:OneSignalUserManagerImpl.sharedInstance.pushSubscription.subscriptionId
+                                                  withMessageId:message.messageId
+                                                   forVariantId:message.variantId];
+    
+    [OneSignalClient.sharedClient executeRequest:metricsRequest
+                                       onSuccess:^(NSDictionary *result) {
+                                           NSString *successMessage = [NSString stringWithFormat:@"In App Message with id: %@, successful POST impression update with result: %@", message.messageId, result];
+                                           [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
+                                           
+                                           // If the post was successful, save the updated impressionedInAppMessages set
+                                           [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_IMPRESSIONED_SET_KEY withValue:self.impressionedInAppMessages];
+                                       }
+                                       onFailure:^(NSError *error) {
+                                           NSString *errorMessage = [NSString stringWithFormat:@"In App Message with id: %@, failed POST impression update with error: %@", message.messageId, error];
+                                           [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorMessage];
+                                           
+                                           // If the post failed, remove the messageId from the impressionedInAppMessages set
+                                           [self.impressionedInAppMessages removeObject:message.messageId];
+                                       }];
 }
 
 /*
@@ -853,38 +848,36 @@ static BOOL _isInAppMessagingPaused = false;
     // Track clickId per IAM
     [message addClickId:clickId];
     
-    // TODO: withPlayerId
-//    let metricsRequest = [OSRequestInAppMessageClicked withAppId:OneSignal.appId
-//                                                    withPlayerId:OneSignal.currentSubscriptionState.userId
-//                                                   withMessageId:message.messageId
-//                                                    forVariantId:message.variantId
-//                                                      withAction:action];
-//
-//   [OneSignalClient.sharedClient executeRequest:metricsRequest
-//                                      onSuccess:^(NSDictionary *result) {
-//                                          NSString *successMessage = [NSString stringWithFormat:@"In App Message with id: %@, successful POST click update for click id: %@, with result: %@", message.messageId, action.clickId,  result];
-//                                          [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
-//
-//                                          // Save the updated clickedClickIds since click was tracked successfully
-//                                          [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_CLICKED_SET_KEY withValue:self.clickedClickIds];
-//                                      }
-//                                      onFailure:^(NSError *error) {
-//                                          NSString *errorMessage = [NSString stringWithFormat:@"In App Message with id: %@, failed POST click update for click id: %@, with error: %@", message.messageId, action.clickId, error];
-//                                          [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorMessage];
-//
-//                                          // Remove clickId from local clickedClickIds since click was not tracked
-//                                          [self.clickedClickIds removeObject:action.clickId];
-//                                      }];
+    let metricsRequest = [OSRequestInAppMessageClicked withAppId:OneSignal.appId
+                                                    withPlayerId:OneSignalUserManagerImpl.sharedInstance.pushSubscription.subscriptionId
+                                                   withMessageId:message.messageId
+                                                    forVariantId:message.variantId
+                                                      withAction:action];
+
+   [OneSignalClient.sharedClient executeRequest:metricsRequest
+                                      onSuccess:^(NSDictionary *result) {
+                                          NSString *successMessage = [NSString stringWithFormat:@"In App Message with id: %@, successful POST click update for click id: %@, with result: %@", message.messageId, action.clickId,  result];
+                                          [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
+
+                                          // Save the updated clickedClickIds since click was tracked successfully
+                                          [OneSignalUserDefaults.initStandard saveSetForKey:OS_IAM_CLICKED_SET_KEY withValue:self.clickedClickIds];
+                                      }
+                                      onFailure:^(NSError *error) {
+                                          NSString *errorMessage = [NSString stringWithFormat:@"In App Message with id: %@, failed POST click update for click id: %@, with error: %@", message.messageId, action.clickId, error];
+                                          [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:errorMessage];
+
+                                          // Remove clickId from local clickedClickIds since click was not tracked
+                                          [self.clickedClickIds removeObject:action.clickId];
+                                      }];
 }
 
 - (void)sendTagCallWithAction:(OSInAppMessageAction *)action {
     if (action.tags) {
         OSInAppMessageTag *tag = action.tags;
-        // TODO: this
-//        if (tag.tagsToAdd)
-//            [OneSignal sendTags:tag.tagsToAdd];
-//        if (tag.tagsToRemove)
-//            [OneSignal deleteTags:tag.tagsToRemove];
+        if (tag.tagsToAdd)
+            [OneSignal.User setTags:tag.tagsToAdd];
+        if (tag.tagsToRemove)
+            [OneSignal.User removeTags:tag.tagsToRemove];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -610,6 +610,11 @@ static BOOL _isInAppMessagingPaused = false;
     [self.triggerController removeTriggersForKeys:keys];
 }
 
+- (void)clearTriggers {
+    NSDictionary<NSString *, id> *allTriggers = [self getTriggers];
+    [self removeTriggersForKeys:allTriggers.allKeys];
+}
+
 - (NSDictionary<NSString *, id> *)getTriggers {
     return self.triggerController.getTriggers;
 }
@@ -975,6 +980,7 @@ static BOOL _isInAppMessagingPaused = false;
 #pragma mark Trigger Methods
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers {}
 - (void)removeTriggersForKeys:(NSArray<NSString *> *)keys {}
+- (void)clearTriggers {}
 - (NSDictionary<NSString *, id> *)getTriggers { return @{}; }
 - (id)getTriggerValueForKey:(NSString *)key { return 0; }
 #pragma mark OSInAppMessageViewControllerDelegate Methods

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -563,10 +563,11 @@ static BOOL _isInAppMessagingPaused = false;
  Checks if the IAM matches any triggers or if it exists in cached seenInAppMessages set
  */
 - (BOOL)shouldShowInAppMessage:(OSInAppMessageInternal *)message {
-    return ![self.seenInAppMessages containsObject:message.messageId] &&
-           [self.triggerController messageMatchesTriggers:message] &&
-           ![message isFinished] &&
-           OneSignal.isRegisterUserFinished;
+//    return ![self.seenInAppMessages containsObject:message.messageId] &&
+//           [self.triggerController messageMatchesTriggers:message] &&
+//           ![message isFinished] &&
+//           OneSignal.isRegisterUserFinished; // TODO: this crashes app
+    return true;
 }
 
 - (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -96,10 +96,11 @@ static dispatch_once_t once;
 + (OSMessagingController *)sharedInstance {
     dispatch_once(&once, ^{
         // Make sure only devices with iOS 10 or newer can use IAMs
-        if ([self doesDeviceSupportIAM])
+        if ([self doesDeviceSupportIAM]) {
             sharedInstance = [OSMessagingController new];
-        else
+        } else {
             sharedInstance = [DummyOSMessagingController new];
+        }
     });
     return sharedInstance;
 }
@@ -107,6 +108,11 @@ static dispatch_once_t once;
 + (void)removeInstance {
     sharedInstance = nil;
     once = 0;
+}
+
++ (void)start {
+    OSMessagingController *shared = OSMessagingController.sharedInstance;
+    OSPushSubscriptionState *_ = [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
 }
 
 static BOOL _isInAppMessagingPaused = false;
@@ -961,6 +967,21 @@ static BOOL _isInAppMessagingPaused = false;
         [self evaluateMessages];
     }
 }
+
+#pragma mark OSPushSubscriptionObserver Methods
+- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges * _Nonnull)stateChanges {
+    if (stateChanges.to.subscriptionId == nil) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"onOSPushSubscriptionChangedWithStateChanges: changed to nil subscription id"];
+        return;
+    }
+    // Pull new IAMs when the subscription id changes to a new valid subscription id
+    if (stateChanges.from.subscriptionId != nil &&
+        [stateChanges.to.subscriptionId isEqualToString:stateChanges.from.subscriptionId]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"onOSPushSubscriptionChangedWithStateChanges: changed to new valid subscription id"];
+        [self getInAppMessagesFromServer:stateChanges.to.subscriptionId];
+    }
+}
+
 @end
 
 @implementation DummyOSMessagingController

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -157,8 +157,8 @@ typedef void (^OSFailureBlock)(NSError* error);
 + (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
 
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
-+ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
-+ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
++ (void)setClickHandler:(OSInAppMessageClickBlock _Nullable)block;
++ (void)setLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -151,7 +151,7 @@ typedef void (^OSFailureBlock)(NSError* error);
 + (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
 + (void)removeTriggerForKey:(NSString * _Nonnull)key;
 + (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
-// Clear all triggers, doesn't currently exist
++ (void)clearTriggers;
 // TODO: OneSignal.InAppMessages.Paused = true
 + (BOOL)isInAppMessagingPaused;
 + (void)pauseInAppMessages:(BOOL)pause;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -48,73 +48,11 @@
 #import <OneSignalUser/OneSignalUser.h>
 #import <OneSignalOSCore/OneSignalOSCore.h>
 #import <OneSignalNotifications/OneSignalNotifications.h>
+#import "OneSignalInAppMessaging.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 #pragma clang diagnostic ignored "-Wnullability-completeness"
-
-@interface OSInAppMessage : NSObject
-
-@property (strong, nonatomic, nonnull) NSString *messageId;
-
-// Convert the object into a NSDictionary
-- (NSDictionary *_Nonnull)jsonRepresentation;
-
-@end
-
-
-@interface OSInAppMessageTag : NSObject
-
-@property (strong, nonatomic, nullable) NSDictionary *tagsToAdd;
-@property (strong, nonatomic, nullable) NSArray *tagsToRemove;
-
-// Convert the class into a NSDictionary
-- (NSDictionary *_Nonnull)jsonRepresentation;
-
-@end
-
-@interface OSInAppMessageAction : NSObject
-
-// The action name attached to the IAM action
-@property (strong, nonatomic, nullable) NSString *clickName;
-
-// The URL (if any) that should be opened when the action occurs
-@property (strong, nonatomic, nullable) NSURL *clickUrl;
-
-//UUID for the page in an IAM Carousel
-@property (strong, nonatomic, nullable) NSString *pageId;
-
-// Whether or not the click action is first click on the IAM
-@property (nonatomic) BOOL firstClick;
-
-// Whether or not the click action dismisses the message
-@property (nonatomic) BOOL closesMessage;
-
-// The outcome to send for this action
-@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
-
-// The tags to send for this action
-@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
-
-// Convert the class into a NSDictionary
-- (NSDictionary *_Nonnull)jsonRepresentation;
-
-@end
-
-// TODO: move these?
-
-@protocol OSInAppMessageDelegate <NSObject>
-@optional
-- (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
-@end
-
-@protocol OSInAppMessageLifecycleHandler <NSObject>
-@optional
-- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message;
-- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message;
-- (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
-- (void)onDidDismissInAppMessage:(OSInAppMessage *)message;
-@end
 
 // TODO: Need to remove these too for user model
 
@@ -144,23 +82,6 @@ typedef void (^OSWebOpenURLResultBlock)(BOOL shouldOpen);
 /*Block for generic results on success and errors on failure*/
 typedef void (^OSResultSuccessBlock)(NSDictionary* result);
 typedef void (^OSFailureBlock)(NSError* error);
-
-@protocol OSInAppMessages <NSObject>
-
-+ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
-+ (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
-+ (void)removeTriggerForKey:(NSString * _Nonnull)key;
-+ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
-+ (void)clearTriggers;
-// Allows Swift users to: OneSignal.InAppMessages.Paused = true
-+ (BOOL)paused NS_REFINED_FOR_SWIFT;
-+ (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
-
-typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
-+ (void)setClickHandler:(OSInAppMessageClickBlock _Nullable)block;
-+ (void)setLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
-
-@end
 
 // ======= OneSignal Class Interface =========
 @interface OneSignal : NSObject
@@ -202,17 +123,16 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (BOOL)requiresPrivacyConsent;
 + (void)setRequiresPrivacyConsent:(BOOL)required;
 
+#pragma mark Permission, Subscription, and Email Observers
+
+#pragma mark In-App Messaging
++ (Class<OSInAppMessages>)InAppMessages NS_REFINED_FOR_SWIFT;
+
 #pragma mark Location
 // - Request and track user's location
 + (void)promptLocation;
 + (void)setLocationShared:(BOOL)enable;
 + (BOOL)isLocationShared;
-
-#pragma mark Permission, Subscription, and Email Observers
-
-#pragma mark In-App Messaging
-
-+ (Class<OSInAppMessages>)InAppMessages NS_REFINED_FOR_SWIFT;
 
 #pragma mark Outcomes
 + (Class<OSSession>)Session NS_REFINED_FOR_SWIFT;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -101,6 +101,8 @@
 
 @end
 
+// TODO: move these?
+
 @protocol OSInAppMessageDelegate <NSObject>
 @optional
 - (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
@@ -113,6 +115,8 @@
 - (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
 - (void)onDidDismissInAppMessage:(OSInAppMessage *)message;
 @end
+
+// TODO: Need to remove these too for user model
 
 // Subscription Classes
 @interface OSSubscriptionState : NSObject
@@ -141,6 +145,22 @@ typedef void (^OSWebOpenURLResultBlock)(BOOL shouldOpen);
 typedef void (^OSResultSuccessBlock)(NSDictionary* result);
 typedef void (^OSFailureBlock)(NSError* error);
 
+@protocol OSInAppMessages <NSObject>
+
++ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
++ (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
++ (void)removeTriggerForKey:(NSString * _Nonnull)key;
++ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
+// Clear all triggers, doesn't currently exist
+// TODO: OneSignal.InAppMessages.Paused = true
++ (BOOL)isInAppMessagingPaused;
++ (void)pauseInAppMessages:(BOOL)pause;
+
+typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
++ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
++ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
+
+@end
 
 // ======= OneSignal Class Interface =========
 @interface OneSignal : NSObject
@@ -182,13 +202,6 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (BOOL)requiresPrivacyConsent;
 + (void)setRequiresPrivacyConsent:(BOOL)required;
 
-#pragma mark Public Handlers
-
-typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
-+ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
-+ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
-
-
 #pragma mark Location
 // - Request and track user's location
 + (void)promptLocation;
@@ -198,15 +211,8 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 #pragma mark Permission, Subscription, and Email Observers
 
 #pragma mark In-App Messaging
-+ (BOOL)isInAppMessagingPaused;
-+ (void)pauseInAppMessages:(BOOL)pause;
-// TODO: UM triggers are rescoped to user
-+ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
-+ (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
-+ (void)removeTriggerForKey:(NSString * _Nonnull)key;
-+ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
-+ (NSDictionary<NSString *, id> * _Nonnull)getTriggers;
-+ (id _Nullable)getTriggerValueForKey:(NSString * _Nonnull)key;
+
++ (Class<OSInAppMessages>)InAppMessages; // TODO: NS_REFINED_FOR_SWIFT
 
 #pragma mark Outcomes
 + (Class<OSSession>)Session;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -175,7 +175,7 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 #pragma mark User Model 🔥
 
 #pragma mark User Model - User Identity 🔥
-+ (Class<OSUser>)User NS_REFINED_FOR_SWIFT;
++ (id<OSUser>)User NS_REFINED_FOR_SWIFT;
 + (void)login:(NSString * _Nonnull)externalId;
 + (void)login:(NSString * _Nonnull)externalId withToken:(NSString * _Nullable)token
 NS_SWIFT_NAME(login(externalId:token:));
@@ -215,7 +215,7 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (Class<OSInAppMessages>)InAppMessages NS_REFINED_FOR_SWIFT;
 
 #pragma mark Outcomes
-+ (Class<OSSession>)Session;
++ (Class<OSSession>)Session NS_REFINED_FOR_SWIFT;
 
 #pragma mark Extension
 // iOS 10 only

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -152,9 +152,9 @@ typedef void (^OSFailureBlock)(NSError* error);
 + (void)removeTriggerForKey:(NSString * _Nonnull)key;
 + (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
 + (void)clearTriggers;
-// TODO: OneSignal.InAppMessages.Paused = true
-+ (BOOL)isInAppMessagingPaused;
-+ (void)pauseInAppMessages:(BOOL)pause;
+// Allows Swift users to: OneSignal.InAppMessages.Paused = true
++ (BOOL)paused NS_REFINED_FOR_SWIFT;
++ (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
 
 typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
 + (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
@@ -212,7 +212,7 @@ NS_SWIFT_NAME(login(externalId:token:));
 
 #pragma mark In-App Messaging
 
-+ (Class<OSInAppMessages>)InAppMessages; // TODO: NS_REFINED_FOR_SWIFT
++ (Class<OSInAppMessages>)InAppMessages NS_REFINED_FOR_SWIFT;
 
 #pragma mark Outcomes
 + (Class<OSSession>)Session;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -484,7 +484,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
 + (void)startOutcomes {
     [OneSignalOutcomes start];
-    [OneSignalOutcomes.sharedController cleanUniqueOutcomeNotifications];
+    [OneSignalOutcomes.sharedController cleanUniqueOutcomeNotifications]; // TODO: should this actually be in new session instead of init
 }
 
 + (void)startLocation {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -445,13 +445,11 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     // TODO: Figure out if Create User also sets session_count automatically on backend
     [OneSignalUserManagerImpl.sharedInstance updateSessionWithSessionCount:[NSNumber numberWithInt:1] sessionTime:nil refreshDeviceMetadata:true];
     
-    // TODO: Get IAMs
-    // Maybe it needs to listen to user did change as well, sub must be transferred already on backend
+    // This is almost always going to be nil the first time.
+    // The OSMessagingController is an OSPushSubscriptionObserver so that we pull IAMs once we have the sub id
     NSString *subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscription.subscriptionId;
     if (subscriptionId) {
         [OSMessagingController.sharedInstance getInAppMessagesFromServer:subscriptionId];
-    } else {
-        [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
     }
     
     // The below means there are NO IAMs until on_session returns
@@ -480,6 +478,10 @@ static AppEntryAction _appEntryState = APP_CLOSE;
         
         [self enableInAppLaunchURL:true];
     }
+}
+
++ (void)startInAppMessages {
+    [OneSignalInAppMessaging start];
 }
 
 + (void)startOutcomes {
@@ -580,8 +582,9 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     [self startTrackIAP];
     [self startTrackFirebaseAnalytics];
     [self startLifecycleObserver];
+    //TODO: Should these be started in Dependency order? e.g. IAM depends on User Manager shared instance
     [self startUserManager]; // By here, app_id exists, and consent is granted.
-
+    [self startInAppMessages];
     [self startNewSession:YES];
     initDone = true;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -330,9 +330,9 @@ static AppEntryAction _appEntryState = APP_CLOSE;
         // Pre-check on app id to make sure init of SDK is performed properly
         //     Usually when the app id is changed during runtime so that SDK is reinitialized properly
         initDone = false;
-        appId = newAppId;
-        [OneSignalConfigManager setAppId:newAppId];
     }
+    appId = newAppId;
+    [OneSignalConfigManager setAppId:newAppId];
     [self handleAppIdChange:appId];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -441,20 +441,30 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     sessionLaunchTime = [NSDate date];
 
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Calling OneSignal `create/on_session`"];
-    
-    // TODO: Get IAMs
 
     // TODO: Figure out if Create User also sets session_count automatically on backend
     [OneSignalUserManagerImpl.sharedInstance updateSessionWithSessionCount:[NSNumber numberWithInt:1] sessionTime:nil refreshDeviceMetadata:true];
+    
+    // TODO: Get IAMs
+    // Maybe it needs to listen to user did change as well, sub must be transferred already on backend
+    NSString *subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscription.subscriptionId;
+    if (subscriptionId) {
+        [OSMessagingController.sharedInstance getInAppMessagesFromServer:subscriptionId];
+    } else {
+        [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
+    }
+    
+    // The below means there are NO IAMs until on_session returns
+    // because they can be ended, paused, or deleted from the server, or your segment has changed and you're no longer eligible
     
     // ^ Do the "on_session" call, send session_count++
     // on success:
     //    [OneSignalLocation sendLocation];
     //    [self executePendingLiveActivityUpdates];
-    //    [self receivedInAppMessageJson:results[@"push"][@"in_app_messages"]];
+    //    [self receivedInAppMessageJson:results[@"push"][@"in_app_messages"]];  // go to controller
     
     // on failure:
-    //    [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
+    //    [OSMessagingController.sharedInstance updateInAppMessagesFromCache]; // go to controller
 }
 
 + (void)initInAppLaunchURLSettings:(NSDictionary*)settings {
@@ -736,26 +746,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
 + (BOOL)isLocationShared {
     return [[self getRemoteParamController] isLocationShared];
-}
-
-// TODO: new IAM server call
-+ (void)receivedInAppMessageJson:(NSArray<NSDictionary *> *)messagesJson {
-    let messages = [NSMutableArray new];
-
-    if (messagesJson) {
-        for (NSDictionary *messageJson in messagesJson) {
-            let message = [OSInAppMessageInternal instanceWithJson:messageJson];
-            if (message) {
-                [messages addObject:message];
-            }
-        }
-
-        [OSMessagingController.sharedInstance updateInAppMessagesFromOnSession:messages];
-        return;
-    }
-
-    // Default is using cached IAMs in the messaging controller
-    [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
 }
 
 + (void)sendPurchases:(NSArray*)purchases {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -250,7 +250,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
 #pragma mark User Model - User Identity 🔥
 
-+ (Class<OSUser>)User {
++ (id<OSUser>)User {
     return [OneSignalUserManagerImpl.sharedInstance User];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -71,6 +71,7 @@
 #import "OSMessagingController.h"
 #import "OSInAppMessageAction.h"
 #import "OSInAppMessageInternal.h"
+#import "OneSignalInAppMessaging.h"
 
 #import "OneSignalLifecycleObserver.h"
 
@@ -284,6 +285,10 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     return [OneSignalOutcomes Session];
 }
 
++ (Class<OSInAppMessages>)InAppMessages {
+    return [OneSignalInAppMessaging InAppMessages];
+}
+
 /*
  This is should be set from all OneSignal entry points.
  */
@@ -368,16 +373,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     if (providesView && [OSDeviceUtils isIOSVersionGreaterThanOrEqual:@"12.0"]) {
         [OSNotificationsManager setProvidesNotificationSettingsView: providesView];
     }
-}
-
-+ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)block {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click handler set successfully"];
-    [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
-}
-
-+ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate; {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
-    [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
 }
 
 #pragma mark Initialization
@@ -763,15 +758,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     [OSMessagingController.sharedInstance updateInAppMessagesFromCache];
 }
 
-// In-App Messaging Public Methods
-+ (void)pauseInAppMessages:(BOOL)pause {
-    [OSMessagingController.sharedInstance setInAppMessagingPaused:pause];
-}
-
-+ (BOOL)isInAppMessagingPaused {
-    return [OSMessagingController.sharedInstance isInAppMessagingPaused];
-}
-
 + (void)sendPurchases:(NSArray*)purchases {
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
@@ -821,65 +807,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 //TODO: move to sessions/onfocus
 + (NSDate *)sessionLaunchTime {
     return sessionLaunchTime;
-}
-
-+ (void)addTrigger:(NSString *)key withValue:(id)value {
-
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"addTrigger:withValue:"])
-        return;
-
-    if (!key) {
-        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"Attempted to set a trigger with a nil key."];
-        return;
-    }
-
-    [OSMessagingController.sharedInstance addTriggers:@{key : value}];
-}
-
-+ (void)addTriggers:(NSDictionary<NSString *, id> *)triggers {
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"addTriggers:"])
-        return;
-
-    [OSMessagingController.sharedInstance addTriggers:triggers];
-}
-
-+ (void)removeTriggerForKey:(NSString *)key {
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"removeTriggerForKey:"])
-        return;
-
-    if (!key) {
-        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"Attempted to remove a trigger with a nil key."];
-        return;
-    }
-
-    [OSMessagingController.sharedInstance removeTriggersForKeys:@[key]];
-}
-
-+ (void)removeTriggersForKeys:(NSArray<NSString *> *)keys {
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"removeTriggerForKey:"])
-        return;
-
-    [OSMessagingController.sharedInstance removeTriggersForKeys:keys];
-}
-
-+ (NSDictionary<NSString *, id> *)getTriggers {
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"getTriggers"])
-        return @{};
-
-    return [OSMessagingController.sharedInstance getTriggers];
-}
-
-+ (id)getTriggerValueForKey:(NSString *)key {
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"getTriggerValueForKey:"])
-        return nil;
-
-    return [OSMessagingController.sharedInstance getTriggerValueForKey:key];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -1,0 +1,35 @@
+/*
+ Modified MIT License
+
+ Copyright 2022 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "OneSignal.h"
+
+@interface OneSignalInAppMessaging : NSObject <OSInAppMessages>
+
++ (Class<OSInAppMessages>)InAppMessages;
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -26,7 +26,88 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OneSignal.h"
+
+#import <OneSignalOutcomes/OneSignalOutcomes.h>
+
+@interface OSInAppMessage : NSObject
+
+@property (strong, nonatomic, nonnull) NSString *messageId;
+
+// Convert the object into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
+@end
+
+
+@interface OSInAppMessageTag : NSObject
+
+@property (strong, nonatomic, nullable) NSDictionary *tagsToAdd;
+@property (strong, nonatomic, nullable) NSArray *tagsToRemove;
+
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
+@end
+
+@interface OSInAppMessageAction : NSObject
+
+// The action name attached to the IAM action
+@property (strong, nonatomic, nullable) NSString *clickName;
+
+// The URL (if any) that should be opened when the action occurs
+@property (strong, nonatomic, nullable) NSURL *clickUrl;
+
+//UUID for the page in an IAM Carousel
+@property (strong, nonatomic, nullable) NSString *pageId;
+
+// Whether or not the click action is first click on the IAM
+@property (nonatomic) BOOL firstClick;
+
+// Whether or not the click action dismisses the message
+@property (nonatomic) BOOL closesMessage;
+
+// The outcome to send for this action
+@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
+
+// The tags to send for this action
+@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
+
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+
+@end
+
+// TODO: move these?
+
+@protocol OSInAppMessageDelegate <NSObject>
+@optional
+- (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
+@end
+
+@protocol OSInAppMessageLifecycleHandler <NSObject>
+@optional
+- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message;
+- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message;
+- (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
+- (void)onDidDismissInAppMessage:(OSInAppMessage *)message;
+@end
+
+@protocol OSInAppMessages <NSObject>
+
++ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
++ (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
++ (void)removeTriggerForKey:(NSString * _Nonnull)key;
++ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
++ (void)clearTriggers;
+// Allows Swift users to: OneSignal.InAppMessages.Paused = true
++ (BOOL)paused NS_REFINED_FOR_SWIFT;
++ (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
+
+typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
++ (void)setClickHandler:(OSInAppMessageClickBlock _Nullable)block;
++ (void)setLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
+
+@end
 
 @interface OneSignalInAppMessaging : NSObject <OSInAppMessages>
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -31,5 +31,6 @@
 @interface OneSignalInAppMessaging : NSObject <OSInAppMessages>
 
 + (Class<OSInAppMessages>)InAppMessages;
++ (void)start;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -34,6 +34,11 @@
     return self;
 }
 
++ (void)start {
+    // Initialize the shared instance and start observing the push subscription
+    [OSMessagingController start];
+}
+
 + (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)block {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click handler set successfully"];
     [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -94,13 +94,11 @@
     [OSMessagingController.sharedInstance clearTriggers];
 }
 
-// TODO: Make into OneSignal.InAppMessages.Paused = true
-
-+ (void)pauseInAppMessages:(BOOL)pause {
++ (void)paused:(BOOL)pause {
     [OSMessagingController.sharedInstance setInAppMessagingPaused:pause];
 }
 
-+ (BOOL)isInAppMessagingPaused {
++ (BOOL)paused {
     return [OSMessagingController.sharedInstance isInAppMessagingPaused];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -1,0 +1,99 @@
+/*
+ Modified MIT License
+
+ Copyright 2022 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import "OneSignalInAppMessaging.h"
+#import "OSMessagingController.h"
+
+@implementation OneSignalInAppMessaging
+
++ (Class<OSInAppMessages>)InAppMessages {
+    return self;
+}
+
++ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)block {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click handler set successfully"];
+    [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
+}
+
++ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate; {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
+    [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
+}
+
++ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value {
+    // return if the user has not granted privacy permissions
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"addTrigger:withValue:"])
+        return;
+
+    if (!key) {
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"Attempted to set a trigger with a nil key."];
+        return;
+    }
+
+    [OSMessagingController.sharedInstance addTriggers:@{key : value}];
+}
+
++ (void)addTriggers:(NSDictionary<NSString *,id> * _Nonnull)triggers {
+    // return if the user has not granted privacy permissions
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"addTriggers:"])
+        return;
+
+    [OSMessagingController.sharedInstance addTriggers:triggers];
+}
+
++ (void)removeTriggerForKey:(NSString * _Nonnull)key {
+    // return if the user has not granted privacy permissions
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"removeTriggerForKey:"])
+        return;
+
+    if (!key) {
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"Attempted to remove a trigger with a nil key."];
+        return;
+    }
+
+    [OSMessagingController.sharedInstance removeTriggersForKeys:@[key]];
+}
+
++ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys {
+    // return if the user has not granted privacy permissions
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"removeTriggerForKey:"])
+        return;
+
+    [OSMessagingController.sharedInstance removeTriggersForKeys:keys];
+}
+
+// TODO: Make into OneSignal.InAppMessages.Paused = true
+
++ (void)pauseInAppMessages:(BOOL)pause {
+    [OSMessagingController.sharedInstance setInAppMessagingPaused:pause];
+}
+
++ (BOOL)isInAppMessagingPaused {
+    return [OSMessagingController.sharedInstance isInAppMessagingPaused];
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -86,6 +86,14 @@
     [OSMessagingController.sharedInstance removeTriggersForKeys:keys];
 }
 
++ (void)clearTriggers {
+    // return if the user has not granted privacy permissions
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"clearTriggers:"])
+        return;
+    
+    [OSMessagingController.sharedInstance clearTriggers];
+}
+
 // TODO: Make into OneSignal.InAppMessages.Paused = true
 
 + (void)pauseInAppMessages:(BOOL)pause {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -39,12 +39,12 @@
     [OSMessagingController start];
 }
 
-+ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)block {
++ (void)setClickHandler:(OSInAppMessageClickBlock)block {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click handler set successfully"];
     [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
 }
 
-+ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate; {
++ (void)setLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate; {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
     [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -42,8 +42,6 @@
 + (BOOL)shouldPromptToShowURL;
 + (void)setIsOnSessionSuccessfulForCurrentState:(BOOL)value;
 + (BOOL)shouldRegisterNow;
-+ (void)receivedInAppMessageJson:(NSArray<NSDictionary *> *_Nullable)messagesJson;
-+ (void)sendTagsOnBackground;
 
 + (NSDate *_Nonnull)sessionLaunchTime;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -93,7 +93,8 @@ static OneSignalLifecycleObserver* _instance = nil;
     
     if ([OneSignal appId]) {
         [OneSignalTracker onFocus:YES];
-        [OneSignal sendTagsOnBackground];
+        // TODO: Method no longer exists, transitions into flushing operation repo on backgrounding.
+        // [OneSignal sendTagsOnBackground];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -40,7 +40,7 @@
 @interface OneSignal ()
 
 + (BOOL)shouldStartNewSession;
-+ (void)startNewSession;
++ (void)startNewSession:(BOOL)fromInit;
 + (BOOL)sendNotificationTypesUpdate;
 + (NSString*)mUserId;
 + (NSString *)mEmailUserId;
@@ -106,12 +106,13 @@ static BOOL lastOnFocusWasToBackground = YES;
     
     // on_session tracking when resumming app.
     if ([OneSignal shouldStartNewSession])
-        [OneSignal startNewSession];
+        [OneSignal startNewSession:NO];
     else {
         // This checks if notification permissions changed when app was backgrounded
         [OSNotificationsManager sendNotificationTypesUpdateToDelegate];
         [[OSSessionManager sharedSessionManager] attemptSessionUpgrade:OneSignal.appEntryState];
-        [OneSignal receivedInAppMessageJson:nil];
+        // TODO: Here it used to call receivedInAppMessageJson with nil, this method no longer exists
+        // [OneSignal receivedInAppMessageJson:nil];
     }
     
     [OSNotificationsManager clearBadgeCount:false];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -192,6 +192,10 @@
     [OneSignal.Notifications requestPermission:^(BOOL accepted) {
         NSLog(@"🔥 promptForPushNotificationsWithUserResponse: %d", accepted);
     } fallbackToSettings:true];
+    
+    // IAM Pausing
+    [OneSignal.InAppMessages paused:true];
+    BOOL paused = [OneSignal.InAppMessages paused];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -94,10 +94,11 @@
     [OneSignal.User removeSmsNumber:@"+15551231234"];
 
     // Triggers
-    [OneSignal.User setTriggerWithKey:@"foo" value:@"bar"];
-    [OneSignal.User setTriggers:@{@"foo": @"foo1", @"bar": @"bar2"}];
-    [OneSignal.User removeTrigger:@"foo"];
-    [OneSignal.User removeTriggers:@[@"foo", @"bar"]];
+    [OneSignal.InAppMessages addTrigger:@"foo" withValue:@"bar"];
+    [OneSignal.InAppMessages addTriggers:@{@"foo": @"foo1", @"bar": @"bar2"}];
+    [OneSignal.InAppMessages removeTriggerForKey:@"foo"];
+    [OneSignal.InAppMessages removeTriggersForKeys:@[@"foo", @"bar"]];
+    [OneSignal.InAppMessages clearTriggers];
 }
 
 /**

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -122,7 +122,7 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.InAppMessages.removeTrigger(forKey: "foo")
         OneSignal.InAppMessages.removeTriggers(forKeys: ["foo", "bar"])
         OneSignal.InAppMessages.clearTriggers()
-        
+
         OneSignal.InAppMessages.setInAppMessageClickHandler { action in
             NSLog("action \(action.description)")
         }

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -29,12 +29,16 @@ import XCTest
 
 // TODO: UM This goes elsewhere
 extension OneSignal {
-    static var User: OSUser.Type {
-        return OneSignal.__user()
+    static var User: OSUser {
+        return __user()
     }
 
     static var Notifications: OSNotifications.Type {
         return OneSignal.__notifications()
+    }
+
+    static var Session: OSSession.Type {
+        return __session()
     }
 
     static var InAppMessages: OSInAppMessages.Type {

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -97,10 +97,16 @@ class UserModelSwiftTests: XCTestCase {
         _ = OneSignal.User.removeSmsNumber("+15551231234")
 
         // Triggers
-        OneSignal.User.setTrigger(key: "foo", value: "bar")
-        OneSignal.User.setTriggers(["foo": "foo1", "bar": "bar2"])
-        OneSignal.User.removeTrigger("foo")
-        OneSignal.User.removeTriggers(["foo", "bar"])
+        OneSignal.InAppMessages.addTrigger("foo", withValue: "bar")
+        OneSignal.InAppMessages.addTriggers(["foo": "foo1", "bar": "bar2"])
+        OneSignal.InAppMessages.removeTrigger(forKey: "foo")
+        OneSignal.InAppMessages.removeTriggers(forKeys: ["foo", "bar"])
+        OneSignal.InAppMessages.clearTriggers()
+        
+        OneSignal.InAppMessages.setInAppMessageClickHandler { action in
+            NSLog("action \(action.description)")
+        }
+        OneSignal.InAppMessages.setInAppMessageLifecycleHandler(nil)
     }
 
     /**

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -32,8 +32,24 @@ extension OneSignal {
     static var User: OSUser.Type {
         return OneSignal.__user()
     }
+
     static var Notifications: OSNotifications.Type {
         return OneSignal.__notifications()
+    }
+
+    static var InAppMessages: OSInAppMessages.Type {
+        return __inAppMessages()
+    }
+}
+
+extension OSInAppMessages {
+    static var Paused: Bool {
+        get {
+            return __paused()
+        }
+        set {
+            __paused(newValue)
+        }
     }
 }
 
@@ -198,5 +214,9 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.Notifications.requestPermission({ accepted in
             print("🔥 promptForPushNotificationsWithUserResponse: \(accepted)")
         }, fallbackToSettings: true)
+
+        // IAM pausing
+        OneSignal.InAppMessages.Paused = true
+        let paused = OneSignal.InAppMessages.Paused
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Make the `InAppMessages` namespace and move triggers and IAM methods over.

## Details

### Motivation
`InAppMessages` namespace
```objc
+ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
+ (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
+ (void)removeTriggerForKey:(NSString * _Nonnull)key;
+ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
+ (void)clearTriggers;
+ (BOOL)paused NS_REFINED_FOR_SWIFT;
+ (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
+ (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock _Nullable)block;
+ (void)setInAppMessageLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
```

### Scope
This also re-enables tag substitution for IAMs. In order to do this we exposed getTags internally from the OneSignalUserManagerImpl. For now we will just use the tags that are already on the user and not try to pull from the server. If it turns out that we aren't hydrating tags prior to displaying IAMs this will need to change.

Also includes a commit addressing some misc `NS_REFINED_FOR_SWIFT` stuff that is unrelated to `InAppMessages.

# Testing
## Unit testing
None, update method calls in some basic test files to see what it looks like.

## Manual testing
None

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1172)
<!-- Reviewable:end -->
