### PR TITLE
Fix badge clearing when calling clearAll

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -114,7 +114,7 @@ NS_SWIFT_NAME(onClick(event:));
 
 + (void)handleWillShowInForegroundForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
 + (void)handleNotificationActionWithUrl:(NSString* _Nullable)url actionID:(NSString* _Nonnull)actionID;
-+ (BOOL)clearBadgeCount:(BOOL)fromNotifOpened;
++ (BOOL)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll;
 
 + (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
 + (void)notificationReceived:(NSDictionary* _Nonnull)messageDict wasOpened:(BOOL)opened;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -383,8 +383,8 @@ static NSString *_pushSubscriptionId;
 
 + (void)clearAll {
     [[UNUserNotificationCenter currentNotificationCenter] removeAllDeliveredNotifications];
-    // TODO: Determine if we also need to call clearBadgeCount
-    [self clearBadgeCount:false];
+    // removing delivered notifications doesn't update the badge count
+    [self clearBadgeCount:false fromClearAll:true];
 }
 
 + (BOOL)registerForAPNsToken {
@@ -686,7 +686,7 @@ static NSString *_lastnonActiveMessageId;
         [self launchWebURL:notification.launchURL]; //TODO: where should this live?
     }
         
-    [self clearBadgeCount:true];
+    [self clearBadgeCount:true fromClearAll:false];
     
     NSString* actionID = NULL;
     if (actionType == OSNotificationActionTypeActionTaken) {
@@ -755,7 +755,7 @@ static NSString *_lastnonActiveMessageId;
     openUrlBlock(true);
 }
 
-+ (BOOL)clearBadgeCount:(BOOL)fromNotifOpened {
++ (BOOL)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll {
     
     NSNumber *disableBadgeNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_BADGE_CLEARING];
     
@@ -764,7 +764,7 @@ static NSString *_lastnonActiveMessageId;
     else
         _disableBadgeClearing = NO;
     
-    if (_disableBadgeClearing) {
+    if (_disableBadgeClearing && !fromClearAll) {
         // The customer could have manually changed the badge value. We must ensure our cached value will match the current state.
         [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:[UIApplication sharedApplication].applicationIconBadgeNumber];
         return false;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -764,8 +764,11 @@ static NSString *_lastnonActiveMessageId;
     else
         _disableBadgeClearing = NO;
     
-    if (_disableBadgeClearing)
+    if (_disableBadgeClearing) {
+        // The customer could have manually changed the badge value. We must ensure our cached value will match the current state.
+        [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:[UIApplication sharedApplication].applicationIconBadgeNumber];
         return false;
+    }
     
     bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;
     

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -506,7 +506,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
      }];
      */
     
-    [OSNotificationsManager clearBadgeCount:false];
+    [OSNotificationsManager clearBadgeCount:false fromClearAll:false];
     [self startOutcomes];
     [self startLocation];
     [self startTrackIAP];
@@ -798,7 +798,6 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 */
 - (void)onesignalSetApplicationIconBadgeNumber:(NSInteger)badge {
     [OneSignalExtensionBadgeHandler updateCachedBadgeValue:badge];
-    
     [self onesignalSetApplicationIconBadgeNumber:badge];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalTracker.m
@@ -114,7 +114,7 @@ static BOOL lastOnFocusWasToBackground = YES;
         // [OneSignal receivedInAppMessageJson:nil];
     }
     
-    [OSNotificationsManager clearBadgeCount:false];
+    [OSNotificationsManager clearBadgeCount:false fromClearAll:false];
 }
 
 + (void)applicationBackgrounded {


### PR DESCRIPTION
# Description
## One Line Summary
This PR allows badges to be cleared when calling clearAll even when the disable badge clearing plist option is set to true

## Details
the disable badge clearing plist option is intended to turn off the automatic badge clearing behavior that occurs when the app is opened or a notification is clicked.

This option should not be respected when the clearAll method is explicitly called because it will result in the wrong value being shown when notifications are incremented.

Additionally when the option is on we should still cache the current value instead of doing a no op incase the value has been manually set by the app.

### Motivation
Fixes #1324 

### Scope
badge counts

# Testing
## Unit testing


## Manual testing
tested on a physical device with the setting both on and off

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1335)
<!-- Reviewable:end -->
