### PR TITLE
[User model] Debug namespace

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -51,7 +51,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     NSLog(@"Bundle URL: %@", [[NSBundle mainBundle] bundleURL]);
     
-    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_NONE];
+    [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
+    [OneSignal.Debug setVisualLevel:ONE_S_LL_NONE];
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
     
     id openNotificationHandler = ^(OSNotificationOpenedResult *result) {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -75,7 +75,7 @@
     NSString *key = [self.removeTriggerKey text];
 
     if (key && [key length]) {
-        [OneSignal.InAppMessages removeTriggerForKey:key];
+        [OneSignal.InAppMessages removeTrigger:key];
     }
 }
 
@@ -99,7 +99,7 @@
     if (self.tagKey.text && self.tagKey.text.length
         && self.tagValue.text && self.tagValue.text.length) {
         NSLog(@"Sending tag with key: %@ value: %@", self.tagKey.text, self.tagValue.text);
-        [OneSignal.User setTagWithKey:self.tagKey.text value:self.tagValue.text];
+        [OneSignal.User addTagWithKey:self.tagKey.text value:self.tagValue.text];
     }
 }
 
@@ -109,7 +109,7 @@
 
 - (IBAction)sendTagsButton:(id)sender {
     NSLog(@"Sending tags %@", @{@"key1": @"value1", @"key2": @"value2"});
-    [OneSignal.User setTags:@{@"key1": @"value1", @"key2": @"value2"}];
+    [OneSignal.User addTags:@{@"key1": @"value1", @"key2": @"value2"}];
 }
 
 - (IBAction)promptPushAction:(UIButton *)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -51,7 +51,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     NSLog(@"Bundle URL: %@", [[NSBundle mainBundle] bundleURL]);
     
-    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_NONE];
+    [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
+    [OneSignal.Debug setVisualLevel:ONE_S_LL_NONE];
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
     
     id openNotificationHandler = ^(OSNotificationOpenedResult *result) {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -70,7 +70,7 @@
     NSString *key = [self.removeTriggerKey text];
 
     if (key && [key length]) {
-        [OneSignal.InAppMessages removeTriggerForKey:key];
+        [OneSignal.InAppMessages removeTrigger:key];
     }
 }
 
@@ -96,7 +96,7 @@
 
 - (IBAction)sendTagsButton:(id)sender {
     NSLog(@"Sending tags %@", @{@"key1": @"value1", @"key2": @"value2"});
-    [OneSignal.User setTags:@{@"key1": @"value1", @"key2": @"value2"}];
+    [OneSignal.User addTags:@{@"key1": @"value1", @"key2": @"value2"}];
 }
 
 - (IBAction)promptPushAction:(UIButton *)sender {

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.h
@@ -26,8 +26,6 @@
  */
 #import <Foundation/Foundation.h>
 
-@interface OneSignalLog : NSObject
-#pragma mark Logging
 typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
     ONE_S_LL_NONE,
     ONE_S_LL_FATAL,
@@ -38,7 +36,14 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
     ONE_S_LL_VERBOSE
 };
 
-+ (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
-+ (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
+@protocol OSDebug <NSObject>
++ (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel;
++ (void)setVisualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
+@end
 
+@interface OneSignalLog : NSObject<OSDebug>
++ (Class<OSDebug>)Debug;
++ (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel;
++ (void)setVisualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
++ (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.m
@@ -34,8 +34,15 @@
 static ONE_S_LOG_LEVEL _nsLogLevel = ONE_S_LL_WARN;
 static ONE_S_LOG_LEVEL _visualLogLevel = ONE_S_LL_NONE;
 
-+ (void)setLogLevel:(ONE_S_LOG_LEVEL)nsLogLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel {
++ (Class<OSDebug>)Debug {
+    return self;
+}
+
++ (void)setLogLevel:(ONE_S_LOG_LEVEL)nsLogLevel {
     _nsLogLevel = nsLogLevel;
+}
+
++ (void)setVisualLevel:(ONE_S_LOG_LEVEL)visualLogLevel {
     _visualLogLevel = visualLogLevel;
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -43,13 +43,12 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (BOOL)canRequestPermission;
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
 + (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
-+ (void)requestPermission:(OSUserResponseBlock)block;
-+ (void)requestPermission:(OSUserResponseBlock)block fallbackToSettings:(BOOL)fallback;
-+ (void)registerForProvisionalAuthorization:(OSUserResponseBlock)block;
-+ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
-+ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer;
-// clearAll
-
++ (void)requestPermission:(OSUserResponseBlock _Nullable )block;
++ (void)requestPermission:(OSUserResponseBlock _Nullable )block fallbackToSettings:(BOOL)fallback;
++ (void)registerForProvisionalAuthorization:(OSUserResponseBlock _Nullable )block;
++ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*_Nonnull)observer;
++ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*_Nonnull)observer;
++ (void)clearAll;
 @end
 
 
@@ -67,11 +66,11 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 
 @property (class, weak, nonatomic, nullable) id<OneSignalNotificationsDelegate> delegate;
 
-+ (Class<OSNotifications>)Notifications;
++ (Class<OSNotifications> _Nonnull)Notifications;
 
 + (void)setColdStartFromTapOnNotification:(BOOL)coldStartFromTapOnNotification;
 + (BOOL)getColdStartFromTapOnNotification;
-+ (void)setAppId:(NSString *)appId;
++ (void)setAppId:(NSString *_Nullable)appId;
 + (NSString *_Nullable)getAppId;
 
 @property (class, readonly) OSPermissionStateInternal* _Nonnull currentPermissionState;
@@ -93,25 +92,22 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (void)sendNotificationTypesUpdateToDelegate;
 
 // Used to manage observers added by the app developer.
-@property (class, readonly) ObservablePermissionStateChangesType* permissionStateChangesObserver;
+@property (class, readonly) ObservablePermissionStateChangesType* _Nullable permissionStateChangesObserver;
 
 @property (class, readonly) OneSignalNotificationSettings* _Nonnull osNotificationSettings;
 
 // This is set by the user module
-+ (void)setPushSubscriptionId:(NSString *)pushSubscriptionId;
++ (void)setPushSubscriptionId:(NSString *_Nullable)pushSubscriptionId;
 
-// - Notification Opened
-+ (void)lastMessageReceived:(NSDictionary*)message;
-
-+ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID;
++ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
++ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString* _Nonnull)actionID;
 
 + (BOOL)clearBadgeCount:(BOOL)fromNotifOpened;
 
-+ (BOOL)receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
-+ (void)notificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
-+ (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary *)payload withCompletion:(OSNotificationDisplayResponse)completion;
-+ (void)didRegisterForRemoteNotifications:(UIApplication *)app deviceToken:(NSData *)inDeviceToken;
-+ (void)handleDidFailRegisterForRemoteNotification:(NSError*)err;
++ (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
++ (void)notificationReceived:(NSDictionary* _Nonnull)messageDict wasOpened:(BOOL)opened;
++ (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary * _Nonnull)payload withCompletion:(OSNotificationDisplayResponse _Nonnull)completion;
++ (void)didRegisterForRemoteNotifications:(UIApplication *_Nonnull)app deviceToken:(NSData *_Nonnull)inDeviceToken;
++ (void)handleDidFailRegisterForRemoteNotification:(NSError*_Nonnull)err;
 + (void)checkProvisionalAuthorizationStatus;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -307,6 +307,10 @@ static NSString *_pushSubscriptionId;
     }
 }
 
++ (void)clearAll {
+    [self clearBadgeCount:false];
+}
+
 + (BOOL)registerForAPNsToken {
     if (self.waitingForApnsResponse)
         return true;

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -93,7 +93,7 @@ class OSPropertiesModel: OSModel {
 
     // MARK: - Tag Methods
 
-    func setTags(_ tags: [String: String]) {
+    func addTags(_ tags: [String: String]) {
         for (key, value) in tags {
             self.tags[key] = value
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -40,7 +40,7 @@ protocol OSUserInternal {
     func addAliases(_ aliases: [String: String])
     func removeAliases(_ labels: [String])
     // Tags
-    func setTags(_ tags: [String: String])
+    func addTags(_ tags: [String: String])
     func removeTags(_ tags: [String])
     // Location
     func setLocation(lat:Float, long:Float)
@@ -118,9 +118,9 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
 
     // MARK: - Tags
 
-    func setTags(_ tags: [String: String]) {
-        print("🔥 OSUserInternalImpl setTags() called")
-        propertiesModel.setTags(tags)
+    func addTags(_ tags: [String: String]) {
+        print("🔥 OSUserInternalImpl addTags() called")
+        propertiesModel.addTags(tags)
     }
 
     func removeTags(_ tags: [String]) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -54,8 +54,8 @@ import OneSignalNotifications
     func removeAlias(_ label: String)
     func removeAliases(_ labels: [String])
     // Tags
-    func setTag(key: String, value: String)
-    func setTags(_ tags: [String: String])
+    func addTag(key: String, value: String)
+    func addTags(_ tags: [String: String])
     func removeTag(_ tag: String)
     func removeTags(_ tags: [String])
     // Email
@@ -462,18 +462,18 @@ extension OneSignalUserManagerImpl: OSUser {
         user.removeAliases(labels)
     }
 
-    public func setTag(key: String, value: String) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "setTag") else {
+    public func addTag(key: String, value: String) {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "addTag") else {
             return
         }
-        user.setTags([key: value])
+        user.addTags([key: value])
     }
 
-    public func setTags(_ tags: [String: String]) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "setTags") else {
+    public func addTags(_ tags: [String: String]) {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "addTags") else {
             return
         }
-        user.setTags(tags)
+        user.addTags(tags)
     }
 
     public func removeTag(_ tag: String) {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -875,7 +875,7 @@ static BOOL _isInAppMessagingPaused = false;
     if (action.tags) {
         OSInAppMessageTag *tag = action.tags;
         if (tag.tagsToAdd)
-            [OneSignal.User setTags:tag.tagsToAdd];
+            [OneSignal.User addTags:tag.tagsToAdd];
         if (tag.tagsToRemove)
             [OneSignal.User removeTags:tag.tagsToRemove];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.h
@@ -112,7 +112,7 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (void)setProvidesNotificationSettingsView:(BOOL)providesView;
 
 #pragma mark Logging
-+ (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel; // TODO: UM split up into 2?
++ (Class<OSDebug>)Debug NS_REFINED_FOR_SWIFT;
 
 #pragma mark Privacy Consent
 + (void)setPrivacyConsent:(BOOL)granted;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -779,9 +779,8 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 }
 
 #pragma mark Logging
-//TODO: delete with um
-+ (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel visualLevel:(ONE_S_LOG_LEVEL)visualLogLevel {
-    [OneSignalLog setLogLevel:logLevel visualLevel:visualLogLevel];
++ (Class<OSDebug>)Debug {
+    return [OneSignalLog Debug];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -84,18 +84,18 @@
 
 @protocol OSInAppMessageLifecycleHandler <NSObject>
 @optional
-- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message;
-- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message;
-- (void)onWillDismissInAppMessage:(OSInAppMessage *)message;
-- (void)onDidDismissInAppMessage:(OSInAppMessage *)message;
+- (void)onWillDisplayInAppMessage:(OSInAppMessage *_Nonnull)message;
+- (void)onDidDisplayInAppMessage:(OSInAppMessage *_Nonnull)message;
+- (void)onWillDismissInAppMessage:(OSInAppMessage *_Nonnull)message;
+- (void)onDidDismissInAppMessage:(OSInAppMessage *_Nonnull)message;
 @end
 
 @protocol OSInAppMessages <NSObject>
 
 + (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
 + (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
-+ (void)removeTriggerForKey:(NSString * _Nonnull)key;
-+ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys;
++ (void)removeTrigger:(NSString * _Nonnull)key;
++ (void)removeTriggers:(NSArray<NSString *> * _Nonnull)keys;
 + (void)clearTriggers;
 // Allows Swift users to: OneSignal.InAppMessages.Paused = true
 + (BOOL)paused NS_REFINED_FOR_SWIFT;
@@ -109,7 +109,7 @@ typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action)
 
 @interface OneSignalInAppMessaging : NSObject <OSInAppMessages>
 
-+ (Class<OSInAppMessages>)InAppMessages;
++ (Class<OSInAppMessages>_Nonnull)InAppMessages;
 + (void)start;
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -70,7 +70,7 @@
     [OSMessagingController.sharedInstance addTriggers:triggers];
 }
 
-+ (void)removeTriggerForKey:(NSString * _Nonnull)key {
++ (void)removeTrigger:(NSString * _Nonnull)key {
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"removeTriggerForKey:"])
         return;
@@ -83,7 +83,7 @@
     [OSMessagingController.sharedInstance removeTriggersForKeys:@[key]];
 }
 
-+ (void)removeTriggersForKeys:(NSArray<NSString *> * _Nonnull)keys {
++ (void)removeTriggers:(NSArray<NSString *> * _Nonnull)keys {
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"removeTriggerForKey:"])
         return;

--- a/iOS_SDK/OneSignalSDK/UnitTests/SMSTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/SMSTests.m
@@ -86,7 +86,8 @@
     self.ONESIGNAL_EXTERNAL_USER_ID = @"test_external_user_id";
     self.ONESIGNAL_EXTERNAL_USER_ID_HASH_TOKEN = @"test_external_user_id_hash_token";
     
-    [OneSignal setLogLevel:ONE_S_LL_VERBOSE visualLevel:ONE_S_LL_NONE];
+    [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
+    [OneSignal.Debug setVisualLevel:ONE_S_LL_NONE];
 }
 
 /*

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTestCommonMethods.m
@@ -227,7 +227,8 @@ static XCTestCase* _currentXCTestCase;
     
     [UIAlertViewOverrider reset];
 
-    [OneSignal setLogLevel:ONE_S_LL_INFO visualLevel:ONE_S_LL_NONE];
+    [OneSignal.Debug setLogLevel:ONE_S_LL_INFO];
+    [OneSignal.Debug setVisualLevel:ONE_S_LL_NONE];
 
     [NSTimerOverrider reset];
     [OneSignalLocationOverrider reset];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelObjcTests.m
@@ -75,8 +75,8 @@
     [OneSignal.User removeAliases:@[@"foo", @"bar"]];
 
     // Tags
-    [OneSignal.User setTagWithKey:@"foo" value:@"bar"];
-    [OneSignal.User setTags:@{@"foo": @"foo1", @"bar": @"bar2"}];
+    [OneSignal.User addTagWithKey:@"foo" value:@"bar"];
+    [OneSignal.User addTags:@{@"foo": @"foo1", @"bar": @"bar2"}];
     [OneSignal.User removeTag:@"foo"];
     [OneSignal.User removeTags:@[@"foo", @"bar"]];
 
@@ -91,8 +91,8 @@
     // Triggers
     [OneSignal.InAppMessages addTrigger:@"foo" withValue:@"bar"];
     [OneSignal.InAppMessages addTriggers:@{@"foo": @"foo1", @"bar": @"bar2"}];
-    [OneSignal.InAppMessages removeTriggerForKey:@"foo"];
-    [OneSignal.InAppMessages removeTriggersForKeys:@[@"foo", @"bar"]];
+    [OneSignal.InAppMessages removeTrigger:@"foo"];
+    [OneSignal.InAppMessages removeTriggers:@[@"foo", @"bar"]];
     [OneSignal.InAppMessages clearTriggers];
 }
 
@@ -147,7 +147,7 @@
     [OneSignal.User addAliases:@{@"test1": @"user1", @"test2": @"user2", @"test3": @"user3"}];
     [OneSignal.User removeAliases:@[@"test1", @"label_01", @"test2"]];
     
-    [OneSignal.User setTagWithKey:@"foo" value:@"bar"];
+    [OneSignal.User addTagWithKey:@"foo" value:@"bar"];
     
     // Sleep to allow the flush to be called 1 time.
     [NSThread sleepForTimeInterval:6.0f];

--- a/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UserModelSwiftTests.swift
@@ -98,8 +98,8 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.User.removeAliases(["foo", "bar"])
 
         // Tags
-        OneSignal.User.setTag(key: "foo", value: "bar")
-        OneSignal.User.setTags(["foo": "foo1", "bar": "bar2"])
+        OneSignal.User.addTag(key: "foo", value: "bar")
+        OneSignal.User.addTags(["foo": "foo1", "bar": "bar2"])
         OneSignal.User.removeTag("foo")
         OneSignal.User.removeTags(["foo", "bar"])
 
@@ -177,7 +177,7 @@ class UserModelSwiftTests: XCTestCase {
         OneSignal.User.addAliases(["test1": "user1", "test2": "user2", "test3": "user3"])
         OneSignal.User.removeAliases(["test1", "label_01", "test2"])
 
-        OneSignal.User.setTag(key: "foo", value: "bar")
+        OneSignal.User.addTag(key: "foo", value: "bar")
 
         // Sleep to allow the flush to be called 1 time.
         Thread.sleep(forTimeInterval: 6)


### PR DESCRIPTION
# Description
## One Line Summary
setLogLevel and setVisualLevel are now on the Debug namespace

## Details
OneSignalLog implements the OSDebug protocol and returns itself as the static class for the .Debug namespace property

### Motivation
new namespace for logging

### Scope
user model public api change

# Testing
## Unit testing
N/A

## Manual testing
Tested the method running a physical device in the example app

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1179)
<!-- Reviewable:end -->
