### PR TITLE
Replace a token name used in testing with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/set_response_time.yml
+++ b/.github/workflows/set_response_time.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ACTIONSTESTTOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: npm install @octokit/action
       - uses: actions/github-script@v6
         id: set-time 


### PR DESCRIPTION
Quick fix to use the github_token in our action

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1239)
<!-- Reviewable:end -->
