### PR TITLE
[5.0.0] Fixes to detecting native permissions

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -57,7 +57,6 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 // can check responds to selector
 - (void)setNotificationTypes:(int)notificationTypes;
 - (void)setPushToken:(NSString * _Nonnull)pushToken;
-- (void)setReachable:(BOOL)inReachable;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -455,9 +455,6 @@ static NSString *_pushSubscriptionId;
 + (void)sendNotificationTypesUpdateToDelegate {
     // We don't delay observer update to wait until the OneSignal server is notified
     // TODO: We can do the above and delay observers until server is updated.
-    if (self.delegate && [self.delegate respondsToSelector:@selector(setReachable:)]) {
-        [self.delegate setReachable:[self getNotificationTypes] > 0];
-    }
     if (self.delegate && [self.delegate respondsToSelector:@selector(setNotificationTypes:)]) {
         [self.delegate setNotificationTypes:[self getNotificationTypes]];
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -208,11 +208,6 @@
         OSNotificationsManager.lastPermissionState = [state copy];
         [OSNotificationsManager.lastPermissionState persistAsFrom];
     }
-    // Update the push subscription's _accepted property
-    // TODO: This can be called before the User Manager has set itself as the delegate
-    if (OSNotificationsManager.delegate && [OSNotificationsManager.delegate respondsToSelector:@selector(setReachable:)]) {
-        [OSNotificationsManager.delegate setReachable:state.reachable];
-    }
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -739,11 +739,4 @@ extension OneSignalUserManagerImpl: OneSignalNotificationsDelegate {
         }
         user.pushSubscriptionModel.address = pushToken
     }
-
-    public func setReachable(_ inReachable: Bool) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: nil) else {
-            return
-        }
-        user.pushSubscriptionModel._reachable = inReachable
-    }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fixes to sending permission change information and notification types to the user module.

## Details

### Motivation
The SDK was behaving oddly and getting into states where the `enabled` flag does not match the `notification_types` when an update subscription request is sent to the server. This happens when permissions are changed on the operating system level, and then returning to the app. It also seems like when returning to the app before these changes, we get the notification settings but too early and it contains the old information. These PR changes seem to remedy the problem mentioned.

### Scope
* Simplify by passing notification types only to user manager, instead of also accounting for permission observer changes firing or passing the device's `reachable` property separately.
* Notification types changes will drive other changes on the subscription model, like setting reachable, optedIn, and enabled.

### Known Issues
* The app has notification permission and `optOut` is called. The push subscription observer is not fired in this case.
* The app does not have notification permission and `optOut` was also called. Calling `optIn` does not change the `notification_types` from `-2`. This does not effect behavior.

# Testing
## Manual testing
Example app with iPhone 13 on iOS 16.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1229)
<!-- Reviewable:end -->
