### PR TITLE
Enable push notifications for iOS simulators

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -1857,9 +1857,13 @@ static BOOL _trackedColdRestart = false;
             userState.carrier = carrierName;
     }
     
+    #if TARGET_OS_SIMULATOR
+    userState.testType = [NSNumber numberWithInt:(int)UIApplicationReleaseDev];
+    #else
     let releaseMode = [OneSignalMobileProvision releaseMode];
     if (releaseMode == UIApplicationReleaseDev || releaseMode == UIApplicationReleaseAdHoc || releaseMode == UIApplicationReleaseWildcard)
         userState.testType = [NSNumber numberWithInt:(int)releaseMode];
+    #endif
     
     if (self.playerTags.tagsToSend)
         userState.tags = self.playerTags.tagsToSend;

--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -257,6 +257,7 @@
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"notification_types"], @-15);
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_model"], deviceModel);
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"device_type"], @0);
+    XCTAssertEqual(OneSignalClientOverrider.lastHTTPRequest[@"test_type"], @1);
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequest[@"language"], @"en-US");
     
     // 2nd init call should not fire another on_session call.


### PR DESCRIPTION
# Description
## One Line Summary
Always set test type to 1 for simulators

## Details
Our provision detection in OneSignalMobileProvision is not successfully able to find the embedded mobile provision for simulators. This might only affect Xcode managed provisioning profiles.

This change is a workaround to that issue to always set testType to 1 since simulators need to receive push in the sandbox environment.

### Motivation
Enable testing push notifications for developers that don't have physical iOS devices.

### Scope
iOS push on simulators

# Testing
## Manual testing
Tested using Xcode 14.3 with iOS 16 simulators

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1244)
<!-- Reviewable:end -->
