### PR TITLE
[5.0.0] Preview IAMs

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -152,6 +152,7 @@
 
 // APNS params
 #define ONESIGNAL_IAM_PREVIEW @"os_in_app_message_preview_id"
+#define ONESIGNAL_POST_PREVIEW_IAM @"ONESIGNAL_POST_PREVIEW_IAM"
 
 #define ONESIGNAL_SUPPORTED_ATTACHMENT_TYPES @[@"aiff", @"wav", @"mp3", @"mp4", @"jpg", @"jpeg", @"png", @"gif", @"mpeg", @"mpg", @"avi", @"m4a", @"m4v"]
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -562,7 +562,7 @@ static NSString *_lastnonActiveMessageId;
         [self handleNotificationOpened:messageDict actionType:type];
     } else if (isPreview && [OSDeviceUtils isIOSVersionGreaterThanOrEqual:@"10.0"]) {
         let notification = [OSNotification parseWithApns:messageDict];
-        //[OneSignalHelper handleIAMPreview:notification]; //TODO: setup a notification center notif for this
+        [self handleIAMPreview:notification];
     }
 }
 
@@ -738,10 +738,9 @@ static NSString *_lastnonActiveMessageId;
 + (BOOL)handleIAMPreview:(OSNotification *)notification {
     NSString *uuid = [notification additionalData][ONESIGNAL_IAM_PREVIEW];
     if (uuid) {
-
         [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"IAM Preview Detected, Begin Handling"];
-//        OSInAppMessageInternal *message = [OSInAppMessageInternal instancePreviewFromNotification:notification];
-//        [[OSMessagingController sharedInstance] presentInAppPreviewMessage:message]; //TODO: Post to notification center for IAM to handle
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:notification forKey:@"notification"];
+        [[NSNotificationCenter defaultCenter] postNotificationName:ONESIGNAL_POST_PREVIEW_IAM object:nil userInfo:userInfo];
         return YES;
     }
     return NO;

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -51,7 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)start;
 + (void)removeInstance;
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message;
-- (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message;
 - (void)updateInAppMessagesFromCache;
 - (void)getInAppMessagesFromServer:(NSString * _Nullable)subscriptionId;
 - (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message;

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -159,6 +159,8 @@ static BOOL _isInAppMessagingPaused = false;
         self.isAppInactive = NO;
         // BOOL that controls if in-app messaging is paused or not (false by default)
         _isInAppMessagingPaused = false;
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleIAMPreview:) name:ONESIGNAL_POST_PREVIEW_IAM object:nil];
     }
     
     return self;
@@ -309,6 +311,12 @@ static BOOL _isInAppMessagingPaused = false;
         [self.inAppMessageDelegate respondsToSelector:@selector(onDidDismissInAppMessage:)]) {
         [self.inAppMessageDelegate onDidDismissInAppMessage:message];
     }
+}
+
+- (void)handleIAMPreview:(NSNotification *)nsNotification {
+    OSNotification *notification = [nsNotification.userInfo objectForKey:@"notification"];
+    OSInAppMessageInternal *message = [OSInAppMessageInternal instancePreviewFromNotification:notification];
+    [self presentInAppPreviewMessage:message];
 }
 
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message {
@@ -980,6 +988,10 @@ static BOOL _isInAppMessagingPaused = false;
     // Pull new IAMs when the subscription id changes to a new valid subscription id
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to new valid subscription id"];
     [self getInAppMessagesFromServer:stateChanges.to.id];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Small PR to add back in preview IAM functionality.

## Details

### Motivation
It was a TODO to have preview IAMs work again. It uses the Notification Center to send the preview IAM to the Messaging Controller as it lives in another module.

# Testing
## Manual testing
Tested sending preview IAMs to a physical iPhone 13.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1247)
<!-- Reviewable:end -->
