### PR TITLE
[User model] Notifications clear all and nullability

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -43,13 +43,12 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (BOOL)canRequestPermission;
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
 + (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
-+ (void)requestPermission:(OSUserResponseBlock)block;
-+ (void)requestPermission:(OSUserResponseBlock)block fallbackToSettings:(BOOL)fallback;
-+ (void)registerForProvisionalAuthorization:(OSUserResponseBlock)block;
-+ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer;
-+ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer;
-// TODO: clearAll
-
++ (void)requestPermission:(OSUserResponseBlock _Nullable )block;
++ (void)requestPermission:(OSUserResponseBlock _Nullable )block fallbackToSettings:(BOOL)fallback;
++ (void)registerForProvisionalAuthorization:(OSUserResponseBlock _Nullable )block;
++ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*_Nonnull)observer;
++ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*_Nonnull)observer;
++ (void)clearAll;
 @end
 
 
@@ -67,11 +66,11 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 
 @property (class, weak, nonatomic, nullable) id<OneSignalNotificationsDelegate> delegate;
 
-+ (Class<OSNotifications>)Notifications;
++ (Class<OSNotifications> _Nonnull)Notifications;
 
 + (void)setColdStartFromTapOnNotification:(BOOL)coldStartFromTapOnNotification;
 + (BOOL)getColdStartFromTapOnNotification;
-+ (void)setAppId:(NSString *)appId;
++ (void)setAppId:(NSString *_Nullable)appId;
 + (NSString *_Nullable)getAppId;
 
 @property (class, readonly) OSPermissionStateInternal* _Nonnull currentPermissionState;
@@ -93,25 +92,22 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (void)sendNotificationTypesUpdateToDelegate;
 
 // Used to manage observers added by the app developer.
-@property (class, readonly) ObservablePermissionStateChangesType* permissionStateChangesObserver;
+@property (class, readonly) ObservablePermissionStateChangesType* _Nullable permissionStateChangesObserver;
 
 @property (class, readonly) OneSignalNotificationSettings* _Nonnull osNotificationSettings;
 
 // This is set by the user module
-+ (void)setPushSubscriptionId:(NSString *)pushSubscriptionId;
++ (void)setPushSubscriptionId:(NSString *_Nullable)pushSubscriptionId;
 
-// - Notification Opened
-+ (void)lastMessageReceived:(NSDictionary*)message;
-
-+ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID;
++ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
++ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString* _Nonnull)actionID;
 
 + (BOOL)clearBadgeCount:(BOOL)fromNotifOpened;
 
-+ (BOOL)receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
-+ (void)notificationReceived:(NSDictionary*)messageDict wasOpened:(BOOL)opened;
-+ (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary *)payload withCompletion:(OSNotificationDisplayResponse)completion;
-+ (void)didRegisterForRemoteNotifications:(UIApplication *)app deviceToken:(NSData *)inDeviceToken;
-+ (void)handleDidFailRegisterForRemoteNotification:(NSError*)err;
++ (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
++ (void)notificationReceived:(NSDictionary* _Nonnull)messageDict wasOpened:(BOOL)opened;
++ (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary * _Nonnull)payload withCompletion:(OSNotificationDisplayResponse _Nonnull)completion;
++ (void)didRegisterForRemoteNotifications:(UIApplication *_Nonnull)app deviceToken:(NSData *_Nonnull)inDeviceToken;
++ (void)handleDidFailRegisterForRemoteNotification:(NSError*_Nonnull)err;
 + (void)checkProvisionalAuthorizationStatus;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -307,6 +307,10 @@ static NSString *_pushSubscriptionId;
     }
 }
 
++ (void)clearAll {
+    [self clearBadgeCount:false];
+}
+
 + (BOOL)registerForAPNsToken {
     if (self.waitingForApnsResponse)
         return true;


### PR DESCRIPTION
# Description
## One Line Summary
Add clearAll and specify nullability in the header

## Details
Add the missing clearAll method
### Motivation
Get rid of nullability warnings and add the missing method.

### Scope
notifications public api

# Testing
## Unit testing
N/A

## Manual testing
Tested running the example app

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1181)
<!-- Reviewable:end -->
