### PR TITLE
Fix failing unit test for Firebase influence open

### DIFF
--- a/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UnitTests.m
@@ -920,16 +920,7 @@ and the app was cold started from opening a notficiation open that the developer
                        withMutableNotificationContent:nil];
     #pragma clang diagnostic pop
     
-    // Make sure we are tracking the notification received event to firebase.
-    XCTAssertEqual(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents.count, 1);
-    id received_event = @{
-         @"os_notification_received": @{
-              @"campaign": @"Template Name - 1117f966-d8cc-11e4-bed1-df8f05be55bb",
-              @"medium": @"notification",
-              @"notification_id": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
-              @"source": @"OneSignal"}
-    };
-    XCTAssertEqualObjects(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents[0], received_event);
+    // Note: we are no longer logging the notification received event to Firebase for iOS.
     
     // Trigger a new app session
     [UnitTestCommonMethods backgroundApp];
@@ -941,7 +932,7 @@ and the app was cold started from opening a notficiation open that the developer
     // TODO: Test carry over causes this influence_open not to fire
     // Since we opened the app under 2 mintues after receiving a notification
     //   an influence_open should be sent to firebase.
-    XCTAssertEqual(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents.count, 2);
+    XCTAssertEqual(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents.count, 1);
     id influence_open_event = @{
         @"os_notification_influence_open": @{
                 @"campaign": @"Template Name - 1117f966-d8cc-11e4-bed1-df8f05be55bb",
@@ -949,7 +940,7 @@ and the app was cold started from opening a notficiation open that the developer
                 @"notification_id": @"b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                 @"source": @"OneSignal"}
     };
-    XCTAssertEqualObjects(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents[1], influence_open_event);
+    XCTAssertEqualObjects(OneSignalTrackFirebaseAnalyticsOverrider.loggedEvents[0], influence_open_event);
 }
 
 - (void)testOSNotificationPayloadParsesTemplateFields {


### PR DESCRIPTION
# Description
## One Line Summary
Fix failing unit test for Firebase influence open

## Details

### Motivation
Unit test `testFirebaseAnalyticsInfluenceNotificationOpen` was failing due to still expecting to track the notification received event, which was removed in #1241. 

# Testing
## Unit testing
Unit test was run and successfully passed:
![Screenshot 2023-04-13 at 2 43 01 PM](https://user-images.githubusercontent.com/46546946/231889424-d4037aac-ff0b-40e5-a0ee-c6456d505c74.png)

## Manual testing
Manual testing for code used in this unit test was done in #1241.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1250)
<!-- Reviewable:end -->
