### PR TITLE
[5.0.0] Better handling server error responses

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSNetworkingUtils.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSNetworkingUtils.h
@@ -29,9 +29,18 @@
 
 // NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, OSResponseStatusType) {
+    OSResponseStatusInvalid = 0,
+    OSResponseStatusRetryable,
+    OSResponseStatusUnauthorized,
+    OSResponseStatusMissing,
+    OSResponseStatusConflict
+};
+
 @interface OSNetworkingUtils : NSObject
 
 + (NSNumber*)getNetType;
++ (OSResponseStatusType)getResponseStatusType:(NSInteger)statusCode;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSNetworkingUtils.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OSNetworkingUtils.m
@@ -38,4 +38,18 @@
     return @1;
 }
 
++ (OSResponseStatusType)getResponseStatusType:(NSInteger)statusCode {
+    if (statusCode == 400 || statusCode == 402) {
+        return OSResponseStatusInvalid;
+    } else if (statusCode == 401 || statusCode == 403) {
+        return OSResponseStatusUnauthorized;
+    } else if (statusCode == 404 || statusCode == 410) {
+        return OSResponseStatusMissing;
+    } else if (statusCode == 409) {
+        return OSResponseStatusConflict;
+    } else {
+        return OSResponseStatusRetryable;
+    }
+}
+
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertyOperationExecutor.swift
@@ -135,17 +135,30 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
 
         OneSignalClient.shared().execute(request) { _ in
             // On success, remove request from cache, and we do need to hydrate
-            // TODO: We need to hydrate after all
+            // TODO: We need to hydrate after all ? What why ?
             self.updateRequestQueue.removeAll(where: { $0 == request})
             OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
         } onFailure: { error in
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSPropertyOperationExecutor update properties request failed with error: \(error.debugDescription)")
-            // TODO: Differentiate error cases
-            // If the error is not retryable, remove from cache and queue
-            if let nsError = error as? NSError,
-               nsError.code < 500 && nsError.code != 0 {
-                self.updateRequestQueue.removeAll(where: { $0 == request})
-                OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
+            if let nsError = error as? NSError {
+                let responseType = OSNetworkingUtils.getResponseStatusType(nsError.code)
+                if responseType == .missing {
+                    // remove from cache and queue
+                    self.updateRequestQueue.removeAll(where: { $0 == request})
+                    OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
+                    // Logout if the user in the SDK is the same
+                    guard OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel)
+                    else {
+                        return
+                    }
+                    // The subscription has been deleted along with the user, so remove the subscription_id but keep the same push subscription model
+                    OneSignalUserManagerImpl.sharedInstance.pushSubscriptionModelStore.getModels()[OS_PUSH_SUBSCRIPTION_MODEL_KEY]?.subscriptionId = nil
+                    OneSignalUserManagerImpl.sharedInstance._logout()
+                } else if responseType != .retryable {
+                    // Fail, no retry, remove from cache and queue
+                    self.updateRequestQueue.removeAll(where: { $0 == request})
+                    OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
+                }
             }
         }
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -359,6 +359,10 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
             OneSignalLog.onesignalLog(.LL_DEBUG, message: "OneSignal.User logout called, but the user is currently anonymous, so not logging out.")
             return
         }
+        _logout()
+    }
+
+    public func _logout() {
         prepareForNewUser()
         _user = nil
         createUserIfNil()


### PR DESCRIPTION
# Description
## One Line Summary
Better, but not yet perfect, handling of error responses for requests including conflicts and deleted users.

## Details

### Motivation
The SDK can receive many types of error responses to the requests it makes such as when we update a user but find the user has been deleted on the server, etc. We want to handle them gracefully.

### Scope
**Make `OSResponseStatusType` enum to categorize status codes**
* Borrow from Android and introduce 5 categories of server responses: Invalid, Unauthorized, Missing, Conflict, Retryable
* Use this enum to categorize server error responses.

**Handling errors**
* When we receive a missing status code, such that the user has been deleted, we will effectively perform a logout within the SDK and create a fresh, blank, anonymous user. But only if the SDK user is still the same one, otherwise, do nothing.
* When a user is deleted, their subscriptions are as well. Therefore, set the subscription_id to `nil` so that the createUser request will hydrate with a new subscription_id. We still keep the same subscription model whose data is sent in the createUser request.
* Requests to add alias can return a 409 (conflict) if any of the aliases exist on another user, and does not apply _any_ of them, even the ones that can be applied. In this case, we remove these aliases from our local model.
* A 404 response for removing an alias can be misleading. It may be that this user is deleted, or that the alias didn't exist on this user. Therefore, treat it as a no-op so we don't inadvertently nix the SDK's user.

# Testing
## Manual testing
Tested on iPhone 13 device using iOS 16.5. Sample of scenarios tested:
1. SDK has an anonymous user -> delete the user via REST API -> add a tag -> a new anonymous user will be created and receive a new subscription_id
2. Delete user via REST API -> add a tag and then an alias -> only 1 createUser request is made -> SDK creates a blank user
3. Kill app -> delete user via REST API -> open app which calls fetch user -> a new createUser request is made
4. Test adding an email to a deleted user
6. In all scenarios I send a notification after these flows and receive it.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1279)
<!-- Reviewable:end -->
