### PR TITLE
Add "contributor" to list of valid responders

### DIFF
--- a/.github/set_response_times.js
+++ b/.github/set_response_times.js
@@ -36,7 +36,7 @@ module.exports = async(context, osmetadata) => {
       console.log(foundString);
       return foundString;
     }
-    if (context.payload.comment && context.payload.comment.author_association != "MEMBER" &&  context.payload.comment.author_association != "OWNER") {
+    if (context.payload.comment && context.payload.comment.author_association != "MEMBER" &&  context.payload.comment.author_association != "OWNER" && context.payload.comment.author_association != "CONTRIBUTOR") {
       return;
     }
     const businessDaysResponseTime = calcResponseTimeForIssueCreatedAt(context.payload.issue.created_at);


### PR DESCRIPTION

# Description
## One Line Summary
Sets response time if an author with the Contributor association responds to an issue.

## Details
The github action is returning members as CONTRIBUTOR in the author_association field. This appears to be what happens when not using a fully authenticated request. When pulling the same comment using an authenticated Octokit session the field now returns MEMBER. This is a temporary workaround.

### Motivation
Fix set response time github action.

### Scope
github action

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1245)
<!-- Reviewable:end -->
