### PR TITLE
[User model] enable push for simulators

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -218,6 +218,11 @@ class OSSubscriptionModel: OSModel {
         // Set test_type if subscription model is PUSH
         if type == .push {
             let releaseMode: OSUIApplicationReleaseMode = OneSignalMobileProvision.releaseMode()
+            #if targetEnvironment(simulator)
+            if (releaseMode == OSUIApplicationReleaseMode.UIApplicationReleaseUnknown) {
+                self.testType = OSUIApplicationReleaseMode.UIApplicationReleaseDev.rawValue
+            }
+            #endif
             // Workaround to unsure how to extract the Int value in 1 step...
             if releaseMode == .UIApplicationReleaseDev {
                 self.testType = OSUIApplicationReleaseMode.UIApplicationReleaseDev.rawValue


### PR DESCRIPTION
# Description
## One Line Summary
Enable push for simulators. Equivalent to #1244 

## Details
Our provision detection in OneSignalMobileProvision is not successfully able to find the embedded mobile provision for simulators. This might only affect Xcode managed provisioning profiles.

This change is a workaround to that issue to always set testType to 1 since simulators need to receive push in the sandbox environment.

### Scope
push on simulators

# Testing


## Manual testing
tested receiving push on a simulator

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1297)
<!-- Reviewable:end -->
