### PR TITLE
[user model] fix bug in identify user: need to fetch

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -293,13 +293,13 @@ extension OSSubscriptionModel {
     // Calculates if the device is opted in to push notification.
     // Must have permission and not be opted out.
     func calculateIsOptedIn(accepted: Bool, isDisabled: Bool) -> Bool {
-        return _accepted && !_isDisabled
+        return accepted && !isDisabled
     }
 
     // Calculates if push notifications are enabled on the device.
     // Does not consider the existence of the subscription_id, as we send this in the request to create a push subscription.
     func calculateIsEnabled(address: String?, accepted: Bool, isDisabled: Bool) -> Bool {
-        return (self.address != nil) && _accepted && !_isDisabled
+        return address != nil && accepted && !isDisabled
     }
 
     func updateNotificationTypes() {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -216,8 +216,9 @@ class OSUserExecutor {
 
     static func executeIdentifyUserRequest(_ request: OSRequestIdentifyUser) {
         OneSignalClient.shared().execute(request) { _ in
-            // the anonymous user has been identified, no further action needed, no need to fetch user
-            executePendingRequests()
+            // the anonymous user has been identified, still need to Fetch User as we cleared local data
+            fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
+            executePendingRequests() // TODO: Here or before fetch?
         } onFailure: { error in
             // Returns 409 if any provided (label, id) pair exists on another User, so the SDK will switch to this user.
             if error?._code == 409 {


### PR DESCRIPTION
# Description
## One Line Summary
When the anonymous user has been identified, we still need to Fetch User as we cleared local data.

## Details

### Motivation
need to fetch user after successfully identifying user
* The anonymous user has been identified, but we still need to Fetch User as we cleared local data
* This will hydrate the `onesignal_id` again as well as other user properties

# Testing
## Manual testing
- Better manual testing this time with identifying user flows and checking the local data before and after. Also checked data on server with REST API.

1. Install app, see an anon user is created
2. Add a tag
3. Check local state: see tag, see the push subscription object
4. Login to a new external_id
5. See the identify user request and fetch user request are sent
6. Check the local data and see the the tag is there, the onesignal_id has not changed, the external_id is there, and pushsubscription model is same as before.
7. Check this user via REST API: see the same data as exists locally, and see it has the push subscription that we expect.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1210)
<!-- Reviewable:end -->
