### PR TITLE
[user model] alpha1 fixes (round 4)

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -105,8 +105,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     return YES;
 }
 
-#define ONESIGNAL_APP_ID_DEFAULT @"1688d8f2-da7f-4815-8ee3-9d13788482c8"
-#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"1688d8f2-da7f-4815-8ee3-9d13788482c8"
+#define ONESIGNAL_APP_ID_DEFAULT @"YOUR_APP_ID_HERE"
+#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"YOUR_APP_ID_HERE"
 
 + (NSString*)getOneSignalAppId {
     NSString* userDefinedAppId = [[NSUserDefaults standardUserDefaults] objectForKey:ONESIGNAL_APP_ID_KEY_FOR_TESTING];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/OneSignalDevApp.entitlements
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/OneSignalDevApp.entitlements
@@ -11,7 +11,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.onesignal.example.staging.onesignal</string>
+		<string>group.com.onesignal.example.onesignal</string>
 	</array>
 </dict>
 </plist>

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/OneSignalDevAppClip.entitlements
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/OneSignalDevAppClip.entitlements
@@ -11,7 +11,7 @@
 	</array>
 	<key>com.apple.developer.parent-application-identifiers</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.onesignal.example.staging</string>
+		<string>$(AppIdentifierPrefix)com.onesignal.example</string>
 	</array>
 </dict>
 </plist>

--- a/iOS_SDK/OneSignalDevApp/OneSignalExample.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalDevApp/OneSignalExample.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = OneSignalExample;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalDevApp/OneSignalExample-Bridging-Header.h";
@@ -776,7 +776,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = OneSignalExample;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalDevApp/OneSignalExample-Bridging-Header.h";
@@ -804,7 +804,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.OneSignalNotificationServiceExtensionA;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
@@ -832,7 +832,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.OneSignalNotificationServiceExtensionA;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
@@ -877,7 +877,7 @@
 				MARKETING_VERSION = 1.4.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.Clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.Clip;
 				PRODUCT_NAME = OneSignalExampleClip;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -915,7 +915,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.Clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.Clip;
 				PRODUCT_NAME = OneSignalExampleClip;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.entitlements
+++ b/iOS_SDK/OneSignalDevApp/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.onesignal.example.staging.onesignal</string>
+		<string>group.com.onesignal.example.onesignal</string>
 	</array>
 </dict>
 </plist>

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -159,6 +159,37 @@
     return OSNotificationPermissionNotDetermined;
 }
 
+- (BOOL)compare:(OSPermissionStateInternal*)from {
+    return self.accepted != from.accepted ||
+           self.ephemeral != from.ephemeral ||
+           self.answeredPrompt != from.answeredPrompt ||
+           self.hasPrompted != from.hasPrompted;
+}
+
+- (OSPermissionState *)getExternalState {
+    return [[OSPermissionState alloc] initWithStatus:self.status reachable:self.reachable hasPrompted:self.hasPrompted provisional:self.provisional providesAppNotificationSettings:self.providesAppNotificationSettings];
+}
+
+- (NSString*)description {
+    static NSString* format = @"<OSPermissionStateInternal: hasPrompted: %d, status: %@, provisional: %d>";
+    return [NSString stringWithFormat:format, self.hasPrompted, self.status, self.provisional];
+}
+
+
+
+@end
+
+@implementation OSPermissionState
+    
+- (instancetype)initWithStatus:(OSNotificationPermission)status reachable:(BOOL)reachable hasPrompted:(BOOL)hasPrompted provisional:(BOOL)provisional providesAppNotificationSettings:(BOOL)providesAppNotificationSettings {
+    _status = status;
+    _reachable = reachable;
+    _hasPrompted = hasPrompted;
+    _providesAppNotificationSettings = providesAppNotificationSettings;
+    _provisional = provisional;
+    return self;
+}
+
 - (NSString*)statusAsString {
     switch(self.status) {
         case OSNotificationPermissionNotDetermined:
@@ -175,35 +206,9 @@
     return @"NotDetermined";
 }
 
-- (BOOL)compare:(OSPermissionStateInternal*)from {
-    return self.accepted != from.accepted ||
-           self.ephemeral != from.ephemeral ||
-           self.answeredPrompt != from.answeredPrompt ||
-           self.hasPrompted != from.hasPrompted;
-}
-
-- (OSPermissionState *)getExternalState {
-    return [[OSPermissionState alloc] initWithStatus:self.status reachable:self.reachable hasPrompted:self.hasPrompted provisional:self.provisional providesAppNotificationSettings:self.providesAppNotificationSettings];
-}
-
 - (NSString*)description {
     static NSString* format = @"<OSPermissionState: hasPrompted: %d, status: %@, provisional: %d>";
     return [NSString stringWithFormat:format, self.hasPrompted, self.statusAsString, self.provisional];
-}
-
-
-
-@end
-
-@implementation OSPermissionState
-    
-- (instancetype)initWithStatus:(OSNotificationPermission)status reachable:(BOOL)reachable hasPrompted:(BOOL)hasPrompted provisional:(BOOL)provisional providesAppNotificationSettings:(BOOL)providesAppNotificationSettings {
-    _status = status;
-    _reachable = reachable;
-    _hasPrompted = hasPrompted;
-    _providesAppNotificationSettings = providesAppNotificationSettings;
-    _provisional = provisional;
-    return self;
 }
 
 - (NSDictionary*)toDictionary {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -49,10 +49,13 @@ open class OSModelStore<TModel: OSModel>: NSObject {
         for model in self.models.values {
             model.changeNotifier.subscribe(self)
         }
+    }
 
-        // register as user observer
+    public func registerAsUserObserver() -> OSModelStore {
+        // This method was taken out of the initializer as the push subscription model store should not be clearing its user defaults
         NotificationCenter.default.addObserver(self, selector: #selector(self.removeModelsFromUserDefaults),
                                                name: Notification.Name(OS_ON_USER_WILL_CHANGE), object: nil)
+        return self
     }
 
     deinit {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -42,13 +42,17 @@ public class OSPushSubscriptionState: NSObject {
     @objc public let token: String?
     @objc public let optedIn: Bool
 
+    @objc public override var description: String {
+        return "<OSPushSubscriptionState: id: \(id ?? "nil"), token: \(token ?? "nil"), optedIn: \(optedIn)>"
+    }
+
     init(id: String?, token: String?, optedIn: Bool) {
         self.id = id
         self.token = token
         self.optedIn = optedIn
     }
 
-    func toDictionary() -> NSDictionary {
+    @objc public func toDictionary() -> NSDictionary {
         let id = self.id ?? "nil"
         let token = self.token ?? "nil"
         return [
@@ -64,12 +68,16 @@ public class OSPushSubscriptionStateChanges: NSObject {
     @objc public let to: OSPushSubscriptionState
     @objc public let from: OSPushSubscriptionState
 
+    @objc public override var description: String {
+        return "<OSPushSubscriptionStateChanges:\nfrom: \(self.from),\nto:   \(self.to)\n>"
+    }
+
     init(to: OSPushSubscriptionState, from: OSPushSubscriptionState) {
         self.to = to
         self.from = from
     }
 
-    func toDictionary() -> NSDictionary {
+    @objc public func toDictionary() -> NSDictionary {
         return ["from": from.toDictionary(), "to": to.toDictionary()]
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -209,6 +209,7 @@ class OSUserExecutor {
     static func executeIdentifyUserRequest(_ request: OSRequestIdentifyUser) {
         OneSignalClient.shared().execute(request) { _ in
             // the anonymous user has been identified, still need to Fetch User
+            // TODO: Is the above true, do we need to Fetch? If the anon user is identified, then no user with this external_id existed, correct?
             fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
 
             executePendingRequests() // TODO: Here or after fetch or after transfer?

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -140,11 +140,11 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         return pushSubscriptionStateChangesObserver
     }
 
-    // has Identity, Properties, Subscription, and Push Subscription Model Stores
-    let identityModelStore = OSModelStore<OSIdentityModel>(changeSubscription: OSEventProducer(), storeKey: OS_IDENTITY_MODEL_STORE_KEY)
-    let propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer(), storeKey: OS_PROPERTIES_MODEL_STORE_KEY)
+    // Model Stores
+    let identityModelStore = OSModelStore<OSIdentityModel>(changeSubscription: OSEventProducer(), storeKey: OS_IDENTITY_MODEL_STORE_KEY).registerAsUserObserver()
+    let propertiesModelStore = OSModelStore<OSPropertiesModel>(changeSubscription: OSEventProducer(), storeKey: OS_PROPERTIES_MODEL_STORE_KEY).registerAsUserObserver()
     // Holds email and sms subscription models
-    let subscriptionModelStore = OSModelStore<OSSubscriptionModel>(changeSubscription: OSEventProducer(), storeKey: OS_SUBSCRIPTION_MODEL_STORE_KEY)
+    let subscriptionModelStore = OSModelStore<OSSubscriptionModel>(changeSubscription: OSEventProducer(), storeKey: OS_SUBSCRIPTION_MODEL_STORE_KEY).registerAsUserObserver()
     // Holds a single push subscription model
     let pushSubscriptionModelStore = OSModelStore<OSSubscriptionModel>(changeSubscription: OSEventProducer(), storeKey: OS_PUSH_SUBSCRIPTION_MODEL_STORE_KEY)
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -331,6 +331,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
         [OSNotificationsManager setColdStartFromTapOnNotification:YES];
 }
 
+// TODO: Should this be in the InAppMessages namespace?
 + (void)setLaunchURLsInApp:(BOOL)launchInApp {
     NSMutableDictionary *newSettings = [[NSMutableDictionary alloc] initWithDictionary:appSettings];
     newSettings[kOSSettingsKeyInAppLaunchURL] = launchInApp ? @true : @false;


### PR DESCRIPTION
# Description
## One Line Summary
More fixes (round 4).

## Details

- printing and toDictionary fixes for push subscription state and permission state.
- push subscription store should not remove user defaults when user will change. We were getting a bug not able to init the user from cache due to missing push sub model
- use `409` response code to Identify User to make the switch to that user

## Manual testing
iPhone 13 physical on staging and production.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1201)
<!-- Reviewable:end -->
