### PR TITLE
Add getters and observer for onesignal ID and external ID

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -320,6 +320,10 @@ The User name space is accessible via `OneSignal.User` and provides access to us
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OneSignal.User.setLanguage("en")`                                                                              | `[OneSignal.User setLanguage:@"en"]`                                                                  | *Set the 2-character language  for this user.*                                                                                                                                                                                         |
 | `let pushSubscriptionProperty = OneSignal.User.pushSubscription.<PROPERTY>`                                    | `id pushSubscriptionProperty = OneSignal.User.pushSubscription.<PROPERTY>`                           | *The push subscription associated to the current user. Please refer to the Push Subscription Namespace API below for additional details.*                                                                                                                                                                                  |
+| `let id: String? = OneSignal.User.onesignalId`                                                  | `NSString* id = OneSignal.User.onesignalId`                           | *Returns the nullable OneSignal ID for the current user.*      |
+| `let id: String? = OneSignal.User.externalId`                                                   | `NSString* id = OneSignal.User.externalId`                            | *Returns the nullable external ID for the current user.*       |
+| `OneSignal.User.addObserver(_ observer: OSUserStateObserver)`<br><br>***See below for usage***  | `[OneSignal.User addObserver:self]`<br><br>***See below for usage***  | *The `OSUserStateObserver.onUserStateDidChange` method will be fired on the passed-in object when the user state changes. The User State contains the nullable onesignalId and externalId, and the observer will be fired when these values change.*  |
+| `OneSignal.User.removeObserver(_ observer: OSUserStateObserver)`                                | `[OneSignal.User removeObserver:self]`                                | *Remove a user state observer that has been previously added.* |
 | `OneSignal.User.addAlias(label: "ALIAS_LABEL", id: "ALIAS_ID")`                                         | `[OneSignal.User addAliasWithLabel:@"ALIAS_LABEL" id:@"ALIAS_ID"]`                                    | *Set an alias for the current user.  If this alias label already exists on this user, it will be overwritten with the new alias id.*                                                                                         |
 | `OneSignal.User.addAliases(["ALIAS_LABEL_01": "ALIAS_ID_01", "ALIAS_LABEL_02": "ALIAS_ID_02"])` | `[OneSignal.User addAliases:@{@"ALIAS_LABEL_01": @"ALIAS_ID_01", @"ALIAS_LABEL_02": @"ALIAS_ID_02"}]` | *Set aliases for the current user. If any alias already exists, it will be overwritten to the new values.*                                                                                                                       |
 | `OneSignal.User.removeAlias("ALIAS_LABEL")`                                                                 | `[OneSignal.User removeAlias:@"ALIAS_LABEL"]`                                                         | *Remove an alias from the current user.*                                                                                                                                                                                                 |
@@ -334,6 +338,61 @@ The User name space is accessible via `OneSignal.User` and provides access to us
 | `let tags = OneSignal.User.getTags()`                                                                           | `NSDictionary<NSString *, NSString*> *tags = [OneSignal.User getTags]`                                                                   | *Returns the local tags for the current user.*                                                                                                                                                                       |
 | `OneSignal.User.removeTags(["KEY_01", "KEY_02"])`                                                       | `[OneSignal.User removeTags:@[@"KEY_01", @"KEY_02"]]`                                                 | *Remove multiple tags with the provided keys from the current user.*                                                                                                                                                             |
 
+
+### User State Observer
+
+Any object implementing the `OSUserStateObserver` protocol can be added as an observer. You can call `removeObserver` to remove any existing listeners.
+
+**Objective-C**
+```objc
+    // AppDelegate.h
+    // Add OSUserStateObserver after UIApplicationDelegate
+    @interface AppDelegate : UIResponder <UIApplicationDelegate, OSUserStateObserver>
+    @end
+
+    // AppDelegate.m
+    @implementation AppDelegate
+
+    - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+        // Add your AppDelegate as an observer
+        [OneSignal.User addObserver:self];
+    }
+
+    // Add this new method
+    - (void)onUserStateDidChangeWithState:(OSUserChangedState * _Nonnull)state {
+        // prints out all properties
+        NSLog(@"OSUserChangedState:\n%@", [state jsonRepresentation]);
+        NSLog(@"current externalId: %@", state.current.externalId);
+        NSLog(@"current onesignalId: %@", state.current.onesignalId);
+    }
+    @end
+
+    // Remove the observer
+    [OneSignal.User removeObserver:self];
+```
+**Swift**
+```swift
+    // AppDelegate.swift
+    // Add OSUserStateObserver after UIApplicationDelegate
+    class AppDelegate: UIResponder, UIApplicationDelegate, OSUserStateObserver {
+
+        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+            // Add your AppDelegate as an observer
+            OneSignal.User.addObserver(self)
+        }
+
+        // Add this new method
+        func onUserStateDidChange(state: OSUserChangedState) {
+            // prints out all properties
+            print("OSUserChangedState: \n\(state.jsonRepresentation())")
+            print(state.current.externalId)
+            print(state.current.onesignalId)
+        }
+    }
+
+    // Remove the observer
+    OneSignal.User.removeObserver(self)
+```
 
 
 ## Push Subscription Namespace

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener, OSUserStateObserver>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -68,6 +68,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
     [OneSignal.User.pushSubscription addObserver:self];
     NSLog(@"OneSignal Demo App push subscription observer added");
     
+    [OneSignal.User addObserver:self];
     [OneSignal.Notifications addPermissionObserver:self];
     [OneSignal.InAppMessages addClickListener:self];
 
@@ -105,6 +106,10 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 
 - (void)onClickNotification:(OSNotificationClickEvent * _Nonnull)event {
     NSLog(@"Dev App onClickNotification with event %@", [event jsonRepresentation]);
+}
+
+- (void)onUserStateDidChangeWithState:(OSUserChangedState * _Nonnull)state {
+    NSLog(@"Dev App onUserStateDidChangeWithState: %@", [state jsonRepresentation]);
 }
 
 #pragma mark OSInAppMessageDelegate

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		3C47A974292642B100312125 /* OneSignalConfigManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C47A972292642B100312125 /* OneSignalConfigManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C47A975292642B100312125 /* OneSignalConfigManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C47A973292642B100312125 /* OneSignalConfigManager.m */; };
 		3C4F9E4428A4466C009F453A /* OSOperationRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */; };
+		3C5117172B15C31E00563465 /* OSUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5117162B15C31E00563465 /* OSUserState.swift */; };
 		3C789DBD293C2206004CF83D /* OSFocusInfluenceParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A600B432453790700514A53 /* OSFocusInfluenceParam.m */; };
 		3C789DBE293D8EAD004CF83D /* OSFocusInfluenceParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A600B41245378ED00514A53 /* OSFocusInfluenceParam.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C8E6DF928A6D89E0031E48A /* OSOperationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */; };
@@ -744,6 +745,7 @@
 		3C47A972292642B100312125 /* OneSignalConfigManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalConfigManager.h; sourceTree = "<group>"; };
 		3C47A973292642B100312125 /* OneSignalConfigManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalConfigManager.m; sourceTree = "<group>"; };
 		3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationRepo.swift; sourceTree = "<group>"; };
+		3C5117162B15C31E00563465 /* OSUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSUserState.swift; sourceTree = "<group>"; };
 		3C8E6DF828A6D89E0031E48A /* OSOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSOperationExecutor.swift; sourceTree = "<group>"; };
 		3C8E6DFE28AB09AE0031E48A /* OSPropertyOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertyOperationExecutor.swift; sourceTree = "<group>"; };
 		3C8E6E0028AC0BA10031E48A /* OSIdentityOperationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityOperationExecutor.swift; sourceTree = "<group>"; };
@@ -1605,6 +1607,7 @@
 				3CE795F828DB99B500736BD4 /* OSSubscriptionModelStoreListener.swift */,
 				3CE795FA28DBDCE700736BD4 /* OSSubscriptionOperationExecutor.swift */,
 				3CA6CE0928E4F19B00CA0585 /* OSUserRequests.swift */,
+				3C5117162B15C31E00563465 /* OSUserState.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -2935,6 +2938,7 @@
 				3C2C7DC8288F3C020020F9AE /* OSSubscriptionModel.swift in Sources */,
 				3CF8629E28A183F900776CA4 /* OSIdentityModel.swift in Sources */,
 				3CE795FB28DBDCE700736BD4 /* OSSubscriptionOperationExecutor.swift in Sources */,
+				3C5117172B15C31E00563465 /* OSUserState.swift in Sources */,
 				3CE9227A289FA88B001B1062 /* OSIdentityModelStoreListener.swift in Sources */,
 				DE69E19F282ED8060090BB3D /* OneSignalUser.docc in Sources */,
 				3CA6CE0A28E4F19B00CA0585 /* OSUserRequests.swift in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -287,6 +287,10 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE, PATCH} HTTP
 
 #define OS_ON_USER_WILL_CHANGE                                              @"OS_ON_USER_WILL_CHANGE"
 
+// OSID and EID snapshots during hydration
+#define OS_SNAPSHOT_ONESIGNAL_ID                                            @"OS_SNAPSHOT_ONESIGNAL_ID"
+#define OS_SNAPSHOT_EXTERNAL_ID                                             @"OS_SNAPSHOT_EXTERNAL_ID"
+
 // Models and Model Stores
 #define OS_IDENTITY_MODEL_KEY                                               @"OS_IDENTITY_MODEL_KEY"
 #define OS_IDENTITY_MODEL_STORE_KEY                                         @"OS_IDENTITY_MODEL_STORE_KEY"

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -166,7 +166,7 @@ static dispatch_once_t once;
 
 + (void)start {
     OSMessagingController *shared = OSMessagingController.sharedInstance;
-    [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
+    [OneSignalUserManagerImpl.sharedInstance.pushSubscriptionImpl addObserver:shared];
 }
 
 static BOOL _isInAppMessagingPaused = false;

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -123,9 +123,8 @@ class OSIdentityModel: OSModel {
         OneSignalUserDefaults.initShared().saveString(forKey: OS_SNAPSHOT_ONESIGNAL_ID, withValue: newOnesignalId)
         OneSignalUserDefaults.initShared().saveString(forKey: OS_SNAPSHOT_EXTERNAL_ID, withValue: newExternalId)
 
-        let prevUserState = OSUserState(onesignalId: prevOnesignalId, externalId: prevExternalId)
         let curUserState = OSUserState(onesignalId: newOnesignalId, externalId: newExternalId)
-        let changedState = OSUserChangedState(previous: prevUserState, current: curUserState)
+        let changedState = OSUserChangedState(current: curUserState)
 
         OneSignalUserManagerImpl.sharedInstance.userStateChangesObserver.notifyChange(changedState)
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -483,6 +483,6 @@ extension OSSubscriptionModel {
 
         // TODO: Don't fire observer until server is udated
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "firePushSubscriptionChanged from \(prevSubscriptionState.jsonRepresentation()) to \(newSubscriptionState.jsonRepresentation())")
-        OneSignalUserManagerImpl.sharedInstance.pushSubscriptionStateChangesObserver.notifyChange(stateChanges)
+        OneSignalUserManagerImpl.sharedInstance.pushSubscriptionImpl.pushSubscriptionStateChangesObserver.notifyChange(stateChanges)
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserRequests.swift
@@ -529,7 +529,7 @@ class OSUserExecutor {
             if let response = response {
                 // Clear local data in preparation for hydration
                 OneSignalUserManagerImpl.sharedInstance.clearUserData()
-                parseFetchUserResponse(response: response, identityModel: request.identityModel, originalPushToken: OneSignalUserManagerImpl.sharedInstance.token)
+                parseFetchUserResponse(response: response, identityModel: request.identityModel, originalPushToken: OneSignalUserManagerImpl.sharedInstance.pushSubscriptionImpl.token)
                 
                 // If this is a on-new-session's fetch user call, check that the subscription still exists
                 if request.onNewSession,

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserState.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserState.swift
@@ -49,20 +49,18 @@ public class OSUserState: NSObject {
 
 @objc
 public class OSUserChangedState: NSObject {
-    @objc public let previous: OSUserState
     @objc public let current: OSUserState
 
     @objc public override var description: String {
-        return "<OSUserState:\nprevious: \(self.previous),\ncurrent: \(self.current)\n>"
+        return "<OSUserState:\ncurrent: \(self.current)\n>"
     }
 
-    init(previous: OSUserState, current: OSUserState) {
-        self.previous = previous
+    init(current: OSUserState) {
         self.current = current
     }
 
     @objc public func jsonRepresentation() -> NSDictionary {
-        return ["previous": previous.jsonRepresentation(), "current": current.jsonRepresentation()]
+        return ["current": current.jsonRepresentation()]
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserState.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserState.swift
@@ -41,8 +41,8 @@ public class OSUserState: NSObject {
 
     @objc public func jsonRepresentation() -> NSDictionary {
         return [
-            "onesignalId": onesignalId ?? "nil",
-            "externalId": externalId ?? "nil"
+            "onesignalId": onesignalId ?? "",
+            "externalId": externalId ?? ""
         ]
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserState.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserState.swift
@@ -1,0 +1,71 @@
+/*
+ Modified MIT License
+
+ Copyright 2023 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+@objc
+public class OSUserState: NSObject {
+    @objc public let onesignalId: String?
+    @objc public let externalId: String?
+
+    @objc public override var description: String {
+        return "<OSUserState: onesignalId: \(onesignalId ?? "nil"), externalId: \(externalId ?? "nil")>"
+    }
+
+    init(onesignalId: String?, externalId: String?) {
+        self.onesignalId = onesignalId
+        self.externalId = externalId
+    }
+
+    @objc public func jsonRepresentation() -> NSDictionary {
+        return [
+            "onesignalId": onesignalId ?? "nil",
+            "externalId": externalId ?? "nil"
+        ]
+    }
+}
+
+@objc
+public class OSUserChangedState: NSObject {
+    @objc public let previous: OSUserState
+    @objc public let current: OSUserState
+
+    @objc public override var description: String {
+        return "<OSUserState:\nprevious: \(self.previous),\ncurrent: \(self.current)\n>"
+    }
+
+    init(previous: OSUserState, current: OSUserState) {
+        self.previous = previous
+        self.current = current
+    }
+
+    @objc public func jsonRepresentation() -> NSDictionary {
+        return ["previous": previous.jsonRepresentation(), "current": current.jsonRepresentation()]
+    }
+}
+
+@objc public protocol OSUserStateObserver {
+    @objc func onUserStateDidChange(state: OSUserChangedState)
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -48,6 +48,8 @@ import OneSignalNotifications
  */
 @objc public protocol OSUser {
     var pushSubscription: OSPushSubscription { get }
+    var onesignalId: String? { get }
+    var externalId: String? { get }
     // Aliases
     func addAlias(label: String, id: String)
     func addAliases(_ aliases: [String: String])
@@ -90,10 +92,6 @@ import OneSignalNotifications
 @objc
 public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     @objc public static let sharedInstance = OneSignalUserManagerImpl()
-
-    @objc public var onesignalId: String? {
-        return _user?.identityModel.onesignalId
-    }
 
     /**
      Convenience accessor. We access the push subscription model via the model store instead of via`user.pushSubscriptionModel`.
@@ -596,6 +594,20 @@ extension OneSignalUserManagerImpl: OSUser {
     public var pushSubscription: OSPushSubscription {
         start()
         return pushSubscriptionImpl
+    }
+    
+    public var externalId: String? {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "externalId") else {
+            return nil
+        }
+        return _user?.identityModel.externalId
+    }
+    
+    public var onesignalId: String? {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "onesignalId") else {
+            return nil
+        }
+        return _user?.identityModel.onesignalId
     }
 
     public func addAlias(label: String, id: String) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -50,7 +50,10 @@ import OneSignalNotifications
     var pushSubscription: OSPushSubscription { get }
     var onesignalId: String? { get }
     var externalId: String? { get }
-    // User State Observer
+    /**
+     Add an observer to the user state, allowing the provider to be notified when the user state has changed. 
+     Important: When using the observer to retrieve the `onesignalId`, check the `externalId` as well to confirm the values are associated with the expected user.
+     */
     func addObserver(_ observer: OSUserStateObserver)
     func removeObserver(_ observer: OSUserStateObserver)
     // Aliases

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
@@ -83,7 +83,7 @@ static dispatch_once_t once;
 + (void)initialize {
     subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
     OneSignalLiveActivityController *shared = OneSignalLiveActivityController.sharedInstance;
-    [OneSignalUserManagerImpl.sharedInstance addObserver:shared];
+    [OneSignalUserManagerImpl.sharedInstance.pushSubscriptionImpl addObserver:shared];
 }
 
 - (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState * _Nonnull)state {


### PR DESCRIPTION
# Description
## One Line Summary
Add getters for onesignal ID and external ID, and a user state observer to know when these values are changed.

## Details

### Motivation
From developer feedback and to support integration partners, we are exposing the onesignal ID and external ID with getters.

Additionally, we are also adding a user state observer to know when these values are changed. App developers want to know the onesignal ID for a user, but it can be null if we have not received the response from the server after a fresh install or after logging in. The user state observer will fire when the response is received and fire with the onesignal ID and external ID.

### Scope
**1. Moved push subscription namespace implementation to another class**
The User Manager is itself the user namespace AND the push subscription namespace via implementing both protocols. The problem is that we will be adding an `addObserver` method to the User namespace and this will conflict with the existing `addObserver` method that exists on the Push Subscription namespace.
_Solution:_
Use a separate class `OSPushSubscriptionImpl` that will implement the push subscription namespace. And an instance of this class will live on the User Manager.

**2. Implementation details of the user state observer:**
👉🏼 The implementation is all in this [single commit](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1344/commits/0bfa648080bf43bc611026d1dea51b02585f0ad2), for easier review. Half of this PR is moving the push subscription namespace.

On Identity Model hydration from the server (when onesignal_id is received), we will snapshot the onesignal_id and external_id as the conclusive IDs for the current user. On future hydrations after logging in, we will compare to the previous snapshot to know if the observer should be fired.

We must not only compare onesignal_id but also external_id for the case of logging in Anonymous -> New Identified. In this case, the onesignal_id will not change from the previous snapshot / hydration but the external_id will be attached to the user on the server.

See Manual Testing Scenarios below >

# Testing
## Unit testing
None

## Manual testing 
iPhone 13 iOS 17.1
Fires once in each scenario

**New App Install**
```
{
    current =     {
        externalId = "";
        onesignalId = "b6ba65b09-cde7-4a1a4-badc3-4bf4f9281b23";
    };
}
```

**Login Anon → Existing User**
```
{
    current =     {
        externalId = nan01;
        onesignalId = "f26404e2c-8f9b-436e-8438-e6716e7dfc677";
    };
}
```

**Login Anon → New Nonexistent User**
No change in `onesignalId`
```
{
    current =     {
        externalId = nan06;
        onesignalId = "da46e6451-e11c-48fa-b500-9c61206c5c11";
    };
}
```

**Login Identified → Identified**
```
{
    current =     {
        externalId = nan02;
        onesignalId = "a7a17c6de-7ac3-4969-9954-5d4ba1ce515c";
    };
}
```

**Call logout**
```
{
    current =     {
        externalId = "";
        onesignalId = "e46d64531-e11c-48fa-b500-9c61206c5c11";
    };
}
```

**If we receive a 404**
If a Fetch User ever returns 404, indicating this user has been deleted, the SDK responds with creating an anonymous user. In this case, the observer also fires:
```
{
    current =     {
        externalId = "";
        onesignalId = "8e5d3bba3-8583-438a3-9bfb-9c1bfd4452c3";
    };
}
```

**Upgrading from SDK 3.x.x to 5.x.x fires**
```
{
    current =     {
        externalId = "";
        onesignalId = "8dbd19d83-238dd-2be30-3bf0f-f95734252e937";
    };
}
```

# Future Work

Manual testing with a `previous` property (Omitted in this PR)
iPhone 13 iOS 17.1

This was testing with a `previous` property, which we are omitting for now. Keeping these test scenarios here for the future.

<details>
  <summary>Click Me to See</summary>
  
**New App Install**
```
{
    current =     {
        externalId = "";
        onesignalId = "b6ba65b09-cde7-4a1a4-badc3-4bf4f9281b23";
    };
    previous =     {
        externalId = "";
        onesignalId = "";
    };
}
```

**Login Anon → Existing User**
```
{
    current =     {
        externalId = nan01;
        onesignalId = "f26404e2c-8f9b-436e-8438-e6716e7dfc677";
    };
    previous =     {
        externalId = "";
        onesignalId = "469de8cd6-24d1-4547-a744-695ed99c31f17";
    };
}
```

**Login Anon → New Nonexistent User**
No change in `onesignalId`
```
{
    current =     {
        externalId = nan06;
        onesignalId = "da46e6451-e11c-48fa-b500-9c61206c5c11";
    };
    previous =     {
        externalId = "";
        onesignalId = "da46e6451-e11c-48fa-b500-9c61206c5c11";
    };
}
```

**Login Identified → Identified**
```
{
    current =     {
        externalId = nan02;
        onesignalId = "a7a17c6de-7ac3-4969-9954-5d4ba1ce515c";
    };
    previous =     {
        externalId = nan01;
        onesignalId = "f26404d2c-8e9b-4368-8438-e67167dfc677";
    };
}
```

**Call logout**
```
{
    current =     {
        externalId = "";
        onesignalId = "e46d64531-e11c-48fa-b500-9c61206c5c11";
    };
    previous =     {
        externalId = nan01;
        onesignalId = "f2440432c-8f9b-4368-8438-e67167dfc677";
    };
}
```

**If we receive a 404**
If a Fetch User ever returns 404, indicating this user has been deleted, the SDK responds with creating an anonymous user. In this case, the observer also fires:
```
{
    current =     {
        externalId = "";
        onesignalId = "8e5d3bba3-8583-438a3-9bfb-9c1bfd4452c3";
    };
    previous =     {
        externalId = nan02;
        onesignalId = "a5ad17c6e-7ac3-43969-9954-5d4ba1ce515c";
    };
}
```

**Upgrading from SDK 3.x.x to 5.x.x fires**
```
{
    current =     {
        externalId = "";
        onesignalId = "8dbd19d83-238dd-2be30-3bf0f-f95734252e937";
    };
    previous =     {
        externalId = "";
        onesignalId = "";
    };
}
```
</details>


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1344)
<!-- Reviewable:end -->
