### PR TITLE
Adding setLanguage to the User namespace

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -44,6 +44,8 @@ protocol OSUserInternal {
     func removeTags(_ tags: [String])
     // Location
     func setLocation(lat:Float, long:Float)
+    // Language
+    func setLanguage(_ language: String?)
 
     // TODO: UM This is a temporary function to create a push subscription for testing
     func testCreatePushSubscription(subscriptionId: String, token: String, enabled: Bool) -> OSSubscriptionModel
@@ -134,5 +136,11 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
         print("🔥 OSUserInternalImpl setLocation() called")
         propertiesModel.lat = lat
         propertiesModel.long = long
+    }
+    
+    // MARK: - Language
+    
+    func setLanguage(_ language: String?) {
+        propertiesModel.language = language
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -64,10 +64,11 @@ import OneSignalNotifications
     // SMS
     func addSmsNumber(_ number: String)
     func removeSmsNumber(_ number: String) -> Bool
+    // Language
+    func setLanguage(_ language: String?)
 
     // TODO: UM This is a temporary function to create a push subscription for testing
     func testCreatePushSubscription(subscriptionId: String, token: String, enabled: Bool)
-    // TODO: Add setLanguage
 }
 
 /**
@@ -552,6 +553,13 @@ extension OneSignalUserManagerImpl: OSUser {
         // Check if is valid SMS?
         createUserIfNil()
         return self.subscriptionModelStore.remove(number)
+    }
+    
+    public func setLanguage(_ language: String?) {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "setLanguage") else {
+            return
+        }
+        user.setLanguage(language)
     }
 
     public func testCreatePushSubscription(subscriptionId: String, token: String, enabled: Bool) {


### PR DESCRIPTION
Currently it is nullable to allow resetting to device default

# Description
## One Line Summary
Adding setLanguage to the User namespace

## Details
I currently have it set to nullable but this might change

### Motivation
user model api

### Scope
language

# Testing
## Unit testing
N/A

## Manual testing
tested in example app

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1182)
<!-- Reviewable:end -->
