### PR TITLE
[5.0.0] add more to update subscription payload

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -1266,6 +1266,9 @@ class OSRequestUpdateSubscription: OneSignalRequest, OSUserRequest {
         subscriptionParams.removeValue(forKey: "address")
         subscriptionParams.removeValue(forKey: "notificationTypes")
         subscriptionParams["token"] = subscriptionModel.address
+        subscriptionParams["device_os"] = subscriptionModel.deviceOs
+        subscriptionParams["sdk"] = subscriptionModel.sdk
+        subscriptionParams["app_version"] = subscriptionModel.appVersion
 
         // notificationTypes defaults to -1 instead of nil, don't send if it's -1
         if subscriptionModel.notificationTypes != -1 {


### PR DESCRIPTION
# Description
## One Line Summary
Send also `device_os`, `sdk` version, `app_version` to the update subscription request.

## Details

### Motivation
The primary motivation for this change is when migrating a legacy player, we don't call Create User but we want to update the server to know the **new 5.x.x sdk version**. We do call Update Subscription, so let's add more information in this payload. Along with this, let's include `device_os` and `app_version` as well since those can change without the SDK detecting them.

### Scope
Giving info on `device_os`, `sdk` version, `app_version` to server more often (with every update subscription request).

### Refactoring Preferred
We detect changes to `subscription_id`, `push token`, `enabled` and send updates to the server. We currently do not create Deltas nor detect for changes to `app_version`, `device_os`, `sdk` version, etc.

# Testing
## Manual testing
Tested on iPhone 13 with os 16.4.1:
1. New install of the example app with SDK version `3.12.5`.
2. Add a tag and an external ID via the example app.
3. Check dashboard for this data as well as `player_id`, `onesignal_id`, `sdk` version, and push token
4. Close app and run example app with SDK version `5.0.0-beta-02` to show migrating a legacy player.
5. Check dashboard that `sdk` version is updated while all other info is the same. Previously, this remained `3.12.5`.
6. Check models information in the device and see that `external_id`, `subscription_id`, `onesignal_id`, `tags` are correct and same as before.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1266)
<!-- Reviewable:end -->
