### PR TITLE
Update backgrounded logic to determine displaying cached IAMs

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -90,7 +90,7 @@ static OneSignalLifecycleObserver* _instance = nil;
 
 - (void)willResignActive {
     [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"application/scene willResignActive"];
-    
+    [OneSignalTracker willResignActiveTriggered];
     if ([OneSignal appId]) {
         [OneSignalTracker onFocus:YES];
         [OneSignal sendTagsOnBackground];
@@ -99,7 +99,7 @@ static OneSignalLifecycleObserver* _instance = nil;
 
 - (void)didEnterBackground {
     [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"application/scene didEnterBackground"];
-    
+    [OneSignalTracker didEnterBackgroundTriggered];
     if ([OneSignal appId])
         [OneSignalLocation onFocus:NO];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.h
@@ -31,5 +31,7 @@
 
 + (void)onFocus:(BOOL)toBackground;
 + (void)onSessionEnded:(NSArray<OSInfluence *> *) lastInfluences;
++ (void)willResignActiveTriggered;
++ (void)didEnterBackgroundTriggered;
 
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Don't display cached IAMs if app returns from an inactive state (**and did not enter the background**), but keep all other behavior the same.

## Details

### Motivation
- [Ticket submitted](https://app.asana.com/0/1203633803008208/1203913594213708/f) about an IAM can be displayed twice when the app loses focus 

### What Was Happening?
When the app is foregrounded and it is not a new session, the SDK initializes IAMs from cache. Any IAM with the trigger "on app open" will display. This can be triggered when a native dialog like notification permission prompt displays over the app and is then dismissed, or the app goes into an inactive "peekaboo" state and returns without entering the background. 

An issue was reported for push pre-prompt IAMs that have the "on app open" trigger. After the IAM displays, the native permission dialog displays. After the user makes a selection and the dialog is dismissed, the original IAM will display once again (as the app is considered to return to the foreground). **See video**.

https://user-images.githubusercontent.com/4022291/223514763-35a3810c-e7a0-4116-af88-dbc71e224741.MOV

<br></br>

After discussions and seeing that Android behaves differently, we decided to keep this behavior to show "on app open" IAMs every time app is foregrounded **as is** but change the behavior for the major release 5.x.x. However, we should distinguish between the following 2 flows:

1. application will resign active → application did become active (in this case, app is not actually backgrounded, it may be that a native prompt displayed over the app) **👈🏼 this leads to the bug in the video and this PR will change this behavior**

2. will resign active → did enter background → will enter foreground → did become active **👈🏼 no behavior change**

### Scope
* Add app backgrounded vs app inactive detection by adding 2 state flags `willResignActiveTriggered` and `didEnterBackgroundTriggered` to track if an app was actually backgrounded or just inactive.
* We will consider the application truly backgrounded if the states are anything **except**:
```
willResignActiveTriggered = TRUE && didEnterBackgroundTriggered = FALSE
```
* Use backgrounded logic to determine if we should display cached IAMs, as we won't if the app was simply inactive.
* I had considered and tested out other options, but this PR makes the minimal amount of behavior changes, as there is a lot of existing logic that I don't want to mess around with. 

# Testing
## Unit testing
None added

## Manual testing
Tested on iPhone 13 with iOS 16
- starting app from killed state
- foregrounding app leading to a new session
- putting the app into a "peekaboo" inactive state and returning
- displaying native dialogs over the app
- setting privacy consent needed and granted

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1233)
<!-- Reviewable:end -->
