### PR TITLE
[5.0.0] Update API for beta-01

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,4 @@
-<h1 align="center">OneSignal iOS SDK v5.0.0-alpha-02 Migration Guide</h1>
+<h1 align="center">OneSignal iOS SDK v5.0.0-beta-01 Migration Guide</h1>
 
 ![OneSignal Omni Channel Banner](https://user-images.githubusercontent.com/11739227/208625336-d28c8d01-a7cf-4f8e-9643-ac8d1948e9ae.png)
 
@@ -8,7 +8,7 @@ In this release, we are making a significant shift from a device-centered model 
 
 To facilitate this change, the `externalId` approach for identifying users is being replaced by the `login` and `logout` methods. In addition, the SDK now makes use of namespaces such as `User`, `Notifications`, and `InAppMessages` to better separate code.
 
-The iOS SDK is making the jump from `v3` to `v5`, in order to align across OneSignal’s suite of client SDKs. This guide will walk you through the iOS SDK `5.0.0-alpha-02` changes as a result of this shift.
+The iOS SDK is making the jump from `v3` to `v5`, in order to align across OneSignal’s suite of client SDKs. This guide will walk you through the iOS SDK `5.0.0-beta-01` changes as a result of this shift.
 
 # Overview
 
@@ -60,10 +60,10 @@ As mentioned above, the iOS SDK is making the jump from `v3` to `v5`, in order t
 ```
 
 ### Option 1. Swift Package Manager
-Update the version of the OneSignal-XCFramework your application uses to `5.0.0-alpha-02`. In addition, the Package Product name has been changed from `OneSignal` to `OneSignalFramework`. See [the existing installation instructions](https://documentation.onesignal.com/docs/swift-package-manager-setup).
+Update the version of the OneSignal-XCFramework your application uses to `5.0.0-beta-01`. In addition, the Package Product name has been changed from `OneSignal` to `OneSignalFramework`. See [the existing installation instructions](https://documentation.onesignal.com/docs/swift-package-manager-setup).
 
 ### Option 2. CocoaPods
-Update the version of the OneSignalXCFramework your application uses to `5.0.0-alpha-02`. Other than updating the import statement above, there are no additional changes needed to import the OneSignal SDK in your Xcode project. See [the existing installation instructions](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-import-the-onesignal-sdk-into-your-xcode-project).
+Update the version of the OneSignalXCFramework your application uses to `5.0.0-beta-01`. Other than updating the import statement above, there are no additional changes needed to import the OneSignal SDK in your Xcode project. See [the existing installation instructions](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-import-the-onesignal-sdk-into-your-xcode-project).
 
 # API Changes
 ## Namespaces
@@ -213,7 +213,7 @@ Email and/or SMS subscriptions can be added or removed via the following methods
 
 # API Reference
 
-Below is a comprehensive reference to the `5.0.0-alpha-02` OneSignal SDK.
+Below is a comprehensive reference to the `5.0.0-beta-01` OneSignal SDK.
 
 ## OneSignal
 
@@ -727,14 +727,12 @@ The Debug namespace is accessible via `OneSignal.Debug` and provide access to de
 
 # Limitations
 
-- Recommend using only in development and staging environments for Alpha releases
-- Aliases will be available in a future release
+- Recommend using only in development and staging environments for Beta releases
 - Outcomes will be available in a future release
-- Users are deleted when the last Subscription (push, email, or sms) is removed
 - Any `User` namespace calls must be invoked **after** initialization. Example: `OneSignal.User.addTag("tag", "2")`
 
 # Known issues
 - User properties may not update correctly when Subscriptions are transferred
     - Please report any issues you find with this
 - Identity Verification 
-    - We will be introducing JWT in a follow up Alpha or Beta release
+    - We will be introducing JWT in a follow up Beta release

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -143,11 +143,15 @@ The current device’s push subscription can be retrieved via:
 
 **Objective-C**
 ```objc
-    id<OSPushSubscription> pushSubscription = OneSignal.User.pushSubscription;
+    OneSignal.User.pushSubscription.id;
+    OneSignal.User.pushSubscription.token;
+    OneSignal.User.pushSubscription.optedIn;
 ```
 **Swift**
 ```swift
-    let pushSubscription: OSPushSubscription = OneSignal.User.pushSubscription
+    OneSignal.User.pushSubscription.id
+    OneSignal.User.pushSubscription.token
+    OneSignal.User.pushSubscription.optedIn
 ```
 
 ### **Opting In and Out of Push Notifications**
@@ -186,12 +190,12 @@ Email and/or SMS subscriptions can be added or removed via the following methods
     // Add email subscription
     [OneSignal.User addEmail:@"customer@company.com"];
     // Remove previously added email subscription
-    BOOL success = [OneSignal.User removeEmail:@"customer@company.com"];
+    [OneSignal.User removeEmail:@"customer@company.com"];
     
     // Add SMS subscription
-    [OneSignal.User addSmsNumber:@"+15558675309"];
+    [OneSignal.User addSms:@"+15558675309"];
     // Remove previously added SMS subscription
-    BOOL succss = [OneSignal.User removeSmsNumber:@"+15558675309"];
+    [OneSignal.User removeSms:@"+15558675309"];
 ```
 
 **Swift**
@@ -199,12 +203,12 @@ Email and/or SMS subscriptions can be added or removed via the following methods
     // Add email subscription
     OneSignal.User.addEmail("customer@company.com")
     // Remove previously added email subscription
-    let success: Bool = OneSignal.User.removeEmail("customer@company.com")
+    OneSignal.User.removeEmail("customer@company.com")
     
     // Add SMS subscription
-    OneSignal.User.addSmsNumber("+15558675309")
+    OneSignal.User.addSms("+15558675309")
     // Remove previously added SMS subscription
-    let success: Bool = OneSignal.User.removeSmsNumber("+15558675309")     
+    OneSignal.User.removeSms("+15558675309")     
 ```
 
 # API Reference
@@ -291,15 +295,15 @@ The User name space is accessible via `OneSignal.User` and provides access to us
 | **Swift**                                                                                                       | **Objective-C**                                                                                       | **Description**                                                                                                                                                                                                                          |
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OneSignal.User.setLanguage("en")`                                                                              | `[OneSignal.User setLanguage:@"en"]`                                                                  | *Set the 2-character language  for this user.*                                                                                                                                                                                         |
-| `let pushSubscription: OSPushSubscription = OneSignal.User.pushSubscription`                                    | `id<OSPushSubscription> pushSubscription = OneSignal.User.pushSubscription`                           | *The push subscription associated to the current user.*                                                                                                                                                                                  |
+| `let pushSubscriptionProperty = OneSignal.User.pushSubscription.<PROPERTY>`                                    | `id pushSubscriptionProperty = OneSignal.User.pushSubscription.<PROPERTY>`                           | *The push subscription associated to the current user.*                                                                                                                                                                                  |
 | `OneSignal.User.addAlias(label: "ALIAS_LABEL", id: "ALIAS_ID")`                                         | `[OneSignal.User addAliasWithLabel:@"ALIAS_LABEL" id:@"ALIAS_ID"]`                                    | *Set an alias for the current user.  If this alias label already exists on this user, it will be overwritten with the new alias id.*                                                                                         |
 | `OneSignal.User.addAliases(["ALIAS_LABEL_01": "ALIAS_ID_01", "ALIAS_LABEL_02": "ALIAS_ID_02"])` | `[OneSignal.User addAliases:@{@"ALIAS_LABEL_01": @"ALIAS_ID_01", @"ALIAS_LABEL_02": @"ALIAS_ID_02"}]` | *Set aliases for the current user. If any alias already exists, it will be overwritten to the new values.*                                                                                                                       |
 | `OneSignal.User.removeAlias("ALIAS_LABEL")`                                                                 | `[OneSignal.User removeAlias:@"ALIAS_LABEL"]`                                                         | *Remove an alias from the current user.*                                                                                                                                                                                                 |
 | `OneSignal.User.removeAliases(["ALIAS_LABEL_01", "ALIAS_LABEL_02"])`                                    | `[OneSignal.User removeAliases:@[@"ALIAS_LABEL_01", @"ALIAS_LABEL_02"]]`                              | *Remove aliases from the current user.*                                                                                                                                                                                              |
 | `OneSignal.User.addEmail("customer@company.com")`                                                           | `[OneSignal.User addEmail:@"customer@company.com"]`                                               | *Add a new email subscription to the current user.*                                                                                                                                                                                      |
-| `let success: Bool = OneSignal.User.removeEmail("customer@company.com")`                                | `BOOL success = [OneSignal.User removeEmail:@"customer@company.com"]`                             | *Remove an email subscription from the current user. Returns `false` if the specified email does not exist on the user within the SDK, and no request will be made.*                                                               |
-| `OneSignal.User.addSmsNumber("+15558675309")`                                                               | `[OneSignal.User addSmsNumber:@"+15558675309"]`                                                   | *Add a new SMS subscription to the current user.*                                                                                                                                                                                        |
-| `let success: Bool = OneSignal.User.removeSmsNumber("+15558675309")`                                    | `BOOL success = [OneSignal.User removeSmsNumber:@"+15558675309"]`                                 | *Remove an SMS subscription from the current user. Returns `false` if the specified SMS number does not exist on the user within the SDK, and no request will be made.*                                                            |
+| `OneSignal.User.removeEmail("customer@company.com")`                                | `[OneSignal.User removeEmail:@"customer@company.com"]`                             | *Remove an email subscription from the current user. Returns `false` if the specified email does not exist on the user within the SDK, and no request will be made.*                                                               |
+| `OneSignal.User.addSms("+15558675309")`                                                               | `[OneSignal.User addSms:@"+15558675309"]`                                                   | *Add a new SMS subscription to the current user.*                                                                                                                                                                                        |
+| `OneSignal.User.removeSms("+15558675309")`                                    | `[OneSignal.User removeSms:@"+15558675309"]`                                 | *Remove an SMS subscription from the current user. Returns `false` if the specified SMS number does not exist on the user within the SDK, and no request will be made.*                                                            |
 | `OneSignal.User.addTag(key: "KEY", value: "VALUE")`                                                     | `[OneSignal.User addTagWithKey:@"KEY" value:@"VALUE"]`                                                | *Add a tag for the current user.  Tags are key:value pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.*         |
 | `OneSignal.User.addTags(["KEY_01": "VALUE_01", "KEY_02": "VALUE_02"])`                          | `[OneSignal.User addTags:@{@"KEY_01": @"VALUE_01", @"KEY_02": @"VALUE_02"}]`                          | *Add multiple tags for the current user.  Tags are key:value pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.* |
 | `OneSignal.User.removeTag("KEY")`                                                                           | `[OneSignal.User removeTag:@"KEY"]`                                                                   | *Remove the data tag with the provided key from the current user.*                                                                                                                                                                       |
@@ -319,7 +323,7 @@ The Push Subscription name space is accessible via `OneSignal.User.pushSubscript
 | `let optedIn: Bool = OneSignal.User.pushSubscription.optedIn`                                                     | `BOOL optedIn = OneSignal.User.pushSubscription.optedIn`                                                                               | *Gets a boolean value indicating whether the current user is opted in to push notifications. This returns `true` when the app has notifications permission and `optedOut` is called. ***Note:*** Does not take into account the existence of the subscription ID and push token. This boolean may return `true` but push notifications may still not be received by the user.* |
 | `OneSignal.User.pushSubscription.optIn()`                                                                         | `[OneSignal.User.pushSubscription optIn]`                                                                                              | *Call this method to receive push notifications on the device or to resume receiving of push notifications after calling `optOut`. If needed, this method will prompt the user for push notifications permission.*                                                                                                                                                                     |
 | `OneSignal.User.pushSubscription.optOut()`                                                                        | `[OneSignal.User.pushSubscription optOut]`                                                                                             | *If at any point you want the user to stop receiving push notifications on the current device (regardless of system-level permission status), you can call this method to opt out.*                                                                                                                                                                                                              |
-| `addObserver(_ observer: OSPushSubscriptionObserver) → OSPushSubscriptionState?`<br><br>***See below for usage*** | `(OSPushSubscriptionState * _Nullable)addObserver:(id <OSPushSubscriptionObserver> _Nonnull)observer`<br><br>***See below for usage*** | *The `OSPushSubscriptionObserver.onOSPushSubscriptionChanged` method will be fired on the passed-in object when the push subscription changes. This method returns the current `OSPushSubscriptionState` at the time of adding this observer.*                                                                                                                                 |
+| `addObserver(_ observer: OSPushSubscriptionObserver)`<br><br>***See below for usage*** | `(void)addObserver:(id <OSPushSubscriptionObserver> _Nonnull)observer`<br><br>***See below for usage*** | *The `OSPushSubscriptionObserver.onOSPushSubscriptionChanged` method will be fired on the passed-in object when the push subscription changes. This method returns the current `OSPushSubscriptionState` at the time of adding this observer.*                                                                                                                                 |
 | `removeObserver(_ observer: OSPushSubscriptionObserver)`<br><br>***See below for usage***                         | `(void)removeObserver:(id <OSPushSubscriptionObserver> _Nonnull)observer`<br><br>***See below for usage***                             | *Remove a push subscription observer that has been previously added.*                                                                                                                                                                                                                                                                                                                      |
 
 ### Push Subscription Observer
@@ -338,7 +342,7 @@ Any object implementing the `OSPushSubscriptionObserver` protocol can be added a
       
     - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
       // Add your AppDelegate as an observer
-      OSPushSubscriptionState* state = [OneSignal.User.pushSubscription addObserver:self];
+      [OneSignal.User.pushSubscription addObserver:self];
     }
     
     // Add this new method
@@ -359,7 +363,7 @@ Any object implementing the `OSPushSubscriptionObserver` protocol can be added a
     
        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Add your AppDelegate as an observer, and the current OSPushSubscriptionState will be returned
-        let state: OSPushSubscriptionState? = OneSignal.User.pushSubscription.addObserver(self as OSPushSubscriptionObserver)
+        OneSignal.User.pushSubscription.addObserver(self as OSPushSubscriptionObserver)
         print("Current pushSubscriptionState: \n\(state)")
        }
     
@@ -464,26 +468,22 @@ Any object implementing the `OSPermissionObserver` protocol can be added as an o
     }
     
     // Add this new method
-    - (void)onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
-        // Example of detecting anwsering the permission prompt
-        if (stateChanges.from.status == OSNotificationPermissionNotDetermined) {
-          if (stateChanges.to.status == OSNotificationPermissionAuthorized)
-             NSLog(@"Thanks for accepting notifications!");
-          else if (stateChanges.to.status == OSNotificationPermissionDenied)
-             NSLog(@"Notifications not accepted. You can turn them on later under your iOS settings.");
+    - (void)onOSPermissionChanged:(OSPermissionState*)state {
+        // Example of detecting the curret permission
+        if (state.permission == true) {
+            NSLog(@"Device has permission to display notifications");
+        } else {
+             NSLog(@"Device does not have permission to display notifications");
         }
         // prints out all properties
-        NSLog(@"PermissionStateChanges:\n%@", stateChanges);
+        NSLog(@"PermissionState:\n%@", state);
     }
     
     // Output:
     /*
-     Thanks for accepting notifications!
-     PermissionStateChanges:
-     <OSPermissionStateChanges:
-     from: <OSPermissionState: hasPrompted: 1, status: NotDetermined, provisional: 0>,
-     to:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>
-     >
+     Device has permission to display notifications
+     PermissionState:
+     <OSPermissionState: permission: 1>
      */
     
     @end
@@ -498,33 +498,28 @@ Any object implementing the `OSPermissionObserver` protocol can be added as an o
     class AppDelegate: UIResponder, UIApplicationDelegate, OSPermissionObserver {
     
        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Add your AppDelegate as an observer
-        OneSignal.Notifications.addPermissionObserver(self as OSPermissionObserver)
-       }
-    
-      // Add this new method
-      func onOSPermissionChanged(_ stateChanges: OSPermissionStateChanges) {
-        // Example of detecting answering the permission prompt
-        if stateChanges.from.status == OSNotificationPermission.notDetermined {
-           if stateChanges.to.status == OSNotificationPermission.authorized {
-              print("Thanks for accepting notifications!")
-           } else if stateChanges.to.status == OSNotificationPermission.denied {
-              print("Notifications not accepted. You can turn them on later under your iOS settings.")
-           }
+            // Add your AppDelegate as an observer
+            OneSignal.Notifications.addPermissionObserver(self as OSPermissionObserver)
         }
-        // prints out all properties
-        print("PermissionStateChanges: \n\(stateChanges)")
-      }
+
+        // Add this new method
+        func onOSPermissionChanged(_ state: OSPermissionState) {
+            // Example of detecting the curret permission
+            if state.permission == true {
+                print("Device has permission to display notifications")
+            } else {
+                print("Device does not have permission to display notifications")
+            }
+            // prints out all properties
+            print("PermissionState: \n\(state)")
+        }
     }
     
     // Output:
     /*
-     Thanks for accepting notifications!
-     PermissionStateChanges:
-     <OSPermissionStateChanges:
-     from: <OSPermissionState: hasPrompted: 1, status: NotDetermined, provisional: 0>,
-     to:   <OSPermissionState: hasPrompted: 1, status: Authorized, provisional: 0>
-     >
+     Device has permission to display notifications
+     PermissionState:
+     <OSPermissionState: permission: 1>
      */
     
     // Remove the observer
@@ -722,7 +717,7 @@ The Debug namespace is accessible via `OneSignal.Debug` and provide access to de
 | **Swift**                                  | **Objective-C**                                  | **Description**                                                                    |
 | ------------------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | `OneSignal.Debug.setLogLevel(.LL_VERBOSE)` | `[OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE]` | *Sets the log level the OneSignal SDK should be writing to the Xcode log.* |
-| `OneSignal.Debug.setVisualLevel(.LL_NONE)` | `[OneSignal.Debug setVisualLevel:ONE_S_LL_NONE]` | *Sets the logging level to show as alert dialogs.*                                 |
+| `OneSignal.Debug.setAlertLevel(.LL_NONE)` | `[OneSignal.Debug setAlertLevel:ONE_S_LL_NONE]` | *Sets the logging level to show as alert dialogs.*                                 |
 
 
 # Glossary

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -117,12 +117,12 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     // [OneSignal setAppId:onesignalAppId];
 }
 
-- (void) onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
-    NSLog(@"onOSPermissionChanged: %@", stateChanges);
+- (void)onOSPermissionChanged:(OSPermissionState*)state {
+    NSLog(@"Dev App onOSPermissionChanged: %@", state);
 }
 
 - (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges *)stateChanges {
-    NSLog(@"onOSPushSubscriptionChangedWithStateChanges: %@", stateChanges);
+    NSLog(@"Dev App onOSPushSubscriptionChangedWithStateChanges: %@", stateChanges);
     ViewController* mainController = (ViewController*) self.window.rootViewController;
     mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.optedIn;
 }

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -51,7 +51,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     NSLog(@"Bundle URL: %@", [[NSBundle mainBundle] bundleURL]);
     [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
-    [OneSignal.Debug setVisualLevel:ONE_S_LL_NONE];
+    [OneSignal.Debug setAlertLevel:ONE_S_LL_NONE];
     
     [OneSignal initialize:[AppDelegate getOneSignalAppId] withLaunchOptions:launchOptions];
     

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -90,8 +90,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.Notifications setNotificationWillShowInForegroundHandler:notificationReceiverBlock];
     [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
 
-    OSPushSubscriptionState* state = [OneSignal.User.pushSubscription addObserver:self];
-    NSLog(@"OneSignal Demo App push subscription observer added, current state: %@", state);
+    [OneSignal.User.pushSubscription addObserver:self];
+    NSLog(@"OneSignal Demo App push subscription observer added");
     
     [OneSignal.Notifications addPermissionObserver:self];
     

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -131,13 +131,7 @@
 }
 
 - (IBAction)getInfoButton:(id)sender {
-    NSLog(@"💛 Dev App: get User and Device information");
-    [OneSignalUserManagerImpl.sharedInstance internalDumpInfo];
-    NSLog(@"💛 Dev App: OneSignal.Notifications permission: %d", [OneSignal.Notifications permission]);
-    NSLog(@"💛 Dev App: OneSignal.Notifications.canRequestPermission: %d", [OneSignal.Notifications canRequestPermission]);
-    [OneSignal internalDumpInfo];
-    NSLog(@"💛 Dev App: getPrivacyConsent: %d", OneSignal.getPrivacyConsent);
-    NSLog(@"💛 Dev App: requiresPrivacyConsent: %d", [OneSignal requiresPrivacyConsent]);
+    NSLog(@"Dev App: get User and Device information, you need to fill in");
 }
 
 - (IBAction)sendTagsButton:(id)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -100,13 +100,13 @@
 - (IBAction)addSmsButton:(id)sender {
     NSString *sms = self.smsTextField.text;
     NSLog(@"Dev App: Add sms: %@", sms);
-    [OneSignal.User addSmsNumber:sms];
+    [OneSignal.User addSms:sms];
 }
 
 - (IBAction)removeSmsButton:(id)sender {
     NSString *sms = self.smsTextField.text;
     NSLog(@"Dev App: Removing sms: %@", sms);
-    [OneSignal.User removeSmsNumber:sms];
+    [OneSignal.User removeSms:sms];
 }
 
 - (IBAction)addAliasButton:(UIButton *)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -52,7 +52,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     NSLog(@"Bundle URL: %@", [[NSBundle mainBundle] bundleURL]);
     
     [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
-    [OneSignal.Debug setVisualLevel:ONE_S_LL_NONE];
+    [OneSignal.Debug setAlertLevel:ONE_S_LL_NONE];
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
     
     id openNotificationHandler = ^(OSNotificationOpenedResult *result) {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -112,8 +112,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal initialize:onesignalAppId withLaunchOptions:nil];
 }
 
-- (void) onOSPermissionChanged:(OSPermissionStateChanges*)stateChanges {
-    NSLog(@"onOSPermissionChanged: %@", stateChanges);
+- (void) onOSPermissionChanged:(OSPermissionState*)state {
+    NSLog(@"onOSPermissionChanged: %@", state);
 }
 
 // TODO: Add push sub observer

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.h
@@ -38,12 +38,12 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 
 @protocol OSDebug <NSObject>
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel;
-+ (void)setVisualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
++ (void)setAlertLevel:(ONE_S_LOG_LEVEL)logLevel NS_REFINED_FOR_SWIFT;
 @end
 
 @interface OneSignalLog : NSObject<OSDebug>
 + (Class<OSDebug>)Debug;
 + (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel;
-+ (void)setVisualLevel:(ONE_S_LOG_LEVEL)visualLogLevel;
++ (void)setAlertLevel:(ONE_S_LOG_LEVEL)logLevel;
 + (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.m
@@ -32,7 +32,7 @@
 @implementation OneSignalLog
 
 static ONE_S_LOG_LEVEL _nsLogLevel = ONE_S_LL_WARN;
-static ONE_S_LOG_LEVEL _visualLogLevel = ONE_S_LL_NONE;
+static ONE_S_LOG_LEVEL _alertLogLevel = ONE_S_LL_NONE;
 
 + (Class<OSDebug>)Debug {
     return self;
@@ -42,8 +42,8 @@ static ONE_S_LOG_LEVEL _visualLogLevel = ONE_S_LL_NONE;
     _nsLogLevel = nsLogLevel;
 }
 
-+ (void)setVisualLevel:(ONE_S_LOG_LEVEL)visualLogLevel {
-    _visualLogLevel = visualLogLevel;
++ (void)setAlertLevel:(ONE_S_LOG_LEVEL)logLevel {
+    _alertLogLevel = logLevel;
 }
 
 + (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message {
@@ -79,7 +79,7 @@ void onesignal_Log(ONE_S_LOG_LEVEL logLevel, NSString* message) {
     if (logLevel <= _nsLogLevel)
         NSLog(@"%@", [levelString stringByAppendingString:message]);
     
-    if (logLevel <= _visualLogLevel) {
+    if (logLevel <= _alertLogLevel) {
         [[OSDialogInstanceManager sharedInstance] presentDialogWithTitle:levelString withMessage:message withActions:nil cancelTitle:NSLocalizedString(@"Close", @"Close button") withActionCompletion:nil];
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/RemoteParameters/OSRemoteParamController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/RemoteParameters/OSRemoteParamController.m
@@ -35,6 +35,8 @@ THE SOFTWARE.
 
 static OSRemoteParamController *_sharedController;
 + (OSRemoteParamController *)sharedController {
+    if (!_sharedController)
+        _sharedController = [OSRemoteParamController new];
     return _sharedController;
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -57,7 +57,7 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 // can check responds to selector
 - (void)setNotificationTypes:(int)notificationTypes;
 - (void)setPushToken:(NSString * _Nonnull)pushToken;
-- (void)setAccepted:(BOOL)inAccepted;
+- (void)setReachable:(BOOL)inReachable;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -143,6 +143,7 @@ static OneSignalNotificationSettings *_osNotificationSettings;
     return _osNotificationSettings;
 }
 
+// static property def to add developer's OSPermissionStateChanges observers to.
 static ObservablePermissionStateChangesType* _permissionStateChangesObserver;
 + (ObservablePermissionStateChangesType*)permissionStateChangesObserver {
     if (!_permissionStateChangesObserver)
@@ -421,11 +422,11 @@ static NSString *_pushSubscriptionId;
     [self sendNotificationTypesUpdateToDelegate];
 }
 
-// onOSPermissionChanged should only fire if something changed.
+// onOSPermissionChanged should only fire if the reachable property changed.
 + (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
     [self.permissionStateChangesObserver addObserver:observer];
     
-    if ([self.currentPermissionState compare:self.lastPermissionState])
+    if (self.currentPermissionState.reachable != self.lastPermissionState.reachable)
         [OSPermissionChangedInternalObserver fireChangesObserver:self.currentPermissionState];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -456,8 +456,8 @@ static NSString *_pushSubscriptionId;
 + (void)sendNotificationTypesUpdateToDelegate {
     // We don't delay observer update to wait until the OneSignal server is notified
     // TODO: We can do the above and delay observers until server is updated.
-    if (self.delegate && [self.delegate respondsToSelector:@selector(setAccepted:)]) {
-        [self.delegate setAccepted:[self getNotificationTypes] > 0];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(setReachable:)]) {
+        [self.delegate setReachable:[self getNotificationTypes] > 0];
     }
     if (self.delegate && [self.delegate respondsToSelector:@selector(setNotificationTypes:)]) {
         [self.delegate setNotificationTypes:[self getNotificationTypes]];

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -337,6 +337,8 @@ static NSString *_pushSubscriptionId;
 }
 
 + (void)clearAll {
+    [[UNUserNotificationCenter currentNotificationCenter] removeAllDeliveredNotifications];
+    // TODO: Determine if we also need to call clearBadgeCount
     [self clearBadgeCount:false];
 }
 
@@ -369,9 +371,6 @@ static NSString *_pushSubscriptionId;
 
 + (void)didRegisterForRemoteNotifications:(UIApplication *)app
                               deviceToken:(NSData *)inDeviceToken {
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
-        return;
-
     let parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
 
     [OneSignalLog onesignalLog:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.h
@@ -49,13 +49,9 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 // Permission Classes
 @interface OSPermissionState : NSObject
 // TODO: Decide: remove/change properties after addition of canRequestPermission and permission boolean
-@property (readonly, nonatomic) BOOL reachable;
-@property (readonly, nonatomic) BOOL hasPrompted;
-@property (readonly, nonatomic) BOOL provisional;
-@property (readonly, nonatomic) BOOL providesAppNotificationSettings;
-@property (readonly, nonatomic) OSNotificationPermission status;
+@property (readonly, nonatomic) BOOL permission;
 - (NSDictionary * _Nonnull)jsonRepresentation;
-- (instancetype _Nonnull )initWithStatus:(OSNotificationPermission)status reachable:(BOOL)reachable hasPrompted:(BOOL)hasPrompted provisional:(BOOL)provisional providesAppNotificationSettings:(BOOL)providesAppNotificationSettings;
+- (instancetype _Nonnull )initWithPermission:(BOOL)permission;
 @end
 
 @protocol OSPermissionStateObserver<NSObject>
@@ -87,24 +83,15 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 - (instancetype _Nonnull )initAsTo;
 - (instancetype _Nonnull )initAsFrom;
 
-- (BOOL)compare:(OSPermissionStateInternal * _Nonnull)from;
 - (OSPermissionState * _Nonnull)getExternalState;
-
-@end
-
-@interface OSPermissionStateChanges : NSObject
-
-@property (readonly, nonnull) OSPermissionState* to;
-@property (readonly, nonnull) OSPermissionState* from;
 - (NSDictionary * _Nonnull)jsonRepresentation;
-- (instancetype _Nonnull)initAsTo:(OSPermissionState * _Nonnull)to from:(OSPermissionState * _Nonnull)from;
 @end
 
 @protocol OSPermissionObserver <NSObject>
-- (void)onOSPermissionChanged:(OSPermissionStateChanges * _Nonnull)stateChanges;
+- (void)onOSPermissionChanged:(OSPermissionState * _Nonnull)state;
 @end
 
-typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionStateChanges*> ObservablePermissionStateChangesType;
+typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionState*> ObservablePermissionStateChangesType;
 
 
 @interface OSPermissionChangedInternalObserver : NSObject<OSPermissionStateObserver>

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -210,8 +210,8 @@
     }
     // Update the push subscription's _accepted property
     // TODO: This can be called before the User Manager has set itself as the delegate
-    if (OSNotificationsManager.delegate && [OSNotificationsManager.delegate respondsToSelector:@selector(setAccepted:)]) {
-        [OSNotificationsManager.delegate setAccepted:state.reachable];
+    if (OSNotificationsManager.delegate && [OSNotificationsManager.delegate respondsToSelector:@selector(setReachable:)]) {
+        [OSNotificationsManager.delegate setReachable:state.reachable];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModelStore.swift
@@ -112,7 +112,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
      Returns false if this model does not exist in the store.
      This can happen if remove email or SMS is called and it doesn't exist in the store.
      */
-    public func remove(_ id: String) -> Bool {
+    public func remove(_ id: String) {
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSModelStore remove() called with model \(id)")
         // TODO: Nothing will happen if model doesn't exist in the store
         if let model = models[id] {
@@ -127,9 +127,7 @@ open class OSModelStore<TModel: OSModel>: NSObject {
             self.changeSubscription.fire { modelStoreListener in
                 modelStoreListener.onRemoved(model)
             }
-            return true
         }
-        return false
     }
 
     /**

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -82,12 +82,10 @@ class OSIdentityModel: OSModel {
     }
 
     func removeAliases(_ labels: [String]) {
-        var aliasesToSend: [String: String] = [:]
         for label in labels {
             self.aliases.removeValue(forKey: label)
-            aliasesToSend[label] = ""
+            self.set(property: "aliases", newValue: [label: ""])
         }
-        self.set(property: "aliases", newValue: aliasesToSend)
     }
 
     public override func hydrateModel(_ response: [String: Any]) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -45,6 +45,27 @@ struct OSPropertiesDeltas {
     }
 }
 
+// Both lat and long must exist to be accepted by the server
+class OSLocationPoint: NSObject, NSCoding {
+    let lat: Float
+    let long: Float
+
+    init(lat: Float, long: Float) {
+        self.lat = lat
+        self.long = long
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(lat, forKey: "lat")
+        coder.encode(long, forKey: "long")
+    }
+
+    public required init?(coder: NSCoder) {
+        self.lat = coder.decodeFloat(forKey: "lat")
+        self.long = coder.decodeFloat(forKey: "long")
+    }
+}
+
 class OSPropertiesModel: OSModel {
     var language: String? {
         didSet {
@@ -52,15 +73,9 @@ class OSPropertiesModel: OSModel {
         }
     }
 
-    var lat: Float? {
+    var location: OSLocationPoint? {
         didSet {
-            self.set(property: "lat", newValue: lat)
-        }
-    }
-
-    var long: Float? {
-        didSet {
-            self.set(property: "long", newValue: long)
+            self.set(property: "location", newValue: location)
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionOperationExecutor.swift
@@ -59,7 +59,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
 
         var requestQueue: [OSRequestCreateSubscription] = []
 
-        if var cachedAddRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestCreateSubscription] {
+        if let cachedAddRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestCreateSubscription] {
             // Hook each uncached Request to the model in the store
             for request in cachedAddRequestQueue {
                 // 1. Hook up the subscription model

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -125,8 +125,7 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
     func setLocation(lat: Float, long: Float) {
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.User setLocation called with lat: \(lat) long: \(long)")
 
-        propertiesModel.lat = lat
-        propertiesModel.long = long
+        propertiesModel.location = OSLocationPoint(lat: lat, long: long)
     }
 
     // MARK: - Language

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -900,8 +900,14 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         self.stringDescription = "OSRequestUpdateProperties with properties: \(properties) deltas: \(String(describing: deltas)) refreshDeviceMetadata: \(String(describing: refreshDeviceMetadata))"
         super.init()
 
+        var propertiesObject = properties
+        if let location = propertiesObject["location"] as? OSLocationPoint {
+            propertiesObject["lat"] = location.lat
+            propertiesObject["long"] = location.long
+            propertiesObject.removeValue(forKey: "location")
+        }
         var params: [String: Any] = [:]
-        params["properties"] = properties
+        params["properties"] = propertiesObject
         params["refresh_device_metadata"] = refreshDeviceMetadata
         if let deltas = deltas {
             params["deltas"] = deltas

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -229,7 +229,7 @@ class OSUserExecutor {
                             type: type,
                             address: address,
                             subscriptionId: subModel["id"] as? String,
-                            accepted: true,
+                            reachable: true,
                             isDisabled: false,
                             changeNotifier: OSEventProducer()), hydrating: true
                         )

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -322,10 +322,14 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     }
 
     /**
-     The SDK needs to have a user at all times, so this method will create a new anonymous user.
+     The SDK needs to have a user at all times, so this method will create a new anonymous user. If the current user is already anonymous, calling `logout` results in a no-op.
      */
     @objc
     public func logout() {
+        guard user.identityModel.externalId != nil else {
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "OneSignal.User logout called, but the user is currently anonymous, so not logging out.")
+            return
+        }
         prepareForNewUser()
         _user = nil
         createUserIfNil()
@@ -670,9 +674,7 @@ extension OneSignalUserManagerImpl: OSUser {
 extension OneSignalUserManagerImpl: OSPushSubscription {
 
     public func addObserver(_ observer: OSPushSubscriptionObserver) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "pushSubscription.addObserver") else {
-            return
-        }
+        // This is a method in the User namespace that doesn't require privacy consent first
         self.pushSubscriptionStateChangesObserver.addObserver(observer)
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -82,7 +82,7 @@ import OneSignalNotifications
 
     func optIn()
     func optOut()
-    func addObserver(_ observer: OSPushSubscriptionObserver) -> OSPushSubscriptionState?
+    func addObserver(_ observer: OSPushSubscriptionObserver)
     func removeObserver(_ observer: OSPushSubscriptionObserver)
 }
 
@@ -669,12 +669,11 @@ extension OneSignalUserManagerImpl: OSUser {
 
 extension OneSignalUserManagerImpl: OSPushSubscription {
 
-    public func addObserver(_ observer: OSPushSubscriptionObserver) -> OSPushSubscriptionState? {
+    public func addObserver(_ observer: OSPushSubscriptionObserver) {
         guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "pushSubscription.addObserver") else {
-            return nil
+            return
         }
         self.pushSubscriptionStateChangesObserver.addObserver(observer)
-        return user.pushSubscriptionModel.currentPushSubscriptionState
     }
 
     public func removeObserver(_ observer: OSPushSubscriptionObserver) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -128,7 +128,7 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     private let _mockUser = OSUserInternalImpl(
         identityModel: OSIdentityModel(aliases: nil, changeNotifier: OSEventProducer()),
         propertiesModel: OSPropertiesModel(changeNotifier: OSEventProducer()),
-        pushSubscriptionModel: OSSubscriptionModel(type: .push, address: nil, subscriptionId: nil, accepted: false, isDisabled: true, changeNotifier: OSEventProducer()))
+        pushSubscriptionModel: OSSubscriptionModel(type: .push, address: nil, subscriptionId: nil, reachable: false, isDisabled: true, changeNotifier: OSEventProducer()))
 
     @objc public var requiresUserAuth = false
 
@@ -387,14 +387,14 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
     func createDefaultPushSubscription() -> OSSubscriptionModel {
         let sharedUserDefaults = OneSignalUserDefaults.initShared()
-        let accepted = OSNotificationsManager.currentPermissionState.accepted
+        let reachable = OSNotificationsManager.currentPermissionState.reachable
         let token = sharedUserDefaults.getSavedString(forKey: OSUD_PUSH_TOKEN, defaultValue: nil)
         let subscriptionId = sharedUserDefaults.getSavedString(forKey: OSUD_PUSH_SUBSCRIPTION_ID, defaultValue: nil)
 
         return OSSubscriptionModel(type: .push,
                                    address: token,
                                    subscriptionId: subscriptionId,
-                                   accepted: accepted,
+                                   reachable: reachable,
                                    isDisabled: false,
                                    changeNotifier: OSEventProducer())
     }
@@ -600,7 +600,7 @@ extension OneSignalUserManagerImpl: OSUser {
             type: .email,
             address: email,
             subscriptionId: nil,
-            accepted: true,
+            reachable: true,
             isDisabled: false,
             changeNotifier: OSEventProducer()
         )
@@ -632,7 +632,7 @@ extension OneSignalUserManagerImpl: OSUser {
             type: .sms,
             address: number,
             subscriptionId: nil,
-            accepted: true,
+            reachable: true,
             isDisabled: false,
             changeNotifier: OSEventProducer()
         )
@@ -739,10 +739,10 @@ extension OneSignalUserManagerImpl: OneSignalNotificationsDelegate {
         user.pushSubscriptionModel.address = pushToken
     }
 
-    public func setAccepted(_ inAccepted: Bool) {
+    public func setReachable(_ inReachable: Bool) {
         guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: nil) else {
             return
         }
-        user.pushSubscriptionModel._accepted = inAccepted
+        user.pushSubscriptionModel._reachable = inReachable
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -60,10 +60,10 @@ import OneSignalNotifications
     func removeTags(_ tags: [String])
     // Email
     func addEmail(_ email: String)
-    func removeEmail(_ email: String) -> Bool
+    func removeEmail(_ email: String)
     // SMS
-    func addSmsNumber(_ number: String)
-    func removeSmsNumber(_ number: String) -> Bool
+    func addSms(_ number: String)
+    func removeSms(_ number: String)
     // Language
     func setLanguage(_ language: String)
     // JWT Token Expire
@@ -612,16 +612,16 @@ extension OneSignalUserManagerImpl: OSUser {
      This will be a no-op and no request will be made.
      Error handling needs to be implemented in the future.
      */
-    public func removeEmail(_ email: String) -> Bool {
+    public func removeEmail(_ email: String) {
         guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "removeEmail") else {
-            return false
+            return
         }
         // Check if is valid email?
         createUserIfNil()
-        return self.subscriptionModelStore.remove(email)
+        self.subscriptionModelStore.remove(email)
     }
 
-    public func addSmsNumber(_ number: String) {
+    public func addSms(_ number: String) {
         guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "addSmsNumber") else {
             return
         }
@@ -644,13 +644,13 @@ extension OneSignalUserManagerImpl: OSUser {
      This will be a no-op and no request will be made.
      Error handling needs to be implemented in the future.
      */
-    public func removeSmsNumber(_ number: String) -> Bool {
+    public func removeSms(_ number: String) {
         guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "removeSmsNumber") else {
-            return false
+            return
         }
         // Check if is valid SMS?
         createUserIfNil()
-        return self.subscriptionModelStore.remove(number)
+        self.subscriptionModelStore.remove(number)
     }
 
     public func setLanguage(_ language: String) {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -111,10 +111,7 @@ static dispatch_once_t once;
 
 + (void)start {
     OSMessagingController *shared = OSMessagingController.sharedInstance;
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunused-variable"
-    OSPushSubscriptionState *_ = [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
-    #pragma clang diagnostic pop
+    [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
 }
 
 static BOOL _isInAppMessagingPaused = false;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -519,7 +519,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 }
 
 + (void)delayInitializationForPrivacyConsent {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Delayed initialization of the OneSignal SDK until the user provides privacy consent using the consentGranted() method"];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Delayed initialization of the OneSignal SDK until the user provides privacy consent using the setPrivacyConsent() method"];
     delayedInitializationForPrivacyConsent = true;
     _delayedInitParameters = [[DelayedConsentInitializationParameters alloc] initWithLaunchOptions:launchOptions withAppId:appId];
     // Init was not successful, set appId back to nil

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -121,15 +121,6 @@ static NSTimeInterval initializationTime;
 // Set when the app is launched
 static NSDate *sessionLaunchTime;
 
-// static property def to add developer's OSPermissionStateChanges observers to.
-static ObservablePermissionStateChangesType* _permissionStateChangesObserver;
-+ (ObservablePermissionStateChangesType*)permissionStateChangesObserver {
-    if (!_permissionStateChangesObserver)
-        _permissionStateChangesObserver = [[OSObservable alloc] initWithChangeSelector:@selector(onOSPermissionChanged:)];
-    return _permissionStateChangesObserver;
-}
-
-
 /*
  Indicates if the iOS params request has started
  Set to true when the method is called and set false if the request's failure callback is triggered
@@ -198,9 +189,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     
     [OSNotificationsManager clearStatics];
     registeredWithApple = false;
-    
-    _permissionStateChangesObserver = nil;
-    
+        
     _downloadedParameters = false;
     _didCallDownloadParameters = false;
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
@@ -79,10 +79,7 @@ static dispatch_once_t once;
 + (void)initialize {
     subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
     OneSignalLiveActivityController *shared = OneSignalLiveActivityController.sharedInstance;
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunused-variable"
-    OSPushSubscriptionState *_ = [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
-    #pragma clang diagnostic pop
+    [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
 }
 
 - (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges * _Nonnull)stateChanges {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -75,6 +75,12 @@ public extension OneSignal {
     }
 }
 
+public extension OSDebug {
+    static func setAlertLevel(_ logLevel: ONE_S_LOG_LEVEL) {
+        __setAlert(logLevel)
+    }
+}
+
 public extension OSInAppMessages {
     static var Paused: Bool {
         get {


### PR DESCRIPTION
# Description
## One Line Summary
Update API to align with current decisions (see below).

## Details

### Motivation
Update API to align with current decisions (see below)

### Scope
**Subscription changes**
* addSmsNumber -> addSms
* removeSmsNumber -> removeSms
* removeSms and removeEmail will return void, not a boolean

**update permission observer callback's object**
* No longer pass a `OSPermissionStateChanges` object with a `to` and `from`
* Instead, we wanted to pass a single boolean to represent the current permission
* However, the observable infrastructure set up does not allow us to pass bools
* Let's for now pass a `OSPermissionState` object representing the current state with 1 property on it called `permission`
* update the permission observer callback to be a `OSPermissionState` object representing the current permission state with a single property on it called `permission`. 

**Rename `setVisualLevel` to `setAlertLevel`**
* To align with schema outlined

**add push subscription observer returns void**
* Don't return the current state when the observer is added, return void


**No change: Not adding a callback/handler to `Location.requestPermission`**
* We wanted to align with Android and offer a callback with the user's response
* However, there is limitation to how we can do this currently and warrant further investigation
* For now, not providing a callback API
* Note: the current iOS SDK does not have a prompt location with callback method.

**Not a public API change, but make it clearer that an internal property on the push subscription should be named `reachable` instead of `accepted`**

# Testing
## Manual testing
iPhone 13

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1223)
<!-- Reviewable:end -->
