### PR TITLE
Fix bug when setting app_id from cache

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -63,7 +63,6 @@ typedef void (^OSFailureBlock)(NSError* error);
 // ======= OneSignal Class Interface =========
 @interface OneSignal : NSObject
 
-+ (NSString*)appId;
 + (NSString* _Nonnull)sdkVersionRaw;
 + (NSString* _Nonnull)sdkSemanticVersion;
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -79,7 +79,7 @@ static OneSignalLifecycleObserver* _instance = nil;
 - (void)didBecomeActive {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"application/scene didBecomeActive"];
     
-    if ([OneSignal appId]) {
+    if ([OneSignalConfigManager getAppId]) {
         [OneSignalTracker onFocus:NO];
         let oneSignalLocation = NSClassFromString(@"OneSignalLocation");
         if (oneSignalLocation != nil && [oneSignalLocation respondsToSelector:@selector(onFocus:)]) {
@@ -95,7 +95,7 @@ static OneSignalLifecycleObserver* _instance = nil;
 - (void)willResignActive {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"application/scene willResignActive"];
     
-    if ([OneSignal appId]) {
+    if ([OneSignalConfigManager getAppId]) {
         [OneSignalTracker onFocus:YES];
         // TODO: Method no longer exists, transitions into flushing operation repo on backgrounding.
         // [OneSignal sendTagsOnBackground];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -170,7 +170,7 @@ static BOOL lastOnFocusWasToBackground = YES;
         [focusInfluenceParams addObject:focusInfluenceParam];
     }
 
-    return [[OSFocusCallParams alloc] initWithParamsAppId:[OneSignal appId]
+    return [[OSFocusCallParams alloc] initWithParamsAppId:[OneSignalConfigManager getAppId]
                                               timeElapsed:timeElapsed
                                           influenceParams:focusInfluenceParams
                                            onSessionEnded:onSessionEnded];


### PR DESCRIPTION
# Description
## One Line Summary
Fix bug to read and set the appId from cache when a `null` appId is used in the `initialize` method.

## Details

### Motivation
Wrappers actually need to call `initialize:nil withLaunchOptions:launchOptions` instead of only `setLaunchOptions` so that the SDK can be initialized in order to get the cold start notification click event, and in order to do so, the SDK will read the appId from cache when `nil` is passed.

The above behavior was pre-existing on player model.

This PR fixes a bug that was not setting the appId correctly from the cache.

### Scope
Fix bug when setting app_id from cache

* Fix a bug in setting an appId that is retrieved from cache. We were overwriting it with nil or "" after reading from cache.
* Additionally, remove `appId` property from the OneSignal class because we can manage the appId via the `OneSignalConfigManager`. Better not to have two sources of truth for appId.
* Remove `kOSSettingsKeyInOmitNoAppIdLogging` as it does not appear to be used anymore
* Nit: Clarify logs

# Testing
## Unit testing
None

## Manual testing
iPhone 13 on iOS 16.6.1
1. Call initialize with `nil` app_id on first install. SDK does not initialize.
2. Call initialize with an app_id on second open. SDK initializes and caches the app_id.
3. Call initialize with `nil` app_id on third open. SDK still initializes by using the cached appId.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1317)
<!-- Reviewable:end -->
