### PR TITLE
Revert resetting sessions' direct influence

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.h
@@ -54,6 +54,5 @@
 - (void)onNotificationReceived:(NSString * _Nonnull)notificationId;
 - (void)onDirectInfluenceFromNotificationOpen:(AppEntryAction)entryAction withNotificationId:(NSString * _Nonnull)directNotificationId;
 - (void)attemptSessionUpgrade:(AppEntryAction)entryAction;
-- (void)resetSessionIfDirect;
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.m
@@ -72,16 +72,6 @@ static OSSessionManager *_sessionManager;
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"SessionManager restored from cache with influences: %@", [self getInfluences].description]];
 }
 
-- (void)resetSessionIfDirect {
-    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"OneSignal SessionManager resetSessionIfDirect"];
-    NSArray<OSChannelTracker *> *channels = [_trackerFactory channels];
-    for (OSChannelTracker *tracker in channels) {
-        if (tracker.influenceType == DIRECT) {
-            [tracker resetAndInitInfluence];
-        }
-    }
-}
-
 - (void)restartSessionIfNeeded:(AppEntryAction)entryAction {
     NSArray<OSChannelTracker *> *channelTrackers = [_trackerFactory channelsToResetByEntryAction:entryAction];
     NSMutableArray<OSInfluence *> *updatedInfluences = [NSMutableArray new];

--- a/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
@@ -117,9 +117,6 @@ static let DELAY_TIME = 30;
 
         [OneSignal.stateSynchronizer sendOnFocusTime:totalTimeActive params:params withSuccess:^(NSDictionary *result) {
             [super saveUnsentActiveTime:0];
-            if (params != nil) {
-                [[OSSessionManager sharedSessionManager] resetSessionIfDirect];
-            }
             [OneSignal onesignalLog:ONE_S_LL_DEBUG message:@"sendOnFocusCallWithParams attributed succeed, saveUnsentActiveTime with 0"];
             [self endDelayBackgroundTask];
         } onFailure:^(NSDictionary<NSString *, NSError *> *errors) {


### PR DESCRIPTION
# Description
## One Line Summary
Revert the change in PR #1240 that changed direct session count behavior.

## Details
This change prevents sessions from being upgraded to Direct sessions. 

### Motivation
Reverting to allow for a release while a complete fix is investigated.

### Scope
Sessions

# Testing
## Unit testing
The broken sessions unit tests now pass

## Manual testing
Tested various direct session scenarios. With the change sessions were not being upgraded to Direct from Indirect. Without the change if you have multiple notifications you may receive multiple direct session counts for a notification.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1251)
<!-- Reviewable:end -->
