### PR TITLE
[5.0.0] Fill out subscription object and make subscription/permission fixes

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -423,14 +423,14 @@ static NSString *_pushSubscriptionId;
 
 // onOSPermissionChanged should only fire if something changed.
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    [_permissionStateChangesObserver addObserver:observer];
+    [self.permissionStateChangesObserver addObserver:observer];
     
     if ([self.currentPermissionState compare:self.lastPermissionState])
         [OSPermissionChangedInternalObserver fireChangesObserver:self.currentPermissionState];
 }
 
 + (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer {
-    [_permissionStateChangesObserver removeObserver:observer];
+    [self.permissionStateChangesObserver removeObserver:observer];
 }
 
 //    User just responed to the iOS native notification permission prompt.

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -228,7 +228,7 @@ static NSString *_pushSubscriptionId;
 }
 
 + (BOOL)canRequestPermission {
-    return !self.currentPermissionState.hasPrompted;
+    return !self.currentPermissionState.answeredPrompt;
 }
 
 + (void)requestPermission:(OSUserResponseBlock)block {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -237,7 +237,7 @@
     // Update the push subscription's _accepted property
     // TODO: This can be called before the User Manager has set itself as the delegate
     if (OSNotificationsManager.delegate && [OSNotificationsManager.delegate respondsToSelector:@selector(setAccepted:)]) {
-        [OSNotificationsManager.delegate setAccepted:state.accepted];
+        [OSNotificationsManager.delegate setAccepted:state.reachable];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -191,6 +191,8 @@ class OSSubscriptionModel: OSModel {
     let deviceOs = UIDevice.current.systemVersion
     let sdk = ONESIGNAL_VERSION
     let deviceModel: String? = OSDeviceUtils.getDeviceVariant()
+    let appVersion: String? = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    let netType: Int? = OSNetworkingUtils.getNetType() as? Int
 
     // When a Subscription is initialized, it may not have a subscriptionId until a request to the backend is made.
     init(type: OSSubscriptionType,
@@ -231,6 +233,7 @@ class OSSubscriptionModel: OSModel {
         coder.encode(_accepted, forKey: "_accepted")
         coder.encode(_isDisabled, forKey: "_isDisabled")
         coder.encode(notificationTypes, forKey: "notificationTypes")
+        coder.encode(testType, forKey: "testType")
     }
 
     required init?(coder: NSCoder) {
@@ -247,6 +250,7 @@ class OSSubscriptionModel: OSModel {
         self._accepted = coder.decodeBool(forKey: "_accepted")
         self._isDisabled = coder.decodeBool(forKey: "_isDisabled")
         self.notificationTypes = coder.decodeInteger(forKey: "notificationTypes")
+        self.testType = coder.decodeObject(forKey: "testType") as? Int
         super.init(coder: coder)
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -162,9 +162,13 @@ class OSSubscriptionModel: OSModel {
             self.set(property: "notificationTypes", newValue: notificationTypes)
         }
     }
+
     // swiftlint:disable identifier_name
-    // This is set by the permission state changing
-    // Defaults to true for email & SMS, defaults to false for push
+    /**
+     This is set by the permission state changing.
+     Defaults to true for email & SMS, defaults to false for push.
+     Note that this property reflects the `reachable` property of a permission state. As provisional permission is considered to be `optedIn` and `enabled`.
+     */
     var _accepted: Bool {
         didSet {
             guard self.type == .push && _accepted != oldValue else {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -331,12 +331,12 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         pushSubscriptionObject["type"] = pushSubscriptionModel.type.rawValue
         pushSubscriptionObject["token"] = pushSubscriptionModel.address
         pushSubscriptionObject["enabled"] = pushSubscriptionModel.enabled
-
         pushSubscriptionObject["test_type"] = pushSubscriptionModel.testType
         pushSubscriptionObject["device_os"] = pushSubscriptionModel.deviceOs
         pushSubscriptionObject["sdk"] = pushSubscriptionModel.sdk
         pushSubscriptionObject["device_model"] = pushSubscriptionModel.deviceModel
-
+        pushSubscriptionObject["app_version"] = pushSubscriptionModel.appVersion
+        pushSubscriptionObject["net_type"] = pushSubscriptionModel.netType
         // notificationTypes defaults to -1 instead of nil, don't send if it's -1
         if pushSubscriptionModel.notificationTypes != -1 {
             pushSubscriptionObject["notification_types"] = pushSubscriptionModel.notificationTypes


### PR DESCRIPTION
## One Line Summary
Fill out the push subscription object sent to server, and make some subscription/permission fixes.


## Details

### Motivation
We want to still send most of the old player information that has moved to the push subscription object. 
There were also some misc. bugs related to subscriptions and permissions as well.

## Changes Made

**(1) Add properties to Subscription Model**
* Fill out the rest of the properties on a push subscription model like the `app_version` and `net_type`
* I chose to omit `rooted` and `carrier` in this PR as `rooted` doesn't appear to be sent to the server for iOS devices and Apple methods to retrieve `carrier` are being deprecated.
<br>


**(2) Fix bug where permission observer was accessing a `nil` internal observer instance**
* Needs to use `self.permissionStateChangesObserver` instead of `_permissionStateChangesObserver`
<br>


**(3) Update the public API `canRequestPermission` to reflect the `answeredPrompt` property instead**
* `OneSignal.Notifications.canRequestPermission` returns a boolean to indicate if the native dialog will appear 
* This is better suited to reflect `answeredPrompt` instead of `hasPrompted`
* Cases may be the app quits before the user chooses a permission, or the permission prompt is swiped away. 
* In these cases, `hasPrompted` will differ from `canRequestPermission`
<br>

**(4) The push subscription properties `optedIn` and `enabled` will consider provisional permission as true**
* Update the `_accepted` property on a push subscription model to reflect `reachable` instead of `accepted`
* Provisional permission means notifications can be displayed.
* In this case, even though the user has not explicitly accepted push notification permissions, we will consider `optedIn` and `enabled` as true
* In addition, the server also considers a device with provisional permission to be subscribed


# Testing
## Unit testing
None

## Manual testing
Manual testing on iPhone 13 physical device.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1216)
<!-- Reviewable:end -->
