### PR TITLE
Fix 5.0.0 onesignal podspec

### DIFF
--- a/OneSignal.podspec
+++ b/OneSignal.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     end
 
     s.subspec 'OneSignalOSCore' do |ss|
-      ss.dependency 'OneSignalXCFramework/OneSignalCore'
+      ss.dependency 'OneSignal/OneSignalCore'
       ss.vendored_frameworks = 'iOS_SDK/OneSignalSDK/OneSignal_OSCore/OneSignalOSCore.xcframework'
     end
 


### PR DESCRIPTION
# Description
## One Line Summary
This PR fixes the OneSignal.podspec to allow it to be published.

## Details
The dependency for the OSCore subspec was pointing to the OneSignalXCFramework/OneSignalCore instead of OneSignal/OneSignalCore

### Motivation
required for releasing the OneSignal.podspec (we may want to drop this though)

### Scope
release

## Manual testing
This fix enabled the release of alpha 01

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1207)
<!-- Reviewable:end -->
