### PR TITLE
Replace NSLog with OneSignalLog

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -373,7 +373,7 @@
        externalIdAuthToken:(NSString *)externalIdAuthToken {
     let request = [OSRequestUpdateLanguage new];
     
-    NSLog(@"Attempting Update to Language");
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Attempting Update to Language"]];
     
     let params = [NSMutableDictionary new];
     params[@"app_id"] = appId;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalClient.m
@@ -101,13 +101,13 @@
                 results[identifier] = result;
                 // Add a success as 1 (success) to the response
                 response[identifier] = @{ @"success" : @(true) };
-                NSLog(@"Request %@ success result %@", request, result);
+                [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Request %@ success result %@", request, result]];
                 dispatch_group_leave(group);
             } onFailure:^(NSError *error) {
                 errors[identifier] = error;
                 // Add a success as 0 (failed) to the response
                 response[identifier] = @{ @"success" : @(false) };
-                NSLog(@"Request %@ fail result error %@", request, error);
+                [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Request %@ fail result error %@", request, error]];
                 dispatch_group_leave(group);
             }];
         }
@@ -153,11 +153,11 @@
             dispatch_group_enter(group);
             [self executeRequest:request onSuccess:^(NSDictionary *result) {
                 results[identifier] = result;
-                NSLog(@"Request %@ success result %@", request, result);
+                [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Request %@ success result %@", request, result]];
                 dispatch_group_leave(group);
             } onFailure:^(NSError *error) {
                 errors[identifier] = error;
-                NSLog(@"Request %@ fail result error %@", request, error);
+                [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Request %@ fail result error %@", request, error]];
                 dispatch_group_leave(group);
             }];
         }

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -477,10 +477,10 @@ static BOOL _isInAppMessagingPaused = false;
     BOOL messageDismissed = [_seenInAppMessages containsObject:message.messageId];
     let redisplayMessageSavedData = [_redisplayedInAppMessages objectForKey:message.messageId];
 
-    NSLog(@"Redisplay dismissed: %@ and data: %@", messageDismissed ? @"YES" : @"NO", redisplayMessageSavedData.jsonRepresentation.description);
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Redisplay dismissed: %@ and data: %@", messageDismissed ? @"YES" : @"NO", redisplayMessageSavedData.jsonRepresentation.description]];
 
     if (messageDismissed && redisplayMessageSavedData) {
-        NSLog(@"Redisplay IAM: %@", message.jsonRepresentation.description);
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Redisplay IAM: %@", message.jsonRepresentation.description]];
         message.displayStats.displayQuantity = redisplayMessageSavedData.displayStats.displayQuantity;
         message.displayStats.lastDisplayTime = redisplayMessageSavedData.displayStats.lastDisplayTime;
 


### PR DESCRIPTION
# Description
## One Line Summary
Replace NSLog with OneSignalLog

## Details

### Motivation
Addresses #1171 where some OneSignal logging was being sent through NSLog instead of OneSignalLog.

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are Change methods where NSLog was used for OneSignal messages.  Update to OneSignalLog so that logging can be adjusted and/or turned off using setLogLevel.

### OPTIONAL - Other
Searched iOS SDK for other instances outside of OneSignalClient where NSLog was being used and updated to OneSignalLog.

# Testing
## Unit testing
No unit testing

## Manual testing
Manually tested  and confirmed on an iOS simulator that these messages no longer display when calling `OneSignal setLogLevel:ONE_S_LL_NONE visualLevel:ONE_S_LL_NONE]`

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1219)
<!-- Reviewable:end -->
