### PR TITLE
[3.x.x] Fix crash when notifId or campaign are nil

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalTrackFirebaseAnalytics.m
@@ -134,13 +134,18 @@ static BOOL trackingEnabled = false;
     NSString *notificationId = [sharedUserDefaults getSavedStringForKey:ONESIGNAL_FB_LAST_NOTIFICATION_ID_RECEIVED defaultValue:nil];
     NSString *campaign = [sharedUserDefaults getSavedStringForKey:ONESIGNAL_FB_LAST_GAF_CAMPAIGN_RECEIVED defaultValue:nil];
     
+    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
+           @"source": @"OneSignal",
+           @"medium": @"notification"
+    }];
+    if (notificationId) {
+        params[@"notification_id"] = notificationId;
+    }
+    if (campaign) {
+        params[@"campaign"] = campaign;
+    }
     [self logEventWithName:@"os_notification_influence_open"
-                parameters:@{
-                    @"source": @"OneSignal",
-                    @"medium": @"notification",
-                    @"notification_id": notificationId,
-                    @"campaign": campaign
-                }];
+               parameters:params];
 }
 
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Fixes #1253 
Fix FirebaseAnalytics crash for nil notifId or campaign

## Details
This change was already made in the user model version in #1296 
If the firebase notification id or campaign is nil the code will crash when trying to send the influence open.

### Motivation
fix crash

### Scope
firebase analytics

# Testing
## Unit testing
added a unit test with no FB campaign and id.


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1312)
<!-- Reviewable:end -->
