### PR TITLE
Always remove the window when an IAM is dismissed 

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMessagingController.m
@@ -322,6 +322,7 @@ static BOOL _isInAppMessagingPaused = false;
 - (void)displayMessage:(OSInAppMessageInternal *)message {
     // Check if the app disabled IAMs for this device before showing an IAM
     if (_isInAppMessagingPaused && !message.isPreview) {
+        [self cleanUpInAppWindow];
         [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"In app messages will not show while paused"];
         return;
     }
@@ -605,7 +606,7 @@ static BOOL _isInAppMessagingPaused = false;
             [self persistInAppMessageForRedisplay:showingIAM];
         }
         // Reset the IAM viewController to prepare for next IAM if one exists
-        self.viewController = nil;
+        [self cleanUpInAppWindow];
         // Reset time since last IAM
         [self setAndPersistTimeSinceLastMessage];
 
@@ -614,6 +615,19 @@ static BOOL _isInAppMessagingPaused = false;
         } else { //do nothing prompt is handling the re-showing
             [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"Stop evaluateMessageDisplayQueue because prompt is currently displayed"];
         }
+    }
+}
+
+- (void)cleanUpInAppWindow {
+    self.viewController = nil;
+    if (self.window) {
+        /*
+         Hide the top level IAM window
+         After the IAM window is hidden, iOS will automatically promote the main window
+         This also re-shows the keyboard automatically if it had focus in a text input
+        */
+        self.window.hidden = true;
+        self.window = nil;
     }
 }
 
@@ -636,19 +650,10 @@ static BOOL _isInAppMessagingPaused = false;
         [self displayMessage:self.messageDisplayQueue.firstObject];
         return;
     } else {
-        [self hideWindow];
+        [self cleanUpInAppWindow];
         // Evaulate any IAMs (could be new IAM or added trigger conditions)
         [self evaluateMessages];
     }
-}
-
-/*
- Hide the top level IAM window
- After the IAM window is hidden, iOS will automatically promote the main window
- This also re-shows the keyboard automatically if it had focus in a text input
-*/
-- (void)hideWindow {
-    self.window.hidden = true;
 }
 
 - (void)persistInAppMessageForRedisplay:(OSInAppMessageInternal *)message {
@@ -861,7 +866,6 @@ static BOOL _isInAppMessagingPaused = false;
         self.window.windowLevel = UIWindowLevelAlert;
         self.window.frame = [[UIScreen mainScreen] bounds];
     }
-    
     self.window.rootViewController = _viewController;
     self.window.backgroundColor = [UIColor clearColor];
     self.window.opaque = true;


### PR DESCRIPTION
# Description
## One Line Summary
Always remove the window when an IAM is dismissed

## Details

If you do any kind of prompt action while having another IAM queued for display with the same trigger the IAM, the IAM can get stuck and prevent clicking on the app beneath it. We can avoid this by ensuring the window is always removed when the IAM is dismissed

### Asana Task
https://app.asana.com/0/1198177413178126/1204945334125976/f

### Motivation
**REQUIRED -** Why is this code change being made? Or what is the goal of this PR? Examples: Fixes a specific bug, provides additional logging to debug future issues, feature to allow X.

Customer is complaining that when they open the iOS native payment screen from an IAM button click, the IAM gets stuck and prevents payment.

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

We've tested trying to dismiss the IAM while simultaneously adding a click name and pausing all IAMs. This can occasionally cause the IAM's view controller to get stuck and it's window will block you from clicking the app underneath

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1276)
<!-- Reviewable:end -->
