### PR TITLE
[User Model] Moving Location to its own namespace

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -43,7 +43,7 @@
 
 //    self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getDeviceState.isSubscribed;
     
-    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isLocationShared];
+    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isShared];
     
     self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal.InAppMessages paused];
 
@@ -151,7 +151,7 @@
 
 - (IBAction)locationSharedSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller location sharing status: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal.Location setLocationShared:(bool) sender.selectedSegmentIndex];
+    [OneSignal.Location setShared:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -43,7 +43,7 @@
 
 //    self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getDeviceState.isSubscribed;
     
-    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) OneSignal.isLocationShared;
+    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isLocationShared];
     
     self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal.InAppMessages paused];
 
@@ -121,7 +121,7 @@
 }
 
 - (IBAction)promptLocationAction:(UIButton *)sender {
-    [OneSignal promptLocation];
+    [OneSignal.Location requestPermission];
 }
 
 - (void)promptForNotificationsWithNativeiOS10Code {
@@ -151,7 +151,7 @@
 
 - (IBAction)locationSharedSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller location sharing status: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal setLocationShared:(bool) sender.selectedSegmentIndex];
+    [OneSignal.Location setLocationShared:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -43,7 +43,7 @@
 
     // self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getDeviceState.isSubscribed;
     
-    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isLocationShared];
+    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isShared];
     
     self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal.InAppMessages paused];
 
@@ -138,7 +138,7 @@
 
 - (IBAction)locationSharedSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller location sharing status: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal.Location setLocationShared:(bool) sender.selectedSegmentIndex];
+    [OneSignal.Location setShared:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -43,7 +43,7 @@
 
     // self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getDeviceState.isSubscribed;
     
-    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) OneSignal.isLocationShared;
+    self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isLocationShared];
     
     self.inAppMessagingSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal.InAppMessages paused];
 
@@ -108,7 +108,7 @@
 }
 
 - (IBAction)promptLocationAction:(UIButton *)sender {
-    [OneSignal promptLocation];
+    [OneSignal.Location requestPermission];
 }
 
 - (void)promptForNotificationsWithNativeiOS10Code {
@@ -138,7 +138,7 @@
 
 - (IBAction)locationSharedSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller location sharing status: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal setLocationShared:(bool) sender.selectedSegmentIndex];
+    [OneSignal.Location setLocationShared:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)inAppMessagingSegmentedControlValueChanged:(UISegmentedControl *)sender {

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 		DE3784852888D00300453A8E /* OneSignalUser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; };
 		DE3784862888D00B00453A8E /* OneSignalUser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE3CD300270FA9F200A5BECD /* OneSignalOutcomes.m in Sources */ = {isa = PBXBuildFile; fileRef = DE3CD2FE270FA9F200A5BECD /* OneSignalOutcomes.m */; };
-		DE51DDE12941697A0073D5C4 /* OneSignalLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FA1E73342200E41FD7 /* OneSignalLocation.h */; };
+		DE51DDE12941697A0073D5C4 /* OneSignalLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FA1E73342200E41FD7 /* OneSignalLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE5EFECA24D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5EFEC924D8DBF70032632D /* OSInAppMessageViewControllerOverrider.m */; };
 		DE69E19F282ED8060090BB3D /* OneSignalUser.docc in Sources */ = {isa = PBXBuildFile; fileRef = DE69E19E282ED8060090BB3D /* OneSignalUser.docc */; };
 		DE69E1A0282ED8060090BB3D /* OneSignalUser.h in Headers */ = {isa = PBXBuildFile; fileRef = DE69E19D282ED8060090BB3D /* OneSignalUser.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -49,6 +49,7 @@
 #import <OneSignalOSCore/OneSignalOSCore.h>
 #import <OneSignalNotifications/OneSignalNotifications.h>
 #import "OneSignalInAppMessaging.h"
+#import "OneSignalLocation.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
@@ -129,10 +130,7 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (Class<OSInAppMessages>)InAppMessages NS_REFINED_FOR_SWIFT;
 
 #pragma mark Location
-// - Request and track user's location
-+ (void)promptLocation;
-+ (void)setLocationShared:(BOOL)enable;
-+ (BOOL)isLocationShared;
++ (Class<OSLocation>)Location NS_REFINED_FOR_SWIFT;
 
 #pragma mark Outcomes
 + (Class<OSSession>)Session NS_REFINED_FOR_SWIFT;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -289,6 +289,10 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     return [OneSignalInAppMessaging InAppMessages];
 }
 
++ (Class<OSLocation>)Location {
+    return [OneSignalLocation Location];
+}
+
 /*
  This is should be set from all OneSignal entry points.
  */
@@ -491,9 +495,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
 + (void)startLocation {
     // TODO: Do we pass location to user module?
-    if (appId && [self isLocationShared]) {
-        [OneSignalLocation getLocation:false fallbackToSettings:false withCompletionHandler:nil];
-    }
+    [OneSignalLocation start];
 }
 
 + (void)startTrackFirebaseAnalytics {
@@ -709,46 +711,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
 + (void)enableInAppLaunchURL:(BOOL)enable {
     [OneSignalUserDefaults.initStandard saveBoolForKey:OSUD_NOTIFICATION_OPEN_LAUNCH_URL withValue:enable];
-}
-
-#pragma mark Location
-
-+ (void)setLocationShared:(BOOL)enable {
-    let remoteController = [self getRemoteParamController];
-    
-    // Already set by remote params
-    if ([remoteController hasLocationKey])
-        return;
-
-    [self startLocationSharedWithFlag:enable];
-}
-
-+ (void)startLocationSharedWithFlag:(BOOL)enable {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"startLocationSharedWithFlag called with status: %d", (int) enable]];
-
-    let remoteController = [self getRemoteParamController];
-    [remoteController saveLocationShared:enable];
-
-    if (!enable) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"startLocationSharedWithFlag set false, clearing last location!"];
-        [OneSignalLocation clearLastLocation];
-    }
-}
-
-+ (void)promptLocation {
-    [self promptLocationFallbackToSettings:false completionHandler:nil];
-}
-
-+ (void)promptLocationFallbackToSettings:(BOOL)fallback completionHandler:(void (^)(PromptActionResult result))completionHandler {
-    // return if the user has not granted privacy permissions
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"promptLocation"])
-        return;
-    
-    [OneSignalLocation getLocation:true fallbackToSettings:fallback withCompletionHandler:completionHandler];
-}
-
-+ (BOOL)isLocationShared {
-    return [[self getRemoteParamController] isLocationShared];
 }
 
 + (void)sendPurchases:(NSArray*)purchases {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
@@ -45,8 +45,8 @@ typedef struct os_last_location {
 @protocol OSLocation <NSObject>
 // - Request and track user's location
 + (void)requestPermission;
-+ (void)setLocationShared:(BOOL)enable;
-+ (BOOL)isLocationShared;
++ (void)setShared:(BOOL)enable;
++ (BOOL)isShared;
 @end
 
 @interface OneSignalLocation : NSObject<OSLocation>

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.h
@@ -27,7 +27,6 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "OneSignalCommonDefines.h"
 
 #ifndef OneSignalLocation_h
 #define OneSignalLocation_h
@@ -43,18 +42,19 @@ typedef struct os_last_location {
     double horizontalAccuracy;
 } os_last_location;
 
-@interface OneSignalLocation : NSObject
+@protocol OSLocation <NSObject>
+// - Request and track user's location
++ (void)requestPermission;
++ (void)setLocationShared:(BOOL)enable;
++ (BOOL)isLocationShared;
+@end
 
+@interface OneSignalLocation : NSObject<OSLocation>
++ (Class<OSLocation>)Location;
 + (OneSignalLocation*) sharedInstance;
-+ (bool)started;
-+ (void)internalGetLocation:(bool)prompt fallbackToSettings:(BOOL)fallback;
-- (void)locationManager:(id)manager didUpdateLocations:(NSArray *)locations;
-+ (void)getLocation:(bool)prompt fallbackToSettings:(BOOL)fallback withCompletionHandler:(void (^)(PromptActionResult result))completionHandler;
-+ (void)sendLocation;
-+ (os_last_location*)lastLocation;
++ (void)start;
 + (void)clearLastLocation;
 + (void)onFocus:(BOOL)isActive;
-
 @end
 
 #endif /* OneSignalLocation_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -88,12 +88,12 @@ static OneSignalLocation* singleInstance = nil;
 }
 
 + (void)start {
-    if ([OneSignalConfigManager getAppId] != nil && [self isLocationShared]) {
+    if ([OneSignalConfigManager getAppId] != nil && [self isShared]) {
         [OneSignalLocation getLocation:false fallbackToSettings:false withCompletionHandler:nil];
     }
 }
 
-+ (void)setLocationShared:(BOOL)enable {
++ (void)setShared:(BOOL)enable {
     //TODO: move remote params to core
 //    let remoteController = [self getRemoteParamController];
 //
@@ -129,7 +129,7 @@ static OneSignalLocation* singleInstance = nil;
     [OneSignalLocation getLocation:true fallbackToSettings:fallback withCompletionHandler:completionHandler];
 }
 
-+ (BOOL)isLocationShared {
++ (BOOL)isShared {
     //TODO: move remote params to core
     //return [[self getRemoteParamController] isLocationShared];
     return true;
@@ -368,7 +368,7 @@ static OneSignalLocation* singleInstance = nil;
 
 - (void)locationManager:(id)manager didUpdateLocations:(NSArray *)locations {
     // return if the user has not granted privacy permissions or location shared is false
-    if (([OSPrivacyConsentController requiresUserPrivacyConsent] || ![OneSignalLocation isLocationShared]) && !fallbackToSettings) {
+    if (([OSPrivacyConsentController requiresUserPrivacyConsent] || ![OneSignalLocation isShared]) && !fallbackToSettings) {
         [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"CLLocationManagerDelegate clear Location listener due to permissions denied or location shared not available"];
         [OneSignalLocation sendAndClearLocationListener:PERMISSION_DENIED];
         return;


### PR DESCRIPTION
# Description
## One Line Summary
This PR moves Location to its own namespace.

## Details
Public methods for Location code will go through OneSignalLocation. OneSignalLocation.h is now exposed as a public header.

iOS Languages don't have true namespaces but OneSignal.Location will return a class that has location methods on it.

**This PR does NOT move remote params to core so calls to remote params are commented out for now. A separate PR will move remote params and update all code that is using it.** 

### Motivation
The SDK now has multiple namespaces for our different product features. Location is one of those.

### Scope
Location methods.
This adds a new public header for the OneSignal framework. Eventually Location and IAMs will be their own modules.

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Unit testing
N/A

## Manual testing
The example app builds and runs and location code can be hit.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1175)
<!-- Reviewable:end -->
