### PR TITLE
[User model] Fix PushSubscriptionChanged state json representation

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -82,7 +82,7 @@ public class OSPushSubscriptionChangedState: NSObject {
     }
 
     @objc public func jsonRepresentation() -> NSDictionary {
-        return ["from": previous.jsonRepresentation(), "to": current.jsonRepresentation()]
+        return ["previous": previous.jsonRepresentation(), "current": current.jsonRepresentation()]
     }
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Use previous/current keys instead of to/from

## Details
The `jsonRepresentation` function of the PushSubscriptionChangedState was still using the old key names instead of previous/current.

### Motivation
fix

### Scope
PushSubscriptionChangedState (wrappers)

# Testing

## Manual testing
tested physically 

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1265)
<!-- Reviewable:end -->
