### PR TITLE
[5.0.0] Support multiple IAM + Notification Lifecycle Listeners

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalExample.xcodeproj/xcshareddata/xcschemes/OneSignalExample.xcscheme
+++ b/iOS_SDK/OneSignalDevApp/OneSignalExample.xcodeproj/xcshareddata/xcschemes/OneSignalExample.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9112E8811E724C320022A1CB"
+               BuildableName = "OneSignalExample.app"
+               BlueprintName = "OneSignalExample"
+               ReferencedContainer = "container:OneSignalExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9112E8811E724C320022A1CB"
+            BuildableName = "OneSignalExample.app"
+            BlueprintName = "OneSignalExample"
+            ReferencedContainer = "container:OneSignalExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9112E8811E724C320022A1CB"
+            BuildableName = "OneSignalExample.app"
+            BlueprintName = "OneSignalExample"
+            ReferencedContainer = "container:OneSignalExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSInAppMessages.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSInAppMessages.h
@@ -33,7 +33,7 @@
 
 @property (strong, nonatomic, nonnull) NSString *messageId;
 
-// Convert the object into a NSDictionary
+// Dictionary of properties available on OSInAppMessage only
 - (NSDictionary *_Nonnull)jsonRepresentation;
 
 @end
@@ -78,18 +78,22 @@ typedef NS_ENUM(NSUInteger, OSInAppMessageActionUrlType) {
 
 @interface OSInAppMessageWillDisplayEvent : NSObject
 @property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+- (NSDictionary *_Nonnull)jsonRepresentation;
 @end
 
 @interface OSInAppMessageDidDisplayEvent : NSObject
 @property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+- (NSDictionary *_Nonnull)jsonRepresentation;
 @end
 
 @interface OSInAppMessageWillDismissEvent : NSObject
 @property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+- (NSDictionary *_Nonnull)jsonRepresentation;
 @end
 
 @interface OSInAppMessageDidDismissEvent : NSObject
 @property (nonatomic, readonly, nonnull) OSInAppMessage *message;
+- (NSDictionary *_Nonnull)jsonRepresentation;
 @end
 
 @interface OSInAppMessageClickEvent : NSObject

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.h
@@ -66,8 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)addInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener;
 - (void)removeInAppMessageClickListener:(NSObject<OSInAppMessageClickListener> *_Nullable)listener;
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate;
-- (void)removeInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate;
+- (void)addInAppMessageLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener;
+- (void)removeInAppMessageLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -123,7 +123,7 @@
 
 @property (nonatomic) NSMutableArray<NSObject<OSInAppMessageClickListener> *> *clickListeners;
 
-@property (weak, nonatomic, nullable) NSObject<OSInAppMessageLifecycleListener> *inAppMessageDelegate;
+@property (nonatomic) NSMutableArray<NSObject<OSInAppMessageLifecycleListener> *> *lifecycleListeners;
 
 @property (strong, nullable) OSInAppMessageViewController *viewController;
 
@@ -201,6 +201,7 @@ static BOOL _isInAppMessagingPaused = false;
         [self initializeTriggerController];
         self.messageDisplayQueue = [NSMutableArray new];
         self.clickListeners = [NSMutableArray new];
+        self.lifecycleListeners = [NSMutableArray new];
         
         let standardUserDefaults = OneSignalUserDefaults.initStandard;
         
@@ -341,43 +342,47 @@ static BOOL _isInAppMessagingPaused = false;
     [_clickListeners removeObject:listener];
 }
 
-- (void)setInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate {
-    _inAppMessageDelegate = delegate;
+- (void)addInAppMessageLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {
+    [_lifecycleListeners addObject:listener];
 }
 
-- (void)removeInAppMessageDelegate:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)delegate {
-    _inAppMessageDelegate = nil;
+- (void)removeInAppMessageLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {
+    [_lifecycleListeners removeObject:listener];
 }
 
 - (void)onWillDisplayInAppMessage:(OSInAppMessageInternal *)message {
-    if (self.inAppMessageDelegate &&
-        [self.inAppMessageDelegate respondsToSelector:@selector(onWillDisplayInAppMessage:)]) {
-        OSInAppMessageWillDisplayEvent *event = [[OSInAppMessageWillDisplayEvent alloc] initWithInAppMessage:message];
-        [self.inAppMessageDelegate onWillDisplayInAppMessage:event];
+    for (NSObject<OSInAppMessageLifecycleListener> *listener in _lifecycleListeners) {
+        if ([listener respondsToSelector:@selector(onWillDisplayInAppMessage:)]) {
+            OSInAppMessageWillDisplayEvent *event = [[OSInAppMessageWillDisplayEvent alloc] initWithInAppMessage:message];
+            [listener onWillDisplayInAppMessage:event];
+        }
     }
 }
 
 - (void)onDidDisplayInAppMessage:(OSInAppMessageInternal *)message {
-    if (self.inAppMessageDelegate &&
-        [self.inAppMessageDelegate respondsToSelector:@selector(onDidDisplayInAppMessage:)]) {
-        OSInAppMessageDidDisplayEvent *event = [[OSInAppMessageDidDisplayEvent alloc] initWithInAppMessage:message];
-        [self.inAppMessageDelegate onDidDisplayInAppMessage:event];
+    for (NSObject<OSInAppMessageLifecycleListener> *listener in _lifecycleListeners) {
+        if ([listener respondsToSelector:@selector(onDidDisplayInAppMessage:)]) {
+            OSInAppMessageDidDisplayEvent *event = [[OSInAppMessageDidDisplayEvent alloc] initWithInAppMessage:message];
+            [listener onDidDisplayInAppMessage:event];
+        }
     }
 }
 
 - (void)onWillDismissInAppMessage:(OSInAppMessageInternal *)message {
-    if (self.inAppMessageDelegate &&
-        [self.inAppMessageDelegate respondsToSelector:@selector(onWillDismissInAppMessage:)]) {
-        OSInAppMessageWillDismissEvent *event = [[OSInAppMessageWillDismissEvent alloc] initWithInAppMessage:message];
-        [self.inAppMessageDelegate onWillDismissInAppMessage:event];
+    for (NSObject<OSInAppMessageLifecycleListener> *listener in _lifecycleListeners) {
+        if ([listener respondsToSelector:@selector(onWillDismissInAppMessage:)]) {
+            OSInAppMessageWillDismissEvent *event = [[OSInAppMessageWillDismissEvent alloc] initWithInAppMessage:message];
+            [listener onWillDismissInAppMessage:event];
+        }
     }
 }
 
 - (void)onDidDismissInAppMessage:(OSInAppMessageInternal *)message {
-    if (self.inAppMessageDelegate &&
-        [self.inAppMessageDelegate respondsToSelector:@selector(onDidDismissInAppMessage:)]) {
-        OSInAppMessageDidDismissEvent *event = [[OSInAppMessageDidDismissEvent alloc] initWithInAppMessage:message];
-        [self.inAppMessageDelegate onDidDismissInAppMessage:event];
+    for (NSObject<OSInAppMessageLifecycleListener> *listener in _lifecycleListeners) {
+        if ([listener respondsToSelector:@selector(onDidDismissInAppMessage:)]) {
+            OSInAppMessageDidDismissEvent *event = [[OSInAppMessageDidDismissEvent alloc] initWithInAppMessage:message];
+            [listener onDidDismissInAppMessage:event];
+        }
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -39,31 +39,63 @@
 #import "OSSessionManager.h"
 
 @implementation OSInAppMessageWillDisplayEvent
+
 - (OSInAppMessageWillDisplayEvent*)initWithInAppMessage:(OSInAppMessage *)message {
     _message = message;
     return self;
 }
+
+- (NSDictionary *)jsonRepresentation {
+    NSMutableDictionary *json = [NSMutableDictionary new];
+    json[@"message"] = [self.message jsonRepresentation];
+    return json;
+}
+
 @end
 
 @implementation OSInAppMessageDidDisplayEvent
+
 - (OSInAppMessageDidDisplayEvent*)initWithInAppMessage:(OSInAppMessage *)message {
     _message = message;
     return self;
 }
+
+- (NSDictionary *)jsonRepresentation {
+    NSMutableDictionary *json = [NSMutableDictionary new];
+    json[@"message"] = [self.message jsonRepresentation];
+    return json;
+}
+
 @end
 
 @implementation OSInAppMessageWillDismissEvent
+
 - (OSInAppMessageWillDismissEvent*)initWithInAppMessage:(OSInAppMessage *)message {
     _message = message;
     return self;
 }
+
+- (NSDictionary *)jsonRepresentation {
+    NSMutableDictionary *json = [NSMutableDictionary new];
+    json[@"message"] = [self.message jsonRepresentation];
+    return json;
+}
+
 @end
 
 @implementation OSInAppMessageDidDismissEvent
+
 - (OSInAppMessageDidDismissEvent*)initWithInAppMessage:(OSInAppMessage *)message {
     _message = message;
     return self;
 }
+
+- (NSDictionary *)jsonRepresentation {
+    NSMutableDictionary *json = [NSMutableDictionary new];
+    json[@"message"] = [self.message jsonRepresentation];
+    return json;
+}
+
 @end
 
 @interface OSMessagingController ()
@@ -565,10 +597,10 @@ static BOOL _isInAppMessagingPaused = false;
     BOOL messageDismissed = [_seenInAppMessages containsObject:message.messageId];
     let redisplayMessageSavedData = [_redisplayedInAppMessages objectForKey:message.messageId];
 
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Redisplay dismissed: %@ and data: %@", messageDismissed ? @"YES" : @"NO", redisplayMessageSavedData.jsonRepresentation.description]];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Redisplay dismissed: %@ and data: %@", messageDismissed ? @"YES" : @"NO", redisplayMessageSavedData.jsonRepresentationInternal.description]];
 
     if (messageDismissed && redisplayMessageSavedData) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Redisplay IAM: %@", message.jsonRepresentation.description]];
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"Redisplay IAM: %@", message.jsonRepresentationInternal.description]];
         
         message.displayStats.displayQuantity = redisplayMessageSavedData.displayStats.displayQuantity;
         message.displayStats.lastDisplayTime = redisplayMessageSavedData.displayStats.lastDisplayTime;

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageClickEvent.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageClickEvent.m
@@ -38,7 +38,7 @@
 
 - (NSDictionary *)jsonRepresentation {
     let json = [NSMutableDictionary new];
-    json[@"message"] = self.message;
+    json[@"message"] = [self.message jsonRepresentation];
     json[@"result"] = [self.result jsonRepresentation];
     return json;
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageInternal.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageInternal.h
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addClickId:(NSString *)clickId;
 
 - (BOOL)isFinished;
+// Dictionary of properties available on OSInAppMessageInternal
+- (NSDictionary *_Nonnull)jsonRepresentationInternal;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageInternal.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageInternal.m
@@ -165,7 +165,7 @@
     return message;
 }
 
--(NSDictionary *)jsonRepresentation {
+- (NSDictionary *)jsonRepresentationInternal {
     let json = [NSMutableDictionary new];
     
     json[@"messageId"] = self.messageId;

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/OneSignalInAppMessages.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/OneSignalInAppMessages.m
@@ -64,12 +64,12 @@
 
 + (void)addLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message lifecycle listener added successfully"];
-    [OSMessagingController.sharedInstance setInAppMessageDelegate:listener];
+    [OSMessagingController.sharedInstance addInAppMessageLifecycleListener:listener];
 }
 
 + (void)removeLifecycleListener:(NSObject<OSInAppMessageLifecycleListener> *_Nullable)listener {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"In app message lifecycle listener removed successfully"];
-    [OSMessagingController.sharedInstance removeInAppMessageDelegate:listener];
+    [OSMessagingController.sharedInstance removeInAppMessageLifecycleListener:listener];
 }
 
 + (void)addTrigger:(NSString * _Nonnull)key withValue:(NSString * _Nonnull)value {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -80,7 +80,6 @@ NS_SWIFT_NAME(onClick(event:));
 @interface OSNotificationsManager : NSObject <OSNotifications>
 
 @property (class, weak, nonatomic, nullable) id<OneSignalNotificationsDelegate> delegate;
-@property (class, weak, nonatomic, nullable) NSObject<OSNotificationLifecycleListener> *lifecycleListener;
 
 + (Class<OSNotifications> _Nonnull)Notifications;
 + (void)start;

--- a/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/OSInAppMessagingHelpers.m
@@ -273,7 +273,7 @@ int messageIdIncrementer = 0;
 
 // jsonRepresentation uses key of "messageId" but we need to use key of "id" for creating IAM, etc.
 + (NSDictionary *)convertIAMtoJson:(OSInAppMessageInternal *)message {
-    NSMutableDictionary *json = [message.jsonRepresentation mutableCopy];
+    NSMutableDictionary *json = [message.jsonRepresentationInternal mutableCopy];
     json[@"id"] = message.messageId;
     [json removeObjectForKey:@"messageId"];
     return json;


### PR DESCRIPTION
# Description
## One Line Summary
Support multiple IAM Lifecycle Listeners + Notification Foreground Lifecycle Listeners.

## Details

### Motivation
No API change, but under the hood, support adding multiple listeners that remained a TODO after these two PRs:
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1257
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1258

### Scope
Letting app developers add and remove multiple listeners. When there are multiple notification foreground listeners, essentially first one wins. The first listener to call `preventDefault` and `display` will trigger these events.

In addition, added `jsonRepresentation` to IAM lifecycle events
* so developers can call `[event jsonRepresentation]`
* We only want to show the properties available on `OSInAppMessage`, however since `OSInAppMessageInternal` is a subclass of `OSInAppMessage`, we end up exposing the internal properties. Therefore, I renamed the method on `OSInAppMessageInternal` to `jsonRepresentationInternal`, which is used for debugging.

# Testing
## Manual testing
Tested on iPhone 13 device on iOS version 16.5
- Tested adding and removing multiple listeners and that they are fired.
- Tested multiple listeners being involved in the notification display, by calling `display` and `preventDefault` in various configurations.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1278)
<!-- Reviewable:end -->
