### PR TITLE
Add refresh_device_metadata to create user so country / IP can be set

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
@@ -82,6 +82,7 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         propertiesObject["timezone_id"] = propertiesModel.timezoneId
         params["properties"] = propertiesObject
 
+        params["refresh_device_metadata"] = true
         self.parameters = params
         self.updatePushSubscriptionModel(pushSubscriptionModel)
         self.method = POST


### PR DESCRIPTION
# Description
## One Line Summary
Add `refresh_device_metadata` to create user so country and IP can be set for the new user.

## Details
When the server receives a create user request, it doesn't automatically update IP and country for this user because this request can come from the SDK or from the customer's server. 

By passing in a `refresh_device_metadata = true` property to the request body, we can let the server know to update IP and country based on where the request originated from.

### Motivation
This flag was added to the create user endpoint and while missing country / IP didn't affect iOS as it did Android, because iOS made a followup session call immediately, let's still add this to our create user request for consistency.

### Scope
Country and IP are based on where the request originated from. This change is not really necessary for iOS due to differing behavior but consistency-wise and future proofing, it is good to have this flag on the create user request.

# Testing
## Unit testing
None

## Manual testing
iPhone 13 iOS 17.1
- tested new app install and seeing country and IP exist on the user
- previous to this PR, testing a new app install (and not allowing a followup session call) does not include country and IP on the user

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1339)
<!-- Reviewable:end -->
