### PR TITLE
[5.0.0] Fix direct session influence

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -70,10 +70,10 @@
 		3C2D8A5928B4C4E300BE41F6 /* OSDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */; };
 		3C44673E296D099D0039A49E /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
 		3C44673F296D09CC0039A49E /* OneSignalMobileProvision.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FC1E73342200E41FD7 /* OneSignalMobileProvision.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3C448B9D2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C448B9B2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h */; };
-		3C448B9E2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */; };
-		3C448B9F2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */; };
-		3C448BA02936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */; };
+		3C448B9D2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C448B9B2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h */; };
+		3C448B9E2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m */; };
+		3C448B9F2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m */; };
+		3C448BA02936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C448B9C2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m */; };
 		3C448BA22936B474002F96BC /* OSBackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C448BA12936B474002F96BC /* OSBackgroundTaskManager.swift */; };
 		3C47A974292642B100312125 /* OneSignalConfigManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C47A972292642B100312125 /* OneSignalConfigManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C47A975292642B100312125 /* OneSignalConfigManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C47A973292642B100312125 /* OneSignalConfigManager.m */; };
@@ -732,8 +732,8 @@
 		3C2C7DC5288E00AA0020F9AE /* UserModelObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserModelObjcTests.m; sourceTree = "<group>"; };
 		3C2C7DC7288F3C020020F9AE /* OSSubscriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSubscriptionModel.swift; sourceTree = "<group>"; };
 		3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDelta.swift; sourceTree = "<group>"; };
-		3C448B9B2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSBackgroundTaskManagerImpl.h; sourceTree = "<group>"; };
-		3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSBackgroundTaskManagerImpl.m; sourceTree = "<group>"; };
+		3C448B9B2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSBackgroundTaskHandlerImpl.h; sourceTree = "<group>"; };
+		3C448B9C2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSBackgroundTaskHandlerImpl.m; sourceTree = "<group>"; };
 		3C448BA12936B474002F96BC /* OSBackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBackgroundTaskManager.swift; sourceTree = "<group>"; };
 		3C47A972292642B100312125 /* OneSignalConfigManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalConfigManager.h; sourceTree = "<group>"; };
 		3C47A973292642B100312125 /* OneSignalConfigManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalConfigManager.m; sourceTree = "<group>"; };
@@ -1539,8 +1539,8 @@
 				912412051E73342200E41FD7 /* OneSignalTrackIAP.m */,
 				7A93269225AF4E6700BBEC27 /* OSPendingCallbacks.h */,
 				7A93269B25AF4F0200BBEC27 /* OSPendingCallbacks.m */,
-				3C448B9B2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h */,
-				3C448B9C2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m */,
+				3C448B9B2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h */,
+				3C448B9C2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m */,
 				DEC08AFF2947D4E900C81DA3 /* OneSignalSwiftInterface.swift */,
 			);
 			path = Source;
@@ -2105,7 +2105,7 @@
 				7AECE59C23675F5700537907 /* OSFocusTimeProcessorFactory.h in Headers */,
 				7AECE59A23674ADC00537907 /* OSUnattributedFocusTimeProcessor.h in Headers */,
 				9124121D1E73342200E41FD7 /* OneSignalJailbreakDetection.h in Headers */,
-				3C448B9D2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.h in Headers */,
+				3C448B9D2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h in Headers */,
 				912412151E73342200E41FD7 /* OneSignalHelper.h in Headers */,
 				91C7725E1E7CCE1000D612D0 /* OneSignalInternal.h in Headers */,
 			);
@@ -2768,7 +2768,7 @@
 				7A93269C25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */,
 				DE20425E24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
 				7AECE59623674AB700537907 /* OSUnattributedFocusTimeProcessor.m in Sources */,
-				3C448B9E2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */,
+				3C448B9E2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m in Sources */,
 				7AECE59023674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				912412361E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				CA1A6E6A20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
@@ -2815,7 +2815,7 @@
 				7AFE856C2368DDB80091D6A5 /* OSFocusCallParams.m in Sources */,
 				7A93269D25AF4F0200BBEC27 /* OSPendingCallbacks.m in Sources */,
 				DE20425F24E21C2C00350E4F /* UIApplication+OneSignal.m in Sources */,
-				3C448B9F2936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */,
+				3C448B9F2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m in Sources */,
 				912412371E73342200E41FD7 /* OneSignalTrackIAP.m in Sources */,
 				7AECE59123674A9700537907 /* OSAttributedFocusTimeProcessor.m in Sources */,
 				CA1A6E6B20DC2E31001C41B9 /* OneSignalDialogController.m in Sources */,
@@ -2847,7 +2847,7 @@
 				DE16C17024D3989A00670EFA /* OneSignalLifecycleObserver.m in Sources */,
 				CAAE0DFD2195216900A57402 /* OneSignalOverrider.m in Sources */,
 				CA8E190B2194FE0B009DA223 /* OSMessagingControllerOverrider.m in Sources */,
-				3C448BA02936ADFD002F96BC /* OSBackgroundTaskManagerImpl.m in Sources */,
+				3C448BA02936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m in Sources */,
 				7A123295235DFE3B002B6CE3 /* OutcomeTests.m in Sources */,
 				7A4274A425D1C99600EE75FC /* SMSTests.m in Sources */,
 				CAA4ED0120646762005BD59B /* BadgeTests.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -34,6 +34,7 @@
 #import "OneSignalWebViewManager.h"
 #import "UNUserNotificationCenter+OneSignalNotifications.h"
 #import "UIApplicationDelegate+OneSignalNotifications.h"
+#import <OneSignalOutcomes/OSSessionManager.h>
 
 @implementation OSNotificationClickEvent
 @synthesize notification = _notification, result = _result;
@@ -696,10 +697,10 @@ static NSString *_lastnonActiveMessageId;
     
     // Call Action Block
     [self lastMessageReceived:messageDict];
-//    if (!isActive) { TODO: Figure out session stuff from notif opened
-//        OneSignal.appEntryState = NOTIFICATION_CLICK;
-//        [[OSSessionManager sharedSessionManager] onDirectInfluenceFromNotificationOpen:_appEntryState withNotificationId:messageId];
-//    }
+    if (!isActive) {
+        OSSessionManager.sharedSessionManager.appEntryState = NOTIFICATION_CLICK;
+        [[OSSessionManager sharedSessionManager] onDirectInfluenceFromNotificationOpen:NOTIFICATION_CLICK withNotificationId:messageId];
+    }
 
     [self handleNotificationActionWithUrl:notification.launchURL actionID:actionID];
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSBackgroundTaskManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSBackgroundTaskManager.swift
@@ -26,6 +26,7 @@
  */
 
 import Foundation
+import OneSignalCore
 
 @objc
 public protocol OSBackgroundTaskManagerDelegate {
@@ -39,12 +40,12 @@ public protocol OSBackgroundTaskManagerDelegate {
 // check if Core needs to use this, then ok to live here
 @objc
 public class OSBackgroundTaskManager: NSObject {
-    @objc public static weak var delegate: OSBackgroundTaskManagerDelegate?
+    @objc public static var delegate: OSBackgroundTaskManagerDelegate? // TODO: This used to be weak, is that still necessary
 
     @objc
     public static func beginBackgroundTask(_ taskIdentifier: String) {
         guard let delegate = delegate else {
-            // Log error, no delegate
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:beginBackgroundTask \(taskIdentifier) cannot be executed due to no delegate.")
             return
         }
         delegate.beginBackgroundTask(taskIdentifier)
@@ -53,7 +54,7 @@ public class OSBackgroundTaskManager: NSObject {
     @objc
     public static func endBackgroundTask(_ taskIdentifier: String) {
         guard let delegate = delegate else {
-            // Log error, no delegate
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:endBackgroundTask \(taskIdentifier) cannot be executed due to no delegate.")
             return
         }
         delegate.endBackgroundTask(taskIdentifier)
@@ -62,7 +63,7 @@ public class OSBackgroundTaskManager: NSObject {
     @objc
     public static func setTaskInvalid(_ taskIdentifier: String) {
         guard let delegate = delegate else {
-            // Log error, no delegate
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:setTaskInvalid \(taskIdentifier) cannot be executed due to no delegate.")
             // But not necessarily an error because this task won't exist
             // Can be called in initialization of services before delegate is set
             return

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSBackgroundTaskManager.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSBackgroundTaskManager.swift
@@ -29,7 +29,7 @@ import Foundation
 import OneSignalCore
 
 @objc
-public protocol OSBackgroundTaskManagerDelegate {
+public protocol OSBackgroundTaskHandler {
     func beginBackgroundTask(_ taskIdentifier: String)
     func endBackgroundTask(_ taskIdentifier: String)
     func setTaskInvalid(_ taskIdentifier: String)
@@ -40,12 +40,12 @@ public protocol OSBackgroundTaskManagerDelegate {
 // check if Core needs to use this, then ok to live here
 @objc
 public class OSBackgroundTaskManager: NSObject {
-    @objc public static var delegate: OSBackgroundTaskManagerDelegate? // TODO: This used to be weak, is that still necessary
+    @objc public static var taskHandler: OSBackgroundTaskHandler?
 
     @objc
     public static func beginBackgroundTask(_ taskIdentifier: String) {
-        guard let delegate = delegate else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:beginBackgroundTask \(taskIdentifier) cannot be executed due to no delegate.")
+        guard let delegate = taskHandler else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:beginBackgroundTask \(taskIdentifier) cannot be executed due to no task handler.")
             return
         }
         delegate.beginBackgroundTask(taskIdentifier)
@@ -53,8 +53,8 @@ public class OSBackgroundTaskManager: NSObject {
 
     @objc
     public static func endBackgroundTask(_ taskIdentifier: String) {
-        guard let delegate = delegate else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:endBackgroundTask \(taskIdentifier) cannot be executed due to no delegate.")
+        guard let delegate = taskHandler else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:endBackgroundTask \(taskIdentifier) cannot be executed due to no task handler.")
             return
         }
         delegate.endBackgroundTask(taskIdentifier)
@@ -62,8 +62,8 @@ public class OSBackgroundTaskManager: NSObject {
 
     @objc
     public static func setTaskInvalid(_ taskIdentifier: String) {
-        guard let delegate = delegate else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:setTaskInvalid \(taskIdentifier) cannot be executed due to no delegate.")
+        guard let delegate = taskHandler else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSBackgroundTaskManager:setTaskInvalid \(taskIdentifier) cannot be executed due to no task handler.")
             // But not necessarily an error because this task won't exist
             // Can be called in initialization of services before delegate is set
             return

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSOutcomesRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSOutcomesRequests.m
@@ -138,7 +138,7 @@ NSString * const OUTCOME_SOURCE = @"source";
     let params = [NSMutableDictionary new];
     params[@"app_id"] = appId;
     params[@"id"] = @"os__session_duration";
-    params[@"session_time"] = activeTime;
+    params[@"session_time"] = @([activeTime intValue]);
     params[@"subscription"] = @{@"id": pushSubscriptionId, @"type": @"iOSPush"};
     params[@"onesignal_id"] = onesignalId;
     

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OSSessionManager.h
@@ -41,19 +41,20 @@
 + (void)resetSharedSessionManager;
 
 @property (nonatomic) id<SessionStatusDelegate> _Nullable delegate;
+@property AppEntryAction appEntryState;
 
 - (instancetype _Nonnull)init:(Class<SessionStatusDelegate> _Nullable)delegate withTrackerFactory:(OSTrackerFactory *_Nonnull)trackerFactory;
 
 - (NSArray<OSInfluence *> *_Nonnull)getInfluences;
 - (NSArray<OSInfluence *> *_Nonnull)getSessionInfluences;
 - (void)initSessionFromCache;
-- (void)restartSessionIfNeeded:(AppEntryAction)entryAction;
+- (void)restartSessionIfNeeded;
 - (void)onInAppMessageReceived:(NSString * _Nonnull)messageId;
 - (void)onDirectInfluenceFromIAMClick:(NSString * _Nonnull)directIAMId;
 - (void)onDirectInfluenceFromIAMClickFinished;
 - (void)onNotificationReceived:(NSString * _Nonnull)notificationId;
 - (void)onDirectInfluenceFromNotificationOpen:(AppEntryAction)entryAction withNotificationId:(NSString * _Nonnull)directNotificationId;
-- (void)attemptSessionUpgrade:(AppEntryAction)entryAction;
-- (NSDate *)sessionLaunchTime;
+- (void)attemptSessionUpgrade;
+- (NSDate *_Nullable)sessionLaunchTime;
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OneSignalOutcomeEventsController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OneSignalOutcomeEventsController.m
@@ -109,6 +109,11 @@ NSMutableSet *unattributedUniqueOutcomeEventsSentSet;
             pushSubscriptionId:(NSString * _Nonnull)pushSubscriptionId
                    onesignalId:(NSString * _Nonnull)onesignalId
                influenceParams:(NSArray<OSFocusInfluenceParam *> * _Nonnull)influenceParams {
+    // Don't send influenced session with time < 1 seconds
+    if ([timeElapsed intValue] < 1) {
+        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"sendSessionEndOutcomes not sending active time %@", timeElapsed]];
+        return;
+    }
     // TODO: What to do onSuccess and onFailure
     [OneSignalClient.sharedClient executeRequest:[OSRequestSendSessionEndOutcomes
                                                   withActiveTime:timeElapsed

--- a/iOS_SDK/OneSignalSDK/Source/OSBackgroundTaskHandlerImpl.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSBackgroundTaskHandlerImpl.h
@@ -28,6 +28,6 @@
 #import <Foundation/Foundation.h>
 #import <OneSignalOSCore/OneSignalOSCore-Swift.h>
 
-@interface OSBackgroundTaskManagerImpl : NSObject <OSBackgroundTaskManagerDelegate>
+@interface OSBackgroundTaskHandlerImpl : NSObject <OSBackgroundTaskHandler>
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OSBackgroundTaskHandlerImpl.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSBackgroundTaskHandlerImpl.m
@@ -25,12 +25,12 @@
  THE SOFTWARE.
  */
 
-#import "OSBackgroundTaskManagerImpl.h"
+#import "OSBackgroundTaskHandlerImpl.h"
 #import <OneSignalOSCore/OneSignalOSCore-Swift.h>
 #import <OneSignalCore/OneSignalCore.h>
 #import <UIKit/UIKit.h>
 
-@implementation OSBackgroundTaskManagerImpl
+@implementation OSBackgroundTaskHandlerImpl
 
 NSMutableDictionary<NSString*, NSNumber*> *tasks;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -137,15 +137,6 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     return _receiveReceiptsController;
 }
 
-static AppEntryAction _appEntryState = APP_CLOSE;
-+ (AppEntryAction)appEntryState {
-    return _appEntryState;
-}
-
-+ (void)setAppEntryState:(AppEntryAction)appEntryState {
-    _appEntryState = appEntryState;
-}
-
 + (NSString*)appId {
     return appId;
 }
@@ -391,7 +382,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
     [OSOutcomes.sharedController clearOutcomes];
 
-    [[OSSessionManager sharedSessionManager] restartSessionIfNeeded:_appEntryState];
+    [[OSSessionManager sharedSessionManager] restartSessionIfNeeded];
     
     [OneSignalTrackFirebaseAnalytics trackInfluenceOpenEvent];
     
@@ -797,6 +788,7 @@ static AppEntryAction _appEntryState = APP_CLOSE;
 
     [[OSMigrationController new] migrate];
 //    sessionLaunchTime = [NSDate date];
+    // TODO: sessionLaunchTime used to always be set in load
     
     [OSDialogInstanceManager setSharedInstance:[OneSignalDialogController sharedInstance]];
 }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -38,7 +38,7 @@
 #import "UIApplicationDelegate+OneSignal.h"
 #import "OSNotification+Internal.h"
 #import "OSMigrationController.h"
-#import "OSBackgroundTaskManagerImpl.h"
+#import "OSBackgroundTaskHandlerImpl.h"
 #import "OSFocusCallParams.h"
 
 #import <OneSignalNotifications/OneSignalNotifications.h>
@@ -481,7 +481,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     
     [[OSMigrationController new] migrate];
     
-    OSBackgroundTaskManager.delegate = [OSBackgroundTaskManagerImpl new];
+    OSBackgroundTaskManager.taskHandler = [OSBackgroundTaskHandlerImpl new];
 
     [self registerForAPNsToken];
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalInternal.h
@@ -39,14 +39,8 @@
 
 @interface OneSignal (OneSignalInternal)
 
-+ (NSDate *_Nonnull)sessionLaunchTime;
-
-
 @property (class, readonly) BOOL didCallDownloadParameters;
 @property (class, readonly) BOOL downloadedParameters;
-
-@property (class) AppEntryAction appEntryState;
-@property (class) OSSessionManager* _Nonnull sessionManager;
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -98,8 +98,8 @@ static BOOL lastOnFocusWasToBackground = YES;
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"Application Foregrounded started"];
     [OSFocusTimeProcessorFactory cancelFocusCall];
     
-    if (OneSignal.appEntryState != NOTIFICATION_CLICK)
-        OneSignal.appEntryState = APP_OPEN;
+    if (OSSessionManager.sharedSessionManager.appEntryState != NOTIFICATION_CLICK)
+        OSSessionManager.sharedSessionManager.appEntryState = APP_OPEN;
    
     lastOpenedTime = [NSDate date].timeIntervalSince1970;
     
@@ -109,7 +109,7 @@ static BOOL lastOnFocusWasToBackground = YES;
     else {
         // This checks if notification permissions changed when app was backgrounded
         [OSNotificationsManager sendNotificationTypesUpdateToDelegate];
-        [[OSSessionManager sharedSessionManager] attemptSessionUpgrade:OneSignal.appEntryState];
+        [[OSSessionManager sharedSessionManager] attemptSessionUpgrade];
         // TODO: Here it used to call receivedInAppMessageJson with nil, this method no longer exists
         // [OneSignal receivedInAppMessageJson:nil];
     }
@@ -125,7 +125,7 @@ static BOOL lastOnFocusWasToBackground = YES;
     if (timeElapsed < -1)
         return;
     
-    OneSignal.appEntryState = APP_CLOSE;
+    OSSessionManager.sharedSessionManager.appEntryState = APP_CLOSE;
 
     let influences = [[OSSessionManager sharedSessionManager] getSessionInfluences];
     let focusCallParams = [self createFocusCallParams:influences onSessionEnded:false];


### PR DESCRIPTION
# Description
## One Line Summary
Fix direct session influence to detect that we opened a notification and will send the influences to the outcomes endpoint.

## Details

### Motivation
We needed to track a session is started from a notification click for influences and outcomes.

### Scope
**Fix session logic from a notification clicked**
* This was a remaining TODO
* Moved where `appEntryState` lives away from `OneSignal` to the `OneSignalOutcomes` module
* Also server expects `session_time` as an int >= 1, not float

**Fix Background Task Manager**
* Removed `weak` reference to delegate as it was immediately null after being set in startup code
* Rename `OSBackgroundTaskManagerDelegate` -> `OSBackgroundTaskHandler` because it is not truly a delegate, but is a concrete implementation that is injected

### Other
A followup PR is made to refactor background tasks further

# Testing
## Unit testing
No

## Manual testing
iPhone 13 pro 16.6 iOS version

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1288)
<!-- Reviewable:end -->
