### PR TITLE
[5.0.0] API Updates

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver, OSInAppMessageLifecycleHandler, OSPushSubscriptionObserver>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -57,44 +57,21 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
     
-    id openNotificationHandler = ^(OSNotificationOpenedResult *result) {
-        // TODO: opened handler Not triggered
-        NSLog(@"OSNotificationOpenedResult: %@", result.action);
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated"
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
-        [alert show];
-        #pragma clang diagnostic pop
-    };
-    id notificationReceiverBlock = ^(OSNotification *notif, OSNotificationDisplayResponse completion) {
-        NSLog(@"Will Receive Notification - %@", notif.notificationId);
-        completion(notif);
-    };
-    
-    // Example block for IAM action click handler
-    id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
-        NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:message];
-    };
-
-    // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal.InAppMessages setClickHandler:inAppMessagingActionClickBlock];
-    
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
     [OneSignal setProvidesNotificationSettingsView:NO];
     
-    [OneSignal.InAppMessages setLifecycleHandler:self];
+    [OneSignal.InAppMessages addLifecycleListener:self];
     [OneSignal.InAppMessages paused:true];
 
-    [OneSignal.Notifications setNotificationWillShowInForegroundHandler:notificationReceiverBlock];
-    [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
-
+    [OneSignal.Notifications addForegroundLifecycleListener:self];
+    [OneSignal.Notifications addClickListener:self];
     [OneSignal.User.pushSubscription addObserver:self];
     NSLog(@"OneSignal Demo App push subscription observer added");
     
     [OneSignal.Notifications addPermissionObserver:self];
-    
+    [OneSignal.InAppMessages addClickListener:self];
+
     NSLog(@"UNUserNotificationCenter.delegate: %@", UNUserNotificationCenter.currentNotificationCenter.delegate);
     
     return YES;
@@ -117,40 +94,51 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     // [OneSignal setAppId:onesignalAppId];
 }
 
-- (void)onOSPermissionChanged:(OSPermissionState*)state {
-    NSLog(@"Dev App onOSPermissionChanged: %@", state);
+- (void)onNotificationPermissionDidChange:(BOOL)permission {
+    NSLog(@"Dev App onNotificationPermissionDidChange: %d", permission);
 }
 
-- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges *)stateChanges {
-    NSLog(@"Dev App onOSPushSubscriptionChangedWithStateChanges: %@", stateChanges);
+- (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState *)state {
+    NSLog(@"Dev App onPushSubscriptionDidChange: %@", state);
     ViewController* mainController = (ViewController*) self.window.rootViewController;
-    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.optedIn;
+    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) state.current.optedIn;
+}
+
+- (void)onClickNotification:(OSNotificationClickEvent * _Nonnull)event {
+    NSLog(@"Dev App onClickNotification with event %@", [event jsonRepresentation]);
 }
 
 #pragma mark OSInAppMessageDelegate
 
-- (void)handleMessageAction:(OSInAppMessageAction *)action {
-    NSLog(@"OSInAppMessageDelegate: handling message action: %@",action);
+- (void)onClickInAppMessage:(OSInAppMessageClickEvent * _Nonnull)event {
+    NSLog(@"Dev App onClickInAppMessage event: %@", [event jsonRepresentation]);
+}
+
+- (void)onWillDisplayNotification:(OSNotificationWillDisplayEvent *)event {
+    NSLog(@"Dev App OSNotificationWillDisplayEvent with event: %@",event);
+    [event preventDefault];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [event.notification display];
+    });
+}
+
+- (void)onWillDisplayInAppMessage:(OSInAppMessageWillDisplayEvent *)event {
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onWillDisplay Message: %@",event.message);
     return;
 }
 
-- (void)onWillDisplayInAppMessage:(OSInAppMessage *)message {
-    NSLog(@"OSInAppMessageDelegate: onWillDisplay Message: %@",message);
+- (void)onDidDisplayInAppMessage:(OSInAppMessageDidDisplayEvent *)event {
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onDidDisplay Message: %@",event.message);
     return;
 }
 
-- (void)onDidDisplayInAppMessage:(OSInAppMessage *)message {
-    NSLog(@"OSInAppMessageDelegate: onDidDisplay Message: %@",message);
+- (void)onWillDismissInAppMessage:(OSInAppMessageWillDismissEvent *)event {
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onWillDismiss Message: %@",event.message);
     return;
 }
 
-- (void)onWillDismissInAppMessage:(OSInAppMessage *)message {
-    NSLog(@"OSInAppMessageDelegate: onWillDismiss Message: %@",message);
-    return;
-}
-
-- (void)onDidDismissInAppMessage:(OSInAppMessage *)message {
-    NSLog(@"OSInAppMessageDelegate: onDidDismiss Message: %@",message);
+- (void)onDidDismissInAppMessage:(OSInAppMessageDidDismissEvent *)event {
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onDidDismiss Message: %@",event.message);
     return;
 }
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Base.lproj/Main.storyboard
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Base.lproj/Main.storyboard
@@ -26,7 +26,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="2500"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kp7-Oh-BQ1" userLabel="Update App Id">
-                                                <rect key="frame" x="140.66666666666666" y="164" width="94" height="30"/>
+                                                <rect key="frame" x="140.66666666666666" y="202" width="94" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="aq3-BI-YWl"/>
                                                 </constraints>
@@ -38,7 +38,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Htv-x2-aPb">
-                                                <rect key="frame" x="118" y="282" width="68" height="30"/>
+                                                <rect key="frame" x="118" y="280" width="68" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="68" id="com-ja-CVD"/>
                                                 </constraints>
@@ -49,7 +49,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UPh-ZU-o2e">
-                                                <rect key="frame" x="201" y="320" width="111" height="30"/>
+                                                <rect key="frame" x="201" y="318" width="111" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Prompt Location"/>
                                                 <connections>
@@ -57,7 +57,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YNF-Jm-wDq">
-                                                <rect key="frame" x="91" y="320" width="99.333333333333314" height="30"/>
+                                                <rect key="frame" x="91" y="318" width="99.333333333333314" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Prompt Push"/>
                                                 <connections>
@@ -65,7 +65,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subscription:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wT0-PD-6z7">
-                                                <rect key="frame" x="102" y="358" width="171" height="21"/>
+                                                <rect key="frame" x="102" y="356" width="171" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="171" id="1Hc-Sp-iz1"/>
                                                     <constraint firstAttribute="height" constant="21" id="J8O-i0-Wue"/>
@@ -75,7 +75,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="gZI-5K-94s">
-                                                <rect key="frame" x="125" y="387" width="125" height="32"/>
+                                                <rect key="frame" x="125" y="385" width="125" height="32"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="31" id="zzg-ME-i8s"/>
                                                 </constraints>
@@ -90,7 +90,7 @@
                                                 </connections>
                                             </segmentedControl>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cWh-Hu-7CP">
-                                                <rect key="frame" x="47" y="873" width="132" height="30"/>
+                                                <rect key="frame" x="47" y="871" width="132" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Hyo-HG-Thf"/>
                                                     <constraint firstAttribute="width" constant="132" id="ber-g2-7Nf"/>
@@ -109,7 +109,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="05S-ud-V2e">
-                                                <rect key="frame" x="93" y="73" width="189" height="32"/>
+                                                <rect key="frame" x="95" y="116" width="189" height="32"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="31" id="98W-5b-swj"/>
                                                 </constraints>
@@ -124,7 +124,7 @@
                                                 </connections>
                                             </segmentedControl>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In App Messaging:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Whm-aD-RCM">
-                                                <rect key="frame" x="104" y="728" width="171" height="20"/>
+                                                <rect key="frame" x="104" y="726" width="171" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="171" id="GlJ-IC-RVW"/>
                                                     <constraint firstAttribute="height" constant="20" id="v0Q-c3-8Q8"/>
@@ -134,7 +134,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Outcomes:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ecj-vJ-K60" userLabel="Outcomes Label">
-                                                <rect key="frame" x="103" y="959" width="171" height="22"/>
+                                                <rect key="frame" x="103" y="957" width="171" height="22"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="22" id="SOz-xd-ZHj"/>
                                                 </constraints>
@@ -143,7 +143,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="saG-x9-o6U">
-                                                <rect key="frame" x="127" y="756" width="121" height="32"/>
+                                                <rect key="frame" x="127" y="754" width="121" height="32"/>
                                                 <segments>
                                                     <segment title="Pause"/>
                                                     <segment title="Enable"/>
@@ -155,7 +155,7 @@
                                                 </connections>
                                             </segmentedControl>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ykz-Wq-cb5">
-                                                <rect key="frame" x="47" y="795" width="134" height="32"/>
+                                                <rect key="frame" x="47" y="793" width="134" height="32"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="32" id="bcm-8l-dBS"/>
                                                 </constraints>
@@ -163,7 +163,7 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="79P-xw-1Q5">
-                                                <rect key="frame" x="147" y="835" width="81" height="30"/>
+                                                <rect key="frame" x="147" y="833" width="81" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Add Trigger"/>
                                                 <connections>
@@ -171,7 +171,7 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="fill" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="OneSignal App Id" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="TVC-yc-aRa">
-                                                <rect key="frame" x="14.666666666666657" y="122" width="345.66666666666674" height="34"/>
+                                                <rect key="frame" x="14.666666666666657" y="160" width="345.66666666666674" height="34"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="34" id="UQH-kD-dGa"/>
                                                 </constraints>
@@ -179,7 +179,7 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bmb-ib-r40">
-                                                <rect key="frame" x="47" y="921" width="132" height="30"/>
+                                                <rect key="frame" x="47" y="919" width="132" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="UJK-GU-nj5"/>
                                                 </constraints>
@@ -187,7 +187,7 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="idh-ud-yeY">
-                                                <rect key="frame" x="196" y="921" width="119" height="30"/>
+                                                <rect key="frame" x="196" y="919" width="119" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Get Trigger Value"/>
                                                 <connections>
@@ -195,7 +195,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A38-En-69W">
-                                                <rect key="frame" x="196" y="873" width="119" height="30"/>
+                                                <rect key="frame" x="196" y="871" width="119" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Remove Trigger"/>
                                                 <connections>
@@ -237,7 +237,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location Shared:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lEs-as-Xak">
-                                                <rect key="frame" x="104" y="662" width="171" height="21"/>
+                                                <rect key="frame" x="104" y="660" width="171" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="171" id="yJi-cv-dCj"/>
                                                 </constraints>
@@ -246,7 +246,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" translatesAutoresizingMaskIntoConstraints="NO" id="udx-VH-OPB">
-                                                <rect key="frame" x="125" y="689" width="129" height="32"/>
+                                                <rect key="frame" x="125" y="687" width="129" height="32"/>
                                                 <segments>
                                                     <segment title="Disable"/>
                                                     <segment title="Enable"/>
@@ -258,7 +258,7 @@
                                                 </connections>
                                             </segmentedControl>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="srQ-s9-3O9" userLabel="Login to External User Id">
-                                                <rect key="frame" x="103.66666666666669" y="586" width="168" height="30"/>
+                                                <rect key="frame" x="103.66666666666669" y="584" width="168" height="30"/>
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Login to External User Id"/>
@@ -267,12 +267,12 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="fill" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="External user id" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H7c-2l-Pkl">
-                                                <rect key="frame" x="14" y="544" width="347" height="34"/>
+                                                <rect key="frame" x="14" y="542" width="347" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fmV-3f-ILa" userLabel="Add Email Button">
-                                                <rect key="frame" x="155.66666666666666" y="468" width="68" height="30"/>
+                                                <rect key="frame" x="155.66666666666666" y="466" width="68" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="t60-TH-3Eo"/>
                                                 </constraints>
@@ -284,7 +284,7 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="fill" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9me-S6-lrh">
-                                                <rect key="frame" x="15" y="426" width="347" height="34"/>
+                                                <rect key="frame" x="15" y="424" width="347" height="34"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="34" id="cQQ-By-nt2"/>
                                                 </constraints>
@@ -292,7 +292,7 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H3K-GA-smE">
-                                                <rect key="frame" x="199" y="282" width="72" height="30"/>
+                                                <rect key="frame" x="199" y="280" width="72" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Send Tags"/>
                                                 <connections>
@@ -300,7 +300,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7ll-OX-6Qj" userLabel="Remove Email Button">
-                                                <rect key="frame" x="139.66666666666666" y="506" width="96" height="30"/>
+                                                <rect key="frame" x="139.66666666666666" y="504" width="96" height="30"/>
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Remove Email"/>
@@ -341,20 +341,20 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a9d-ER-L2X" userLabel="Send Tag Key">
-                                                <rect key="frame" x="47" y="202" width="134" height="34"/>
+                                                <rect key="frame" x="63" y="240" width="78" height="34"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="134" id="xHt-5B-DLB"/>
+                                                    <constraint firstAttribute="width" constant="78" id="xHt-5B-DLB"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rIN-rI-IgX" userLabel="Send Tag Value">
-                                                <rect key="frame" x="198" y="202" width="63.666666666666686" height="34"/>
+                                                <rect key="frame" x="156" y="240" width="63.666666666666657" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yRP-dg-rBy" userLabel="Send Tag Button">
-                                                <rect key="frame" x="145.66666666666666" y="244" width="84" height="30"/>
+                                                <rect key="frame" x="231" y="242" width="84" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="84" id="gHd-cB-4TM"/>
                                                 </constraints>
@@ -365,12 +365,12 @@
                                                 </connections>
                                             </button>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="G56-cW-rWo">
-                                                <rect key="frame" x="196" y="795" width="139" height="32"/>
+                                                <rect key="frame" x="196" y="793" width="139" height="32"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OiG-L7-Ot2" userLabel="Logout">
-                                                <rect key="frame" x="104" y="624" width="167" height="30"/>
+                                                <rect key="frame" x="104" y="622" width="167" height="30"/>
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Logout"/>
@@ -510,20 +510,20 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dlG-XI-zeT">
-                                                <rect key="frame" x="115" y="1852" width="145" height="30"/>
+                                                <rect key="frame" x="185" y="73" width="76" height="30"/>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <state key="normal" title="Dont require consent"/>
+                                                <state key="normal" title="No Require"/>
                                                 <connections>
                                                     <action selector="dontRequireConsent:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Kjh-GZ-MyL"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3fx-6I-1V6">
-                                                <rect key="frame" x="107" y="1819" width="161" height="30"/>
+                                                <rect key="frame" x="113" y="73" width="64" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="161" id="NnG-7I-PP1"/>
+                                                    <constraint firstAttribute="width" constant="64" id="NnG-7I-PP1"/>
                                                 </constraints>
                                                 <color key="tintColor" red="1" green="0.1367101157" blue="0.01701983743" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <state key="normal" title="Require consent"/>
+                                                <state key="normal" title="Require"/>
                                                 <connections>
                                                     <action selector="requireConsent:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vxn-ST-TBu"/>
                                                 </connections>
@@ -538,7 +538,7 @@
                                             <constraint firstItem="zQ9-CS-si6" firstAttribute="leading" secondItem="9Tw-qJ-FVq" secondAttribute="trailing" constant="16" id="3RX-rT-bgK"/>
                                             <constraint firstItem="saG-x9-o6U" firstAttribute="centerX" secondItem="79P-xw-1Q5" secondAttribute="centerX" id="3TW-dg-dyJ"/>
                                             <constraint firstItem="Ykz-Wq-cb5" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="47" id="3YQ-a2-ECj"/>
-                                            <constraint firstItem="q4D-1P-6cD" firstAttribute="leading" secondItem="rIN-rI-IgX" secondAttribute="leading" id="4zB-mY-ahZ"/>
+                                            <constraint firstItem="q4D-1P-6cD" firstAttribute="leading" secondItem="rIN-rI-IgX" secondAttribute="leading" constant="42" id="4zB-mY-ahZ"/>
                                             <constraint firstAttribute="bottom" secondItem="XxB-ij-UMV" secondAttribute="bottom" constant="1162" id="5Le-GR-vgh"/>
                                             <constraint firstItem="XxB-ij-UMV" firstAttribute="top" secondItem="HVt-vl-fuR" secondAttribute="bottom" constant="8" symbolic="YES" id="5st-AH-QcT"/>
                                             <constraint firstItem="saG-x9-o6U" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="6Fo-GM-4BO"/>
@@ -552,7 +552,7 @@
                                             <constraint firstItem="SzM-YZ-1ls" firstAttribute="leading" secondItem="mOc-AZ-oON" secondAttribute="trailing" constant="15" id="9D5-0J-g3D"/>
                                             <constraint firstAttribute="bottom" secondItem="htU-cG-NyO" secondAttribute="bottom" constant="1030" id="9Rr-Pe-cy6"/>
                                             <constraint firstItem="bmb-ib-r40" firstAttribute="top" secondItem="idh-ud-yeY" secondAttribute="top" id="9yE-lu-NwI"/>
-                                            <constraint firstItem="05S-ud-V2e" firstAttribute="top" secondItem="j3e-42-uww" secondAttribute="bottom" constant="8" id="BEp-Rs-HmE"/>
+                                            <constraint firstItem="05S-ud-V2e" firstAttribute="top" secondItem="j3e-42-uww" secondAttribute="bottom" constant="51" id="BEp-Rs-HmE"/>
                                             <constraint firstItem="jbt-gq-j0O" firstAttribute="centerX" secondItem="De4-AJ-nrw" secondAttribute="centerX" id="BI3-Q0-EGW"/>
                                             <constraint firstItem="Kp7-Oh-BQ1" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="BRj-Hj-dn6"/>
                                             <constraint firstAttribute="trailing" secondItem="9me-S6-lrh" secondAttribute="trailing" constant="13" id="Bd2-dk-une"/>
@@ -561,14 +561,14 @@
                                             <constraint firstItem="yRP-dg-rBy" firstAttribute="baseline" secondItem="H3K-GA-smE" secondAttribute="firstBaseline" id="DGT-HM-vmK"/>
                                             <constraint firstItem="lEs-as-Xak" firstAttribute="top" secondItem="OiG-L7-Ot2" secondAttribute="bottom" constant="8" id="DKU-uU-Zkx"/>
                                             <constraint firstItem="468-Vy-JbK" firstAttribute="top" secondItem="jbt-gq-j0O" secondAttribute="bottom" constant="8" symbolic="YES" id="E1j-bO-SQU"/>
-                                            <constraint firstItem="rIN-rI-IgX" firstAttribute="leading" secondItem="H3K-GA-smE" secondAttribute="leading" constant="-1" id="E4a-hE-QnV"/>
-                                            <constraint firstItem="a9d-ER-L2X" firstAttribute="leading" secondItem="Htv-x2-aPb" secondAttribute="leading" constant="-71" id="E6e-OU-Jp2"/>
+                                            <constraint firstItem="rIN-rI-IgX" firstAttribute="leading" secondItem="H3K-GA-smE" secondAttribute="leading" constant="-43" id="E4a-hE-QnV"/>
+                                            <constraint firstItem="a9d-ER-L2X" firstAttribute="leading" secondItem="Htv-x2-aPb" secondAttribute="leading" constant="-55" id="E6e-OU-Jp2"/>
                                             <constraint firstItem="nRH-WN-pj0" firstAttribute="centerX" secondItem="Whm-aD-RCM" secondAttribute="centerX" id="EGZ-Gb-Ib2"/>
                                             <constraint firstAttribute="trailing" secondItem="f4C-he-vQl" secondAttribute="trailing" constant="45.333333333333371" id="ESB-NY-zGu"/>
                                             <constraint firstItem="cWh-Hu-7CP" firstAttribute="top" secondItem="A38-En-69W" secondAttribute="top" id="ET2-Bx-oB2"/>
                                             <constraint firstItem="udx-VH-OPB" firstAttribute="top" secondItem="lEs-as-Xak" secondAttribute="bottom" constant="6" id="EeW-Wz-D7f"/>
                                             <constraint firstItem="XxB-ij-UMV" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="Ek9-He-sk3"/>
-                                            <constraint firstItem="3fx-6I-1V6" firstAttribute="top" secondItem="xRQ-ep-yvV" secondAttribute="bottom" constant="27" id="Exy-Tb-dnC"/>
+                                            <constraint firstItem="3fx-6I-1V6" firstAttribute="top" secondItem="xRQ-ep-yvV" secondAttribute="bottom" constant="-1719" id="Exy-Tb-dnC"/>
                                             <constraint firstItem="wT0-PD-6z7" firstAttribute="leading" secondItem="Whm-aD-RCM" secondAttribute="leading" constant="-2" id="GCU-dL-7XC"/>
                                             <constraint firstItem="srQ-s9-3O9" firstAttribute="top" secondItem="H7c-2l-Pkl" secondAttribute="bottom" constant="8" id="GjJ-A2-hHZ"/>
                                             <constraint firstItem="L3h-sn-LJN" firstAttribute="top" secondItem="WOr-el-mEb" secondAttribute="bottom" constant="8" id="Gxw-1F-LHM"/>
@@ -611,32 +611,32 @@
                                             <constraint firstItem="q4D-1P-6cD" firstAttribute="bottom" secondItem="2Vb-S3-WOf" secondAttribute="bottom" id="ZR1-qy-KxK"/>
                                             <constraint firstItem="cWh-Hu-7CP" firstAttribute="trailing" secondItem="bmb-ib-r40" secondAttribute="trailing" id="Zi0-Ak-z1H"/>
                                             <constraint firstItem="nCe-CR-rPW" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="ZpZ-oe-zx5"/>
-                                            <constraint firstItem="yRP-dg-rBy" firstAttribute="top" secondItem="a9d-ER-L2X" secondAttribute="bottom" constant="8" id="a7K-69-UWC"/>
+                                            <constraint firstItem="yRP-dg-rBy" firstAttribute="top" secondItem="a9d-ER-L2X" secondAttribute="bottom" constant="-32" id="a7K-69-UWC"/>
                                             <constraint firstItem="De4-AJ-nrw" firstAttribute="top" secondItem="Xj9-lX-hR2" secondAttribute="bottom" id="aCi-3j-537"/>
                                             <constraint firstItem="H3K-GA-smE" firstAttribute="top" secondItem="yRP-dg-rBy" secondAttribute="bottom" constant="8" id="aSG-2M-dTc"/>
                                             <constraint firstItem="OiG-L7-Ot2" firstAttribute="leading" secondItem="lEs-as-Xak" secondAttribute="leading" id="aZk-rm-Cdu"/>
                                             <constraint firstItem="saG-x9-o6U" firstAttribute="top" secondItem="Whm-aD-RCM" secondAttribute="bottom" constant="8" id="adb-5Q-raZ"/>
                                             <constraint firstItem="bYz-SP-tnS" firstAttribute="top" secondItem="L3h-sn-LJN" secondAttribute="bottom" constant="30" id="aqY-jg-Jko"/>
                                             <constraint firstItem="YNF-Jm-wDq" firstAttribute="top" secondItem="Htv-x2-aPb" secondAttribute="bottom" constant="8" id="azq-9H-rhn"/>
-                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="top" secondItem="05S-ud-V2e" secondAttribute="bottom" constant="18" id="bgg-xw-XwK"/>
+                                            <constraint firstItem="TVC-yc-aRa" firstAttribute="top" secondItem="05S-ud-V2e" secondAttribute="bottom" constant="13" id="bgg-xw-XwK"/>
                                             <constraint firstAttribute="width" constant="375" id="c19-TN-GiR"/>
                                             <constraint firstItem="468-Vy-JbK" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="cMZ-h7-Fdr"/>
-                                            <constraint firstItem="yRP-dg-rBy" firstAttribute="top" secondItem="rIN-rI-IgX" secondAttribute="bottom" constant="8" id="cXt-ue-gkI"/>
+                                            <constraint firstItem="yRP-dg-rBy" firstAttribute="top" secondItem="rIN-rI-IgX" secondAttribute="bottom" constant="-32" id="cXt-ue-gkI"/>
                                             <constraint firstItem="j3e-42-uww" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="caU-Jq-UKA"/>
                                             <constraint firstItem="HVt-vl-fuR" firstAttribute="top" secondItem="468-Vy-JbK" secondAttribute="bottom" constant="8" symbolic="YES" id="cbS-MD-s1Y"/>
                                             <constraint firstItem="fmV-3f-ILa" firstAttribute="centerX" secondItem="lEs-as-Xak" secondAttribute="centerX" id="cbe-aI-qXe"/>
                                             <constraint firstItem="L3h-sn-LJN" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="cjj-9E-8s2"/>
-                                            <constraint firstItem="yRP-dg-rBy" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="d2m-Ge-buz"/>
+                                            <constraint firstItem="yRP-dg-rBy" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" constant="85.5" id="d2m-Ge-buz"/>
                                             <constraint firstItem="Htv-x2-aPb" firstAttribute="trailing" secondItem="Ykz-Wq-cb5" secondAttribute="trailing" constant="5" id="dEk-7w-Ffq"/>
                                             <constraint firstItem="Htv-x2-aPb" firstAttribute="top" secondItem="H3K-GA-smE" secondAttribute="bottom" constant="8" id="dGl-mF-7SU"/>
                                             <constraint firstItem="nRH-WN-pj0" firstAttribute="top" secondItem="XxB-ij-UMV" secondAttribute="bottom" constant="19" id="eXQ-ay-b29"/>
                                             <constraint firstItem="NdZ-yd-14F" firstAttribute="centerX" secondItem="q4D-1P-6cD" secondAttribute="centerX" id="evg-Kp-3gm"/>
                                             <constraint firstItem="htU-cG-NyO" firstAttribute="leading" secondItem="79P-xw-1Q5" secondAttribute="leading" id="gSD-AV-cLt"/>
                                             <constraint firstItem="Whm-aD-RCM" firstAttribute="trailing" secondItem="Ecj-vJ-K60" secondAttribute="trailing" constant="1" id="gic-WK-yi1"/>
-                                            <constraint firstAttribute="bottom" secondItem="3fx-6I-1V6" secondAttribute="bottom" constant="651" id="gvp-gJ-TiS"/>
+                                            <constraint firstAttribute="bottom" secondItem="3fx-6I-1V6" secondAttribute="bottom" constant="2397" id="gvp-gJ-TiS"/>
                                             <constraint firstItem="yRP-dg-rBy" firstAttribute="top" secondItem="6dV-2z-2jJ" secondAttribute="top" constant="244" id="hN8-d5-5HN"/>
                                             <constraint firstItem="A38-En-69W" firstAttribute="leading" secondItem="idh-ud-yeY" secondAttribute="leading" id="hOo-6r-9uP"/>
-                                            <constraint firstItem="3fx-6I-1V6" firstAttribute="centerX" secondItem="dlG-XI-zeT" secondAttribute="centerX" id="ht7-Ck-Vsl"/>
+                                            <constraint firstItem="3fx-6I-1V6" firstAttribute="centerX" secondItem="dlG-XI-zeT" secondAttribute="centerX" constant="-78" id="ht7-Ck-Vsl"/>
                                             <constraint firstItem="Ykz-Wq-cb5" firstAttribute="top" secondItem="saG-x9-o6U" secondAttribute="bottom" constant="8" id="hyN-FW-j9s"/>
                                             <constraint firstItem="HVt-vl-fuR" firstAttribute="centerX" secondItem="468-Vy-JbK" secondAttribute="centerX" id="iW2-UF-ypl"/>
                                             <constraint firstItem="NdZ-yd-14F" firstAttribute="leading" secondItem="bYz-SP-tnS" secondAttribute="trailing" constant="15" id="ixw-Sw-MYZ"/>
@@ -661,15 +661,15 @@
                                             <constraint firstItem="H7c-2l-Pkl" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="qAH-t4-Hbo"/>
                                             <constraint firstAttribute="height" constant="2500" id="qKR-2z-UgG"/>
                                             <constraint firstItem="f4C-he-vQl" firstAttribute="leading" secondItem="Whw-1A-6W0" secondAttribute="trailing" constant="16" id="qQa-dC-XOo"/>
-                                            <constraint firstItem="3fx-6I-1V6" firstAttribute="centerX" secondItem="L3h-sn-LJN" secondAttribute="centerX" id="qZu-sW-GqU"/>
+                                            <constraint firstItem="3fx-6I-1V6" firstAttribute="centerX" secondItem="L3h-sn-LJN" secondAttribute="centerX" constant="-42.666666666666657" id="qZu-sW-GqU"/>
                                             <constraint firstItem="udx-VH-OPB" firstAttribute="centerX" secondItem="Whm-aD-RCM" secondAttribute="centerX" id="r5m-4t-kSR"/>
                                             <constraint firstItem="mOc-AZ-oON" firstAttribute="top" secondItem="SzM-YZ-1ls" secondAttribute="top" id="sqq-HD-a7j"/>
                                             <constraint firstItem="gZI-5K-94s" firstAttribute="top" secondItem="wT0-PD-6z7" secondAttribute="bottom" constant="8" id="teY-sG-FWL"/>
                                             <constraint firstItem="Ecj-vJ-K60" firstAttribute="top" secondItem="bmb-ib-r40" secondAttribute="bottom" constant="8" id="uFL-iF-4YC"/>
-                                            <constraint firstItem="dlG-XI-zeT" firstAttribute="top" secondItem="3fx-6I-1V6" secondAttribute="bottom" constant="3" id="uU3-5S-r0b"/>
+                                            <constraint firstItem="dlG-XI-zeT" firstAttribute="top" secondItem="3fx-6I-1V6" secondAttribute="bottom" constant="-30" id="uU3-5S-r0b"/>
                                             <constraint firstItem="H7c-2l-Pkl" firstAttribute="leading" secondItem="6dV-2z-2jJ" secondAttribute="leading" constant="14" id="uXc-mi-LZ9"/>
                                             <constraint firstItem="7ll-OX-6Qj" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="ujG-XB-cbU"/>
-                                            <constraint firstItem="05S-ud-V2e" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" id="vUP-J1-f11"/>
+                                            <constraint firstItem="05S-ud-V2e" firstAttribute="centerX" secondItem="6dV-2z-2jJ" secondAttribute="centerX" constant="2" id="vUP-J1-f11"/>
                                             <constraint firstItem="bmb-ib-r40" firstAttribute="top" secondItem="cWh-Hu-7CP" secondAttribute="bottom" constant="18" id="w2d-na-OzR"/>
                                             <constraint firstItem="knZ-rP-bRU" firstAttribute="leading" secondItem="Xj9-lX-hR2" secondAttribute="trailing" constant="11" id="wEH-6x-IiH"/>
                                             <constraint firstItem="G56-cW-rWo" firstAttribute="leading" secondItem="A38-En-69W" secondAttribute="leading" id="xmz-74-IFS"/>

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface ViewController : UIViewController <OSInAppMessageDelegate>
+@interface ViewController : UIViewController
 
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -241,7 +241,7 @@
         if (activityId && activityId.length) {
             [LiveActivityController createActivityWithCompletionHandler:^(NSString * token) {
                 if(token){
-                    [OneSignal enterLiveActivity:activityId withToken:token];
+                    [OneSignal.LiveActivities enter:activityId withToken:token];
                 }
             }];
         }
@@ -251,7 +251,7 @@
 }
 - (IBAction)exitLiveActivity:(id)sender {
     if (self.activityId.text && self.activityId.text.length) {
-        [OneSignal exitLiveActivity:self.activityId.text];
+        [OneSignal.LiveActivities exit:self.activityId.text];
     }
 }
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -40,8 +40,6 @@
     
     self.activityIndicatorView.hidden = true;
     
-    self.consentSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal requiresPrivacyConsent];
-
     self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.User.pushSubscription.optedIn;
     
     self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isShared];
@@ -168,7 +166,7 @@
 
 - (IBAction)consentSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller consent granted: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal setPrivacyConsent:(bool) sender.selectedSegmentIndex];
+    [OneSignal setConsentGiven:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)subscriptionSegmentedControlValueChanged:(UISegmentedControl *)sender {
@@ -267,13 +265,13 @@
 }
 
 - (IBAction)requireConsent:(id)sender {
-    NSLog(@"Dev App: setting setRequiresPrivacyConsent to true.");
-    [OneSignal setRequiresPrivacyConsent:true];
+    NSLog(@"Dev App: setting setConsentRequired to true.");
+    [OneSignal setConsentRequired:true];
 }
 
 - (IBAction)dontRequireConsent:(id)sender {
-    NSLog(@"Dev App: setting setRequiresPrivacyConsent to false.");
-    [OneSignal setRequiresPrivacyConsent:false];
+    NSLog(@"Dev App: setting setConsentRequired to false.");
+    [OneSignal setConsentRequired:false];
 }
 
 @end

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -190,10 +190,6 @@
     [OneSignal.InAppMessages paused:(bool) !sender.selectedSegmentIndex];
 }
 
-- (void)handleMessageAction:(NSString *)actionId {
-    NSLog(@"View controller did get action: %@", actionId);
-}
-
 - (IBAction)loginExternalUserId:(UIButton *)sender {
     NSString* externalUserId = self.externalUserIdTextField.text;
     NSLog(@"Dev App: Logging in to external user ID %@", externalUserId);

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.h
@@ -10,7 +10,7 @@
 #import <OneSignalFramework/OneSignalFramework.h>
 
 // TODO: Add subscription observer
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSPermissionObserver>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -54,24 +54,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
     [OneSignal.Debug setAlertLevel:ONE_S_LL_NONE];
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
-    
-    id openNotificationHandler = ^(OSNotificationOpenedResult *result) {
-        NSLog(@"OSNotificationOpenedResult: %@", result.action);
-    };
-    id notificationReceiverBlock = ^(OSNotification *notif, OSNotificationDisplayResponse completion) {
-        NSLog(@"Will Receive Notification - %@", notif.notificationId);
-        completion(notif);
-    };
-    
-    // Example block for IAM action click handler
-    id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
-        NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:message];
-    };
 
-    // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal.InAppMessages setClickHandler:inAppMessagingActionClickBlock];
-    
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
     [OneSignal setProvidesNotificationSettingsView:NO];
@@ -87,9 +70,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     [OneSignal.InAppMessages paused:false];
     
-    [OneSignal.Notifications setNotificationWillShowInForegroundHandler:notificationReceiverBlock];
-    [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
-
     NSLog(@"UNUserNotificationCenter.delegate: %@", UNUserNotificationCenter.currentNotificationCenter.delegate);
     
     return YES;
@@ -112,8 +92,8 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal initialize:onesignalAppId withLaunchOptions:nil];
 }
 
-- (void) onOSPermissionChanged:(OSPermissionState*)state {
-    NSLog(@"onOSPermissionChanged: %@", state);
+- (void)onNotificationPermissionDidChange:(BOOL)permission {
+    NSLog(@"onNotificationPermissionDidChange: %d", permission);
 }
 
 // TODO: Add push sub observer

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface ViewController : UIViewController <OSInAppMessageDelegate>
+@interface ViewController : UIViewController
 
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -39,8 +39,6 @@
     
     self.activityIndicatorView.hidden = true;
     
-    self.consentSegmentedControl.selectedSegmentIndex = (NSInteger) ![OneSignal requiresPrivacyConsent];
-
     // self.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) OneSignal.getDeviceState.isSubscribed;
     
     self.locationSharedSegementedControl.selectedSegmentIndex = (NSInteger) [OneSignal.Location isShared];
@@ -128,7 +126,7 @@
 
 - (IBAction)consentSegmentedControlValueChanged:(UISegmentedControl *)sender {
     NSLog(@"View controller consent granted: %i", (int) sender.selectedSegmentIndex);
-    [OneSignal setPrivacyConsent:(bool) sender.selectedSegmentIndex];
+    [OneSignal setConsentGiven:(bool) sender.selectedSegmentIndex];
 }
 
 - (IBAction)subscriptionSegmentedControlValueChanged:(UISegmentedControl *)sender {

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -144,10 +144,6 @@
     [OneSignal.InAppMessages paused:(bool) !sender.selectedSegmentIndex];
 }
 
-- (void)handleMessageAction:(NSString *)actionId {
-    NSLog(@"View controller did get action: %@", actionId);
-}
-
 - (IBAction)loginExternalUserId:(UIButton *)sender {
     NSLog(@"setExternalUserId is no longer supported. Please use login or addAlias.");
     // TODO: Update

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -78,6 +78,10 @@
 		3C47A974292642B100312125 /* OneSignalConfigManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C47A972292642B100312125 /* OneSignalConfigManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C47A975292642B100312125 /* OneSignalConfigManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C47A973292642B100312125 /* OneSignalConfigManager.m */; };
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
+		3C6302FA29FC7E17004FAEB3 /* OSInAppMessageClickEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */; };
+		3C6302FB29FC7EA3004FAEB3 /* OSInAppMessageClickEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6302F829FC7E17004FAEB3 /* OSInAppMessageClickEvent.h */; };
+		3C6302FC29FC7EC6004FAEB3 /* OSInAppMessageClickEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */; };
+		3C6302FD29FC7EC7004FAEB3 /* OSInAppMessageClickEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */; };
 		3C789DBD293C2206004CF83D /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
 		3C789DBE293D8EAD004CF83D /* OSFocusInfluenceParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C79BEB9293DC88F0034CB10 /* OneSignalInAppMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -256,10 +260,10 @@
 		CA8E190B2194FE0B009DA223 /* OSMessagingControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CA8E190A2194FE0B009DA223 /* OSMessagingControllerOverrider.m */; };
 		CAA4ED0120646762005BD59B /* BadgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAA4ED0020646762005BD59B /* BadgeTests.m */; };
 		CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CAAE0DFC2195216900A57402 /* OneSignalOverrider.m */; };
-		CAB269D921B0B6F000F8A43C /* OSInAppMessageAction.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */; };
-		CAB269DA21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */; };
-		CAB269DB21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */; };
-		CAB269DC21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */; };
+		CAB269D921B0B6F000F8A43C /* OSInAppMessageClickResult.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB269D721B0B6F000F8A43C /* OSInAppMessageClickResult.h */; };
+		CAB269DA21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */; };
+		CAB269DB21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */; };
+		CAB269DC21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */; };
 		CAB269DF21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */; };
 		CAB269E021B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */; };
 		CAB269E121B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */; };
@@ -466,7 +470,7 @@
 		DEF784642912FA5100A1F3A5 /* OSDialogInstanceManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF784632912FA5100A1F3A5 /* OSDialogInstanceManager.m */; };
 		DEF784652912FB2200A1F3A5 /* OSDialogInstanceManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DEF784622912F79700A1F3A5 /* OSDialogInstanceManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DEF7846B2913176800A1F3A5 /* OneSignalNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEF784292912DEB600A1F3A5 /* OneSignalNotifications.framework */; };
-		DEF7847229132AA700A1F3A5 /* OSNotification+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DEF7847029132AA700A1F3A5 /* OSNotification+OneSignal.h */; };
+		DEF7847229132AA700A1F3A5 /* OSNotification+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DEF7847029132AA700A1F3A5 /* OSNotification+OneSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DEF7847329132AA700A1F3A5 /* OSNotification+OneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF7847129132AA700A1F3A5 /* OSNotification+OneSignal.m */; };
 		DEF784792914667A00A1F3A5 /* NSDateFormatter+OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DE9877292591654600DE07D5 /* NSDateFormatter+OneSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DEF7847D29146B2700A1F3A5 /* OneSignalWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = DEF7847B29146B2700A1F3A5 /* OneSignalWebView.m */; };
@@ -682,6 +686,8 @@
 		3C47A972292642B100312125 /* OneSignalConfigManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalConfigManager.h; sourceTree = "<group>"; };
 		3C47A973292642B100312125 /* OneSignalConfigManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalConfigManager.m; sourceTree = "<group>"; };
 		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
+		3C6302F829FC7E17004FAEB3 /* OSInAppMessageClickEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageClickEvent.h; sourceTree = "<group>"; };
+		3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageClickEvent.m; sourceTree = "<group>"; };
 		3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalInAppMessaging.h; sourceTree = "<group>"; };
 		3C79BEB8293DC88F0034CB10 /* OneSignalInAppMessaging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalInAppMessaging.m; sourceTree = "<group>"; };
 		3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationExecutor.swift; sourceTree = "<group>"; };
@@ -898,8 +904,8 @@
 		CAAE0DFC2195216900A57402 /* OneSignalOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalOverrider.m; sourceTree = "<group>"; };
 		CAAEA68521ED68A30049CF15 /* OneSignalNotificationCategoryController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OneSignalNotificationCategoryController.m; sourceTree = "<group>"; };
 		CAAEA68621ED68A40049CF15 /* OneSignalNotificationCategoryController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalNotificationCategoryController.h; sourceTree = "<group>"; };
-		CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageAction.h; sourceTree = "<group>"; };
-		CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageAction.m; sourceTree = "<group>"; };
+		CAB269D721B0B6F000F8A43C /* OSInAppMessageClickResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageClickResult.h; sourceTree = "<group>"; };
+		CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageClickResult.m; sourceTree = "<group>"; };
 		CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageBridgeEvent.h; sourceTree = "<group>"; };
 		CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageBridgeEvent.m; sourceTree = "<group>"; };
 		CAB4112720852E48005A70D1 /* DelayedConsentInitializationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DelayedConsentInitializationParameters.h; sourceTree = "<group>"; };
@@ -1469,8 +1475,10 @@
 				CA47439C2190FEA80020DC8C /* OSTrigger.m */,
 				CACBAA93218A6243000ACAA5 /* OSInAppMessageInternal.h */,
 				CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */,
-				CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */,
-				CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */,
+				3C6302F829FC7E17004FAEB3 /* OSInAppMessageClickEvent.h */,
+				3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */,
+				CAB269D721B0B6F000F8A43C /* OSInAppMessageClickResult.h */,
+				CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */,
 				CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */,
 				CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */,
 				7A72EB1123E252D400B4D50F /* OSInAppMessageDisplayStats.h */,
@@ -1975,6 +1983,7 @@
 				CA4742E4218B8FF30020DC8C /* OSTriggerController.h in Headers */,
 				DE7D18EC2703B5AA002D3A5D /* OSInAppMessagingRequests.h in Headers */,
 				DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */,
+				3C6302FB29FC7EA3004FAEB3 /* OSInAppMessageClickEvent.h in Headers */,
 				DE51DDE12941697A0073D5C4 /* OneSignalLocation.h in Headers */,
 				7A674F192360D813001F9ACD /* OSBaseFocusTimeProcessor.h in Headers */,
 				CA36F35821C33A2500300C77 /* OSInAppMessageController.h in Headers */,
@@ -1989,7 +1998,7 @@
 				9124123D1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.h in Headers */,
 				7AF9865324451F3900C36EAE /* OSFocusCallParams.h in Headers */,
 				DE7D18DD2703B44B002D3A5D /* OSFocusRequests.h in Headers */,
-				CAB269D921B0B6F000F8A43C /* OSInAppMessageAction.h in Headers */,
+				CAB269D921B0B6F000F8A43C /* OSInAppMessageClickResult.h in Headers */,
 				DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */,
 				7AECE59C23675F5700537907 /* OSFocusTimeProcessorFactory.h in Headers */,
 				7AECE59A23674ADC00537907 /* OSUnattributedFocusTimeProcessor.h in Headers */,
@@ -2543,6 +2552,7 @@
 				7A1F2D8F2406EFC5007799A9 /* OSInAppMessageTag.m in Sources */,
 				7A72EB0E23E252C200B4D50F /* OSInAppMessageDisplayStats.m in Sources */,
 				9124121E1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
+				3C6302FA29FC7E17004FAEB3 /* OSInAppMessageClickEvent.m in Sources */,
 				912412471E73369600E41FD7 /* OneSignalHelper.m in Sources */,
 				7A880F312404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,
 				CA8E19062193C76D009DA223 /* OSInAppMessagingHelpers.m in Sources */,
@@ -2574,7 +2584,7 @@
 				7AECE59023674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				912412361E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				CACBAA9D218A6243000ACAA5 /* OSInAppMessageView.m in Sources */,
-				CAB269DA21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				CAB269DA21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */,
 				CA1A6E6A20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2633,6 +2643,7 @@
 				7A674F1C2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */,
 				7AFE856C2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
 				CACBAAA5218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */,
+				3C6302FC29FC7EC6004FAEB3 /* OSInAppMessageClickEvent.m in Sources */,
 				CA7FC8A121927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				7A93269D25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */,
@@ -2641,7 +2652,7 @@
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				7AECE59123674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				CACBAA9E218A6243000ACAA5 /* OSInAppMessageView.m in Sources */,
-				CAB269DB21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				CAB269DB21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */,
 				3C79BEBA293DC88F0034CB10 /* OneSignalInAppMessaging.m in Sources */,
 				CA1A6E6B20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 			);
@@ -2672,7 +2683,7 @@
 				4529DEED1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m in Sources */,
 				CA1A6E6C20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 				7A65D62A246627AD007FF196 /* OSInAppMessageViewOverrider.m in Sources */,
-				CAB269DC21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				CAB269DC21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */,
 				DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
@@ -2743,6 +2754,7 @@
 				03CCCC832835D90F004BF794 /* OneSignalUNUserNotificationCenterHelper.m in Sources */,
 				03866CC12378A67B0009C1D8 /* RestClientAsserts.m in Sources */,
 				7ADF891C230DB5BD0054E0D6 /* UnitTestAppDelegate.m in Sources */,
+				3C6302FD29FC7EC7004FAEB3 /* OSInAppMessageClickEvent.m in Sources */,
 				4529DEF01FA8433500CEAB1D /* NSLocaleOverrider.m in Sources */,
 				CA1A6E7220DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */,
 				7A880F332404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 		918CB0301E73388E0067130F /* OneSignalFramework.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 912411F01E73342200E41FD7 /* OneSignalFramework.h */; };
 		91C7725E1E7CCE1000D612D0 /* OneSignalInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 91C7725D1E7CCE1000D612D0 /* OneSignalInternal.h */; };
 		91F60F7D1E80E4E400706E60 /* UncaughtExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 91F60F7C1E80E4E400706E60 /* UncaughtExceptionHandler.m */; };
-		944F7ED1296F9F0700AEBA54 /* OneSignalLiveActivityController.h in Headers */ = {isa = PBXBuildFile; fileRef = 944F7ED0296F892400AEBA54 /* OneSignalLiveActivityController.h */; };
+		944F7ED1296F9F0700AEBA54 /* OneSignalLiveActivityController.h in Headers */ = {isa = PBXBuildFile; fileRef = 944F7ED0296F892400AEBA54 /* OneSignalLiveActivityController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		944F7ED2296F9F1200AEBA54 /* OneSignalLiveActivityController.m in Sources */ = {isa = PBXBuildFile; fileRef = 944F7ECE296F890900AEBA54 /* OneSignalLiveActivityController.m */; };
 		9D3300F523145AF3000F0A83 /* OneSignalViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3300F223145AF3000F0A83 /* OneSignalViewHelper.m */; };
 		9D3300F623145AF3000F0A83 /* OneSignalViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3300F223145AF3000F0A83 /* OneSignalViewHelper.m */; };

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.h
@@ -53,14 +53,14 @@ NS_ASSUME_NONNULL_END
 @end
 
 @interface OSRequestLiveActivityEnter: OneSignalRequest
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
++ (instancetype _Nonnull)withSubscriptionId:(NSString * _Nonnull)subscriptionId
                               appId:(NSString * _Nonnull)appId
                          activityId:(NSString * _Nonnull)activityId
                               token:(NSString * _Nonnull)token;
 @end
 
 @interface OSRequestLiveActivityExit: OneSignalRequest
-+ (instancetype _Nonnull)withUserId:(NSString * _Nonnull)userId
++ (instancetype _Nonnull)withSubscriptionId:(NSString * _Nonnull)subscriptionId
                               appId:(NSString * _Nonnull)appId
                          activityId:(NSString * _Nonnull)activityId;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSRequests.m
@@ -107,14 +107,14 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
 @end
 
 @implementation OSRequestLiveActivityEnter
-+ (instancetype)withUserId:(NSString * _Nonnull)userId
++ (instancetype)withSubscriptionId:(NSString * _Nonnull)subscriptionId
                      appId:(NSString * _Nonnull)appId
                 activityId:(NSString * _Nonnull)activityId
                      token:(NSString * _Nonnull)token {
     let request = [OSRequestLiveActivityEnter new];
     let params = [NSMutableDictionary new];
     params[@"push_token"] = token;
-    params[@"subscription_id"] = userId; // pre-5.X.X subscription_id = player_id = userId
+    params[@"subscription_id"] = subscriptionId; // pre-5.X.X subscription_id = player_id = userId
     params[@"device_type"] = @0;
     request.parameters = params;
     request.method = POST;
@@ -127,7 +127,7 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
 @end
 
 @implementation OSRequestLiveActivityExit
-+ (instancetype)withUserId:(NSString * _Nonnull)userId
++ (instancetype)withSubscriptionId:(NSString * _Nonnull)subscriptionId
                      appId:(NSString * _Nonnull)appId
                 activityId:(NSString * _Nonnull)activityId {
     let request = [OSRequestLiveActivityExit new];
@@ -135,7 +135,7 @@ NSString * const OS_USAGE_DATA = @"OS-Usage-Data";
     
     NSString *urlSafeActivityId = [activityId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLUserAllowedCharacterSet]];
     
-    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@", appId, urlSafeActivityId, userId];
+    request.path = [NSString stringWithFormat:@"apps/%@/live_activities/%@/token/%@", appId, urlSafeActivityId, subscriptionId];
     
     return request;
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification+Internal.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification+Internal.h
@@ -31,10 +31,6 @@
 #define OSNotification_Internal_h
 
 @interface OSNotification(Internal)
-+(instancetype _Nonnull )parseWithApns:(nonnull NSDictionary *)message;
-- (void)setCompletionBlock:(OSNotificationDisplayResponse _Nonnull)completion;
-- (void)startTimeoutTimer;
-- (void)complete:(nullable OSNotification *)notification;
 @end
 
 #endif /* OSNotification_Internal_h */

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification.m
@@ -26,23 +26,12 @@
  */
 
 #import <Foundation/Foundation.h>
-
 #import <UIKit/UIKit.h>
-
 #import "OSNotification+Internal.h"
-
 #import "OSNotification.h"
-
-#import "OneSignalCommonDefines.h"
-
-#import "OneSignalUserDefaults.h"
-
 #import "OneSignalLog.h"
 
 @implementation OSNotification
-
- OSNotificationDisplayResponse _completion;
- NSTimer *_timeoutTimer;
  
 + (instancetype)parseWithApns:(nonnull NSDictionary*)message {
     if (!message)
@@ -63,8 +52,6 @@
         [self parseOriginalPayload];
     
     [self parseOtherApnsFields];
-    
-    _timeoutTimer = [NSTimer timerWithTimeInterval:CUSTOM_DISPLAY_TYPE_TIMEOUT target:self selector:@selector(timeoutTimerFired:) userInfo:_notificationId repeats:false];
 }
 
 // Original OneSignal payload format.
@@ -299,35 +286,5 @@
     NSData *jsonData = [NSJSONSerialization  dataWithJSONObject:obj options:0 error:&err];
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
-
-#pragma mark willShowInForegroundHandler Methods
-
-- (void)setCompletionBlock:(OSNotificationDisplayResponse)completion {
-    _completion = completion;
-}
-
- - (void)complete:(OSNotification *)notification {
-     [_timeoutTimer invalidate];
-     if (_completion) {
-         _completion(notification);
-         _completion = nil;
-     }
- }
-
- - (void)startTimeoutTimer {
-     [[NSRunLoop currentRunLoop] addTimer:_timeoutTimer forMode:NSRunLoopCommonModes];
- }
-
- - (void)timeoutTimerFired:(NSTimer *)timer {
-     [OneSignalLog onesignalLog:ONE_S_LL_ERROR
-     message:[NSString stringWithFormat:@"Notification willShowInForeground completion timed out. Completion was not called within %f seconds.", CUSTOM_DISPLAY_TYPE_TIMEOUT]];
-     [self complete:self];
- }
-
- - (void)dealloc {
-     if (_timeoutTimer && _completion) {
-         [_timeoutTimer invalidate];
-     }
- }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotificationClasses.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotificationClasses.h
@@ -36,20 +36,17 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeActionTaken
 };
 
-@interface OSNotificationAction : NSObject
-
-/* The type of the notification action */
-@property(readonly)OSNotificationActionType type;
-
+@interface OSNotificationClickResult : NSObject
 /* The ID associated with the button tapped. NULL when the actionType is NotificationTapped */
 @property(readonly, nullable)NSString* actionId;
+@property(readonly, nullable)NSString* url;
 
 @end
 
-@interface OSNotificationOpenedResult : NSObject
+@interface OSNotificationClickEvent : NSObject
 
 @property(readonly, nonnull)OSNotification* notification;
-@property(readonly, nonnull)OSNotificationAction *action;
+@property(readonly, nonnull)OSNotificationClickResult *result;
 
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
 - (NSString* _Nonnull)stringify;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSObservable.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSObservable.h
@@ -40,4 +40,13 @@
 - (BOOL)notifyChange:(ObjectType)state;
 @end
 
+// OSBoolObservable is for BOOL states which OSObservable above does not work with
+
+@interface OSBoolObservable<__covariant ObserverType> : NSObject
+- (instancetype _Nonnull)initWithChangeSelector:(SEL)selector;
+- (void)addObserver:(ObserverType)observer;
+- (void)removeObserver:(ObserverType)observer;
+- (BOOL)notifyChange:(BOOL)state;
+@end
+
 #endif /* OSObservable_h */

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.m
@@ -43,7 +43,7 @@ THE SOFTWARE.
         return;
 
     if ([self requiresUserPrivacyConsent] && !required) {
-        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"Cannot change requiresUserPrivacyConsent() from TRUE to FALSE"];
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"Cannot change setConsentRequired() from TRUE to FALSE"];
         return;
     }
     [OneSignalUserDefaults.initShared saveBoolForKey:OSUD_REQUIRES_USER_PRIVACY_CONSENT withValue:required];

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalLog.h
@@ -43,7 +43,5 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 
 @interface OneSignalLog : NSObject<OSDebug>
 + (Class<OSDebug>)Debug;
-+ (void)setLogLevel:(ONE_S_LOG_LEVEL)logLevel;
-+ (void)setAlertLevel:(ONE_S_LOG_LEVEL)logLevel;
 + (void)onesignalLog:(ONE_S_LOG_LEVEL)logLevel message:(NSString* _Nonnull)message;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.h
@@ -33,7 +33,7 @@
 +(void)init;
 +(void)updateFromDownloadParams:(NSDictionary*)params;
 
-+(void)trackOpenEvent:(OSNotificationOpenedResult*)results;
++(void)trackOpenEvent:(OSNotificationClickEvent*)event;
 +(void)trackReceivedEvent:(OSNotification*)notification;
 +(void)trackInfluenceOpenEvent;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
@@ -87,7 +87,7 @@ static BOOL trackingEnabled = false;
     return [notification.title substringToIndex:titleLength];
 }
 
-+ (void)trackOpenEvent:(OSNotificationOpenedResult*)results {
++ (void)trackOpenEvent:(OSNotificationClickEvent*)event {
     if (!trackingEnabled)
         return;
     
@@ -97,8 +97,8 @@ static BOOL trackingEnabled = false;
                 parameters:@{
                     @"source": @"OneSignal",
                     @"medium": @"notification",
-                    @"notification_id": results.notification.notificationId,
-                    @"campaign": [self getCampaignNameFromNotification:results.notification]
+                    @"notification_id": event.notification.notificationId,
+                    @"campaign": [self getCampaignNameFromNotification:event.notification]
                 }];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotification+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotification+OneSignal.m
@@ -25,22 +25,86 @@
  * THE SOFTWARE.
  */
 
-
 #import "OSNotification+OneSignal.h"
+#import <OneSignalCore/OneSignalCore.h>
 #import <UIKit/UIKit.h>
-@implementation OSNotification (OneSignal)
- - (OSNotificationDisplayResponse)getCompletionBlock {
-     OSNotificationDisplayResponse block = ^(OSNotification *notification){
-         /*
-          If notification is null here then display was cancelled and we need to
-          reset the badge count to the value prior to receipt of this notif
-          */
-         if (!notification) {
-             NSInteger previousBadgeCount = [UIApplication sharedApplication].applicationIconBadgeNumber;
-             [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:previousBadgeCount];
-         }
-         [self complete:notification];
-     };
-     return block;
- }
+
+@interface OSNotification ()
+- (void)initWithRawMessage:(NSDictionary*)message;
+@end
+
+@implementation OSDisplayableNotification
+
+OSNotificationDisplayResponse _completion;
+NSTimer *_timeoutTimer;
+BOOL _wantsToDisplay = true;
+
++ (instancetype)parseWithApns:(nonnull NSDictionary*)message {
+    if (!message)
+        return nil;
+    
+    OSDisplayableNotification *osNotification = [OSDisplayableNotification new];
+    
+    [osNotification initWithRawMessage:message];
+    [osNotification setTimeoutTimer];
+    return osNotification;
+}
+
+- (void)setTimeoutTimer {
+    _timeoutTimer = [NSTimer timerWithTimeInterval:CUSTOM_DISPLAY_TYPE_TIMEOUT target:self selector:@selector(timeoutTimerFired:) userInfo:self.notificationId repeats:false];
+}
+
+- (void)startTimeoutTimer {
+    [[NSRunLoop currentRunLoop] addTimer:_timeoutTimer forMode:NSRunLoopCommonModes];
+}
+
+- (void)setCompletionBlock:(OSNotificationDisplayResponse)completion {
+    _completion = completion;
+}
+
+- (void)display {
+    if (!_completion) {
+        [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"OSNotificationWillDisplayEvent.notification.display cannot be called due to timing out or notification was already displayed."];
+    }
+    [self complete:self];
+}
+
+- (void)complete:(OSDisplayableNotification *)notification {
+    [_timeoutTimer invalidate];
+    /*
+     If notification is null here then display was cancelled and we need to
+     reset the badge count to the value prior to receipt of this notif
+     */
+    if (!notification) {
+        NSInteger previousBadgeCount = [UIApplication sharedApplication].applicationIconBadgeNumber;
+        [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:previousBadgeCount];
+    }
+    if (_completion) {
+        _completion(notification);
+        _completion = nil;
+    }
+}
+
+- (BOOL)wantsToDisplay {
+    return _wantsToDisplay;
+}
+
+- (void)setWantsToDisplay:(BOOL)display {
+    _wantsToDisplay = display;
+}
+
+- (void)timeoutTimerFired:(NSTimer *)timer {
+    [OneSignalLog onesignalLog:ONE_S_LL_WARN message:[NSString stringWithFormat:@"OSNotificationLifecycleListener:onWillDisplayNotification timed out. Display was not called within %f seconds. Continue with display notification: %d", CUSTOM_DISPLAY_TYPE_TIMEOUT, _wantsToDisplay]];
+    if (_wantsToDisplay) {
+        [self complete:self];
+    } else {
+        [self complete:nil];
+    }
+}
+
+- (void)dealloc {
+    if (_timeoutTimer && _completion) {
+        [_timeoutTimer invalidate];
+    }
+}
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -30,10 +30,23 @@
 #import <OneSignalNotifications/OSPermission.h>
 #import <OneSignalCore/OneSignalCore.h>
 #import <UIKit/UIKit.h>
+#import <OneSignalNotifications/OSNotification+OneSignal.h>
 
-// If the completion block is not called within 25 seconds of this block being called in notificationWillShowInForegroundHandler then the completion will be automatically fired.
-typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull notification, OSNotificationDisplayResponse _Nonnull completion);
-typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull result);
+@protocol OSNotificationClickListener <NSObject>
+- (void)onClickNotification:(OSNotificationClickEvent *_Nonnull)event
+NS_SWIFT_NAME(onClick(event:));
+@end
+
+@interface OSNotificationWillDisplayEvent : NSObject
+
+@property (readonly, strong, nonatomic, nonnull) OSDisplayableNotification *notification; // TODO: strong? nonatomic? nullable?
+- (void)preventDefault;
+
+@end
+
+@protocol OSNotificationLifecycleListener <NSObject>
+- (void)onWillDisplayNotification:(OSNotificationWillDisplayEvent *_Nonnull)event NS_SWIFT_NAME(onWillDisplay(event:));
+@end
 
 /**
  Public API for the Notifications namespace.
@@ -42,13 +55,15 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (BOOL)permission NS_REFINED_FOR_SWIFT;
 + (BOOL)canRequestPermission NS_REFINED_FOR_SWIFT;
 + (OSNotificationPermission)permissionNative NS_REFINED_FOR_SWIFT;
-+ (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
-+ (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
++ (void)addForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener;
++ (void)removeForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener;
++ (void)addClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener NS_REFINED_FOR_SWIFT;
++ (void)removeClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener NS_REFINED_FOR_SWIFT;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block fallbackToSettings:(BOOL)fallback;
 + (void)registerForProvisionalAuthorization:(OSUserResponseBlock _Nullable )block NS_REFINED_FOR_SWIFT;
-+ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*_Nonnull)observer NS_REFINED_FOR_SWIFT;
-+ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*_Nonnull)observer NS_REFINED_FOR_SWIFT;
++ (void)addPermissionObserver:(NSObject<OSNotificationPermissionObserver>*_Nonnull)observer NS_REFINED_FOR_SWIFT;
++ (void)removePermissionObserver:(NSObject<OSNotificationPermissionObserver>*_Nonnull)observer NS_REFINED_FOR_SWIFT;
 + (void)clearAll;
 @end
 
@@ -65,6 +80,7 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 @interface OSNotificationsManager : NSObject <OSNotifications>
 
 @property (class, weak, nonatomic, nullable) id<OneSignalNotificationsDelegate> delegate;
+@property (class, weak, nonatomic, nullable) NSObject<OSNotificationLifecycleListener> *lifecycleListener;
 
 + (Class<OSNotifications> _Nonnull)Notifications;
 + (void)start;
@@ -97,9 +113,8 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 // This is set by the user module
 + (void)setPushSubscriptionId:(NSString *_Nullable)pushSubscriptionId;
 
-+ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString* _Nonnull)actionID;
-
++ (void)handleWillShowInForegroundForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
++ (void)handleNotificationActionWithUrl:(NSString* _Nullable)url actionID:(NSString* _Nonnull)actionID;
 + (BOOL)clearBadgeCount:(BOOL)fromNotifOpened;
 
 + (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -36,11 +36,12 @@ typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnul
 typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull result);
 
 /**
- Public API.
+ Public API for the Notifications namespace.
  */
 @protocol OSNotifications <NSObject>
 + (BOOL)permission NS_REFINED_FOR_SWIFT;
 + (BOOL)canRequestPermission NS_REFINED_FOR_SWIFT;
++ (OSNotificationPermission)permissionNative NS_REFINED_FOR_SWIFT;
 + (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block;
 + (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -232,6 +232,10 @@ static NSString *_pushSubscriptionId;
     return !self.currentPermissionState.answeredPrompt;
 }
 
++ (OSNotificationPermission)permissionNative {
+    return self.currentPermissionState.status;
+}
+
 + (void)requestPermission:(OSUserResponseBlock)block {
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"requestPermission:"])

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -35,14 +35,14 @@
 #import "UNUserNotificationCenter+OneSignalNotifications.h"
 #import "UIApplicationDelegate+OneSignalNotifications.h"
 
-@implementation OSNotificationOpenedResult
-@synthesize notification = _notification, action = _action;
+@implementation OSNotificationClickEvent
+@synthesize notification = _notification, result = _result;
 
-- (id)initWithNotification:(OSNotification*)notification action:(OSNotificationAction*)action {
+- (id)initWithNotification:(OSNotification*)notification result:(OSNotificationClickResult*)result {
     self = [super init];
     if(self) {
         _notification = notification;
-        _action = action;
+        _result = result;
     }
     return self;
 }
@@ -63,28 +63,56 @@
                                                                 error:&jsonError];
     
     NSMutableDictionary* obj = [NSMutableDictionary new];
-    NSMutableDictionary* action = [NSMutableDictionary new];
-    [action setObject:self.action.actionId forKeyedSubscript:@"actionID"];
-    [obj setObject:action forKeyedSubscript:@"action"];
+    NSMutableDictionary* result = [NSMutableDictionary new];
+    [result setObject:self.result.actionId forKeyedSubscript:@"actionID"];
+    [result setObject:self.result.url forKeyedSubscript:@"url"];
+    [obj setObject:result forKeyedSubscript:@"result"];
     [obj setObject:notifDict forKeyedSubscript:@"notification"];
-    if(self.action.type)
-        [obj[@"action"] setObject:@(self.action.type) forKeyedSubscript: @"type"];
-    
+
     return obj;
 }
 
 @end
 
-@implementation OSNotificationAction
-@synthesize type = _type, actionId = _actionId;
+@implementation OSNotificationClickResult
+@synthesize url = _url, actionId = _actionId;
 
--(id)initWithActionType:(OSNotificationActionType)type :(NSString*)actionID {
+-(id)initWithUrl:(NSString*)url :(NSString*)actionID {
     self = [super init];
     if(self) {
-        _type = type;
+        _url = url;
         _actionId = actionID;
     }
     return self;
+}
+
+@end
+
+@interface OSDisplayableNotification ()
+- (void)startTimeoutTimer;
+- (void)setCompletionBlock:(OSNotificationDisplayResponse)completion;
+- (void)complete:(OSDisplayableNotification *)notification;
+- (BOOL)wantsToDisplay;
+- (void)setWantsToDisplay:(BOOL)display;
+@end
+
+@implementation OSNotificationWillDisplayEvent
+
+- (id)initWithDisplayableNotification:(OSDisplayableNotification*)notification {
+    self = [super init];
+    if(self) {
+        _notification = notification;
+    }
+    return self;
+}
+
+- (BOOL)isPreventDefault {
+    return !_notification.wantsToDisplay;
+}
+
+- (void)preventDefault {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OSNotificationWillDisplayEvent.preventDefault called."]];
+    _notification.wantsToDisplay = false;
 }
 
 @end
@@ -103,6 +131,14 @@ static id<OneSignalNotificationsDelegate> _delegate;
     _delegate = delegate;
 }
 
+static id<OSNotificationLifecycleListener> _lifecycleListener;
++ (id<OSNotificationLifecycleListener>)lifecycleListener {
+    return _lifecycleListener;
+}
++ (void)setLifecycleListener:(id<OSNotificationLifecycleListener>)lifecycleListener {
+    _lifecycleListener = lifecycleListener;
+}
+
 // UIApplication-registerForRemoteNotifications has been called but a success or failure has not triggered yet.
 static BOOL _waitingForApnsResponse = false;
 static BOOL _providesAppNotificationSettings = false;
@@ -110,9 +146,14 @@ BOOL requestedProvisionalAuthorization = false;
 
 static int mSubscriptionStatus = -1;
 
-static NSMutableArray<OSNotificationOpenedResult*> *_unprocessedOpenedNotifis;
-static OSNotificationOpenedBlock _notificationOpenedHandler;
-static OSNotificationWillShowInForegroundBlock _notificationWillShowInForegroundHandler;
+static NSMutableArray<OSNotificationClickEvent*> *_unprocessedClickEvents;
+static NSMutableArray<NSObject<OSNotificationClickListener> *> *_clickListeners;
++ (NSMutableArray<NSObject<OSNotificationClickListener> *>*)clickListeners {
+    if (!_clickListeners)
+        _clickListeners = [NSMutableArray new];
+    return _clickListeners;
+}
+
 static NSDictionary* _lastMessageReceived;
 static NSString *_lastMessageID = @"";
 static NSString *_lastMessageIdFromAction;
@@ -147,7 +188,7 @@ static OneSignalNotificationSettings *_osNotificationSettings;
 static ObservablePermissionStateChangesType* _permissionStateChangesObserver;
 + (ObservablePermissionStateChangesType*)permissionStateChangesObserver {
     if (!_permissionStateChangesObserver)
-        _permissionStateChangesObserver = [[OSObservable alloc] initWithChangeSelector:@selector(onOSPermissionChanged:)];
+        _permissionStateChangesObserver = [[OSBoolObservable alloc] initWithChangeSelector:@selector(onNotificationPermissionDidChange:)];
     return _permissionStateChangesObserver;
 }
 
@@ -217,7 +258,7 @@ static NSString *_pushSubscriptionId;
     _lastMessageReceived = nil;
     _lastMessageIdFromAction = nil;
     _lastMessageID = @"";
-    _unprocessedOpenedNotifis = nil;
+    _unprocessedClickEvents = nil;
 }
 
 + (void)setLastPermissionState:(OSPermissionStateInternal *)lastPermissionState {
@@ -425,15 +466,15 @@ static NSString *_pushSubscriptionId;
     [self sendNotificationTypesUpdateToDelegate];
 }
 
-// onOSPermissionChanged should only fire if the reachable property changed.
-+ (void)addPermissionObserver:(NSObject<OSPermissionObserver>*)observer {
+// onNotificationPermissionDidChange should only fire if the reachable property changed.
++ (void)addPermissionObserver:(NSObject<OSNotificationPermissionObserver>*)observer {
     [self.permissionStateChangesObserver addObserver:observer];
     
     if (self.currentPermissionState.reachable != self.lastPermissionState.reachable)
         [OSPermissionChangedInternalObserver fireChangesObserver:self.currentPermissionState];
 }
 
-+ (void)removePermissionObserver:(NSObject<OSPermissionObserver>*)observer {
++ (void)removePermissionObserver:(NSObject<OSNotificationPermissionObserver>*)observer {
     [self.permissionStateChangesObserver removeObserver:observer];
 }
 
@@ -587,22 +628,27 @@ static NSString *_lastnonActiveMessageId;
         completion([OSNotification new]);
         return;
     }
-    //Only call the willShowInForegroundHandler for notifications not preview IAMs
+    //Only call the OSNotificationLifecycleListener for notifications not preview IAMs
 
-    OSNotification *osNotification = [OSNotification parseWithApns:payload];
+    OSDisplayableNotification *osNotification = [OSDisplayableNotification parseWithApns:payload];
     if ([osNotification additionalData][ONESIGNAL_IAM_PREVIEW]) {
         completion(nil);
         return;
     }
-    [self handleWillShowInForegroundHandlerForNotification:osNotification  completion:completion];
+    [self handleWillShowInForegroundForNotification:osNotification completion:completion];
 }
 
-
-+ (void)handleWillShowInForegroundHandlerForNotification:(OSNotification *)notification completion:(OSNotificationDisplayResponse)completion {
++ (void)handleWillShowInForegroundForNotification:(OSDisplayableNotification *)notification completion:(OSNotificationDisplayResponse)completion {
     [notification setCompletionBlock:completion];
-    if (_notificationWillShowInForegroundHandler) {
+    if (self.lifecycleListener && [self.lifecycleListener respondsToSelector:@selector(onWillDisplayNotification:)]) {
         [notification startTimeoutTimer];
-        _notificationWillShowInForegroundHandler(notification, [notification getCompletionBlock]);
+        OSNotificationWillDisplayEvent *event = [[OSNotificationWillDisplayEvent alloc] initWithDisplayableNotification:notification];
+
+        [self.lifecycleListener onWillDisplayNotification:event];
+        if (![event isPreventDefault]) {
+            [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OSNotificationWillDisplayEvent's preventDefault not called, now display notification with notificationId %@.", notification.notificationId]];
+            [notification complete:notification];
+        }
     } else {
         completion(notification);
     }
@@ -650,7 +696,7 @@ static NSString *_lastnonActiveMessageId;
 //        [[OSSessionManager sharedSessionManager] onDirectInfluenceFromNotificationOpen:_appEntryState withNotificationId:messageId];
 //    }
 
-    [self handleNotificationAction:actionType actionID:actionID];
+    [self handleNotificationActionWithUrl:notification.launchURL actionID:actionID];
 }
 
 + (void)submitNotificationOpened:(NSString*)messageId {
@@ -750,28 +796,35 @@ static NSString *_lastnonActiveMessageId;
     return NO;
 }
 
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString*)actionID {
++ (void)handleNotificationActionWithUrl:(NSString*)url actionID:(NSString*)actionID {
     if (![OneSignalCoreHelper isOneSignalPayload:_lastMessageReceived])
         return;
     
-    OSNotificationAction *action = [[OSNotificationAction alloc] initWithActionType:actionType :actionID];
+    OSNotificationClickResult *result = [[OSNotificationClickResult alloc] initWithUrl:url :actionID];
     OSNotification *notification = [OSNotification parseWithApns:_lastMessageReceived];
-    OSNotificationOpenedResult *result = [[OSNotificationOpenedResult alloc] initWithNotification:notification action:action];
+    OSNotificationClickEvent *event = [[OSNotificationClickEvent alloc] initWithNotification:notification result:result];
     
     // Prevent duplicate calls to same action
     if ([notification.notificationId isEqualToString:_lastMessageIdFromAction])
         return;
     _lastMessageIdFromAction = notification.notificationId;
     
-    [OneSignalTrackFirebaseAnalytics trackOpenEvent:result];
-    
-    if (!_notificationOpenedHandler) {
-        [self addUnprocessedOpenedNotifi:result];
+    [OneSignalTrackFirebaseAnalytics trackOpenEvent:event];
+  
+    if (self.clickListeners.count == 0) {
+        [self addUnprocessedClickEvent:event];
         return;
     }
-    _notificationOpenedHandler(result);
+    [self fireClickListenersForEvent:event];
 }
 
++ (void)fireClickListenersForEvent:(OSNotificationClickEvent*)event {
+    for (NSObject<OSNotificationClickListener> *listener in self.clickListeners) {
+        if ([listener respondsToSelector:@selector(onClickNotification:)]) {
+            [listener onClickNotification:event];
+        }
+    }
+}
 
 + (void)lastMessageReceived:(NSDictionary*)message {
     _lastMessageReceived = message;
@@ -785,36 +838,45 @@ static NSString *_lastnonActiveMessageId;
     return shouldSuppress ?: false;
 }
 
-+ (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock)block {
-    _notificationOpenedHandler = block;
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Notification opened handler set successfully"];
-    [self fireNotificationOpenedHandlerForUnprocessedEvents];
-    
++ (void)addClickListener:(NSObject<OSNotificationClickListener>*)listener {
+    [self.clickListeners addObject:listener];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Notification click listener added successfully"];
+    [self fireClickListenersForUnprocessedEvents];
 }
 
-+ (void)setNotificationWillShowInForegroundHandler:(OSNotificationWillShowInForegroundBlock _Nullable)block {
-    _notificationWillShowInForegroundHandler = block;
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Notification will show in foreground handler set successfully"];
++ (void)removeClickListener:(NSObject<OSNotificationClickListener>*)listener {
+    [self.clickListeners removeObject:listener];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Notification click listener removed successfully"];
 }
 
-+ (NSMutableArray<OSNotificationOpenedResult*>*)getUnprocessedOpenedNotifis {
-    if (!_unprocessedOpenedNotifis)
-        _unprocessedOpenedNotifis = [NSMutableArray new];
-    return _unprocessedOpenedNotifis;
++ (void)addForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener {
+    _lifecycleListener = listener;
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"ForegroundLifecycleListener added successfully"];
 }
 
-+ (void)addUnprocessedOpenedNotifi:(OSNotificationOpenedResult*)result {
-    [[self getUnprocessedOpenedNotifis] addObject:result];
++ (void)removeForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> * _Nullable)listener {
+    _lifecycleListener = nil;
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"ForegroundLifecycleListener removed successfully"];
 }
 
-+ (void)fireNotificationOpenedHandlerForUnprocessedEvents {
-    if (!_notificationOpenedHandler)
++ (NSMutableArray<OSNotificationClickEvent*>*)getUnprocessedClickEvents {
+    if (!_unprocessedClickEvents)
+        _unprocessedClickEvents = [NSMutableArray new];
+    return _unprocessedClickEvents;
+}
+
++ (void)addUnprocessedClickEvent:(OSNotificationClickEvent*)event {
+    [[self getUnprocessedClickEvents] addObject:event];
+}
+
++ (void)fireClickListenersForUnprocessedEvents {
+    if (self.clickListeners.count == 0) {
         return;
-    
-    for (OSNotificationOpenedResult* notification in [self getUnprocessedOpenedNotifis]) {
-        _notificationOpenedHandler(notification);
     }
-    _unprocessedOpenedNotifis = [NSMutableArray new];
+    for (OSNotificationClickEvent* event in [self getUnprocessedClickEvents]) {
+        [self fireClickListenersForEvent:event];
+    }
+    _unprocessedClickEvents = [NSMutableArray new];
 }
 
 + (BOOL)receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.h
@@ -47,8 +47,9 @@ typedef NS_ENUM(NSInteger, OSNotificationPermission) {
 };
 
 // Permission Classes
+
+// TODO: this object can be REMOVED now that permission is a boolean
 @interface OSPermissionState : NSObject
-// TODO: Decide: remove/change properties after addition of canRequestPermission and permission boolean
 @property (readonly, nonatomic) BOOL permission;
 - (NSDictionary * _Nonnull)jsonRepresentation;
 - (instancetype _Nonnull )initWithPermission:(BOOL)permission;
@@ -87,11 +88,11 @@ typedef OSObservable<NSObject<OSPermissionStateObserver>*, OSPermissionState*> O
 - (NSDictionary * _Nonnull)jsonRepresentation;
 @end
 
-@protocol OSPermissionObserver <NSObject>
-- (void)onOSPermissionChanged:(OSPermissionState * _Nonnull)state;
+@protocol OSNotificationPermissionObserver <NSObject>
+- (void)onNotificationPermissionDidChange:(BOOL)permission;
 @end
 
-typedef OSObservable<NSObject<OSPermissionObserver>*, OSPermissionState*> ObservablePermissionStateChangesType;
+typedef OSBoolObservable<NSObject<OSNotificationPermissionObserver>*> ObservablePermissionStateChangesType;
 
 
 @interface OSPermissionChangedInternalObserver : NSObject<OSPermissionStateObserver>

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSPermission.m
@@ -196,14 +196,11 @@
 }
 
 + (void)fireChangesObserver:(OSPermissionStateInternal*)state  {
-    OSPermissionState *externalToState = [state getExternalState];
-    OSPermissionState *externalFromState = [OSNotificationsManager.lastPermissionState getExternalState];
-    
-    if (externalToState.permission == externalFromState.permission) {
+    if (state.reachable == OSNotificationsManager.lastPermissionState.reachable) {
         return;
     }
     
-    BOOL hasReceiver = [OSNotificationsManager.permissionStateChangesObserver notifyChange:externalToState];
+    BOOL hasReceiver = [OSNotificationsManager.permissionStateChangesObserver notifyChange:state.reachable];
     if (hasReceiver) {
         OSNotificationsManager.lastPermissionState = [state copy];
         [OSNotificationsManager.lastPermissionState persistAsFrom];

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OneSignalNotifications.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OneSignalNotifications.h
@@ -12,3 +12,4 @@
 #import <OneSignalNotifications/OSPermission.h>
 #import <OneSignalNotifications/OneSignalWebView.h>
 #import <OneSignalNotifications/OneSignalWebViewManager.h>
+#import <OneSignalNotifications/OSNotification+OneSignal.h>

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -33,7 +33,7 @@ import OneSignalNotifications
 // MARK: - Push Subscription Specific
 
 @objc public protocol OSPushSubscriptionObserver { // TODO: weak reference?
-    @objc func onOSPushSubscriptionChanged(stateChanges: OSPushSubscriptionStateChanges)
+    @objc func onPushSubscriptionDidChange(state: OSPushSubscriptionChangedState)
 }
 
 @objc
@@ -68,21 +68,21 @@ public class OSPushSubscriptionState: NSObject {
 }
 
 @objc
-public class OSPushSubscriptionStateChanges: NSObject {
-    @objc public let to: OSPushSubscriptionState
-    @objc public let from: OSPushSubscriptionState
+public class OSPushSubscriptionChangedState: NSObject {
+    @objc public let current: OSPushSubscriptionState
+    @objc public let previous: OSPushSubscriptionState
 
     @objc public override var description: String {
-        return "<OSPushSubscriptionStateChanges:\nfrom: \(self.from),\nto:   \(self.to)\n>"
+        return "<OSPushSubscriptionChangedState:\nprevious: \(self.previous),\ncurrent:   \(self.current)\n>"
     }
 
-    init(to: OSPushSubscriptionState, from: OSPushSubscriptionState) {
-        self.to = to
-        self.from = from
+    init(current: OSPushSubscriptionState, previous: OSPushSubscriptionState) {
+        self.current = current
+        self.previous = previous
     }
 
     @objc public func jsonRepresentation() -> NSDictionary {
-        return ["from": from.jsonRepresentation(), "to": to.jsonRepresentation()]
+        return ["from": previous.jsonRepresentation(), "to": current.jsonRepresentation()]
     }
 }
 
@@ -368,7 +368,7 @@ extension OSSubscriptionModel {
             return
         }
 
-        let stateChanges = OSPushSubscriptionStateChanges(to: newSubscriptionState, from: prevSubscriptionState)
+        let stateChanges = OSPushSubscriptionChangedState(current: newSubscriptionState, previous: prevSubscriptionState)
 
         // TODO: Don't fire observer until server is udated
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "firePushSubscriptionChanged from \(prevSubscriptionState.jsonRepresentation()) to \(newSubscriptionState.jsonRepresentation())")

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -133,12 +133,12 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     @objc public var requiresUserAuth = false
 
     // Push Subscription
-    private var _pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionStateChanges>?
-    var pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionStateChanges> {
+    private var _pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionChangedState>?
+    var pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionChangedState> {
         if let observer = _pushSubscriptionStateChangesObserver {
             return observer
         }
-        let pushSubscriptionStateChangesObserver = OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionStateChanges>(change: #selector(OSPushSubscriptionObserver.onOSPushSubscriptionChanged(stateChanges:)))
+        let pushSubscriptionStateChangesObserver = OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionChangedState>(change: #selector(OSPushSubscriptionObserver.onPushSubscriptionDidChange(state:)))
         _pushSubscriptionStateChangesObserver = pushSubscriptionStateChangesObserver
 
         return pushSubscriptionStateChangesObserver

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.h
@@ -26,7 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OSInAppMessagePage.h"
 #import "OSInAppMessagingDefines.h"
 #import <OneSignalCore/OneSignalCore.h>
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageBridgeEventType) {
 @property (nonatomic) OSInAppMessageBridgeEventRenderingComplete *renderingComplete;
 @property (nonatomic) OSInAppMessageBridgeEventResize *resize;
 @property (nonatomic, nullable) OSInAppMessageBridgeEventPageChange *pageChange;
-@property (strong, nonatomic, nullable) OSInAppMessageAction *userAction;
+@property (strong, nonatomic, nullable) OSInAppMessageClickResult *userAction;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.m
@@ -26,7 +26,7 @@
  */
 
 #import "OSInAppMessageBridgeEvent.h"
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OneSignalHelper.h"
 
 @implementation OSInAppMessageBridgeEvent
@@ -55,7 +55,7 @@
             // deserialize the action JSON
             if ([json[@"body"] isKindOfClass:[NSDictionary class]]) {
                 
-                let action = [OSInAppMessageAction instanceWithJson:json[@"body"]];
+                let action = [OSInAppMessageClickResult instanceWithJson:json[@"body"]];
                 
                 if (!action)
                     return nil;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2021OneSignal
+ * Copyright 2023 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,13 +25,14 @@
  * THE SOFTWARE.
  */
 
-
 #import <Foundation/Foundation.h>
-#import <OneSignalCore/OSNotification.h>
+#import "OneSignalInAppMessaging.h"
+#import "OSInAppMessageInternal.h"
 
-/**
- Public interface used in the OSNotificationLifecycleListener's onWillDisplay event.
- */
-@interface OSDisplayableNotification : OSNotification
-- (void)display;
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OSInAppMessageClickEvent ()
+- (instancetype _Nonnull)initWithInAppMessage:(OSInAppMessageInternal *)message clickResult:(OSInAppMessageClickResult *)result;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2021OneSignal
+ * Copyright 2023 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,12 +26,25 @@
  */
 
 
-#import <Foundation/Foundation.h>
-#import <OneSignalCore/OSNotification.h>
+#import "OSInAppMessageClickEvent.h"
 
-/**
- Public interface used in the OSNotificationLifecycleListener's onWillDisplay event.
- */
-@interface OSDisplayableNotification : OSNotification
-- (void)display;
+@implementation OSInAppMessageClickEvent
+
+- (instancetype)initWithInAppMessage:(OSInAppMessageInternal *)message clickResult:(OSInAppMessageClickResult *)result {
+    _message = message;
+    _result = result;
+    return self;
+}
+
+- (NSDictionary *)jsonRepresentation {
+    let json = [NSMutableDictionary new];
+    json[@"message"] = self.message;
+    json[@"result"] = [self.result jsonRepresentation];
+    return json;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"OSInAppMessageClickEvent message: %@ \nresult: %@", _message, [_result description]];
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.h
@@ -34,15 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
-    OSInAppMessageActionUrlTypeSafari,
-    
-    OSInAppMessageActionUrlTypeWebview,
-    
-    OSInAppMessageActionUrlTypeReplaceContent
-};
-
-@interface OSInAppMessageAction () <OSJSONDecodable>
+@interface OSInAppMessageClickResult () <OSJSONDecodable>
 
 // The type of element that was clicked, button or image
 @property (strong, nonatomic, nonnull) NSString *clickType;
@@ -50,11 +42,21 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
 // The unique identifier for this click
 @property (strong, nonatomic, nonnull) NSString *clickId;
 
+//UUID for the page in an IAM Carousel
+@property (strong, nonatomic, nullable) NSString *pageId;
+
+
+// Whether or not the click action is first click on the IAM
+@property (nonatomic) BOOL firstClick;
+
 // The prompt action available
 @property (nonatomic, nullable) NSArray<NSObject<OSInAppMessagePrompt>*> *promptActions;
 
-// Determines where the URL is loaded, ie. app opens a webview
-@property (nonatomic) OSInAppMessageActionUrlType urlActionType;
+// The outcome to send for this action
+@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
+
+// The tags to send for this action
+@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.m
@@ -26,11 +26,11 @@
  */
 
 #import "OneSignalHelper.h"
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OSInAppMessagePushPrompt.h"
 #import "OSInAppMessageLocationPrompt.h"
 
-@implementation OSInAppMessageAction
+@implementation OSInAppMessageClickResult
 
 #define OS_URL_ACTION_TYPES @[@"browser", @"webview", @"replacement"]
 #define OS_IS_VALID_URL_ACTION(string) [OS_URL_ACTION_TYPES containsObject:string]
@@ -49,7 +49,7 @@
 }
 
 + (instancetype _Nullable)instanceWithJson:(NSDictionary *)json {
-    OSInAppMessageAction *action = [OSInAppMessageAction new];
+    OSInAppMessageClickResult *action = [OSInAppMessageClickResult new]; // on click goes here
     
     if ([json[@"click_type"] isKindOfClass:[NSString class]])
         action.clickType = json[@"click_type"];
@@ -58,25 +58,25 @@
         action.clickId = json[@"id"];
     
     if ([json[@"url"] isKindOfClass:[NSString class]])
-        action.clickUrl = [NSURL URLWithString:json[@"url"]];
+        action.url = json[@"url"];
     
     if ([json[@"name"] isKindOfClass:[NSString class]])
-        action.clickName = json[@"name"];
+        action.actionId = json[@"name"];
     
     if ([json[@"pageId"] isKindOfClass:[NSString class]])
         action.pageId = json[@"pageId"];
     
     if ([json[@"url_target"] isKindOfClass:[NSString class]] && OS_IS_VALID_URL_ACTION(json[@"url_target"]))
-        action.urlActionType = OS_URL_ACTION_TYPE_FROM_STRING(json[@"url_target"]);
+        action.urlTarget = OS_URL_ACTION_TYPE_FROM_STRING(json[@"url_target"]);
     else
-        action.urlActionType = OSInAppMessageActionUrlTypeWebview;
+        action.urlTarget = OSInAppMessageActionUrlTypeWebview;
     
     if ([json[@"close"] isKindOfClass:[NSNumber class]])
-        action.closesMessage = [json[@"close"] boolValue];
+        action.closingMessage = [json[@"close"] boolValue];
     else
-        action.closesMessage = true; // Default behavior
+        action.closingMessage = true; // Default behavior
     
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OSInAppMessageAction %@", json]];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OSInAppMessageClickResult %@", json]];
 
     NSMutableArray *outcomes = [NSMutableArray new];
     //TODO: when backend is ready check that key matches
@@ -122,30 +122,18 @@
 - (NSDictionary *)jsonRepresentation {
     let json = [NSMutableDictionary new];
     
-    json[@"click_name"] = self.clickName;
-    json[@"first_click"] = @(self.firstClick);
-    json[@"closes_message"] = @(self.closesMessage);
+    json[@"actionId"] = self.actionId;
+    json[@"urlTarget"] = @(self.urlTarget);
+    json[@"closingMessage"] = @(self.closingMessage);
     
-    if (self.clickUrl)
-        json[@"click_url"] = self.clickUrl.absoluteString;
-        
-    if (self.outcomes && self.outcomes.count > 0) {
-        let *jsonOutcomes = [NSMutableArray new];
-        for (OSInAppMessageOutcome *outcome in self.outcomes) {
-            [jsonOutcomes addObject:[outcome jsonRepresentation]];
-        }
-        
-        json[@"outcomes"] = jsonOutcomes;
-    }
-    
-    if (self.tags)
-        json[@"tags"] = [self.tags jsonRepresentation];
+    if (self.url)
+        json[@"url"] = self.url;
     
     return json;
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"OSInAppMessageAction outcome: %@ \ntag: %@ promptAction: %@", _outcomes, _tags, [_promptActions description]];
+    return [NSString stringWithFormat:@"OSInAppMessageClickResult actionId: %@ \nurl: %@ urlTarget: %@ closingMessage: %@", _actionId, _url, @(_urlTarget), @(_closingMessage)];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -28,7 +28,7 @@
 #import "OSInAppMessageView.h"
 #import "OneSignalHelper.h"
 #import <WebKit/WebKit.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OneSignalViewHelper.h"
 
 @interface OSInAppMessageView () <UIScrollViewDelegate, WKUIDelegate, WKNavigationDelegate>

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -29,14 +29,14 @@
 #import <UIKit/UIKit.h>
 #import "OSInAppMessageInternal.h"
 #import "OSInAppMessageView.h"
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import <WebKit/WebKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol OSInAppMessageViewControllerDelegate <NSObject>
 
-- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action;
 - (void)messageViewDidDisplayPage:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
 - (void)messageViewControllerDidDisplay:(OSInAppMessageInternal *)message;
 - (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -738,9 +738,9 @@
             case OSInAppMessageBridgeEventTypeActionTaken: {
                 if (event.userAction.clickType)
                    [self.delegate messageViewDidSelectAction:self.message withAction:event.userAction];
-                if (event.userAction.urlActionType == OSInAppMessageActionUrlTypeReplaceContent)
-                   [self.messageView loadReplacementURL:event.userAction.clickUrl];
-                if (event.userAction.closesMessage)
+                if (event.userAction.urlTarget == OSInAppMessageActionUrlTypeReplaceContent)
+                    [self.messageView loadReplacementURL:[NSURL URLWithString:event.userAction.url]];
+                if (event.userAction.closingMessage)
                    [self dismissCurrentInAppMessage];
                 break;
             }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.h
@@ -7,7 +7,7 @@
 //
 
 #import <OneSignalCore/OneSignalCore.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 
 @interface OSRequestGetInAppMessages : OneSignalRequest
 + (instancetype _Nonnull)withSubscriptionId:(NSString * _Nonnull)subscriptionId;
@@ -34,5 +34,5 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                       forVariantId:(NSString * _Nonnull)variantId
-                     withAction:(OSInAppMessageAction * _Nonnull)action;
+                     withAction:(OSInAppMessageClickResult * _Nonnull)action;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.m
@@ -68,7 +68,7 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                       forVariantId:(NSString * _Nonnull)variantId
-                     withAction:(OSInAppMessageAction * _Nonnull)action {
+                     withAction:(OSInAppMessageClickResult * _Nonnull)action {
     let request = [OSRequestInAppMessageClicked new];
 
     request.parameters = @{

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -64,8 +64,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, id> *)getTriggers;
 - (id)getTriggerValueForKey:(NSString *)key;
 
-- (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock;
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
+- (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener;
+- (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener;
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate;
+- (void)removeInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -30,7 +30,8 @@
 #import "UIApplication+OneSignal.h" // Previously imported via "OneSignalHelper.h"
 #import "NSDateFormatter+OneSignal.h" // Previously imported via "OneSignalHelper.h"
 #import <OneSignalCore/OneSignalCore.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
+#import "OSInAppMessageClickEvent.h"
 #import "OSInAppMessageController.h"
 #import "OSInAppMessagePrompt.h"
 #import "OneSignalDialogController.h"
@@ -40,6 +41,34 @@
 
 + (void)sendClickActionOutcomes:(NSArray<OSInAppMessageOutcome *> *)outcomes;
 
+@end
+
+@implementation OSInAppMessageWillDisplayEvent
+- (OSInAppMessageWillDisplayEvent*)initWithInAppMessage:(OSInAppMessage *)message {
+    _message = message;
+    return self;
+}
+@end
+
+@implementation OSInAppMessageDidDisplayEvent
+- (OSInAppMessageDidDisplayEvent*)initWithInAppMessage:(OSInAppMessage *)message {
+    _message = message;
+    return self;
+}
+@end
+
+@implementation OSInAppMessageWillDismissEvent
+- (OSInAppMessageWillDismissEvent*)initWithInAppMessage:(OSInAppMessage *)message {
+    _message = message;
+    return self;
+}
+@end
+
+@implementation OSInAppMessageDidDismissEvent
+- (OSInAppMessageDidDismissEvent*)initWithInAppMessage:(OSInAppMessage *)message {
+    _message = message;
+    return self;
+}
 @end
 
 @interface OSMessagingController ()
@@ -65,10 +94,9 @@
 // Tracking for impessions so that an IAM is only tracked once and not several times if it is reshown
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *viewedPageIDs;
 
-// Click action block to allow overridden behavior when clicking an IAM
-@property (strong, nonatomic, nullable) OSInAppMessageClickBlock actionClickBlock;
+@property (nonatomic) NSMutableArray<NSObject<OSInAppMessageClickListener> *> *clickListeners;
 
-@property (weak, nonatomic, nullable) NSObject<OSInAppMessageLifecycleHandler> *inAppMessageDelegate;
+@property (weak, nonatomic, nullable) NSObject<OSInAppMessageLifecycleListener> *inAppMessageDelegate;
 
 @property (strong, nullable) OSInAppMessageViewController *viewController;
 
@@ -145,6 +173,7 @@ static BOOL _isInAppMessagingPaused = false;
                                                                                           defaultValue:[NSArray<OSInAppMessageInternal *> new]];
         [self initializeTriggerController];
         self.messageDisplayQueue = [NSMutableArray new];
+        self.clickListeners = [NSMutableArray new];
         
         let standardUserDefaults = OneSignalUserDefaults.initStandard;
         
@@ -277,39 +306,51 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
-- (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {
-    self.actionClickBlock = actionClickBlock;
+- (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [_clickListeners addObject:listener];
 }
 
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate {
+- (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [_clickListeners removeObject:listener];
+}
+
+- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate {
     _inAppMessageDelegate = delegate;
+}
+
+- (void)removeInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate {
+    _inAppMessageDelegate = nil;
 }
 
 - (void)onWillDisplayInAppMessage:(OSInAppMessageInternal *)message {
     if (self.inAppMessageDelegate &&
         [self.inAppMessageDelegate respondsToSelector:@selector(onWillDisplayInAppMessage:)]) {
-        [self.inAppMessageDelegate onWillDisplayInAppMessage:message];
+        OSInAppMessageWillDisplayEvent *event = [[OSInAppMessageWillDisplayEvent alloc] initWithInAppMessage:message];
+        [self.inAppMessageDelegate onWillDisplayInAppMessage:event];
     }
 }
 
 - (void)onDidDisplayInAppMessage:(OSInAppMessageInternal *)message {
     if (self.inAppMessageDelegate &&
         [self.inAppMessageDelegate respondsToSelector:@selector(onDidDisplayInAppMessage:)]) {
-        [self.inAppMessageDelegate onDidDisplayInAppMessage:message];
+        OSInAppMessageDidDisplayEvent *event = [[OSInAppMessageDidDisplayEvent alloc] initWithInAppMessage:message];
+        [self.inAppMessageDelegate onDidDisplayInAppMessage:event];
     }
 }
 
 - (void)onWillDismissInAppMessage:(OSInAppMessageInternal *)message {
     if (self.inAppMessageDelegate &&
         [self.inAppMessageDelegate respondsToSelector:@selector(onWillDismissInAppMessage:)]) {
-        [self.inAppMessageDelegate onWillDismissInAppMessage:message];
+        OSInAppMessageWillDismissEvent *event = [[OSInAppMessageWillDismissEvent alloc] initWithInAppMessage:message];
+        [self.inAppMessageDelegate onWillDismissInAppMessage:event];
     }
 }
 
 - (void)onDidDismissInAppMessage:(OSInAppMessageInternal *)message {
     if (self.inAppMessageDelegate &&
         [self.inAppMessageDelegate respondsToSelector:@selector(onDidDismissInAppMessage:)]) {
-        [self.inAppMessageDelegate onDidDismissInAppMessage:message];
+        OSInAppMessageDidDismissEvent *event = [[OSInAppMessageDidDismissEvent alloc] initWithInAppMessage:message];
+        [self.inAppMessageDelegate onDidDismissInAppMessage:event];
     }
 }
 
@@ -581,13 +622,13 @@ static BOOL _isInAppMessagingPaused = false;
     return true;
 }
 
-- (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {
-    switch (action.urlActionType) {
+- (void)handleMessageActionWithURL:(OSInAppMessageClickResult *)action {
+    switch (action.urlTarget) {
         case OSInAppMessageActionUrlTypeSafari:
-            [[UIApplication sharedApplication] openURL:action.clickUrl options:@{} completionHandler:^(BOOL success) {}];
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:action.url] options:@{} completionHandler:^(BOOL success) {}];
             break;
         case OSInAppMessageActionUrlTypeWebview:
-            [OneSignalHelper displayWebView:action.clickUrl];
+            [OneSignalHelper displayWebView:[NSURL URLWithString:action.url]];
             break;
         case OSInAppMessageActionUrlTypeReplaceContent:
             // This case is handled by the in-app message view controller.
@@ -781,20 +822,26 @@ static BOOL _isInAppMessagingPaused = false;
     }];
 }
 
-- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {
     // Assign firstClick BOOL based on message being clicked previously or not
     action.firstClick = [message takeActionAsUnique];
     
-    if (action.clickUrl)
+    if (action.url)
         [self handleMessageActionWithURL:action];
     
     if (action.promptActions && action.promptActions.count > 0)
         [self handlePromptActions:action.promptActions withMessage:message];
-
-    if (self.actionClickBlock) {
-        // Any outcome sent on this callback should count as DIRECT from this IAM
+    
+    if (_clickListeners.count > 0) {
+        // Any outcome sent on the listener's callback should count as DIRECT from this IAM
         [[OSSessionManager sharedSessionManager] onDirectInfluenceFromIAMClick:message.messageId];
-        self.actionClickBlock(action);
+    }
+    
+    for (NSObject<OSInAppMessageClickListener> *listener in _clickListeners) {
+        if ([listener respondsToSelector:@selector(onClickInAppMessage:)]) {
+            OSInAppMessageClickEvent *event = [[OSInAppMessageClickEvent alloc] initWithInAppMessage:message clickResult:action];
+            [listener onClickInAppMessage:event];
+        }
     }
 
     if (message.isPreview) {
@@ -826,7 +873,7 @@ static BOOL _isInAppMessagingPaused = false;
 /*
 * Show the developer what will happen with a non IAM preview
  */
-- (void)processPreviewInAppMessage:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
+- (void)processPreviewInAppMessage:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {
      if (action.tags)
         [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Tags detected inside of the action click payload, ignoring because action came from IAM preview\nTags: %@", action.tags.jsonRepresentation]];
 
@@ -845,7 +892,7 @@ static BOOL _isInAppMessagingPaused = false;
     return ([message.displayStats isRedisplayEnabled] && [message isClickAvailable:clickId]) || ![_clickedClickIds containsObject:clickId];
 }
 
-- (void)sendClickRESTCall:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
+- (void)sendClickRESTCall:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {
     let clickId = action.clickId;
     // If the IAM clickId exists within the cached clickedClickIds return early so the click is not tracked
     // unless that click is from an IAM with redisplay
@@ -880,7 +927,7 @@ static BOOL _isInAppMessagingPaused = false;
                                       }];
 }
 
-- (void)sendTagCallWithAction:(OSInAppMessageAction *)action {
+- (void)sendTagCallWithAction:(OSInAppMessageClickResult *)action {
     if (action.tags) {
         OSInAppMessageTag *tag = action.tags;
         if (tag.tagsToAdd)
@@ -972,22 +1019,22 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 #pragma mark OSPushSubscriptionObserver Methods
-- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges * _Nonnull)stateChanges {
+- (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState * _Nonnull)state {
     // Don't pull IAMs if the new subscription ID is nil
-    if (stateChanges.to.id == nil) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to nil subscription id"];
+    if (state.current.id == nil) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onPushSubscriptionDidChange: changed to nil subscription id"];
         return;
     }
     // Don't pull IAMs if the subscription ID has not changed
-    if (stateChanges.from.id != nil &&
-        [stateChanges.to.id isEqualToString:stateChanges.from.id]) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to the same subscription id"];
+    if (state.previous.id != nil &&
+        [state.current.id isEqualToString:state.previous.id]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onPushSubscriptionDidChange: changed to the same subscription id"];
         return;
     }
 
     // Pull new IAMs when the subscription id changes to a new valid subscription id
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to new valid subscription id"];
-    [self getInAppMessagesFromServer:stateChanges.to.id];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onPushSubscriptionDidChange: changed to new valid subscription id"];
+    [self getInAppMessagesFromServer:state.current.id];
 }
 
 - (void)dealloc {
@@ -1003,14 +1050,15 @@ static BOOL _isInAppMessagingPaused = false;
 - (BOOL)isInAppMessagingPaused { return false; }
 - (void)setInAppMessagingPaused:(BOOL)pause {}
 - (void)getInAppMessagesFromServer {}
-- (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {}
+- (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *)listener {}
+- (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *)listener {}
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message {}
 - (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message {}
 - (void)displayMessage:(OSInAppMessageInternal *)message {}
 - (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message {}
 - (void)evaluateMessages {}
 - (BOOL)shouldShowInAppMessage:(OSInAppMessageInternal *)message { return false; }
-- (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {}
+- (void)handleMessageActionWithURL:(OSInAppMessageClickResult *)action {}
 #pragma mark Trigger Methods
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers {}
 - (void)removeTriggersForKeys:(NSArray<NSString *> *)keys {}
@@ -1019,7 +1067,7 @@ static BOOL _isInAppMessagingPaused = false;
 - (id)getTriggerValueForKey:(NSString *)key { return 0; }
 #pragma mark OSInAppMessageViewControllerDelegate Methods
 - (void)messageViewControllerWasDismissed {}
-- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {}
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {}
 - (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message {}
 #pragma mark OSTriggerControllerDelegate Methods
 - (void)triggerConditionChanged {}

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -69,7 +69,6 @@
 #import "OneSignalDialogController.h"
 
 #import "OSMessagingController.h"
-#import "OSInAppMessageAction.h"
 #import "OSInAppMessageInternal.h"
 #import "OneSignalInAppMessaging.h"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -33,7 +33,6 @@
 #import "OneSignalJailbreakDetection.h"
 #import "OneSignalMobileProvision.h"
 #import "OneSignalHelper.h"
-#import "OneSignalLiveActivityController.h"
 
 // #import "UNUserNotificationCenter+OneSignal.h" // TODO: This is in Notifications
 #import "OneSignalSelectorHelpers.h"
@@ -223,6 +222,8 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     [OneSignalUserManagerImpl.sharedInstance logout];
 }
 
+#pragma mark: Namespaces
+
 + (Class<OSNotifications>)Notifications {
     return [OSNotificationsManager Notifications];
 }
@@ -235,8 +236,16 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     return [OneSignalInAppMessaging InAppMessages];
 }
 
++ (Class<OSLiveActivities>)LiveActivities {
+    return [OneSignalLiveActivityController LiveActivities];
+}
+
 + (Class<OSLocation>)Location {
     return [OneSignalLocation Location];
+}
+
++ (Class<OSDebug>)Debug {
+    return [OneSignalLog Debug];
 }
 
 #pragma mark Initialization
@@ -333,51 +342,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
         [OSNotificationsManager setProvidesNotificationSettingsView: providesView];
     }
 }
-
-#pragma mark: LIVE ACTIVITIES
-
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token {
-    
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:"])
-        return;
-    
-    [self enterLiveActivity:activityId withToken:token withSuccess:nil withFailure:nil];
-}
-
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
-    
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:onSuccess:onFailure:"]) {
-        if (failureBlock) {
-            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called enterLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
-            failureBlock(error);
-        }
-        return;
-    }
-    
-    [OneSignalLiveActivityController enterLiveActivity:activityId appId:appId withToken:token withSuccess: successBlock withFailure: failureBlock];
-}
-
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId{
-    
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:"])
-        return;
-    
-    [self exitLiveActivity:activityId withSuccess:nil withFailure:nil];
-}
-
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
-
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"exitLiveActivity:onSuccess:onFailure:"]) {
-        if (failureBlock) {
-            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called exitLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
-            failureBlock(error);
-        }
-        return;
-    }
-    
-    [OneSignalLiveActivityController exitLiveActivity:activityId appId:appId withSuccess: successBlock withFailure: failureBlock];
-}
-
 
 #pragma mark Initialization
 
@@ -788,11 +752,6 @@ static AppEntryAction _appEntryState = APP_CLOSE;
                                                    onesignalId:onesignalId
                                                influenceParams:params.influenceParams];
     return true;
-}
-
-#pragma mark Logging
-+ (Class<OSDebug>)Debug {
-    return [OneSignalLog Debug];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -511,7 +511,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     // using classes as delegates is not best practice. We should consider using a shared instance of a class instead
     [OSSessionManager sharedSessionManager].delegate = (id<SessionStatusDelegate>)self;
         
-    if ([self requiresPrivacyConsent]) {
+    if ([OSPrivacyConsentController requiresUserPrivacyConsent]) {
         [self delayInitializationForPrivacyConsent];
         return;
     }
@@ -602,15 +602,11 @@ static AppEntryAction _appEntryState = APP_CLOSE;
     }
 }
 
-+ (void)setRequiresPrivacyConsent:(BOOL)required {
++ (void)setConsentRequired:(BOOL)required {
     [OSPrivacyConsentController setRequiresPrivacyConsent:required];
 }
 
-+ (BOOL)requiresPrivacyConsent {
-    return [OSPrivacyConsentController requiresUserPrivacyConsent];
-}
-
-+ (void)setPrivacyConsent:(BOOL)granted {
++ (void)setConsentGiven:(BOOL)granted {
     [OSPrivacyConsentController consentGranted:granted];
     
     if (!granted || !delayedInitializationForPrivacyConsent || _delayedInitParameters == nil)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -49,6 +49,7 @@
 #import <OneSignalOSCore/OneSignalOSCore.h>
 #import <OneSignalNotifications/OneSignalNotifications.h>
 #import "OneSignalInAppMessaging.h"
+#import "OneSignalLiveActivityController.h"
 #import "OneSignalLocation.h"
 
 #pragma clang diagnostic push
@@ -85,11 +86,7 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (void)setProvidesNotificationSettingsView:(BOOL)providesView;
 
 #pragma mark Live Activity
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token;
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
-
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId;
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
++ (Class<OSLiveActivities>)LiveActivities NS_REFINED_FOR_SWIFT;
 
 #pragma mark Logging
 + (Class<OSDebug>)Debug NS_REFINED_FOR_SWIFT;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -92,14 +92,12 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (Class<OSDebug>)Debug NS_REFINED_FOR_SWIFT;
 
 #pragma mark Privacy Consent
-+ (void)setPrivacyConsent:(BOOL)granted NS_REFINED_FOR_SWIFT;
-+ (BOOL)getPrivacyConsent NS_REFINED_FOR_SWIFT;
 /**
- * Tells your application if privacy consent is still needed from the current device.
+ * Set to `true` if your application requires privacy consent.
  * Consent should be provided prior to the invocation of `initialize` to ensure compliance.
  */
-+ (BOOL)requiresPrivacyConsent NS_REFINED_FOR_SWIFT;
-+ (void)setRequiresPrivacyConsent:(BOOL)required NS_REFINED_FOR_SWIFT;
++ (void)setConsentRequired:(BOOL)required;
++ (void)setConsentGiven:(BOOL)granted;
 
 #pragma mark In-App Messaging
 + (Class<OSInAppMessages>)InAppMessages NS_REFINED_FOR_SWIFT;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -90,10 +90,13 @@
 - (void)onDidDismissInAppMessage:(OSInAppMessage *_Nonnull)message;
 @end
 
+/**
+ Public API for the InAppMessages namespace.
+ */
 @protocol OSInAppMessages <NSObject>
 
-+ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value;
-+ (void)addTriggers:(NSDictionary<NSString *, id> * _Nonnull)triggers;
++ (void)addTrigger:(NSString * _Nonnull)key withValue:(NSString * _Nonnull)value;
++ (void)addTriggers:(NSDictionary<NSString *, NSString *> * _Nonnull)triggers;
 + (void)removeTrigger:(NSString * _Nonnull)key;
 + (void)removeTriggers:(NSArray<NSString *> * _Nonnull)keys;
 + (void)clearTriggers;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -49,45 +49,71 @@
 
 @end
 
-@interface OSInAppMessageAction : NSObject
+typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
+    OSInAppMessageActionUrlTypeSafari,
+    
+    OSInAppMessageActionUrlTypeWebview,
+    
+    OSInAppMessageActionUrlTypeReplaceContent
+};
+
+@interface OSInAppMessageClickResult : NSObject
 
 // The action name attached to the IAM action
-@property (strong, nonatomic, nullable) NSString *clickName;
+@property (strong, nonatomic, nullable) NSString *actionId;
 
 // The URL (if any) that should be opened when the action occurs
-@property (strong, nonatomic, nullable) NSURL *clickUrl;
-
-//UUID for the page in an IAM Carousel
-@property (strong, nonatomic, nullable) NSString *pageId;
-
-// Whether or not the click action is first click on the IAM
-@property (nonatomic) BOOL firstClick;
+@property (strong, nonatomic, nullable) NSString *url;
 
 // Whether or not the click action dismisses the message
-@property (nonatomic) BOOL closesMessage;
+@property (nonatomic) BOOL closingMessage;
 
-// The outcome to send for this action
-@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
-
-// The tags to send for this action
-@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
+// Determines where the URL is loaded, ie. app opens a webview
+@property (nonatomic) OSInAppMessageActionUrlType urlTarget;
 
 // Convert the class into a NSDictionary
 - (NSDictionary *_Nonnull)jsonRepresentation;
 
 @end
 
-@protocol OSInAppMessageDelegate <NSObject>
-@optional
-- (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
+@interface OSInAppMessageWillDisplayEvent : NSObject
+@property (nonatomic, readonly, nonnull) OSInAppMessage *message;
 @end
 
-@protocol OSInAppMessageLifecycleHandler <NSObject>
+@interface OSInAppMessageDidDisplayEvent : NSObject
+@property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+@end
+
+@interface OSInAppMessageWillDismissEvent : NSObject
+@property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+@end
+
+@interface OSInAppMessageDidDismissEvent : NSObject
+@property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+@end
+
+@protocol OSInAppMessageLifecycleListener <NSObject>
 @optional
-- (void)onWillDisplayInAppMessage:(OSInAppMessage *_Nonnull)message;
-- (void)onDidDisplayInAppMessage:(OSInAppMessage *_Nonnull)message;
-- (void)onWillDismissInAppMessage:(OSInAppMessage *_Nonnull)message;
-- (void)onDidDismissInAppMessage:(OSInAppMessage *_Nonnull)message;
+- (void)onWillDisplayInAppMessage:(OSInAppMessageWillDisplayEvent *_Nonnull)event
+NS_SWIFT_NAME(onWillDisplay(event:));
+- (void)onDidDisplayInAppMessage:(OSInAppMessageDidDisplayEvent *_Nonnull)event
+NS_SWIFT_NAME(onDidDisplay(event:));
+- (void)onWillDismissInAppMessage:(OSInAppMessageWillDismissEvent *_Nonnull)event
+NS_SWIFT_NAME(onWillDismiss(event:));
+- (void)onDidDismissInAppMessage:(OSInAppMessageDidDismissEvent *_Nonnull)event
+NS_SWIFT_NAME(onDidDismiss(event:));
+@end
+
+@interface OSInAppMessageClickEvent : NSObject
+@property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+@property (nonatomic, readonly, nonnull) OSInAppMessageClickResult *result;
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+@end
+
+@protocol OSInAppMessageClickListener <NSObject>
+- (void)onClickInAppMessage:(OSInAppMessageClickEvent *_Nonnull)event
+NS_SWIFT_NAME(onClick(event:));
 @end
 
 /**
@@ -104,10 +130,10 @@
 + (BOOL)paused NS_REFINED_FOR_SWIFT;
 + (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
 
-typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
-+ (void)setClickHandler:(OSInAppMessageClickBlock _Nullable)block;
-+ (void)setLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate;
-
++ (void)addClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
++ (void)removeClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
++ (void)addLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
++ (void)removeLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
 @end
 
 @interface OneSignalInAppMessaging : NSObject <OSInAppMessages>

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -100,7 +100,7 @@
 + (void)removeTrigger:(NSString * _Nonnull)key;
 + (void)removeTriggers:(NSArray<NSString *> * _Nonnull)keys;
 + (void)clearTriggers;
-// Allows Swift users to: OneSignal.InAppMessages.Paused = true
+// Allows Swift users to: OneSignal.InAppMessages.paused = true
 + (BOOL)paused NS_REFINED_FOR_SWIFT;
 + (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -39,14 +39,24 @@
     [OSMessagingController start];
 }
 
-+ (void)setClickHandler:(OSInAppMessageClickBlock)block {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click handler set successfully"];
-    [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
++ (void)addClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click listener added successfully"];
+    [OSMessagingController.sharedInstance addInAppMessageClickListener:listener];
 }
 
-+ (void)setLifecycleHandler:(NSObject<OSInAppMessageLifecycleHandler> *_Nullable)delegate; {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message delegate set successfully"];
-    [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
++ (void)removeClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click listener removed successfully"];
+    [OSMessagingController.sharedInstance removeInAppMessageClickListener:listener];
+}
+
++ (void)addLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message lifecycle listener added successfully"];
+    [OSMessagingController.sharedInstance setInAppMessageDelegate:listener];
+}
+
++ (void)removeLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message lifecycle listener removed successfully"];
+    [OSMessagingController.sharedInstance removeInAppMessageDelegate:listener];
 }
 
 + (void)addTrigger:(NSString * _Nonnull)key withValue:(NSString * _Nonnull)value {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -49,7 +49,7 @@
     [OSMessagingController.sharedInstance setInAppMessageDelegate:delegate];
 }
 
-+ (void)addTrigger:(NSString * _Nonnull)key withValue:(id _Nonnull)value {
++ (void)addTrigger:(NSString * _Nonnull)key withValue:(NSString * _Nonnull)value {
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"addTrigger:withValue:"])
         return;
@@ -62,7 +62,7 @@
     [OSMessagingController.sharedInstance addTriggers:@{key : value}];
 }
 
-+ (void)addTriggers:(NSDictionary<NSString *,id> * _Nonnull)triggers {
++ (void)addTriggers:(NSDictionary<NSString *, NSString *> * _Nonnull)triggers {
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"addTriggers:"])
         return;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.h
@@ -30,12 +30,18 @@
 
 #import <OneSignalUser/OneSignalUser-Swift.h>
 
-@interface OneSignalLiveActivityController: NSObject<OSPushSubscriptionObserver>
+/**
+ Public API for the LiveActivities namespace.
+ */
+@protocol OSLiveActivities <NSObject>
++ (void)enter:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token;
++ (void)enter:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
++ (void)exit:(NSString * _Nonnull)activityId;
++ (void)exit:(NSString * _Nonnull)activityId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
+@end
 
-+ (void)enterLiveActivity:(NSString * _Nonnull)activityId appId:(NSString *)appId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
-+ (void)exitLiveActivity:(NSString * _Nonnull)activityId appId:(NSString *)appId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock;
-
-
+@interface OneSignalLiveActivityController: NSObject <OSLiveActivities, OSPushSubscriptionObserver>
++ (Class<OSLiveActivities>_Nonnull)LiveActivities;
 @end
 
 #endif /* OneSignalLiveActivityController_h */

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
@@ -86,8 +86,8 @@ static dispatch_once_t once;
     [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
 }
 
-- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges * _Nonnull)stateChanges {
-    if(stateChanges.to.id){
+- (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState * _Nonnull)state {
+    if(state.current.id){
         subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
         [OneSignalLiveActivityController executePendingLiveActivityUpdates];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
@@ -26,8 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <OneSignalFramework.h>
-#import <OneSignalUser/OneSignalUser-Swift.h>
+#import <OneSignalCore/OneSignalCore.h>
 #import "OneSignalLiveActivityController.h"
 
 @interface OSPendingLiveActivityUpdate: NSObject
@@ -76,6 +75,11 @@ static dispatch_once_t once;
     });
     return sharedInstance;
 }
+
++ (Class<OSLiveActivities>)LiveActivities {
+    return self;
+}
+
 + (void)initialize {
     subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
     OneSignalLiveActivityController *shared = OneSignalLiveActivityController.sharedInstance;
@@ -89,19 +93,40 @@ static dispatch_once_t once;
     }
 }
 
++ (void)enter:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token {
+    
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:"])
+        return;
+    
+    [self enter:activityId withToken:token withSuccess:nil withFailure:nil];
+}
+
++ (void)enter:(NSString * _Nonnull)activityId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
+    
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:onSuccess:onFailure:"]) {
+        if (failureBlock) {
+            NSError *error = [NSError errorWithDomain:@"OneSignal.LiveActivities" code:0 userInfo:@{@"error" : @"Your application has called enterLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+            failureBlock(error);
+        }
+        return;
+    }
+    
+    [self enterLiveActivity:activityId appId:[OneSignalConfigManager getAppId] withToken:token withSuccess: successBlock withFailure: failureBlock];
+}
+
 + (void)enterLiveActivity:(NSString * _Nonnull)activityId appId:(NSString *)appId withToken:(NSString * _Nonnull)token withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"enterLiveActivity called with activityId: %@ token: %@", activityId, token]];
     
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:onSuccess:onFailure:"]) {
         if (failureBlock) {
-            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called enterLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+            NSError *error = [NSError errorWithDomain:@"OneSignal.LiveActivities" code:0 userInfo:@{@"error" : @"Your application has called enterLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
             failureBlock(error);
         }
         return;
     }
 
     if(subscriptionId) {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:subscriptionId appId:appId activityId:activityId token:token]
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withSubscriptionId:subscriptionId appId:appId activityId:activityId token:token]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:successBlock withResult:result];
         } onFailure:^(NSError *error) {
@@ -112,18 +137,39 @@ static dispatch_once_t once;
     }
 }
 
++ (void)exit:(NSString * _Nonnull)activityId{
+    
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"enterLiveActivity:"])
+        return;
+    
+    [self exit:activityId withSuccess:nil withFailure:nil];
+}
+
++ (void)exit:(NSString * _Nonnull)activityId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
+
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"exitLiveActivity:onSuccess:onFailure:"]) {
+        if (failureBlock) {
+            NSError *error = [NSError errorWithDomain:@"OneSignal.LiveActivities" code:0 userInfo:@{@"error" : @"Your application has called exitLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+            failureBlock(error);
+        }
+        return;
+    }
+    
+    [self exitLiveActivity:activityId appId:[OneSignalConfigManager getAppId] withSuccess: successBlock withFailure: failureBlock];
+}
+
 + (void)exitLiveActivity:(NSString * _Nonnull)activityId appId:(NSString *)appId withSuccess:(OSResultSuccessBlock _Nullable)successBlock withFailure:(OSFailureBlock _Nullable)failureBlock{
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"exitLiveActivity called with activityId: %@", activityId]];
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:@"exitLiveActivity:onSuccess:onFailure:"]) {
         if (failureBlock) {
-            NSError *error = [NSError errorWithDomain:@"com.onesignal.tags" code:0 userInfo:@{@"error" : @"Your application has called exitLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
+            NSError *error = [NSError errorWithDomain:@"OneSignal.LiveActivities" code:0 userInfo:@{@"error" : @"Your application has called exitLiveActivity:onSuccess:onFailure: before the user granted privacy permission. Please call `consentGranted(bool)` in order to provide user privacy consent"}];
             failureBlock(error);
         }
         return;
     }
     
     if(subscriptionId) {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:subscriptionId appId:appId activityId:activityId]
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withSubscriptionId:subscriptionId appId:appId activityId:activityId]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:successBlock withResult:result];
         } onFailure:^(NSError *error) {
@@ -175,7 +221,7 @@ static dispatch_once_t once;
     OSPendingLiveActivityUpdate * updateToProcess = [pendingLiveActivityUpdates objectAtIndex:0];
     [pendingLiveActivityUpdates removeObjectAtIndex: 0];
     if (updateToProcess.isEnter) {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withUserId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId token:updateToProcess.token]
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityEnter withSubscriptionId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId token:updateToProcess.token]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:updateToProcess.successBlock withResult:result];
             [self executePendingLiveActivityUpdates];
@@ -184,7 +230,7 @@ static dispatch_once_t once;
             [self executePendingLiveActivityUpdates];
         }];
     } else {
-        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withUserId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId]
+        [OneSignalClient.sharedClient executeRequest:[OSRequestLiveActivityExit withSubscriptionId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:updateToProcess.successBlock withResult:result];
             [self executePendingLiveActivityUpdates];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -68,7 +68,7 @@ public extension OSDebug {
 }
 
 public extension OSInAppMessages {
-    static var Paused: Bool {
+    static var paused: Bool {
         get {
             return __paused()
         }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -76,6 +76,22 @@ public extension OSInAppMessages {
             __paused(newValue)
         }
     }
+    
+    static func addLifecycleListener(_ listener: OSInAppMessageLifecycleListener) {
+        __add(listener)
+    }
+    
+    static func removeLifecycleListener(_ listener: OSInAppMessageLifecycleListener) {
+        __remove(listener)
+    }
+    
+    static func addClickListener(_ listener: OSInAppMessageClickListener) {
+        __add(listener)
+    }
+    
+    static func removeClickListener(_ listener: OSInAppMessageClickListener) {
+        __remove(listener)
+    }
 }
 
 public extension OSSession {
@@ -101,12 +117,20 @@ public extension OSNotifications {
         return __register(forProvisionalAuthorization: block)
     }
 
-    static func addPermissionObserver(_ observer: OSPermissionObserver) {
+    static func addPermissionObserver(_ observer: OSNotificationPermissionObserver) {
         return __add(observer)
     }
 
-    static func removePermissionObserver(_ observer: OSPermissionObserver) {
+    static func removePermissionObserver(_ observer: OSNotificationPermissionObserver) {
         return __remove(observer)
+    }
+    
+    static func addClickListener(_ listener: OSNotificationClickListener) {
+        return __add(listener)
+    }
+    
+    static func removeClickListener(_ listener: OSNotificationClickListener) {
+        return __remove(listener)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -55,6 +55,10 @@ public extension OneSignal {
     static var Location: OSLocation.Type {
         return __location()
     }
+    
+    static var LiveActivities: OSLiveActivities.Type {
+        return __liveActivities()
+    }
 
     static var requiresPrivacyConsent: Bool {
         get {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -93,6 +93,10 @@ public extension OSNotifications {
         return __canRequestPermission()
     }
 
+    static var permissionNative: OSNotificationPermission {
+        return __permissionNative()
+    }
+    
     static func registerForProvisionalAuthorization(_ block: OSUserResponseBlock?) {
         return __register(forProvisionalAuthorization: block)
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -58,25 +58,7 @@ public extension OneSignal {
     
     static var LiveActivities: OSLiveActivities.Type {
         return __liveActivities()
-    }
-
-    static var requiresPrivacyConsent: Bool {
-        get {
-            return __requiresPrivacyConsent()
-        }
-        set {
-            __setRequiresPrivacyConsent(newValue)
-        }
-    }
-
-    static var privacyConsent: Bool {
-        get {
-            return __getPrivacyConsent()
-        }
-        set {
-            __setPrivacyConsent(newValue)
-        }
-    }
+    }  
 }
 
 public extension OSDebug {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -79,7 +79,7 @@ static BOOL lastOnFocusWasToBackground = YES;
 
 + (void)onFocus:(BOOL)toBackground {
     // return if the user has not granted privacy permissions
-    if ([OneSignal requiresPrivacyConsent])
+    if ([OSPrivacyConsentController requiresUserPrivacyConsent])
         return;
     
     // Prevent the onFocus to be called twice when app being terminated


### PR DESCRIPTION
# Description
## One Line Summary
API updates for the changes not related to observer/handler/listener changes.

## Details

### Motivation
A desire to align terminologies and naming conventions across the OneSignal SDKs.

### Details
The changes are split up into individual commits for more details of each change.

**1. API for adding triggers has string values**
* `addTrigger` and `addTriggers` public API will only accept `string` values, not types string/bool/number, etc.
* No logic changes are needed as the SDK already supports string-only trigger values and evaluates booleans and numerics correctly.

- Tested scenarios with these triggers set via the dashboard on IAMs:
  - 🟢 myTrigger is true
  - 🟡 myTrigger is 1.58 (must pass in "1.58" and not "1.580" for example, the "is" operator does not support numeric equivalence, it arrives to the SDK as value "1.58")
  - 🟢 myTrigger > 5
  - 🟢 myTrigger > 7.689
  - 🟡 myTrigger >= 7.689 (note margin of error due to rounding, this value actually came to the SDK as 7.689000129699707, so adding a trigger value of "7.689" does not trigger the IAM to display)

**2. Make Live Activities namespace**
* Make Live Activities namespace `OneSignal.LiveActivities`

**3. Update privacy consent API names and no public getters**
* Rename `requiresPrivacyConsent` to `consentRequired`
* Rename `privacyConsent` to `consentGiven`
* Remove public getters for these 2 properties
* Swift cannot have computed write-only properties so instead of `OneSignal.consentGiven = true`, it will be `OneSignal.setConsentGiven(true)`

**4. Add OneSignal.Notifications.permissionNative**
* Add `permissionNative` to Notifications namespace which tells if it's provisional, ephemeral, denied, authorized etc
* Expose enum `OSNotificationPermission` which has these 5 values

**5. Update InAppMessages.paused to not be capitalized** 
* For Swift, let's not capitalize the paused boolean: it will be `OneSignal.InAppMessages.paused` instead of `OneSignal.InAppMessages.Paused`.

# Testing

## Manual testing
Physical iPhone 13 on iOS 16.x.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1255)
<!-- Reviewable:end -->
