### PR TITLE
[5.0.0] no functional changes - `jsonRepresentation` method name consistency

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 @property (readonly, nonatomic) BOOL provisional;
 @property (readonly, nonatomic) BOOL providesAppNotificationSettings;
 @property (readonly, nonatomic) OSNotificationPermission status;
-- (NSDictionary* _Nonnull)toDictionary;
+- (NSDictionary * _Nonnull)jsonRepresentation;
 - (instancetype _Nonnull )initWithStatus:(OSNotificationPermission)status reachable:(BOOL)reachable hasPrompted:(BOOL)hasPrompted provisional:(BOOL)provisional providesAppNotificationSettings:(BOOL)providesAppNotificationSettings;
 @end
 
@@ -96,7 +96,7 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 
 @property (readonly, nonnull) OSPermissionState* to;
 @property (readonly, nonnull) OSPermissionState* from;
-- (NSDictionary* _Nonnull)toDictionary;
+- (NSDictionary * _Nonnull)jsonRepresentation;
 - (instancetype _Nonnull)initAsTo:(OSPermissionState * _Nonnull)to from:(OSPermissionState * _Nonnull)from;
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -211,7 +211,7 @@
     return [NSString stringWithFormat:format, self.hasPrompted, self.statusAsString, self.provisional];
 }
 
-- (NSDictionary*)toDictionary {
+- (NSDictionary*)jsonRepresentation {
     return @{@"hasPrompted": @(self.hasPrompted),
              @"status": @(self.status),
              @"provisional" : @(self.provisional)};
@@ -250,8 +250,8 @@
     return [NSString stringWithFormat:format, _from, _to];
 }
 
-- (NSDictionary*)toDictionary {
-    return @{@"from": [_from toDictionary], @"to": [_to toDictionary]};
+- (NSDictionary*)jsonRepresentation {
+    return @{@"from": [_from jsonRepresentation], @"to": [_to jsonRepresentation]};
 }
 
 - (instancetype)initAsTo:(OSPermissionState *)to from:(OSPermissionState *)from {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -35,7 +35,7 @@ struct OSPropertiesDeltas {
     let amountSpent: NSNumber?
     let purchases: [[String: AnyObject]]?
 
-    func toDictionary() -> [String: Any] {
+    func jsonRepresentation() -> [String: Any] {
         var deltas = [String: Any]()
         deltas["session_count"] = sessionCount
         deltas["session_time"] = sessionTime?.intValue // server expects an int

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -144,7 +144,7 @@ extension OSPropertyOperationExecutor {
 
         let request = OSRequestUpdateProperties(
             properties: [:],
-            deltas: propertiesDeltas.toDictionary(),
+            deltas: propertiesDeltas.jsonRepresentation(),
             refreshDeviceMetadata: refreshDeviceMetadata,
             modelToUpdate: propertiesModel,
             identityModel: identityModel)

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -52,7 +52,7 @@ public class OSPushSubscriptionState: NSObject {
         self.optedIn = optedIn
     }
 
-    @objc public func toDictionary() -> NSDictionary {
+    @objc public func jsonRepresentation() -> NSDictionary {
         let id = self.id ?? "nil"
         let token = self.token ?? "nil"
         return [
@@ -77,8 +77,8 @@ public class OSPushSubscriptionStateChanges: NSObject {
         self.from = from
     }
 
-    @objc public func toDictionary() -> NSDictionary {
-        return ["from": from.toDictionary(), "to": to.toDictionary()]
+    @objc public func jsonRepresentation() -> NSDictionary {
+        return ["from": from.jsonRepresentation(), "to": to.jsonRepresentation()]
     }
 }
 
@@ -353,7 +353,7 @@ extension OSSubscriptionModel {
         let stateChanges = OSPushSubscriptionStateChanges(to: newSubscriptionState, from: prevSubscriptionState)
 
         // TODO: Don't fire observer until server is udated
-        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "firePushSubscriptionChanged from \(prevSubscriptionState.toDictionary()) to \(newSubscriptionState.toDictionary())")
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "firePushSubscriptionChanged from \(prevSubscriptionState.jsonRepresentation()) to \(newSubscriptionState.jsonRepresentation())")
         OneSignalUserManagerImpl.sharedInstance.pushSubscriptionStateChangesObserver.notifyChange(stateChanges)
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
All public objects that need a serialization method for wrapper SDKs have one, but make the method naming consistent by using `jsonRepresentation` for all.

## Details

### Motivation
* All public objects that need a serialization method for wrapper SDKs have one
* But some are named `toDictionary` while the majority are named `jsonRepresentation`
* For consistency, name all these to `jsonRepresentation`

Checked all of these objects:
```
✅ OSInAppMessage 
✅ OSInAppMessageAction 
✅ OSOutcomeEvent 
✅ OSPushSubscriptionState 
✅ OSPushSubscriptionStateChanges 
✅ OSPermissionState
✅ OSPermissionStateChanges 
✅ OSNotification 
✅ OSNotificationOpenedResult 
```

I don't think I am missing any other public objects.

### Scope
Nit naming.

# Testing
## Manual testing
Dev app builds and runs.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1215)
<!-- Reviewable:end -->
