### PR TITLE
Fix swizzling subclass of already swizzled class

### DIFF
--- a/iOS_SDK/OneSignalSDK/UnitTests/UIApplicationDelegateSwizzlingTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/UIApplicationDelegateSwizzlingTests.m
@@ -466,7 +466,7 @@ static id<UIApplicationDelegate> orignalDelegate;
     XCTAssertTrue([OtherLibraryASwizzler selectorCalled]);
     
     // 7. Ensure other library subclass selector is still called too.
-    XCTAssertTrue([OtherLibraryASwizzler selectorCalled]);
+    XCTAssertTrue([OtherLibraryBSwizzlerSubClass selectorCalled]);
 }
 
 - (void)testCompatibleWithOtherSwizzlerWhenSwapingBetweenNil {


### PR DESCRIPTION
# Description
## One Line Summary
Fixing an issue where OneSignal would swizzle a subclass of an already swizzled class

## Details
Fixes #1272
Fixes  #1143 
The bug is only reproducible with both Instabug and Firebase libraries.
The crucial factor here is that Google's libraries create GULApplicationDelegate classes which subclass the App's AppDelegate class.
OneSignal swizzles AppDelegate on load, then the Google libraries set their GULApplicationDelegate classes as the application's delegate, which triggers OneSignal to swizzle again. 
This was not creating an issue with only firebase, but when also including Instabug there was an infinite loop. This is because when we swizzle the second time, the original implementation already includes Instabug calling OneSignal's AppDelegate. This means that our new implementation will include calling Instabug, which calls OneSignal, which calls Instabug, etc.


### Motivation
Fixes infinite loop issues with other libraries

### Scope
AppDelegate swizzling

# Testing
## Unit testing
New unit test to detect this case

## Manual testing
I tested by integrating both Instabug and Firebase. The bug is only reproducible with both of those libraries. I tested on the branch named "instabug_conflict" if reviewers would like to manually test with that integration setup.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1284)
<!-- Reviewable:end -->
