### PR TITLE
Fix crash with direct influence but nil direct id

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/Influence/OSChannelTracker.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/Influence/OSChannelTracker.m
@@ -139,9 +139,14 @@ THE SOFTWARE.
     
     if (_influenceType == DIRECT) {
         if ([self isDirectSessionEnabled]) {
-            NSArray *ids = [NSArray arrayWithObject:_directId];
-            builder.ids = ids;
-            builder.influenceType = DIRECT;
+            if (_directId) {
+                NSArray *ids = [NSArray arrayWithObject:_directId];
+                builder.ids = ids;
+                builder.influenceType = DIRECT;
+            } else {
+                [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"OSChannelTracker:currentSessionInfluence found a direct influence without a direct id."];
+            }
+            
         }
     } else if (_influenceType == INDIRECT) {
         if ([self isIndirectSessionEnabled]) {

--- a/iOS_SDK/OneSignalSDK/UnitTests/ChannelTrackersTests.m
+++ b/iOS_SDK/OneSignalSDK/UnitTests/ChannelTrackersTests.m
@@ -32,6 +32,7 @@
 #import "OneSignalHelper.h"
 
 #import "UnitTestCommonMethods.h"
+#import "OSNotificationTracker.h"
 #import "CommonAsserts.h"
 
 @interface ChannelTrackersTests : XCTestCase
@@ -165,6 +166,21 @@
     XCTAssertEqual(0, [trackerFactory channelsToResetByEntryAction:APP_CLOSE].count);
     XCTAssertEqual(1, [trackerFactory channelsToResetByEntryAction:NOTIFICATION_CLICK].count);
     XCTAssertEqualObjects(@"iam_id", [[[trackerFactory channelsToResetByEntryAction:NOTIFICATION_CLICK] objectAtIndex:0] idTag]);
+}
+
+- (void)testDirectInfluenceWithNullId {
+    [self setOutcomesParamsEnabled];
+    OSNotificationTracker *channelTracker = [[OSNotificationTracker alloc] initWithRepository:[OSInfluenceDataRepository sharedInfluenceDataRepository]];
+    // Set the influence type to direct but do not set the direct id
+    channelTracker.influenceType = DIRECT;
+    OSInfluence *influence = [channelTracker currentSessionInfluence];
+    // The current influence was invalid so the type should be disabled
+    XCTAssertEqual(influence.influenceType, DISABLED);
+    // Set the directId
+    channelTracker.directId = @"testid";
+    influence = [channelTracker currentSessionInfluence];
+    // Now that the directId is set the influence should be valid.
+    XCTAssertEqual(influence.influenceType, DIRECT);
 }
 
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Fixes a crash when a session has a direct influence but the direct id is nil.
Fixes #1310 

## Details
This does not resolve getting into this situation in the first place since we should not have a direction session without a direct id, but this will at least prevent a crash when the issue happens. Instead we will log an error.

### Motivation
prevent crash

### Scope
direct influences

# Testing
## Unit testing
added a unit test for this case

## Manual testing
I could not reproduce the case with a direct influence but no id

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [x] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1311)
<!-- Reviewable:end -->
