### PR TITLE
migration guide alpha-01: update SDK install instructions

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -40,7 +40,7 @@ As mentioned above, the iOS SDK is making the jump from `v3` to `v5`, in order t
 
 ## SDK Installation
 
-### Import Changes
+### Code Import Changes
 **Objective-C**
 
 ```objc
@@ -59,7 +59,11 @@ As mentioned above, the iOS SDK is making the jump from `v3` to `v5`, in order t
     import OneSignalFramework
 ```
 
-Update the version of the OneSignal iOS SDK your application uses to `5.0.0`. Other than updating the import statement above, there are no additional changes needed to import the OneSignal SDK in your Xcode project. See [the existing installation instructions](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-import-the-onesignal-sdk-into-your-xcode-project).
+### Option 1. Swift Package Manager
+Update the version of the OneSignal-XCFramework your application uses to `5.0.0-alpha-01`. In addition, the Package Product name has been changed from `OneSignal` to `OneSignalFramework`. See [the existing installation instructions](https://documentation.onesignal.com/docs/swift-package-manager-setup).
+
+### Option 2. CocoaPods
+Update the version of the OneSignalXCFramework your application uses to `5.0.0-alpha-01`. Other than updating the import statement above, there are no additional changes needed to import the OneSignal SDK in your Xcode project. See [the existing installation instructions](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-import-the-onesignal-sdk-into-your-xcode-project).
 
 # API Changes
 ## Namespaces


### PR DESCRIPTION
# Description
## One Line Summary
Update SDK install instructions to account for SPM changes, and note specific version of `5.0.0-alpha-01`.

### Motivation
For Swift Package Manager, the package product for the OneSignal-iOS-SDK repo was renamed to `OneSignalFramework` from `OneSignal` since the module name changed. Update this as a migration step.

### Scope
alpha-01 migration guide

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-ios-sdk/1209)
<!-- Reviewable:end -->
