### PR TITLE
[v5] Fix forwarding notification opens from non onesignal notifs

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
@@ -308,37 +308,13 @@ void finishProcessingNotification(UNNotification *notification,
     completionHandler(completionHandlerOptions);
 }
 
-// Apple's docs - Called to let your app know which action was selected by the user for a given notification.
-- (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
-         didReceiveNotificationResponse:(UNNotificationResponse *)response
-                  withCompletionHandler:(void(^)(void))completionHandler {
-    [OneSignalNotificationsUNUserNotificationCenter traceCall:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"];
-    // return if the user has not granted privacy permissions or if not a OneSignal payload
-    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil] || ![OneSignalCoreHelper isOneSignalPayload:response.notification.request.content.userInfo]) {
-        SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
-            initWithTarget:self
-            withYourSelector:@selector(
-                onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
-            )
-            withOriginalSelector:@selector(
-                userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
-            )
-        ];
-        if (forwarder.hasReceiver) {
-            [forwarder invokeWithArgs:@[center, response, completionHandler]];
-        } else {
-            completionHandler();
-        }
-        return;
-    }
-    
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: Fired!"];
-    
-    [OneSignalNotificationsUNUserNotificationCenter processiOS10Open:response];
-    
-    // Call orginal selector if one was set.
++ (void)forwardReceivedNotificationResponseWithCenter:(UNUserNotificationCenter *)center
+                       didReceiveNotificationResponse:(UNNotificationResponse *)response
+                                      OneSignalCenter:(id)instance
+                                withCompletionHandler:(void(^)(void))completionHandler {
+    // Call original selector if one was set.
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
-        initWithTarget:self
+        initWithTarget:instance
         withYourSelector:@selector(
             onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
         )
@@ -363,6 +339,21 @@ void finishProcessingNotification(UNNotification *notification,
     }
     else
         completionHandler();
+}
+
+// Apple's docs - Called to let your app know which action was selected by the user for a given notification.
+- (void)onesignalUserNotificationCenter:(UNUserNotificationCenter *)center
+         didReceiveNotificationResponse:(UNNotificationResponse *)response
+                  withCompletionHandler:(void(^)(void))completionHandler {
+    [OneSignalNotificationsUNUserNotificationCenter traceCall:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"];
+
+    if (![OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil] && [OneSignalCoreHelper isOneSignalPayload:response.notification.request.content.userInfo]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: Fired!"];
+
+        [OneSignalNotificationsUNUserNotificationCenter processiOS10Open:response];
+    }
+
+    [OneSignalNotificationsUNUserNotificationCenter forwardReceivedNotificationResponseWithCenter:center didReceiveNotificationResponse:response OneSignalCenter:self withCompletionHandler:completionHandler];
 }
 
 + (BOOL)isDismissEvent:(UNNotificationResponse *)response {


### PR DESCRIPTION
# Description
## One Line Summary
Cherry-pick of https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1131 from `main`.

## Details

### Motivation
Fixing a swizzling issue where for non OneSignal notifications we were not forwarding notification opens to the app delegate remoteNotificationReceive.

# Testing
## Unit testing
Brought over the unit test from original PR even though it will not run.

## Manual testing
No manual testing of functionality in this PR
- tested example app runs and opening a notification only

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1326)
<!-- Reviewable:end -->
