### PR TITLE
[5.0.0] Some more `beta-01` fixes to incorporate

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,4 +1,4 @@
-<h1 align="center">OneSignal iOS SDK v5.0.0-alpha-02 Migration Guide</h1>
+<h1 align="center">OneSignal iOS SDK v5.0.0-beta-01 Migration Guide</h1>
 
 ![OneSignal Omni Channel Banner](https://user-images.githubusercontent.com/11739227/208625336-d28c8d01-a7cf-4f8e-9643-ac8d1948e9ae.png)
 
@@ -8,7 +8,7 @@ In this release, we are making a significant shift from a device-centered model 
 
 To facilitate this change, the `externalId` approach for identifying users is being replaced by the `login` and `logout` methods. In addition, the SDK now makes use of namespaces such as `User`, `Notifications`, and `InAppMessages` to better separate code.
 
-The iOS SDK is making the jump from `v3` to `v5`, in order to align across OneSignal’s suite of client SDKs. This guide will walk you through the iOS SDK `5.0.0-alpha-02` changes as a result of this shift.
+The iOS SDK is making the jump from `v3` to `v5`, in order to align across OneSignal’s suite of client SDKs. This guide will walk you through the iOS SDK `5.0.0-beta-01` changes as a result of this shift.
 
 # Overview
 
@@ -60,10 +60,10 @@ As mentioned above, the iOS SDK is making the jump from `v3` to `v5`, in order t
 ```
 
 ### Option 1. Swift Package Manager
-Update the version of the OneSignal-XCFramework your application uses to `5.0.0-alpha-02`. In addition, the Package Product name has been changed from `OneSignal` to `OneSignalFramework`. See [the existing installation instructions](https://documentation.onesignal.com/docs/swift-package-manager-setup).
+Update the version of the OneSignal-XCFramework your application uses to `5.0.0-beta-01`. In addition, the Package Product name has been changed from `OneSignal` to `OneSignalFramework`. See [the existing installation instructions](https://documentation.onesignal.com/docs/swift-package-manager-setup).
 
 ### Option 2. CocoaPods
-Update the version of the OneSignalXCFramework your application uses to `5.0.0-alpha-02`. Other than updating the import statement above, there are no additional changes needed to import the OneSignal SDK in your Xcode project. See [the existing installation instructions](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-import-the-onesignal-sdk-into-your-xcode-project).
+Update the version of the OneSignalXCFramework your application uses to `5.0.0-beta-01`. Other than updating the import statement above, there are no additional changes needed to import the OneSignal SDK in your Xcode project. See [the existing installation instructions](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-import-the-onesignal-sdk-into-your-xcode-project).
 
 # API Changes
 ## Namespaces
@@ -213,7 +213,7 @@ Email and/or SMS subscriptions can be added or removed via the following methods
 
 # API Reference
 
-Below is a comprehensive reference to the `5.0.0-alpha-02` OneSignal SDK.
+Below is a comprehensive reference to the `5.0.0-beta-01` OneSignal SDK.
 
 ## OneSignal
 
@@ -727,14 +727,12 @@ The Debug namespace is accessible via `OneSignal.Debug` and provide access to de
 
 # Limitations
 
-- Recommend using only in development and staging environments for Alpha releases
-- Aliases will be available in a future release
+- Recommend using only in development and staging environments for Beta releases
 - Outcomes will be available in a future release
-- Users are deleted when the last Subscription (push, email, or sms) is removed
 - Any `User` namespace calls must be invoked **after** initialization. Example: `OneSignal.User.addTag("tag", "2")`
 
 # Known issues
 - User properties may not update correctly when Subscriptions are transferred
     - Please report any issues you find with this
 - Identity Verification 
-    - We will be introducing JWT in a follow up Alpha or Beta release
+    - We will be introducing JWT in a follow up Beta release

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/RemoteParameters/OSRemoteParamController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/RemoteParameters/OSRemoteParamController.m
@@ -35,6 +35,8 @@ THE SOFTWARE.
 
 static OSRemoteParamController *_sharedController;
 + (OSRemoteParamController *)sharedController {
+    if (!_sharedController)
+        _sharedController = [OSRemoteParamController new];
     return _sharedController;
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -371,9 +371,6 @@ static NSString *_pushSubscriptionId;
 
 + (void)didRegisterForRemoteNotifications:(UIApplication *)app
                               deviceToken:(NSData *)inDeviceToken {
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
-        return;
-
     let parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
 
     [OneSignalLog onesignalLog:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -337,6 +337,8 @@ static NSString *_pushSubscriptionId;
 }
 
 + (void)clearAll {
+    [[UNUserNotificationCenter currentNotificationCenter] removeAllDeliveredNotifications];
+    // TODO: Determine if we also need to call clearBadgeCount
     [self clearBadgeCount:false];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -82,12 +82,10 @@ class OSIdentityModel: OSModel {
     }
 
     func removeAliases(_ labels: [String]) {
-        var aliasesToSend: [String: String] = [:]
         for label in labels {
             self.aliases.removeValue(forKey: label)
-            aliasesToSend[label] = ""
+            self.set(property: "aliases", newValue: [label: ""])
         }
-        self.set(property: "aliases", newValue: aliasesToSend)
     }
 
     public override func hydrateModel(_ response: [String: Any]) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -45,6 +45,27 @@ struct OSPropertiesDeltas {
     }
 }
 
+// Both lat and long must exist to be accepted by the server
+class OSLocationPoint: NSObject, NSCoding {
+    let lat: Float
+    let long: Float
+
+    init(lat: Float, long: Float) {
+        self.lat = lat
+        self.long = long
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(lat, forKey: "lat")
+        coder.encode(long, forKey: "long")
+    }
+
+    public required init?(coder: NSCoder) {
+        self.lat = coder.decodeFloat(forKey: "lat")
+        self.long = coder.decodeFloat(forKey: "long")
+    }
+}
+
 class OSPropertiesModel: OSModel {
     var language: String? {
         didSet {
@@ -52,15 +73,9 @@ class OSPropertiesModel: OSModel {
         }
     }
 
-    var lat: Float? {
+    var location: OSLocationPoint? {
         didSet {
-            self.set(property: "lat", newValue: lat)
-        }
-    }
-
-    var long: Float? {
-        didSet {
-            self.set(property: "long", newValue: long)
+            self.set(property: "location", newValue: location)
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionOperationExecutor.swift
@@ -59,7 +59,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
 
         var requestQueue: [OSRequestCreateSubscription] = []
 
-        if var cachedAddRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestCreateSubscription] {
+        if let cachedAddRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestCreateSubscription] {
             // Hook each uncached Request to the model in the store
             for request in cachedAddRequestQueue {
                 // 1. Hook up the subscription model

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -125,8 +125,7 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
     func setLocation(lat: Float, long: Float) {
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.User setLocation called with lat: \(lat) long: \(long)")
 
-        propertiesModel.lat = lat
-        propertiesModel.long = long
+        propertiesModel.location = OSLocationPoint(lat: lat, long: long)
     }
 
     // MARK: - Language

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -900,8 +900,14 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         self.stringDescription = "OSRequestUpdateProperties with properties: \(properties) deltas: \(String(describing: deltas)) refreshDeviceMetadata: \(String(describing: refreshDeviceMetadata))"
         super.init()
 
+        var propertiesObject = properties
+        if let location = propertiesObject["location"] as? OSLocationPoint {
+            propertiesObject["lat"] = location.lat
+            propertiesObject["long"] = location.long
+            propertiesObject.removeValue(forKey: "location")
+        }
         var params: [String: Any] = [:]
-        params["properties"] = properties
+        params["properties"] = propertiesObject
         params["refresh_device_metadata"] = refreshDeviceMetadata
         if let deltas = deltas {
             params["deltas"] = deltas

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -322,10 +322,14 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     }
 
     /**
-     The SDK needs to have a user at all times, so this method will create a new anonymous user.
+     The SDK needs to have a user at all times, so this method will create a new anonymous user. If the current user is already anonymous, calling `logout` results in a no-op.
      */
     @objc
     public func logout() {
+        guard user.identityModel.externalId != nil else {
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "OneSignal.User logout called, but the user is currently anonymous, so not logging out.")
+            return
+        }
         prepareForNewUser()
         _user = nil
         createUserIfNil()

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -674,9 +674,7 @@ extension OneSignalUserManagerImpl: OSUser {
 extension OneSignalUserManagerImpl: OSPushSubscription {
 
     public func addObserver(_ observer: OSPushSubscriptionObserver) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "pushSubscription.addObserver") else {
-            return
-        }
+        // This is a method in the User namespace that doesn't require privacy consent first
         self.pushSubscriptionStateChangesObserver.addObserver(observer)
     }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -519,7 +519,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 }
 
 + (void)delayInitializationForPrivacyConsent {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Delayed initialization of the OneSignal SDK until the user provides privacy consent using the consentGranted() method"];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Delayed initialization of the OneSignal SDK until the user provides privacy consent using the setPrivacyConsent() method"];
     delayedInitializationForPrivacyConsent = true;
     _delayedInitParameters = [[DelayedConsentInitializationParameters alloc] initWithLaunchOptions:launchOptions withAppId:appId];
     // Init was not successful, set appId back to nil


### PR DESCRIPTION
# Description
## One Line Summary
Some misc fixes to add into the `5.0.0-beta-01`, details below.

## Details

### Motivation
I promise this is my last PR before `beta-01`!
Some misc fixes to add into the `5.0.0-beta-01`, details below.

### Scope
**small bug fixes**
* Fix OSRemoteParamController bug where it is nil
* Fix removeAliases bug

**fix sending location**
- We were previously sending `lat` and `long` in 2 separate update requests.
- While the backend was returning success for these 2 requests, it wasn't actually updating and it seems we need to send both in one request

**update Notifications.clearAll() method to really clear all**
* using APIU UNUserNotificationCenter removeAllDeliveredNotifications

**saving push token locally doesn't need privacy consent**
* If the app starts up without privacy consent, and later grant it, we never get the push token
* Save the push token, this is ok without privacy consent as we don't send it anywhere but keep locally in the SDK.

**logging out of anonymous user is a no-op**
* As discussed in design forum, calling logout multiple times should result in a no-op.
* Note that states can carry over.

**Allow adding push subscription observer before privacy consent** 
* Even though the User namespace is invoked when calling `OneSignal.User.pushSubscription.addObserver()`, this is ok. We want them to be able to add it at startup before consent may be granted.

# Testing

## Manual testing
iPhone 13

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1224)
<!-- Reviewable:end -->
