### PR TITLE
[User model] Fix in app display

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -738,7 +738,7 @@ static BOOL _isInAppMessagingPaused = false;
             [self persistInAppMessageForRedisplay:showingIAM];
         }
         // Reset the IAM viewController to prepare for next IAM if one exists
-        [self cleanUpInAppWindow];
+        self.viewController = nil;
         // Reset time since last IAM
         [self setAndPersistTimeSinceLastMessage];
 

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
@@ -95,12 +95,15 @@
 
 @implementation OSInAppMessageViewController
 
+OSInAppMessageInternal *_dismissingMessage = nil;
+
 - (instancetype _Nonnull)initWithMessage:(OSInAppMessageInternal *)inAppMessage delegate:(id<OSInAppMessageViewControllerDelegate>)delegate {
     if (self = [super init]) {
         self.message = inAppMessage;
         self.delegate = delegate;
         self.useHeightMargin = YES;
         self.useWidthMargin = YES;
+        _dismissingMessage = nil;
     }
     
     return self;
@@ -490,6 +493,10 @@
         [self.delegate messageViewControllerWasDismissed:self.message displayed:NO];
         return;
     }
+    
+    if (_dismissingMessage == self.message) {
+        return;
+    }
         
     [self.delegate messageViewControllerWillDismiss:self.message];
     
@@ -521,7 +528,7 @@
         animationOption = UIViewAnimationOptionCurveEaseIn;
         dismissAnimationDuration = MIN_DISMISSAL_ANIMATION_DURATION;
     }
-
+    _dismissingMessage = self.message;
     [UIView animateWithDuration:dismissAnimationDuration delay:0.0f options:animationOption animations:^{
         self.view.backgroundColor = [UIColor clearColor];
         self.view.alpha = 0.0f;


### PR DESCRIPTION
# Description
## One Line Summary
cherry pick #1276 to the user model branch

## Details
We now always clean up the entire IAM window when an in app is dismissed

### Motivation
Fixes an issue where IAMs with the same trigger were not being displayed back to back

### Scope
IAMs

# Testing

## Manual testing
Tested with on app open trigger IAMs including permission prompts

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1294)
<!-- Reviewable:end -->
