### PR TITLE
Fix Crash for In App Message clicks with no id

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -793,6 +793,11 @@ static BOOL _isInAppMessagingPaused = false;
     // Handles body, button, or image clicks
     if (![self isClickAvailable:message withClickId:clickId])
         return;
+    
+    if (!clickId) {
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"sendClickRESTCall:withAction: call could not be made because the click action does not have an id."];
+        return;
+    }
     // Add clickId to clickedClickIds
     [self.clickedClickIds addObject:clickId];
     // Track clickId per IAM

--- a/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/InAppMessagingIntegrationTests.m
@@ -833,6 +833,32 @@
     XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestInAppMessageClicked class]));
 }
 
+- (void)testIAMClickWithNoIDLogsError {
+    let message = [OSInAppMessageTestHelper testMessageJsonWithTriggerPropertyName:OS_DYNAMIC_TRIGGER_KIND_SESSION_TIME withId:@"test_id1" withOperator:OSTriggerOperatorTypeLessThan withValue:@10.0];
+    
+    let registrationResponse = [OSInAppMessageTestHelper testRegistrationJsonWithMessages:@[message]];
+    
+    // the trigger should immediately evaluate to true and should
+    // be shown once the SDK is fully initialized.
+    [OneSignalClientOverrider setMockResponseForRequest:NSStringFromClass([OSRequestRegisterUser class]) withResponse:registrationResponse];
+    
+    [UnitTestCommonMethods initOneSignal_andThreadWait];
+    
+    // the message should now be displayed
+    // simulate a button press (action) on the inapp message with a nil id
+    let action = [OSInAppMessageAction new];
+    action.clickType = @"button";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+    action.clickId = nil;
+#pragma GCC diagnostic pop
+    let testMessage = [OSInAppMessageInternal instanceWithJson:message];
+    
+    [OSMessagingController.sharedInstance messageViewDidSelectAction:testMessage withAction:action];
+    // The action should not send a request due to the nil id but it should not crash
+    XCTAssertEqualObjects(OneSignalClientOverrider.lastHTTPRequestType, NSStringFromClass([OSRequestRegisterUser class]));
+}
+
 - (void)testIAMClickedLaunchesOutcomeAPIRequest {
     [self setOutcomesParamsEnabled];
 


### PR DESCRIPTION
# Description
## One Line Summary
Logs an error instead of crashing if a click action event is sent to the SDK with no id.

## Details
If an In App Message built using HTML is created improperly it can send a click action with a nil id to the SDK. This results in a crash.

### Motivation
Don't crash

### Scope
HTML In App Messages

# Testing
## Unit testing
added a unit test to validate we don't crash

## Manual testing
tested using [this IAM ](https://dashboard.onesignal.com/apps/77e32082-ea27-42e3-a898-c72e141824ef/in_app_messages/9dfd1377-0a23-410e-acdd-3b04fa7296c7/)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1248)
<!-- Reviewable:end -->
