### PR TITLE
Fix direct session count

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.h
@@ -54,5 +54,6 @@
 - (void)onNotificationReceived:(NSString * _Nonnull)notificationId;
 - (void)onDirectInfluenceFromNotificationOpen:(AppEntryAction)entryAction withNotificationId:(NSString * _Nonnull)directNotificationId;
 - (void)attemptSessionUpgrade:(AppEntryAction)entryAction;
+- (void)resetSessionIfDirect;
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.m
@@ -72,6 +72,16 @@ static OSSessionManager *_sessionManager;
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"SessionManager restored from cache with influences: %@", [self getInfluences].description]];
 }
 
+- (void)resetSessionIfDirect {
+    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"OneSignal SessionManager resetSessionIfDirect"];
+    NSArray<OSChannelTracker *> *channels = [_trackerFactory channels];
+    for (OSChannelTracker *tracker in channels) {
+        if (tracker.influenceType == DIRECT) {
+            [tracker resetAndInitInfluence];
+        }
+    }
+}
+
 - (void)restartSessionIfNeeded:(AppEntryAction)entryAction {
     NSArray<OSChannelTracker *> *channelTrackers = [_trackerFactory channelsToResetByEntryAction:entryAction];
     NSMutableArray<OSInfluence *> *updatedInfluences = [NSMutableArray new];

--- a/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
@@ -117,6 +117,9 @@ static let DELAY_TIME = 30;
 
         [OneSignal.stateSynchronizer sendOnFocusTime:totalTimeActive params:params withSuccess:^(NSDictionary *result) {
             [super saveUnsentActiveTime:0];
+            if (params != nil) {
+                [[OSSessionManager sharedSessionManager] resetSessionIfDirect];
+            }
             [OneSignal onesignalLog:ONE_S_LL_DEBUG message:@"sendOnFocusCallWithParams attributed succeed, saveUnsentActiveTime with 0"];
             [self endDelayBackgroundTask];
         } onFailure:^(NSDictionary<NSString *, NSError *> *errors) {


### PR DESCRIPTION
# Description
## One Line Summary
Reset direct sessions when the session ends.

## Details

### Motivation
Fix incorrect direct session count for notifications, prevents a direct session count from being sent up twice for the same notification.

# Testing
## Manual testing
Tested sending notifications from a direct session to another direct session, app build with Xcode 14.2 with the OneSignal example app on an iPhone 12 with iOS 15.5.

Steps
1. Send 2 notifications
2. Open notification 1 and immediately background the app
3. Wait for session to end (30+ seconds)
4. Open notification 2

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1240)
<!-- Reviewable:end -->
