### PR TITLE
[5.0.0] Notification Click Listener - API update

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -57,16 +57,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
     
-    id openNotificationHandler = ^(OSNotificationOpenedResult *result) {
-        // TODO: opened handler Not triggered
-        NSLog(@"OSNotificationOpenedResult: %@", result.action);
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated"
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notifiation Opened In App Delegate" message:@"Notification Opened In App Delegate" delegate:self cancelButtonTitle:@"Delete" otherButtonTitles:@"Cancel", nil];
-        [alert show];
-        #pragma clang diagnostic pop
-    };
-    
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
     [OneSignal setProvidesNotificationSettingsView:NO];
@@ -75,8 +65,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.InAppMessages paused:true];
 
     [OneSignal.Notifications addForegroundLifecycleListener:self];
-    [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
-
+    [OneSignal.Notifications addClickListener:self];
     [OneSignal.User.pushSubscription addObserver:self];
     NSLog(@"OneSignal Demo App push subscription observer added");
     
@@ -113,6 +102,10 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     NSLog(@"Dev App onPushSubscriptionDidChange: %@", state);
     ViewController* mainController = (ViewController*) self.window.rootViewController;
     mainController.subscriptionSegmentedControl.selectedSegmentIndex = (NSInteger) state.current.optedIn;
+}
+
+- (void)onClickNotification:(OSNotificationClickEvent * _Nonnull)event {
+    NSLog(@"Dev App onClickNotification with event %@", [event jsonRepresentation]);
 }
 
 #pragma mark OSInAppMessageDelegate

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevAppClip/AppDelegate.m
@@ -54,10 +54,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.Debug setLogLevel:ONE_S_LL_VERBOSE];
     [OneSignal.Debug setAlertLevel:ONE_S_LL_NONE];
     _notificationDelegate = [OneSignalNotificationCenterDelegate new];
-    
-    id openNotificationHandler = ^(OSNotificationOpenedResult *result) {
-        NSLog(@"OSNotificationOpenedResult: %@", result.action);
-    };
 
     // OneSignal Init with app id and lauch options
     [OneSignal setLaunchURLsInApp:YES];
@@ -74,8 +70,6 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     
     [OneSignal.InAppMessages paused:false];
     
-    [OneSignal.Notifications setNotificationOpenedHandler:openNotificationHandler];
-
     NSLog(@"UNUserNotificationCenter.delegate: %@", UNUserNotificationCenter.currentNotificationCenter.delegate);
     
     return YES;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotificationClasses.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotificationClasses.h
@@ -36,20 +36,17 @@ typedef NS_ENUM(NSUInteger, OSNotificationActionType)  {
     OSNotificationActionTypeActionTaken
 };
 
-@interface OSNotificationAction : NSObject
-
-/* The type of the notification action */
-@property(readonly)OSNotificationActionType type;
-
+@interface OSNotificationClickResult : NSObject
 /* The ID associated with the button tapped. NULL when the actionType is NotificationTapped */
 @property(readonly, nullable)NSString* actionId;
+@property(readonly, nullable)NSString* url;
 
 @end
 
-@interface OSNotificationOpenedResult : NSObject
+@interface OSNotificationClickEvent : NSObject
 
 @property(readonly, nonnull)OSNotification* notification;
-@property(readonly, nonnull)OSNotificationAction *action;
+@property(readonly, nonnull)OSNotificationClickResult *result;
 
 /* Convert object into an NSString that can be convertible into a custom Dictionary / JSON Object */
 - (NSString* _Nonnull)stringify;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.h
@@ -33,7 +33,7 @@
 +(void)init;
 +(void)updateFromDownloadParams:(NSDictionary*)params;
 
-+(void)trackOpenEvent:(OSNotificationOpenedResult*)results;
++(void)trackOpenEvent:(OSNotificationClickEvent*)event;
 +(void)trackReceivedEvent:(OSNotification*)notification;
 +(void)trackInfluenceOpenEvent;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
@@ -87,7 +87,7 @@ static BOOL trackingEnabled = false;
     return [notification.title substringToIndex:titleLength];
 }
 
-+ (void)trackOpenEvent:(OSNotificationOpenedResult*)results {
++ (void)trackOpenEvent:(OSNotificationClickEvent*)event {
     if (!trackingEnabled)
         return;
     
@@ -97,8 +97,8 @@ static BOOL trackingEnabled = false;
                 parameters:@{
                     @"source": @"OneSignal",
                     @"medium": @"notification",
-                    @"notification_id": results.notification.notificationId,
-                    @"campaign": [self getCampaignNameFromNotification:results.notification]
+                    @"notification_id": event.notification.notificationId,
+                    @"campaign": [self getCampaignNameFromNotification:event.notification]
                 }];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -32,7 +32,10 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalNotifications/OSNotification+OneSignal.h>
 
-typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull result);
+@protocol OSNotificationClickListener <NSObject>
+- (void)onClickNotification:(OSNotificationClickEvent *_Nonnull)event
+NS_SWIFT_NAME(onClick(event:));
+@end
 
 @interface OSNotificationWillDisplayEvent : NSObject
 
@@ -54,8 +57,8 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (OSNotificationPermission)permissionNative NS_REFINED_FOR_SWIFT;
 + (void)addForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener;
 + (void)removeForegroundLifecycleListener:(NSObject<OSNotificationLifecycleListener> *_Nullable)listener;
-
-+ (void)setNotificationOpenedHandler:(OSNotificationOpenedBlock _Nullable)block;
++ (void)addClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener NS_REFINED_FOR_SWIFT;
++ (void)removeClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener NS_REFINED_FOR_SWIFT;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block;
 + (void)requestPermission:(OSUserResponseBlock _Nullable )block fallbackToSettings:(BOOL)fallback;
 + (void)registerForProvisionalAuthorization:(OSUserResponseBlock _Nullable )block NS_REFINED_FOR_SWIFT;
@@ -111,8 +114,7 @@ typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull 
 + (void)setPushSubscriptionId:(NSString *_Nullable)pushSubscriptionId;
 
 + (void)handleWillShowInForegroundForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
-+ (void)handleNotificationAction:(OSNotificationActionType)actionType actionID:(NSString* _Nonnull)actionID;
-
++ (void)handleNotificationActionWithUrl:(NSString* _Nullable)url actionID:(NSString* _Nonnull)actionID;
 + (BOOL)clearBadgeCount:(BOOL)fromNotifOpened;
 
 + (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalSwiftInterface.swift
@@ -124,6 +124,14 @@ public extension OSNotifications {
     static func removePermissionObserver(_ observer: OSNotificationPermissionObserver) {
         return __remove(observer)
     }
+    
+    static func addClickListener(_ listener: OSNotificationClickListener) {
+        return __add(listener)
+    }
+    
+    static func removeClickListener(_ listener: OSNotificationClickListener) {
+        return __remove(listener)
+    }
 }
 
 public extension OSLocation {


### PR DESCRIPTION
# Description
## One Line Summary
Notification Click Listener - API update

## Details

### Motivation
Notification Click Listener - API update

### Scope
* Rename API around `setNotificationOpenedHandler` -> `addClickListener`, `removeClickListener`
* Also support adding multiple listeners, and removal.
* Rename object `OSNotificationOpenedResult` -> `OSNotificationClickEvent`
* Rename object `OSNotificationAction` -> `OSNotificationClickResult`
* Some small properties changes on those interfaces.

### Public API
```objc
OneSignal.Notifications namespace
    + (void)addClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener
    + (void)removeClickListener:(NSObject<OSNotificationClickListener>*_Nonnull)listener
```

```objc
OSNotificationClickListener
    - (void)onClickNotification:(OSNotificationClickEvent *_Nonnull)event
    func onClick(event: OSNotificationClickEvent) // For Swift API refined
```

```objc
OSNotificationClickEvent
    @property(readonly, nonnull)OSNotification* notification
    @property(readonly, nonnull)OSNotificationClickResult *result
    - (NSString* _Nonnull)stringify
    - (NSDictionary *_Nonnull)jsonRepresentation
```

```objc
OSNotificationClickResult
    @property(readonly, nullable)NSString* actionId
    @property(readonly, nullable)NSString* url
```

# Testing
## Manual testing
Test on physical iPhone 13 with iOS 16.x
- tested adding multiple click listeners and their removal
- tested accessing properties of the objects
- tested that click events are saved if there are no click listeners and then once a click listener is added, it is fired with the saved click events (existing behavior pre-user model).


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1262)
<!-- Reviewable:end -->
