### PR TITLE
Remove early return of trackReceivedEvent to allow for os_notification_influence_open event to be sent to Firebase

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
@@ -103,22 +103,11 @@ static BOOL trackingEnabled = false;
 }
 
 + (void)trackReceivedEvent:(OSNotification*)notification {
-    if (!trackingEnabled)
-        return;
-    
     NSString *campaign = [self getCampaignNameFromNotification:notification];
     OneSignalUserDefaults *sharedUserDefaults = OneSignalUserDefaults.initShared;
     [sharedUserDefaults saveStringForKey:ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED withValue:notification.notificationId];
     [sharedUserDefaults saveStringForKey:ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED withValue:campaign];
     [sharedUserDefaults saveDoubleForKey:ONESIGNAL_FB_LAST_TIME_RECEIVED withValue:[[NSDate date] timeIntervalSince1970]];
-    
-    [self logEventWithName:@"os_notification_received"
-                parameters:@{
-                    @"source": @"OneSignal",
-                    @"medium": @"notification",
-                    @"notification_id": notification.notificationId,
-                    @"campaign": campaign
-                }];
 }
 
 + (void)trackInfluenceOpenEvent {


### PR DESCRIPTION
# Description
## One Line Summary
Remove early return of `trackReceivedEvent` method to allow for the `os_notification_influence_open` event to be sent to Firebase.

## Details

### Motivation
The `os_notification_influence_open` event is not currently logged in Firebase. While initially thought to be an issue with the `trackInfluenceOpenEvent` method logic, it was eventually determined that the previous method,`trackReceivedEvent`, returned early and prevented the influence event from being sent.

### Other
Since iOS does not support this `os_notification_received` event, the `logEventWithName` method for this event was also removed. 

Our [documentation](https://documentation.onesignal.com/docs/google-analytics-for-firebase#events) currently states that the `os_notification_influence_open` event will be sent if the app is opened within two minutes of receiving a notification. This was originally thought to be the flawed logic preventing the event from being sent altogether. However, after updating the `trackReceivedEvent` method, the original logic works. However, if we determine to change the duration, that can be easily updated.

# Testing
## Unit testing
No unit testing was used.

## Manual testing
Tested on an iPad running iOS 15.2. 

Test Scenarios:

1. Tested opening the app **within** 2 minutes of receiving a notification. Confirmed in Firebase DebugView that the `os_notification_influence_open` event was successfully logged:
<img width="915" alt="Screenshot 2023-03-30 at 4 22 16 PM" src="https://user-images.githubusercontent.com/46546946/228986105-c0bd89c7-2337-424f-8beb-8172bfe6d7ea.png">

2. Tested opening the app **after** 2 minutes of receiving a notification and confirmed that no `os_notification_influence_open` event was logged in Firebase DebugView.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [X] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1241)
<!-- Reviewable:end -->
