### PR TITLE
[5.0.0] Push Subscription Observer - API update

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -117,10 +117,10 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     NSLog(@"Dev App onNotificationPermissionDidChange: %d", permission);
 }
 
-- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges *)stateChanges {
-    NSLog(@"Dev App onOSPushSubscriptionChangedWithStateChanges: %@", stateChanges);
+- (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState *)state {
+    NSLog(@"Dev App onPushSubscriptionDidChange: %@", state);
     ViewController* mainController = (ViewController*) self.window.rootViewController;
-    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) stateChanges.to.optedIn;
+    mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) state.current.optedIn;
 }
 
 #pragma mark OSInAppMessageDelegate

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -57,25 +57,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
     
-    id openNotificationHandler = ^(OSNotificationOpenedResult *result) {
-        // TODO: opened handler Not triggered
-        NSLog(@"OSNotificationOpenedResult: %@", result.action);
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated"
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
-        [alert show];
-        #pragma clang diagnostic pop
-    };
-    
-    // Example block for IAM action click handler
-    id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
-        NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:message];
-    };
-
-    // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal.InAppMessages setClickHandler:inAppMessagingActionClickBlock];
-    
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
     [OneSignal setProvidesNotificationSettingsView:NO];
@@ -84,13 +65,13 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.InAppMessages paused:true];
 
     [OneSignal.Notifications addForegroundLifecycleListener:self];
-    [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
-
+    [OneSignal.Notifications addClickListener:self];
     [OneSignal.User.pushSubscription addObserver:self];
     NSLog(@"OneSignal Demo App push subscription observer added");
     
     [OneSignal.Notifications addPermissionObserver:self];
-    
+    [OneSignal.InAppMessages addClickListener:self];
+
     NSLog(@"UNUserNotificationCenter.delegate: %@", UNUserNotificationCenter.currentNotificationCenter.delegate);
     
     return YES;
@@ -123,11 +104,14 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) state.current.optedIn;
 }
 
+- (void)onClickNotification:(OSNotificationClickEvent * _Nonnull)event {
+    NSLog(@"Dev App onClickNotification with event %@", [event jsonRepresentation]);
+}
+
 #pragma mark OSInAppMessageDelegate
 
-- (void)handleMessageAction:(OSInAppMessageAction *)action {
-    NSLog(@"OSInAppMessageDelegate: handling message action: %@",action);
-    return;
+- (void)onClickInAppMessage:(OSInAppMessageClickEvent * _Nonnull)event {
+    NSLog(@"Dev App onClickInAppMessage event: %@", [event jsonRepresentation]);
 }
 
 - (void)onWillDisplayNotification:(OSNotificationWillDisplayEvent *)event {
@@ -139,22 +123,22 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 }
 
 - (void)onWillDisplayInAppMessage:(OSInAppMessageWillDisplayEvent *)event {
-    NSLog(@"OSInAppMessageDelegate: onWillDisplay Message: %@",event.message);
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onWillDisplay Message: %@",event.message);
     return;
 }
 
 - (void)onDidDisplayInAppMessage:(OSInAppMessageDidDisplayEvent *)event {
-    NSLog(@"OSInAppMessageDelegate: onDidDisplay Message: %@",event.message);
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onDidDisplay Message: %@",event.message);
     return;
 }
 
 - (void)onWillDismissInAppMessage:(OSInAppMessageWillDismissEvent *)event {
-    NSLog(@"OSInAppMessageDelegate: onWillDismiss Message: %@",event.message);
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onWillDismiss Message: %@",event.message);
     return;
 }
 
 - (void)onDidDismissInAppMessage:(OSInAppMessageDidDismissEvent *)event {
-    NSLog(@"OSInAppMessageDelegate: onDidDismiss Message: %@",event.message);
+    NSLog(@"Dev App OSInAppMessageLifecycleListener: onDidDismiss Message: %@",event.message);
     return;
 }
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface ViewController : UIViewController <OSInAppMessageDelegate>
+@interface ViewController : UIViewController
 
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -190,10 +190,6 @@
     [OneSignal.InAppMessages paused:(bool) !sender.selectedSegmentIndex];
 }
 
-- (void)handleMessageAction:(NSString *)actionId {
-    NSLog(@"View controller did get action: %@", actionId);
-}
-
 - (IBAction)loginExternalUserId:(UIButton *)sender {
     NSString* externalUserId = self.externalUserIdTextField.text;
     NSLog(@"Dev App: Logging in to external user ID %@", externalUserId);

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -54,20 +54,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
     [OneSignal.Debug setAlertLevel:ONE_S_LL_NONE];
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
-    
-    id openNotificationHandler = ^(OSNotificationOpenedResult *result) {
-        NSLog(@"OSNotificationOpenedResult: %@", result.action);
-    };
-    
-    // Example block for IAM action click handler
-    id inAppMessagingActionClickBlock = ^(OSInAppMessageAction *action) {
-        NSString *message = [NSString stringWithFormat:@"Click Action Occurred: %@", [action jsonRepresentation]];
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:message];
-    };
 
-    // Example setter for IAM action click handler using OneSignal public method
-    [OneSignal.InAppMessages setClickHandler:inAppMessagingActionClickBlock];
-    
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
     [OneSignal setProvidesNotificationSettingsView:NO];
@@ -83,8 +70,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     [OneSignal.InAppMessages paused:false];
     
-    [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
-
     NSLog(@"UNUserNotificationCenter.delegate: %@", UNUserNotificationCenter.currentNotificationCenter.delegate);
     
     return YES;

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface ViewController : UIViewController <OSInAppMessageDelegate>
+@interface ViewController : UIViewController
 
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicatorView;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *consentSegmentedControl;

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/ViewController.m
@@ -144,10 +144,6 @@
     [OneSignal.InAppMessages paused:(bool) !sender.selectedSegmentIndex];
 }
 
-- (void)handleMessageAction:(NSString *)actionId {
-    NSLog(@"View controller did get action: %@", actionId);
-}
-
 - (IBAction)loginExternalUserId:(UIButton *)sender {
     NSLog(@"setExternalUserId is no longer supported. Please use login or addAlias.");
     // TODO: Update

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -78,6 +78,10 @@
 		3C47A974292642B100312125 /* OneSignalConfigManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C47A972292642B100312125 /* OneSignalConfigManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C47A975292642B100312125 /* OneSignalConfigManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C47A973292642B100312125 /* OneSignalConfigManager.m */; };
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
+		3C6302FA29FC7E17004FAEB3 /* OSInAppMessageClickEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */; };
+		3C6302FB29FC7EA3004FAEB3 /* OSInAppMessageClickEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6302F829FC7E17004FAEB3 /* OSInAppMessageClickEvent.h */; };
+		3C6302FC29FC7EC6004FAEB3 /* OSInAppMessageClickEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */; };
+		3C6302FD29FC7EC7004FAEB3 /* OSInAppMessageClickEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */; };
 		3C789DBD293C2206004CF83D /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
 		3C789DBE293D8EAD004CF83D /* OSFocusInfluenceParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C79BEB9293DC88F0034CB10 /* OneSignalInAppMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -256,10 +260,10 @@
 		CA8E190B2194FE0B009DA223 /* OSMessagingControllerOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CA8E190A2194FE0B009DA223 /* OSMessagingControllerOverrider.m */; };
 		CAA4ED0120646762005BD59B /* BadgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAA4ED0020646762005BD59B /* BadgeTests.m */; };
 		CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = CAAE0DFC2195216900A57402 /* OneSignalOverrider.m */; };
-		CAB269D921B0B6F000F8A43C /* OSInAppMessageAction.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */; };
-		CAB269DA21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */; };
-		CAB269DB21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */; };
-		CAB269DC21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */; };
+		CAB269D921B0B6F000F8A43C /* OSInAppMessageClickResult.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB269D721B0B6F000F8A43C /* OSInAppMessageClickResult.h */; };
+		CAB269DA21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */; };
+		CAB269DB21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */; };
+		CAB269DC21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */; };
 		CAB269DF21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */; };
 		CAB269E021B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */; };
 		CAB269E121B2038B00F8A43C /* OSInAppMessageBridgeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */; };
@@ -682,6 +686,8 @@
 		3C47A972292642B100312125 /* OneSignalConfigManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalConfigManager.h; sourceTree = "<group>"; };
 		3C47A973292642B100312125 /* OneSignalConfigManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalConfigManager.m; sourceTree = "<group>"; };
 		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
+		3C6302F829FC7E17004FAEB3 /* OSInAppMessageClickEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageClickEvent.h; sourceTree = "<group>"; };
+		3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageClickEvent.m; sourceTree = "<group>"; };
 		3C79BEB7293DC88F0034CB10 /* OneSignalInAppMessaging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalInAppMessaging.h; sourceTree = "<group>"; };
 		3C79BEB8293DC88F0034CB10 /* OneSignalInAppMessaging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalInAppMessaging.m; sourceTree = "<group>"; };
 		3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationExecutor.swift; sourceTree = "<group>"; };
@@ -898,8 +904,8 @@
 		CAAE0DFC2195216900A57402 /* OneSignalOverrider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalOverrider.m; sourceTree = "<group>"; };
 		CAAEA68521ED68A30049CF15 /* OneSignalNotificationCategoryController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OneSignalNotificationCategoryController.m; sourceTree = "<group>"; };
 		CAAEA68621ED68A40049CF15 /* OneSignalNotificationCategoryController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignalNotificationCategoryController.h; sourceTree = "<group>"; };
-		CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageAction.h; sourceTree = "<group>"; };
-		CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageAction.m; sourceTree = "<group>"; };
+		CAB269D721B0B6F000F8A43C /* OSInAppMessageClickResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageClickResult.h; sourceTree = "<group>"; };
+		CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageClickResult.m; sourceTree = "<group>"; };
 		CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSInAppMessageBridgeEvent.h; sourceTree = "<group>"; };
 		CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSInAppMessageBridgeEvent.m; sourceTree = "<group>"; };
 		CAB4112720852E48005A70D1 /* DelayedConsentInitializationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DelayedConsentInitializationParameters.h; sourceTree = "<group>"; };
@@ -1469,8 +1475,10 @@
 				CA47439C2190FEA80020DC8C /* OSTrigger.m */,
 				CACBAA93218A6243000ACAA5 /* OSInAppMessageInternal.h */,
 				CACBAA94218A6243000ACAA5 /* OSInAppMessageInternal.m */,
-				CAB269D721B0B6F000F8A43C /* OSInAppMessageAction.h */,
-				CAB269D821B0B6F000F8A43C /* OSInAppMessageAction.m */,
+				3C6302F829FC7E17004FAEB3 /* OSInAppMessageClickEvent.h */,
+				3C6302F929FC7E17004FAEB3 /* OSInAppMessageClickEvent.m */,
+				CAB269D721B0B6F000F8A43C /* OSInAppMessageClickResult.h */,
+				CAB269D821B0B6F000F8A43C /* OSInAppMessageClickResult.m */,
 				CAB269DD21B2038B00F8A43C /* OSInAppMessageBridgeEvent.h */,
 				CAB269DE21B2038B00F8A43C /* OSInAppMessageBridgeEvent.m */,
 				7A72EB1123E252D400B4D50F /* OSInAppMessageDisplayStats.h */,
@@ -1975,6 +1983,7 @@
 				CA4742E4218B8FF30020DC8C /* OSTriggerController.h in Headers */,
 				DE7D18EC2703B5AA002D3A5D /* OSInAppMessagingRequests.h in Headers */,
 				DE16C14724D3727200670EFA /* OneSignalLifecycleObserver.h in Headers */,
+				3C6302FB29FC7EA3004FAEB3 /* OSInAppMessageClickEvent.h in Headers */,
 				DE51DDE12941697A0073D5C4 /* OneSignalLocation.h in Headers */,
 				7A674F192360D813001F9ACD /* OSBaseFocusTimeProcessor.h in Headers */,
 				CA36F35821C33A2500300C77 /* OSInAppMessageController.h in Headers */,
@@ -1989,7 +1998,7 @@
 				9124123D1E73342200E41FD7 /* UIApplicationDelegate+OneSignal.h in Headers */,
 				7AF9865324451F3900C36EAE /* OSFocusCallParams.h in Headers */,
 				DE7D18DD2703B44B002D3A5D /* OSFocusRequests.h in Headers */,
-				CAB269D921B0B6F000F8A43C /* OSInAppMessageAction.h in Headers */,
+				CAB269D921B0B6F000F8A43C /* OSInAppMessageClickResult.h in Headers */,
 				DEE8198D24E21DF000868CBA /* UIApplication+OneSignal.h in Headers */,
 				7AECE59C23675F5700537907 /* OSFocusTimeProcessorFactory.h in Headers */,
 				7AECE59A23674ADC00537907 /* OSUnattributedFocusTimeProcessor.h in Headers */,
@@ -2543,6 +2552,7 @@
 				7A1F2D8F2406EFC5007799A9 /* OSInAppMessageTag.m in Sources */,
 				7A72EB0E23E252C200B4D50F /* OSInAppMessageDisplayStats.m in Sources */,
 				9124121E1E73342200E41FD7 /* OneSignalJailbreakDetection.m in Sources */,
+				3C6302FA29FC7E17004FAEB3 /* OSInAppMessageClickEvent.m in Sources */,
 				912412471E73369600E41FD7 /* OneSignalHelper.m in Sources */,
 				7A880F312404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,
 				CA8E19062193C76D009DA223 /* OSInAppMessagingHelpers.m in Sources */,
@@ -2574,7 +2584,7 @@
 				7AECE59023674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				912412361E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				CACBAA9D218A6243000ACAA5 /* OSInAppMessageView.m in Sources */,
-				CAB269DA21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				CAB269DA21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */,
 				CA1A6E6A20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2633,6 +2643,7 @@
 				7A674F1C2360D82E001F9ACD /* OSBaseFocusTimeProcessor.m in Sources */,
 				7AFE856C2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
 				CACBAAA5218A6243000ACAA5 /* OSInAppMessageViewController.m in Sources */,
+				3C6302FC29FC7EC6004FAEB3 /* OSInAppMessageClickEvent.m in Sources */,
 				CA7FC8A121927229002C4FD9 /* OSDynamicTriggerController.m in Sources */,
 				912412231E73342200E41FD7 /* OneSignalLocation.m in Sources */,
 				7A93269D25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */,
@@ -2641,7 +2652,7 @@
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				7AECE59123674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				CACBAA9E218A6243000ACAA5 /* OSInAppMessageView.m in Sources */,
-				CAB269DB21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				CAB269DB21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */,
 				3C79BEBA293DC88F0034CB10 /* OneSignalInAppMessaging.m in Sources */,
 				CA1A6E6B20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 			);
@@ -2672,7 +2683,7 @@
 				4529DEED1FA83C5D00CEAB1D /* OneSignalHelperOverrider.m in Sources */,
 				CA1A6E6C20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
 				7A65D62A246627AD007FF196 /* OSInAppMessageViewOverrider.m in Sources */,
-				CAB269DC21B0B6F000F8A43C /* OSInAppMessageAction.m in Sources */,
+				CAB269DC21B0B6F000F8A43C /* OSInAppMessageClickResult.m in Sources */,
 				DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */,
 				912412241E73342200E41FD7 /* OneSignalLocation.m in Sources */,
@@ -2743,6 +2754,7 @@
 				03CCCC832835D90F004BF794 /* OneSignalUNUserNotificationCenterHelper.m in Sources */,
 				03866CC12378A67B0009C1D8 /* RestClientAsserts.m in Sources */,
 				7ADF891C230DB5BD0054E0D6 /* UnitTestAppDelegate.m in Sources */,
+				3C6302FD29FC7EC7004FAEB3 /* OSInAppMessageClickEvent.m in Sources */,
 				4529DEF01FA8433500CEAB1D /* NSLocaleOverrider.m in Sources */,
 				CA1A6E7220DC2E73001C41B9 /* OneSignalDialogRequest.m in Sources */,
 				7A880F332404AE7B0081F5E8 /* OSInAppMessagePushPrompt.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotificationClasses.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotificationClasses.h
@@ -36,20 +36,17 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeActionTaken
 };
 
-@interface OSNotificationAction : NSObject
-
-/* The type of the notification action */
-@property(readonly)OSNotificationActionType type;
-
+@interface OSNotificationClickResult : NSObject
 /* The ID associated with the button tapped. NULL when the actionType is NotificationTapped */
 @property(readonly, nullable)NSString* actionId;
+@property(readonly, nullable)NSString* url;
 
 @end
 
-@interface OSNotificationOpenedResult : NSObject
+@interface OSNotificationClickEvent : NSObject
 
 @property(readonly, nonnull)OSNotification* notification;
-@property(readonly, nonnull)OSNotificationAction *action;
+@property(readonly, nonnull)OSNotificationClickResult *result;
 
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
 - (NSString* _Nonnull)stringify;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.h
@@ -33,7 +33,7 @@
 +(void)init;
 +(void)updateFromDownloadParams:(NSDictionary*)params;
 
-+(void)trackOpenEvent:(OSNotificationOpenedResult*)results;
++(void)trackOpenEvent:(OSNotificationClickEvent*)event;
 +(void)trackReceivedEvent:(OSNotification*)notification;
 +(void)trackInfluenceOpenEvent;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
@@ -87,7 +87,7 @@ static BOOL trackingEnabled = false;
     return [notification.title substringToIndex:titleLength];
 }
 
-+ (void)trackOpenEvent:(OSNotificationOpenedResult*)results {
++ (void)trackOpenEvent:(OSNotificationClickEvent*)event {
     if (!trackingEnabled)
         return;
     
@@ -97,8 +97,8 @@ static BOOL trackingEnabled = false;
                 parameters:@{
                     @"source": @"OneSignal",
                     @"medium": @"notification",
-                    @"notification_id": results.notification.notificationId,
-                    @"campaign": [self getCampaignNameFromNotification:results.notification]
+                    @"notification_id": event.notification.notificationId,
+                    @"campaign": [self getCampaignNameFromNotification:event.notification]
                 }];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -32,7 +32,10 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalNotifications/OSNotification+OneSignal.h>
 
-typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull result);
+@protocol OSNotificationClickListener <NSObject>
+- (void)onClickNotification:(OSNotificationClickEvent *_Nonnull)event
+NS_SWIFT_NAME(onClick(event:));
+@end
 
 @interface OSNotificationWillDisplayEvent : NSObject
 
@@ -54,8 +57,8 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (OSNotificationPermission)permissionNative NS_REFINED_FOR_SWIFT;
 + (void)addForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener;
 + (void)removeForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener;
-
-+ (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
++ (void)addClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener NS_REFINED_FOR_SWIFT;
++ (void)removeClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener NS_REFINED_FOR_SWIFT;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block fallbackToSettings:(BOOL)fallback;
 + (void)registerForProvisionalAuthorization:(OSUserResponseBlock _Nullable )block NS_REFINED_FOR_SWIFT;
@@ -111,8 +114,7 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (void)setPushSubscriptionId:(NSString *_Nullable)pushSubscriptionId;
 
 + (void)handleWillShowInForegroundForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString* _Nonnull)actionID;
-
++ (void)handleNotificationActionWithUrl:(NSString* _Nullable)url actionID:(NSString* _Nonnull)actionID;
 + (BOOL)clearBadgeCount:(BOOL)fromNotifOpened;
 
 + (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -33,7 +33,7 @@ import OneSignalNotifications
 // MARK: - Push Subscription Specific
 
 @objc public protocol OSPushSubscriptionObserver { // TODO: weak reference?
-    @objc func onOSPushSubscriptionChanged(stateChanges: OSPushSubscriptionStateChanges)
+    @objc func onPushSubscriptionDidChange(state: OSPushSubscriptionChangedState)
 }
 
 @objc
@@ -68,21 +68,21 @@ public class OSPushSubscriptionState: NSObject {
 }
 
 @objc
-public class OSPushSubscriptionStateChanges: NSObject {
-    @objc public let to: OSPushSubscriptionState
-    @objc public let from: OSPushSubscriptionState
+public class OSPushSubscriptionChangedState: NSObject {
+    @objc public let current: OSPushSubscriptionState
+    @objc public let previous: OSPushSubscriptionState
 
     @objc public override var description: String {
-        return "<OSPushSubscriptionStateChanges:\nfrom: \(self.from),\nto:   \(self.to)\n>"
+        return "<OSPushSubscriptionChangedState:\nprevious: \(self.previous),\ncurrent:   \(self.current)\n>"
     }
 
-    init(to: OSPushSubscriptionState, from: OSPushSubscriptionState) {
-        self.to = to
-        self.from = from
+    init(current: OSPushSubscriptionState, previous: OSPushSubscriptionState) {
+        self.current = current
+        self.previous = previous
     }
 
     @objc public func jsonRepresentation() -> NSDictionary {
-        return ["from": from.jsonRepresentation(), "to": to.jsonRepresentation()]
+        return ["from": previous.jsonRepresentation(), "to": current.jsonRepresentation()]
     }
 }
 
@@ -368,7 +368,7 @@ extension OSSubscriptionModel {
             return
         }
 
-        let stateChanges = OSPushSubscriptionStateChanges(to: newSubscriptionState, from: prevSubscriptionState)
+        let stateChanges = OSPushSubscriptionChangedState(current: newSubscriptionState, previous: prevSubscriptionState)
 
         // TODO: Don't fire observer until server is udated
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "firePushSubscriptionChanged from \(prevSubscriptionState.jsonRepresentation()) to \(newSubscriptionState.jsonRepresentation())")

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -133,12 +133,12 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     @objc public var requiresUserAuth = false
 
     // Push Subscription
-    private var _pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionStateChanges>?
-    var pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionStateChanges> {
+    private var _pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionChangedState>?
+    var pushSubscriptionStateChangesObserver: OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionChangedState> {
         if let observer = _pushSubscriptionStateChangesObserver {
             return observer
         }
-        let pushSubscriptionStateChangesObserver = OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionStateChanges>(change: #selector(OSPushSubscriptionObserver.onOSPushSubscriptionChanged(stateChanges:)))
+        let pushSubscriptionStateChangesObserver = OSObservable<OSPushSubscriptionObserver, OSPushSubscriptionChangedState>(change: #selector(OSPushSubscriptionObserver.onPushSubscriptionDidChange(state:)))
         _pushSubscriptionStateChangesObserver = pushSubscriptionStateChangesObserver
 
         return pushSubscriptionStateChangesObserver

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.h
@@ -26,7 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OSInAppMessagePage.h"
 #import "OSInAppMessagingDefines.h"
 #import <OneSignalCore/OneSignalCore.h>
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageBridgeEventType) {
 @property (nonatomic) OSInAppMessageBridgeEventRenderingComplete *renderingComplete;
 @property (nonatomic) OSInAppMessageBridgeEventResize *resize;
 @property (nonatomic, nullable) OSInAppMessageBridgeEventPageChange *pageChange;
-@property (strong, nonatomic, nullable) OSInAppMessageAction *userAction;
+@property (strong, nonatomic, nullable) OSInAppMessageClickResult *userAction;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageBridgeEvent.m
@@ -26,7 +26,7 @@
  */
 
 #import "OSInAppMessageBridgeEvent.h"
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OneSignalHelper.h"
 
 @implementation OSInAppMessageBridgeEvent
@@ -55,7 +55,7 @@
             // deserialize the action JSON
             if ([json[@"body"] isKindOfClass:[NSDictionary class]]) {
                 
-                let action = [OSInAppMessageAction instanceWithJson:json[@"body"]];
+                let action = [OSInAppMessageClickResult instanceWithJson:json[@"body"]];
                 
                 if (!action)
                     return nil;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2023 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,18 +25,14 @@
  * THE SOFTWARE.
  */
 
-// Please see the root Example folder of this repo for an Example project.
-// This project exisits to make testing OneSignal SDK changes.
+#import <Foundation/Foundation.h>
+#import "OneSignalInAppMessaging.h"
+#import "OSInAppMessageInternal.h"
 
-#import <UIKit/UIKit.h>
-#import <OneSignalFramework/OneSignalFramework.h>
+NS_ASSUME_NONNULL_BEGIN
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener>
-
-@property (strong, nonatomic) UIWindow *window;
-
-+ (NSString*)getOneSignalAppId;
-+ (void) setOneSignalAppId:(NSString*)onesignalAppId;
-
+@interface OSInAppMessageClickEvent ()
+- (instancetype _Nonnull)initWithInAppMessage:(OSInAppMessageInternal *)message clickResult:(OSInAppMessageClickResult *)result;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickEvent.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2023 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,18 +25,26 @@
  * THE SOFTWARE.
  */
 
-// Please see the root Example folder of this repo for an Example project.
-// This project exisits to make testing OneSignal SDK changes.
 
-#import <UIKit/UIKit.h>
-#import <OneSignalFramework/OneSignalFramework.h>
+#import "OSInAppMessageClickEvent.h"
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener>
+@implementation OSInAppMessageClickEvent
 
-@property (strong, nonatomic) UIWindow *window;
+- (instancetype)initWithInAppMessage:(OSInAppMessageInternal *)message clickResult:(OSInAppMessageClickResult *)result {
+    _message = message;
+    _result = result;
+    return self;
+}
 
-+ (NSString*)getOneSignalAppId;
-+ (void) setOneSignalAppId:(NSString*)onesignalAppId;
+- (NSDictionary *)jsonRepresentation {
+    let json = [NSMutableDictionary new];
+    json[@"message"] = self.message;
+    json[@"result"] = [self.result jsonRepresentation];
+    return json;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"OSInAppMessageClickEvent message: %@ \nresult: %@", _message, [_result description]];
+}
 
 @end
-

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.h
@@ -34,15 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
-    OSInAppMessageActionUrlTypeSafari,
-    
-    OSInAppMessageActionUrlTypeWebview,
-    
-    OSInAppMessageActionUrlTypeReplaceContent
-};
-
-@interface OSInAppMessageAction () <OSJSONDecodable>
+@interface OSInAppMessageClickResult () <OSJSONDecodable>
 
 // The type of element that was clicked, button or image
 @property (strong, nonatomic, nonnull) NSString *clickType;
@@ -50,11 +42,21 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
 // The unique identifier for this click
 @property (strong, nonatomic, nonnull) NSString *clickId;
 
+//UUID for the page in an IAM Carousel
+@property (strong, nonatomic, nullable) NSString *pageId;
+
+
+// Whether or not the click action is first click on the IAM
+@property (nonatomic) BOOL firstClick;
+
 // The prompt action available
 @property (nonatomic, nullable) NSArray<NSObject<OSInAppMessagePrompt>*> *promptActions;
 
-// Determines where the URL is loaded, ie. app opens a webview
-@property (nonatomic) OSInAppMessageActionUrlType urlActionType;
+// The outcome to send for this action
+@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
+
+// The tags to send for this action
+@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageClickResult.m
@@ -26,11 +26,11 @@
  */
 
 #import "OneSignalHelper.h"
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OSInAppMessagePushPrompt.h"
 #import "OSInAppMessageLocationPrompt.h"
 
-@implementation OSInAppMessageAction
+@implementation OSInAppMessageClickResult
 
 #define OS_URL_ACTION_TYPES @[@"browser", @"webview", @"replacement"]
 #define OS_IS_VALID_URL_ACTION(string) [OS_URL_ACTION_TYPES containsObject:string]
@@ -49,7 +49,7 @@
 }
 
 + (instancetype _Nullable)instanceWithJson:(NSDictionary *)json {
-    OSInAppMessageAction *action = [OSInAppMessageAction new];
+    OSInAppMessageClickResult *action = [OSInAppMessageClickResult new]; // on click goes here
     
     if ([json[@"click_type"] isKindOfClass:[NSString class]])
         action.clickType = json[@"click_type"];
@@ -58,25 +58,25 @@
         action.clickId = json[@"id"];
     
     if ([json[@"url"] isKindOfClass:[NSString class]])
-        action.clickUrl = [NSURL URLWithString:json[@"url"]];
+        action.url = json[@"url"];
     
     if ([json[@"name"] isKindOfClass:[NSString class]])
-        action.clickName = json[@"name"];
+        action.actionId = json[@"name"];
     
     if ([json[@"pageId"] isKindOfClass:[NSString class]])
         action.pageId = json[@"pageId"];
     
     if ([json[@"url_target"] isKindOfClass:[NSString class]] && OS_IS_VALID_URL_ACTION(json[@"url_target"]))
-        action.urlActionType = OS_URL_ACTION_TYPE_FROM_STRING(json[@"url_target"]);
+        action.urlTarget = OS_URL_ACTION_TYPE_FROM_STRING(json[@"url_target"]);
     else
-        action.urlActionType = OSInAppMessageActionUrlTypeWebview;
+        action.urlTarget = OSInAppMessageActionUrlTypeWebview;
     
     if ([json[@"close"] isKindOfClass:[NSNumber class]])
-        action.closesMessage = [json[@"close"] boolValue];
+        action.closingMessage = [json[@"close"] boolValue];
     else
-        action.closesMessage = true; // Default behavior
+        action.closingMessage = true; // Default behavior
     
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OSInAppMessageAction %@", json]];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OSInAppMessageClickResult %@", json]];
 
     NSMutableArray *outcomes = [NSMutableArray new];
     //TODO: when backend is ready check that key matches
@@ -122,30 +122,18 @@
 - (NSDictionary *)jsonRepresentation {
     let json = [NSMutableDictionary new];
     
-    json[@"click_name"] = self.clickName;
-    json[@"first_click"] = @(self.firstClick);
-    json[@"closes_message"] = @(self.closesMessage);
+    json[@"actionId"] = self.actionId;
+    json[@"urlTarget"] = @(self.urlTarget);
+    json[@"closingMessage"] = @(self.closingMessage);
     
-    if (self.clickUrl)
-        json[@"click_url"] = self.clickUrl.absoluteString;
-        
-    if (self.outcomes && self.outcomes.count > 0) {
-        let *jsonOutcomes = [NSMutableArray new];
-        for (OSInAppMessageOutcome *outcome in self.outcomes) {
-            [jsonOutcomes addObject:[outcome jsonRepresentation]];
-        }
-        
-        json[@"outcomes"] = jsonOutcomes;
-    }
-    
-    if (self.tags)
-        json[@"tags"] = [self.tags jsonRepresentation];
+    if (self.url)
+        json[@"url"] = self.url;
     
     return json;
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"OSInAppMessageAction outcome: %@ \ntag: %@ promptAction: %@", _outcomes, _tags, [_promptActions description]];
+    return [NSString stringWithFormat:@"OSInAppMessageClickResult actionId: %@ \nurl: %@ urlTarget: %@ closingMessage: %@", _actionId, _url, @(_urlTarget), @(_closingMessage)];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageView.m
@@ -28,7 +28,7 @@
 #import "OSInAppMessageView.h"
 #import "OneSignalHelper.h"
 #import <WebKit/WebKit.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import "OneSignalViewHelper.h"
 
 @interface OSInAppMessageView () <UIScrollViewDelegate, WKUIDelegate, WKNavigationDelegate>

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.h
@@ -29,14 +29,14 @@
 #import <UIKit/UIKit.h>
 #import "OSInAppMessageInternal.h"
 #import "OSInAppMessageView.h"
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 #import <WebKit/WebKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol OSInAppMessageViewControllerDelegate <NSObject>
 
-- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action;
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action;
 - (void)messageViewDidDisplayPage:(OSInAppMessageInternal *)message withPageId:(NSString *)pageId;
 - (void)messageViewControllerDidDisplay:(OSInAppMessageInternal *)message;
 - (void)messageViewControllerWillDismiss:(OSInAppMessageInternal *)message;

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessageViewController.m
@@ -738,9 +738,9 @@
             case OSInAppMessageBridgeEventTypeActionTaken: {
                 if (event.userAction.clickType)
                    [self.delegate messageViewDidSelectAction:self.message withAction:event.userAction];
-                if (event.userAction.urlActionType == OSInAppMessageActionUrlTypeReplaceContent)
-                   [self.messageView loadReplacementURL:event.userAction.clickUrl];
-                if (event.userAction.closesMessage)
+                if (event.userAction.urlTarget == OSInAppMessageActionUrlTypeReplaceContent)
+                    [self.messageView loadReplacementURL:[NSURL URLWithString:event.userAction.url]];
+                if (event.userAction.closingMessage)
                    [self dismissCurrentInAppMessage];
                 break;
             }

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.h
@@ -7,7 +7,7 @@
 //
 
 #import <OneSignalCore/OneSignalCore.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
 
 @interface OSRequestGetInAppMessages : OneSignalRequest
 + (instancetype _Nonnull)withSubscriptionId:(NSString * _Nonnull)subscriptionId;
@@ -34,5 +34,5 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                       forVariantId:(NSString * _Nonnull)variantId
-                     withAction:(OSInAppMessageAction * _Nonnull)action;
+                     withAction:(OSInAppMessageClickResult * _Nonnull)action;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSInAppMessagingRequests.m
@@ -68,7 +68,7 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                       forVariantId:(NSString * _Nonnull)variantId
-                     withAction:(OSInAppMessageAction * _Nonnull)action {
+                     withAction:(OSInAppMessageClickResult * _Nonnull)action {
     let request = [OSRequestInAppMessageClicked new];
 
     request.parameters = @{

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.h
@@ -64,7 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, id> *)getTriggers;
 - (id)getTriggerValueForKey:(NSString *)key;
 
-- (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock;
+- (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener;
+- (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener;
 - (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate;
 - (void)removeInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate;
 

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -1008,22 +1008,22 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 #pragma mark OSPushSubscriptionObserver Methods
-- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges * _Nonnull)stateChanges {
+- (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState * _Nonnull)state {
     // Don't pull IAMs if the new subscription ID is nil
-    if (stateChanges.to.id == nil) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to nil subscription id"];
+    if (state.current.id == nil) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onPushSubscriptionDidChange: changed to nil subscription id"];
         return;
     }
     // Don't pull IAMs if the subscription ID has not changed
-    if (stateChanges.from.id != nil &&
-        [stateChanges.to.id isEqualToString:stateChanges.from.id]) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to the same subscription id"];
+    if (state.previous.id != nil &&
+        [state.current.id isEqualToString:state.previous.id]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onPushSubscriptionDidChange: changed to the same subscription id"];
         return;
     }
 
     // Pull new IAMs when the subscription id changes to a new valid subscription id
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onOSPushSubscriptionChangedWithStateChanges: changed to new valid subscription id"];
-    [self getInAppMessagesFromServer:stateChanges.to.id];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OSMessagingController onPushSubscriptionDidChange: changed to new valid subscription id"];
+    [self getInAppMessagesFromServer:state.current.id];
 }
 
 - (void)dealloc {

--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -30,7 +30,8 @@
 #import "UIApplication+OneSignal.h" // Previously imported via "OneSignalHelper.h"
 #import "NSDateFormatter+OneSignal.h" // Previously imported via "OneSignalHelper.h"
 #import <OneSignalCore/OneSignalCore.h>
-#import "OSInAppMessageAction.h"
+#import "OSInAppMessageClickResult.h"
+#import "OSInAppMessageClickEvent.h"
 #import "OSInAppMessageController.h"
 #import "OSInAppMessagePrompt.h"
 #import "OneSignalDialogController.h"
@@ -93,8 +94,7 @@
 // Tracking for impessions so that an IAM is only tracked once and not several times if it is reshown
 @property (strong, nonatomic, nonnull) NSMutableSet <NSString *> *viewedPageIDs;
 
-// Click action block to allow overridden behavior when clicking an IAM
-@property (strong, nonatomic, nullable) OSInAppMessageClickBlock actionClickBlock;
+@property (nonatomic) NSMutableArray<NSObject<OSInAppMessageClickListener> *> *clickListeners;
 
 @property (weak, nonatomic, nullable) NSObject<OSInAppMessageLifecycleListener> *inAppMessageDelegate;
 
@@ -173,6 +173,7 @@ static BOOL _isInAppMessagingPaused = false;
                                                                                           defaultValue:[NSArray<OSInAppMessageInternal *> new]];
         [self initializeTriggerController];
         self.messageDisplayQueue = [NSMutableArray new];
+        self.clickListeners = [NSMutableArray new];
         
         let standardUserDefaults = OneSignalUserDefaults.initStandard;
         
@@ -305,8 +306,12 @@ static BOOL _isInAppMessagingPaused = false;
     }
 }
 
-- (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {
-    self.actionClickBlock = actionClickBlock;
+- (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [_clickListeners addObject:listener];
+}
+
+- (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [_clickListeners removeObject:listener];
 }
 
 - (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate {
@@ -617,13 +622,13 @@ static BOOL _isInAppMessagingPaused = false;
     return true;
 }
 
-- (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {
-    switch (action.urlActionType) {
+- (void)handleMessageActionWithURL:(OSInAppMessageClickResult *)action {
+    switch (action.urlTarget) {
         case OSInAppMessageActionUrlTypeSafari:
-            [[UIApplication sharedApplication] openURL:action.clickUrl options:@{} completionHandler:^(BOOL success) {}];
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:action.url] options:@{} completionHandler:^(BOOL success) {}];
             break;
         case OSInAppMessageActionUrlTypeWebview:
-            [OneSignalHelper displayWebView:action.clickUrl];
+            [OneSignalHelper displayWebView:[NSURL URLWithString:action.url]];
             break;
         case OSInAppMessageActionUrlTypeReplaceContent:
             // This case is handled by the in-app message view controller.
@@ -817,20 +822,26 @@ static BOOL _isInAppMessagingPaused = false;
     }];
 }
 
-- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {
     // Assign firstClick BOOL based on message being clicked previously or not
     action.firstClick = [message takeActionAsUnique];
     
-    if (action.clickUrl)
+    if (action.url)
         [self handleMessageActionWithURL:action];
     
     if (action.promptActions && action.promptActions.count > 0)
         [self handlePromptActions:action.promptActions withMessage:message];
-
-    if (self.actionClickBlock) {
-        // Any outcome sent on this callback should count as DIRECT from this IAM
+    
+    if (_clickListeners.count > 0) {
+        // Any outcome sent on the listener's callback should count as DIRECT from this IAM
         [[OSSessionManager sharedSessionManager] onDirectInfluenceFromIAMClick:message.messageId];
-        self.actionClickBlock(action);
+    }
+    
+    for (NSObject<OSInAppMessageClickListener> *listener in _clickListeners) {
+        if ([listener respondsToSelector:@selector(onClickInAppMessage:)]) {
+            OSInAppMessageClickEvent *event = [[OSInAppMessageClickEvent alloc] initWithInAppMessage:message clickResult:action];
+            [listener onClickInAppMessage:event];
+        }
     }
 
     if (message.isPreview) {
@@ -862,7 +873,7 @@ static BOOL _isInAppMessagingPaused = false;
 /*
 * Show the developer what will happen with a non IAM preview
  */
-- (void)processPreviewInAppMessage:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
+- (void)processPreviewInAppMessage:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {
      if (action.tags)
         [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Tags detected inside of the action click payload, ignoring because action came from IAM preview\nTags: %@", action.tags.jsonRepresentation]];
 
@@ -881,7 +892,7 @@ static BOOL _isInAppMessagingPaused = false;
     return ([message.displayStats isRedisplayEnabled] && [message isClickAvailable:clickId]) || ![_clickedClickIds containsObject:clickId];
 }
 
-- (void)sendClickRESTCall:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {
+- (void)sendClickRESTCall:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {
     let clickId = action.clickId;
     // If the IAM clickId exists within the cached clickedClickIds return early so the click is not tracked
     // unless that click is from an IAM with redisplay
@@ -916,7 +927,7 @@ static BOOL _isInAppMessagingPaused = false;
                                       }];
 }
 
-- (void)sendTagCallWithAction:(OSInAppMessageAction *)action {
+- (void)sendTagCallWithAction:(OSInAppMessageClickResult *)action {
     if (action.tags) {
         OSInAppMessageTag *tag = action.tags;
         if (tag.tagsToAdd)
@@ -1039,14 +1050,15 @@ static BOOL _isInAppMessagingPaused = false;
 - (BOOL)isInAppMessagingPaused { return false; }
 - (void)setInAppMessagingPaused:(BOOL)pause {}
 - (void)getInAppMessagesFromServer {}
-- (void)setInAppMessageClickHandler:(OSInAppMessageClickBlock)actionClickBlock {}
+- (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *)listener {}
+- (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *)listener {}
 - (void)presentInAppMessage:(OSInAppMessageInternal *)message {}
 - (void)presentInAppPreviewMessage:(OSInAppMessageInternal *)message {}
 - (void)displayMessage:(OSInAppMessageInternal *)message {}
 - (void)messageViewImpressionRequest:(OSInAppMessageInternal *)message {}
 - (void)evaluateMessages {}
 - (BOOL)shouldShowInAppMessage:(OSInAppMessageInternal *)message { return false; }
-- (void)handleMessageActionWithURL:(OSInAppMessageAction *)action {}
+- (void)handleMessageActionWithURL:(OSInAppMessageClickResult *)action {}
 #pragma mark Trigger Methods
 - (void)addTriggers:(NSDictionary<NSString *, id> *)triggers {}
 - (void)removeTriggersForKeys:(NSArray<NSString *> *)keys {}
@@ -1055,7 +1067,7 @@ static BOOL _isInAppMessagingPaused = false;
 - (id)getTriggerValueForKey:(NSString *)key { return 0; }
 #pragma mark OSInAppMessageViewControllerDelegate Methods
 - (void)messageViewControllerWasDismissed {}
-- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageAction *)action {}
+- (void)messageViewDidSelectAction:(OSInAppMessageInternal *)message withAction:(OSInAppMessageClickResult *)action {}
 - (void)webViewContentFinishedLoading:(OSInAppMessageInternal *)message {}
 #pragma mark OSTriggerControllerDelegate Methods
 - (void)triggerConditionChanged {}

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -69,7 +69,6 @@
 #import "OneSignalDialogController.h"
 
 #import "OSMessagingController.h"
-#import "OSInAppMessageAction.h"
 #import "OSInAppMessageInternal.h"
 #import "OneSignalInAppMessaging.h"
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.h
@@ -49,37 +49,31 @@
 
 @end
 
-@interface OSInAppMessageAction : NSObject
+typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
+    OSInAppMessageActionUrlTypeSafari,
+    
+    OSInAppMessageActionUrlTypeWebview,
+    
+    OSInAppMessageActionUrlTypeReplaceContent
+};
+
+@interface OSInAppMessageClickResult : NSObject
 
 // The action name attached to the IAM action
-@property (strong, nonatomic, nullable) NSString *clickName;
+@property (strong, nonatomic, nullable) NSString *actionId;
 
 // The URL (if any) that should be opened when the action occurs
-@property (strong, nonatomic, nullable) NSURL *clickUrl;
-
-//UUID for the page in an IAM Carousel
-@property (strong, nonatomic, nullable) NSString *pageId;
-
-// Whether or not the click action is first click on the IAM
-@property (nonatomic) BOOL firstClick;
+@property (strong, nonatomic, nullable) NSString *url;
 
 // Whether or not the click action dismisses the message
-@property (nonatomic) BOOL closesMessage;
+@property (nonatomic) BOOL closingMessage;
 
-// The outcome to send for this action
-@property (strong, nonatomic, nullable) NSArray<OSInAppMessageOutcome *> *outcomes;
-
-// The tags to send for this action
-@property (strong, nonatomic, nullable) OSInAppMessageTag *tags;
+// Determines where the URL is loaded, ie. app opens a webview
+@property (nonatomic) OSInAppMessageActionUrlType urlTarget;
 
 // Convert the class into a NSDictionary
 - (NSDictionary *_Nonnull)jsonRepresentation;
 
-@end
-
-@protocol OSInAppMessageDelegate <NSObject>
-@optional
-- (void)handleMessageAction:(OSInAppMessageAction * _Nonnull)action NS_SWIFT_NAME(handleMessageAction(action:));
 @end
 
 @interface OSInAppMessageWillDisplayEvent : NSObject
@@ -110,6 +104,18 @@ NS_SWIFT_NAME(onWillDismiss(event:));
 NS_SWIFT_NAME(onDidDismiss(event:));
 @end
 
+@interface OSInAppMessageClickEvent : NSObject
+@property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+@property (nonatomic, readonly, nonnull) OSInAppMessageClickResult *result;
+// Convert the class into a NSDictionary
+- (NSDictionary *_Nonnull)jsonRepresentation;
+@end
+
+@protocol OSInAppMessageClickListener <NSObject>
+- (void)onClickInAppMessage:(OSInAppMessageClickEvent *_Nonnull)event
+NS_SWIFT_NAME(onClick(event:));
+@end
+
 /**
  Public API for the InAppMessages namespace.
  */
@@ -124,8 +130,8 @@ NS_SWIFT_NAME(onDidDismiss(event:));
 + (BOOL)paused NS_REFINED_FOR_SWIFT;
 + (void)paused:(BOOL)pause NS_REFINED_FOR_SWIFT;
 
-typedef void (^OSInAppMessageClickBlock)(OSInAppMessageAction * _Nonnull action);
-+ (void)setClickHandler:(OSInAppMessageClickBlock _Nullable)block;
++ (void)addClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
++ (void)removeClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
 + (void)addLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
 + (void)removeLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener NS_REFINED_FOR_SWIFT;
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInAppMessaging.m
@@ -39,9 +39,14 @@
     [OSMessagingController start];
 }
 
-+ (void)setClickHandler:(OSInAppMessageClickBlock)block {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click handler set successfully"];
-    [OSMessagingController.sharedInstance setInAppMessageClickHandler:block];
++ (void)addClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click listener added successfully"];
+    [OSMessagingController.sharedInstance addInAppMessageClickListener:listener];
+}
+
++ (void)removeClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener {
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message click listener removed successfully"];
+    [OSMessagingController.sharedInstance removeInAppMessageClickListener:listener];
 }
 
 + (void)addLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
@@ -86,8 +86,8 @@ static dispatch_once_t once;
     [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
 }
 
-- (void)onOSPushSubscriptionChangedWithStateChanges:(OSPushSubscriptionStateChanges * _Nonnull)stateChanges {
-    if(stateChanges.to.id){
+- (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState * _Nonnull)state {
+    if(state.current.id){
         subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
         [OneSignalLiveActivityController executePendingLiveActivityUpdates];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -84,6 +84,14 @@ public extension OSInAppMessages {
     static func removeLifecycleListener(_ listener: OSInAppMessageLifecycleListener) {
         __remove(listener)
     }
+    
+    static func addClickListener(_ listener: OSInAppMessageClickListener) {
+        __add(listener)
+    }
+    
+    static func removeClickListener(_ listener: OSInAppMessageClickListener) {
+        __remove(listener)
+    }
 }
 
 public extension OSSession {
@@ -115,6 +123,14 @@ public extension OSNotifications {
 
     static func removePermissionObserver(_ observer: OSNotificationPermissionObserver) {
         return __remove(observer)
+    }
+    
+    static func addClickListener(_ listener: OSNotificationClickListener) {
+        return __add(listener)
+    }
+    
+    static func removeClickListener(_ listener: OSNotificationClickListener) {
+        return __remove(listener)
     }
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Push Subscription Observer - API update.

## Details

### Motivation
Push Subscription Observer - API update.

### Scope
* Rename `OSPushSubscriptionStateChanges` to `OSPushSubscriptionChangedState`
* Rename event from `onOSPushSubscriptionChanged` to `onPushSubscriptionDidChange`
* Use `current` and `previous` instead of `to` and `from`
* No other logic changes, only naming

### Public API
```swift
OneSignal.User.pushSubscription namespace
    func addObserver(_ observer: OSPushSubscriptionObserver)
    func removeObserver(_ observer: OSPushSubscriptionObserver)
```

```swift
protocol OSPushSubscriptionObserver {
    func onPushSubscriptionDidChange(state: OSPushSubscriptionChangedState)
}
```

```swift
class OSPushSubscriptionChangedState
    let current: OSPushSubscriptionState
    let previous: OSPushSubscriptionState
    func jsonRepresentation() -> NSDictionary 
```

# Testing

## Manual testing
Tested on Physical iPhone 13 with iOS 16.x
- AppDelegate and messaging controller and live activities controllers' callbacks fire when the push subscription changes

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1260)
<!-- Reviewable:end -->
