### PR TITLE
[user model] add more properties to push subscription object

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		3C2C7DC6288E00AA0020F9AE /* UserModelObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */; };
 		3C2C7DC8288F3C020020F9AE /* OSSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSSubscriptionModel.swift */; };
 		3C2D8A5928B4C4E300BE41F6 /* OSDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */; };
+		3C44673E296D099D0039A49E /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
+		3C44673F296D09CC0039A49E /* OneSignalMobileProvision.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FC1E73342200E41FD7 /* OneSignalMobileProvision.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C448B9D2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C448B9B2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h */; };
 		3C448B9E2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */; };
 		3C448B9F2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */; };
@@ -182,10 +184,6 @@
 		912412221E73342200E41FD7 /* OneSignalLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FB1E73342200E41FD7 /* OneSignalLocation.m */; };
 		912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FB1E73342200E41FD7 /* OneSignalLocation.m */; };
 		912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FB1E73342200E41FD7 /* OneSignalLocation.m */; };
-		912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FC1E73342200E41FD7 /* OneSignalMobileProvision.h */; };
-		912412261E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
-		912412271E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
-		912412281E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
 		912412311E73342200E41FD7 /* OneSignalTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 912412021E73342200E41FD7 /* OneSignalTracker.h */; };
 		912412321E73342200E41FD7 /* OneSignalTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 912412031E73342200E41FD7 /* OneSignalTracker.m */; };
 		912412331E73342200E41FD7 /* OneSignalTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 912412031E73342200E41FD7 /* OneSignalTracker.m */; };
@@ -1447,8 +1445,6 @@
 				912411F91E73342200E41FD7 /* OneSignalJailbreakDetection.m */,
 				912411FA1E73342200E41FD7 /* OneSignalLocation.h */,
 				912411FB1E73342200E41FD7 /* OneSignalLocation.m */,
-				912411FC1E73342200E41FD7 /* OneSignalMobileProvision.h */,
-				912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */,
 				912412021E73342200E41FD7 /* OneSignalTracker.h */,
 				912412031E73342200E41FD7 /* OneSignalTracker.m */,
 				912412041E73342200E41FD7 /* OneSignalTrackIAP.h */,
@@ -1646,6 +1642,8 @@
 				CA70E3382023F24500019273 /* OneSignalCommonDefines.h */,
 				7AD8DDE8234BD3CF00747A8A /* OneSignalUserDefaults.h */,
 				7AD8DDE6234BD3BE00747A8A /* OneSignalUserDefaults.m */,
+				912411FC1E73342200E41FD7 /* OneSignalMobileProvision.h */,
+				912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */,
 				4529DF0A1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.h */,
 				4529DF0B1FA932AC00CEAB1D /* OneSignalTrackFirebaseAnalytics.m */,
 				DE7D1831270279D9002D3A5D /* OSNotificationClasses.h */,
@@ -1998,7 +1996,6 @@
 				A63E9E3F26742C1400EA273E /* LanguageProvider.h in Headers */,
 				A66239952686612F00D52FD8 /* OneSignalFramework.h in Headers */,
 				7A93269325AF4E6700BBEC27 /* OSPendingCallbacks.h in Headers */,
-				912412251E73342200E41FD7 /* OneSignalMobileProvision.h in Headers */,
 				A63E9E3E26742C1000EA273E /* LanguageContext.h in Headers */,
 				CA4742E4218B8FF30020DC8C /* OSTriggerController.h in Headers */,
 				DE7D18EC2703B5AA002D3A5D /* OSInAppMessagingRequests.h in Headers */,
@@ -2072,6 +2069,7 @@
 				3CE8CC4E2911ADD1000DB0D3 /* OSDeviceUtils.h in Headers */,
 				3C47A974292642B100312125 /* OneSignalConfigManager.h in Headers */,
 				DE7D183627027AA0002D3A5D /* OneSignalLog.h in Headers */,
+				3C44673F296D09CC0039A49E /* OneSignalMobileProvision.h in Headers */,
 				DE7D182D270273B0002D3A5D /* OSNotification.h in Headers */,
 				DE7D183F27027F62002D3A5D /* NSString+OneSignal.h in Headers */,
 			);
@@ -2582,7 +2580,6 @@
 				9D3300F523145AF3000F0A83 /* OneSignalViewHelper.m in Sources */,
 				9124123E1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.m in Sources */,
 				CA47439E2190FEA80020DC8C /* OSTrigger.m in Sources */,
-				912412261E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				CAB4112920852E48005A70D1 /* DelayedConsentInitializationParameters.m in Sources */,
 				CA1A6E7020DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */,
 				912412321E73342200E41FD7 /* OneSignalTracker.m in Sources */,
@@ -2658,7 +2655,6 @@
 				CA1A6E7120DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */,
 				CA4742E6218B8FF30020DC8C /* OSTriggerController.m in Sources */,
 				CAB269E121B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */,
-				912412271E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				912412331E73342200E41FD7 /* OneSignalTracker.m in Sources */,
 				DE367CC824EEF2BE00165207 /* OSInAppMessagePage.m in Sources */,
 				DE7D18EF2703B5B9002D3A5D /* OSInAppMessagingRequests.m in Sources */,
@@ -2765,7 +2761,6 @@
 				03CCCC852835F291004BF794 /* UIApplicationDelegateSwizzlingTests.m in Sources */,
 				4529DEEA1FA8360C00CEAB1D /* UIApplicationOverrider.m in Sources */,
 				DEC08B022947D4E900C81DA3 /* OneSignalSwiftInterface.swift in Sources */,
-				912412281E73342200E41FD7 /* OneSignalMobileProvision.m in Sources */,
 				7A93269E25AF4F0300BBEC27 /* OSPendingCallbacks.m in Sources */,
 				7AECE59823674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
 				7A5A818224897693002E07C8 /* MigrationTests.m in Sources */,
@@ -2817,6 +2812,7 @@
 				DEF784642912FA5100A1F3A5 /* OSDialogInstanceManager.m in Sources */,
 				DE7D183B27027EFC002D3A5D /* NSURL+OneSignal.m in Sources */,
 				DE7D186B270374EE002D3A5D /* OneSignalRequest.m in Sources */,
+				3C44673E296D099D0039A49E /* OneSignalMobileProvision.m in Sources */,
 				DEF78492291479B200A1F3A5 /* OneSignalSelectorHelpers.m in Sources */,
 				DE7D182B27027376002D3A5D /* OSNotification.m in Sources */,
 				DE7D187A27037A26002D3A5D /* OneSignalCoreHelper.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
@@ -52,4 +52,4 @@
 #import <OneSignalCore/OneSignalSelectorHelpers.h>
 #import <OneSignalCore/OneSignalConfigManager.h>
 #import <OneSignalCore/OSRemoteParamController.h>
-
+#import <OneSignalCore/OneSignalMobileProvision.h>

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalMobileProvision.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalMobileProvision.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 The Blindsight Corporation. All rights reserved.
 //  Released under the BSD 2-Clause License (see LICENSE)
 
-typedef NS_ENUM(NSInteger, UIApplicationReleaseMode) {
+typedef NS_ENUM(NSInteger, OSUIApplicationReleaseMode) {
     UIApplicationReleaseUnknown,
     UIApplicationReleaseDev,
     UIApplicationReleaseAdHoc,
@@ -18,6 +18,6 @@ typedef NS_ENUM(NSInteger, UIApplicationReleaseMode) {
 
 @interface OneSignalMobileProvision : NSObject
 
-+ (UIApplicationReleaseMode) releaseMode;
++ (OSUIApplicationReleaseMode) releaseMode;
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalMobileProvision.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalMobileProvision.m
@@ -5,13 +5,10 @@
 //  Created by kaolin fire on 2013-06-24.
 //  Copyright (c) 2013 The Blindsight Corporation. All rights reserved.
 //  Released under the BSD 2-Clause License (see LICENSE)
-#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 
 #import "OneSignalMobileProvision.h"
-#import "TargetConditionals.h"
-#import "OneSignalFramework.h"
-#import "OneSignalInternal.h"
+#import "OneSignalLog.h"
 
 @implementation OneSignalMobileProvision
 
@@ -86,7 +83,7 @@
     [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:message];
 }
 
-+ (UIApplicationReleaseMode) releaseMode {
++ (OSUIApplicationReleaseMode) releaseMode {
     NSDictionary *entitlements = nil;
     NSDictionary *provision = [self getProvision];
     if (provision) {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -131,14 +131,6 @@ static BOOL _coldStartFromTapOnNotification = NO;
     _coldStartFromTapOnNotification = coldStartFromTapOnNotification;
 }
 
-static NSString *_appId;
-+ (void)setAppId:(NSString *)appId {
-    _appId = appId;
-}
-+ (NSString *_Nullable)getAppId {
-    return _appId;
-}
-
 + (void)setMSubscriptionStatus:(NSNumber*)status {
     mSubscriptionStatus = [status intValue];
 }
@@ -537,8 +529,9 @@ static NSString *_lastnonActiveMessageId;
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
     
-    if (!_appId)
+    if (![OneSignalConfigManager getAppId]) {
         return;
+    }
     
     // This method should not continue to be executed for non-OS push notifications
     if (![OneSignalCoreHelper isOneSignalPayload:messageDict])
@@ -670,8 +663,8 @@ static NSString *_lastnonActiveMessageId;
     NSString* lastMessageId = [standardUserDefaults getSavedStringForKey:OSUD_LAST_MESSAGE_OPENED defaultValue:nil];
     //Only submit request if messageId not nil and: (lastMessage is nil or not equal to current one)
     if(messageId && (!lastMessageId || ![lastMessageId isEqualToString:messageId])) {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestSubmitNotificationOpened withUserId:_pushSubscriptionId
-                                                                                             appId:_appId
+        [OneSignalClient.sharedClient executeRequest:[OSRequestSubmitNotificationOpened withUserId:[self pushSubscriptionId]
+                                                                                             appId:[OneSignalConfigManager getAppId]
                                                                                          wasOpened:YES
                                                                                          messageId:messageId
                                                                                     withDeviceType:[NSNumber numberWithInt:DEVICE_TYPE_PUSH]]

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -186,6 +186,12 @@ class OSSubscriptionModel: OSModel {
         }
     }
 
+    // Properties for push subscription
+    var testType: Int?
+    let deviceOs = UIDevice.current.systemVersion
+    let sdk = ONESIGNAL_VERSION
+    let deviceModel: String? = OSDeviceUtils.getDeviceVariant()
+
     // When a Subscription is initialized, it may not have a subscriptionId until a request to the backend is made.
     init(type: OSSubscriptionType,
          address: String?,
@@ -198,6 +204,22 @@ class OSSubscriptionModel: OSModel {
         self.subscriptionId = subscriptionId
         _accepted = accepted
         _isDisabled = isDisabled
+
+        // Set test_type if subscription model is PUSH
+        if type == .push {
+            let releaseMode: OSUIApplicationReleaseMode = OneSignalMobileProvision.releaseMode()
+            // Workaround to unsure how to extract the Int value in 1 step...
+            if releaseMode == .UIApplicationReleaseDev {
+                self.testType = OSUIApplicationReleaseMode.UIApplicationReleaseDev.rawValue
+            }
+            if releaseMode == .UIApplicationReleaseAdHoc {
+                self.testType = OSUIApplicationReleaseMode.UIApplicationReleaseAdHoc.rawValue
+            }
+            if releaseMode == .UIApplicationReleaseWildcard {
+                self.testType = OSUIApplicationReleaseMode.UIApplicationReleaseWildcard.rawValue
+            }
+        }
+
         super.init(changeNotifier: changeNotifier)
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -324,6 +324,11 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         pushSubscriptionObject["token"] = pushSubscriptionModel.address
         pushSubscriptionObject["enabled"] = pushSubscriptionModel.enabled
 
+        pushSubscriptionObject["test_type"] = pushSubscriptionModel.testType
+        pushSubscriptionObject["device_os"] = pushSubscriptionModel.deviceOs
+        pushSubscriptionObject["sdk"] = pushSubscriptionModel.sdk
+        pushSubscriptionObject["device_model"] = pushSubscriptionModel.deviceModel
+
         // notificationTypes defaults to -1 instead of nil, don't send if it's -1
         if pushSubscriptionModel.notificationTypes != -1 {
             pushSubscriptionObject["notification_types"] = pushSubscriptionModel.notificationTypes

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -66,6 +66,13 @@ class OSUserExecutor {
      Used to parse Create User and Fetch User responses. The `originalPushToken` is the push token when the request was created, which may be different from the push token currently in the SDK. For example, when the request was created, there may be no push token yet, but soon after, the SDK receives a push token. This is used to determine whether or not to hydrate the push subscription.
      */
     static func parseFetchUserResponse(response: [AnyHashable: Any], identityModel: OSIdentityModel, originalPushToken: String?) {
+
+        // If this was a create user, it hydrates the onesignal_id of the request's identityModel
+        // The model in the store may be different, and it may be waiting on the onesignal_id of this previous model
+        if let identityObject = parseIdentityObjectResponse(response) {
+            identityModel.hydrate(identityObject)
+        }
+
         // On success, check if the current user is the same as the one in the request
         // If user has changed, don't hydrate, except for push subscription
         let modelInStore = OneSignalUserManagerImpl.sharedInstance.identityModelStore.getModel(key: OS_IDENTITY_MODEL_KEY)


### PR DESCRIPTION
# Description
## One Line Summary
Add more properties to the push subscription object as we realized we needed to pass `test_type` to the subscription object during Create User to receive push notifications _(but also fixed a couple other things below)_.

## Details
We should revisit all the properties to include in the push subscription model but for now, these are sufficient to work.

**Move `OneSignalMobileProvision` to OneSignalCore**
* This is used in the User Module to get the `test_type` for the push subscription model
* So it needs to move out of OneSignalFramework into Core
* Rename `UIApplicationReleaseMode` to `OSUIApplicationReleaseMode` since it is defined by us, not by Apple APIs

**Add more properties to push subscription model**
* Motivation: we need to send `test_type` in the push subscription model because this is what tells the backend the APNS environment (prod, sandbox)
* Also add a few other properties that used to exist like `device_model` and the `sdk` version.
* Add these properties to the subscription object to the Create User request

**Now that we fixed receiving notifications, testing showed that the `OSNotificationsManager` was not getting push subscription ID and appId correctly.**
* Problem: The `_appId` in the `OSNotificationsManager` was never being set, so it was always `nil`. Instead, let's use the appId from  `OneSignalConfigManager`, who should be controlling this data.
* Also, replace accessing `_pushSubscriptionId` with `[self pushSubscriptionId]` which will init it from user defaults if `nil`.

**Fix bug: need to update identity model even when user changed**
* Noticed a bug if someone calls `login` right away upon SDK init. I had been testing with a button tap, giving too much time in between to notice this bug earlier.
* The initial anonymous create user request is sent, then the model in the stores are replaced with new models when the `login` is called (which will result in an Identify User request). This request is waiting on the `onesignal_id` of the previous user in order to be sent.
* However, when the first create user request returns, we see that the user has changed, so we weren't hydrating anything.
* As a result, the identify user request could never be sent.
* Instead, always hydrate the identity model in the request first. Then we can hydrate the models in the stores, if the user is the same.

# Testing
## Manual testing
Physical iphone on production.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1204)
<!-- Reviewable:end -->
