### PR TITLE
[user model] Fix firing the push subscription observer

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -293,13 +293,13 @@ extension OSSubscriptionModel {
     // Calculates if the device is opted in to push notification.
     // Must have permission and not be opted out.
     func calculateIsOptedIn(accepted: Bool, isDisabled: Bool) -> Bool {
-        return _accepted && !_isDisabled
+        return accepted && !isDisabled
     }
 
     // Calculates if push notifications are enabled on the device.
     // Does not consider the existence of the subscription_id, as we send this in the request to create a push subscription.
     func calculateIsEnabled(address: String?, accepted: Bool, isDisabled: Bool) -> Bool {
-        return (self.address != nil) && _accepted && !_isDisabled
+        return address != nil && accepted && !isDisabled
     }
 
     func updateNotificationTypes() {


### PR DESCRIPTION
# Description
## One Line Summary
Fix bug in firing the push subscription observer, two methods were not correct.

## Details

### Motivation
* `calculateIsOptedIn` and `calculateIsEnabled` were not actually using the passed in arguments, and these methods were using the instance variables.

### Scope
Bug fix for firing push subscription observer. 

# Testing
## Manual testing
**Manual testing of push subscription observer behavior:**
1. Install app, fires twice for `token` and `subscriptionId`
2. prompt for push, fires once for the `optedIn` flag

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1211)
<!-- Reviewable:end -->
