### PR TITLE
[5.0.0] Migrating SDK 3.x players

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -65,9 +65,12 @@
 #define OSUD_PERMISSION_EPHEMERAL_FROM                                      @"OSUD_PERMISSION_EPHEMERAL_FROM"                                   // * OSUD_PERMISSION_EPHEMERAL_FROM
 #define OSUD_LANGUAGE                                                       @"OSUD_LANGUAGE"                                                    // * OSUD_LANGUAGE
 #define DEFAULT_LANGUAGE                                                    @"en"                                                               // * OSUD_LANGUAGE
-// Push Subscription
-#define OSUD_PUSH_SUBSCRIPTION_ID                                           @"GT_PLAYER_ID"                                                     // * OSUD_PUSH_SUBSCRIPTION_ID
-#define OSUD_PUSH_TOKEN                                                     @"GT_DEVICE_TOKEN"                                                  // * OSUD_PUSH_TOKEN
+
+/* Push Subscription */
+#define OSUD_LEGACY_PLAYER_ID                                               @"GT_PLAYER_ID" // The legacy player ID from SDKs prior to 5.x.x
+#define OSUD_PUSH_SUBSCRIPTION_ID                                           @"OSUD_PUSH_SUBSCRIPTION_ID"
+#define OSUD_PUSH_TOKEN                                                     @"GT_DEVICE_TOKEN"
+
 // Notification
 #define OSUD_LAST_MESSAGE_OPENED                                            @"GT_LAST_MESSAGE_OPENED_"                                          // * OSUD_MOST_RECENT_NOTIFICATION_OPENED
 #define OSUD_NOTIFICATION_OPEN_LAUNCH_URL                                   @"ONESIGNAL_INAPP_LAUNCH_URL"                                       // * OSUD_NOTIFICATION_OPEN_LAUNCH_URL

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -189,8 +189,8 @@ class OSSubscriptionModel: OSModel {
             guard self.type == .push && _isDisabled != oldValue else {
                 return
             }
-            notificationTypes = -2
             firePushSubscriptionChanged(.isDisabled(oldValue))
+            notificationTypes = -2
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -320,7 +320,7 @@ class OSUserExecutor {
                 // If this user already exists and we logged into an external_id, fetch the user data
                 // TODO: Only do this if response code is 200 or 202
                 // Fetch the user only if its the current user
-                if let _ = OneSignalUserManagerImpl.sharedInstance.identityModelStore.getModel(modelId: request.identityModel.modelId),
+                if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel),
                    let identity = request.parameters?["identity"] as? [String: String],
                    let externalId = identity[OS_EXTERNAL_ID] {
                     fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: externalId, identityModel: request.identityModel)
@@ -368,7 +368,7 @@ class OSUserExecutor {
                 request.identityModel.hydrate(identityObject)
                 
                 // Fetch this user's data if it is the current user
-                guard OneSignalUserManagerImpl.sharedInstance.identityModelStore.getModel(modelId: request.identityModel.modelId) != nil
+                guard OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel)
                 else {
                     executePendingRequests()
                     return
@@ -421,7 +421,7 @@ class OSUserExecutor {
 
             // the anonymous user has been identified, still need to Fetch User as we cleared local data
             // Fetch the user only if its the current user
-            if let _ = OneSignalUserManagerImpl.sharedInstance.identityModelStore.getModel(modelId: request.identityModelToUpdate.modelId) {
+            if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModelToUpdate) {
                 fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
             } else {
                 executePendingRequests()
@@ -435,7 +435,7 @@ class OSUserExecutor {
 
                     removeFromQueue(request)
                     // Fetch the user only if its the current user
-                    if let _ = OneSignalUserManagerImpl.sharedInstance.identityModelStore.getModel(modelId: request.identityModelToUpdate.modelId) {
+                    if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModelToUpdate) {
                         fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
                         // TODO: Link ^ to the new user... what was this todo for?
                     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -359,7 +359,6 @@ class OSUserExecutor {
             }
         } onFailure: { error in
             OneSignalLog.onesignalLog(.LL_VERBOSE, message: "executeIdentifyUserRequest failed with error \(error.debugDescription)")
-            removeFromQueue(request)
             // Returns 409 if any provided (label, id) pair exists on another User, so the SDK will switch to this user.
             if let nsError = error as? NSError {
                 if nsError.code == 409 {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -613,6 +613,8 @@ static AppEntryAction _appEntryState = APP_CLOSE;
         // Remove player_id from both standard and shared NSUserDefaults
         [standardUserDefaults removeValueForKey:OSUD_PUSH_SUBSCRIPTION_ID];
         [sharedUserDefaults removeValueForKey:OSUD_PUSH_SUBSCRIPTION_ID];
+        [standardUserDefaults removeValueForKey:OSUD_LEGACY_PLAYER_ID];
+        [sharedUserDefaults removeValueForKey:OSUD_LEGACY_PLAYER_ID];
         
         // Clear all cached data, does not start User Module nor call logout.
         [OneSignalUserManagerImpl.sharedInstance clearAllModelsFromStores];


### PR DESCRIPTION
# Description
## One Line Summary
Migrates a cached 3.x player to a 5.x user with the player ID becoming the new push subscription ID.

## Details

### Motivation
Handles migrating someone using SDK 3.x to the new user model, who may not uninstall and reinstall the app.

### Scope
Affects migrating old players. If there is a cached player ID, we will create a new user with that player ID as the new push subscription ID, and fetch this subscription ID's identity.

Error handling server responses will be part of another PR.

1. Detect there is a player_id when the User Manager starts up
2. Create a push subscription model using that ID
3. Create a blank user in the SDK and make a fetch identity by subscription ID request
4. Get the onesignal_id in the response and hydrate it locally
5. Fetch this user to hydrate the local user (if it is the same user)

- 🐛 also fixed a bug with firing the push sub observer in this commit: https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1243/commits/5a5a648b39460a56d8410b892e91aa7ec3d4a97a

# Testing
## Unit testing
None

## Manual testing
Tested on iPhone 13 physical device with iOS 16.x.
1. Install the app with SDK 3.12.4, and add a tag
7. Check the player ID, onesignal ID, and push token in the dashboard for this player
8. Now run the app with SDK 5.0.0-beta-02
9. See that the IDs are the same as in (2) and no new player was created in the dashboard
10. See the SDK user has the tag added in (1) above
11. Add a tag to see it applied to this user/player in the dashboard

Tested on iPhone 13 physical device with iOS 16.x. Testing the request is cached
1. Install the app with SDK 3.12.4
2. Check the player ID, onesignal ID, and push token in the dashboard for this player
3. Turn off wifi/data so we test caching. 
4. Now run the app with SDK 5.0.0-beta-02
5. See the requests are not able to go through
12. Turn back on wifi/data and run the app with SDK 5.0.0-beta-02
13. See the cached requests go through
14. See that the IDs are the same as in (2) and no new player was created in the dashboard
15. Add a tag to see it applied to this user/player in the dashboard

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1243)
<!-- Reviewable:end -->
