### PR TITLE
[5.0.0] expose `setLaunchOptions` method for wrapper SDKs

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -321,9 +321,15 @@ static AppEntryAction _appEntryState = APP_CLOSE;
  1/2 steps in OneSignal init, relying on setAppId (usage order does not matter)
  Sets the iOS sepcific app settings
  Method must be called to successfully init OneSignal
+ Note: While this is called via `initialize`, it is also called directly from wrapper SDKs.
  */
 + (void)setLaunchOptions:(nullable NSDictionary*)newLaunchOptions {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"setLaunchOptions() called with launchOptions: %@!", launchOptions.description]];
+
+    // Don't continue if the newLaunchOptions are nil
+    if (!newLaunchOptions) {
+        return;
+    }
 
     launchOptions = newLaunchOptions;
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -82,6 +82,7 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (Class<OSNotifications>)Notifications NS_REFINED_FOR_SWIFT;
 
 #pragma mark Initialization
++ (void)setLaunchOptions:(nullable NSDictionary*)newLaunchOptions; // meant for use by wrappers
 + (void)initialize:(nonnull NSString*)newAppId withLaunchOptions:(nullable NSDictionary*)launchOptions;
 + (void)setLaunchURLsInApp:(BOOL)launchInApp;
 + (void)setProvidesNotificationSettingsView:(BOOL)providesView;


### PR DESCRIPTION
# Description
## One Line Summary
Expose `setLaunchOptions` method for use by wrappers.

## Details

### Motivation
This was a method wrapper SDKs had access to before. They need to pass the `launchOptions` early, before the app developer's `setAppId` method runs.

If the `launchOptions` passed through are `nil`, do nothing. They start out as `nil` in the SDK anyway before being set.

### Scope
Setting `launchOptions` from the wrapper SDKs.

# Testing
## Manual testing
Dev app builds and runs, but testing by wrapper SDKs is what will be needed.
- To mimic wrapper SDK calls, ran:
```objc
    [OneSignal setLaunchOptions:launchOptions];
    [OneSignal initialize:@"<APP_ID>" withLaunchOptions:nil];
```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1214)
<!-- Reviewable:end -->
