### PR TITLE
Location sharing with OneSignal now defaults to false

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -694,11 +694,11 @@ OneSignal.Notifications.addClickListener(myListener)
 
 ## Location Namespace
 
-The Location namespace is accessible via `OneSignal.Location` and provide access to location-scoped functionality.
+The Location namespace is accessible via `OneSignal.Location` and provide access to location-scoped functionality. As of `v5.1.0`, location sharing must be enabled by setting `isShared` to `true`.
 
 | **Swift**                                                                                      | **Objective-C**                                                                              | **Description**                                                                                                                                          |
 | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `let isShared: Bool = OneSignal.Location.isShared`<br><br>`OneSignal.Location.isShared = true` | `BOOL isShared = [OneSignal.Location isShared]`<br><br>`[OneSignal.Location setShared:true]` | *Whether location is currently shared with OneSignal.*                                                                                                   |
+| `let isShared: Bool = OneSignal.Location.isShared`<br><br>`OneSignal.Location.isShared = true` | `BOOL isShared = [OneSignal.Location isShared]`<br><br>`[OneSignal.Location setShared:true]` | *Whether location is currently shared with OneSignal. As of `v5.1.0`, this is false by default, and you must set to `true` to enable sharing.*                                                                                                   |
 | `OneSignal.Location.requestPermission()`                                                       | `[OneSignal.Location requestPermission]`                                                     | *Use this method to manually prompt the user for location permissions. This allows for geotagging so you send notifications to users based on location.* |
 
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -118,6 +118,10 @@
 // can use them directly.
 #define DEFAULT_UNAUTHORIZATIONOPTIONS (UNAuthorizationOptionSound + UNAuthorizationOptionBadge + UNAuthorizationOptionAlert)
 
+// Class Names used with NSClassFromString
+#define ONE_SIGNAL_LOCATION_CLASS_NAME @"OneSignalLocationManager"
+#define ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME @"OneSignalInAppMessages"
+
 // iOS Parameter Names
 #define IOS_FBA @"fba"
 #define IOS_USES_PROVISIONAL_AUTHORIZATION @"uses_provisional_auth"

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/RemoteParameters/OSRemoteParamController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/RemoteParameters/OSRemoteParamController.m
@@ -53,7 +53,7 @@ static OSRemoteParamController *_sharedController;
 }
 
 - (BOOL)isLocationShared {
-    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_LOCATION_ENABLED defaultValue:YES];
+    return [OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_LOCATION_ENABLED defaultValue:NO];
 }
 
 - (void)saveLocationShared:(BOOL)shared {

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageLocationPrompt.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Model/OSInAppMessageLocationPrompt.m
@@ -52,7 +52,7 @@
      This code calls [OneSignalLocation promptLocationFallbackToSettings:true completionHandler:completionHandler];
      */
     BOOL fallback = YES;
-    let oneSignalLocationManager = NSClassFromString(@"OneSignalLocationManager");
+    let oneSignalLocationManager = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
     if (oneSignalLocationManager != nil && [oneSignalLocationManager respondsToSelector:@selector(promptLocationFallbackToSettings:completionHandler:)]) {
         NSMethodSignature* signature = [oneSignalLocationManager methodSignatureForSelector:@selector(promptLocationFallbackToSettings:completionHandler:)];
         NSInvocation* invocation = [NSInvocation invocationWithMethodSignature: signature];

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
 - (void)migrate {
     [self migrateToVersion_02_14_00_AndGreater];
-    let oneSignalInAppMessages = NSClassFromString(@"OneSignalInAppMessages");
+    let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
     if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(migrate)]) {
         [oneSignalInAppMessages performSelector:@selector(migrate)];
     }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -208,7 +208,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 }
 
 + (Class<OSInAppMessages>)InAppMessages {
-    let oneSignalInAppMessages = NSClassFromString(@"OneSignalInAppMessages");
+    let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
     if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(InAppMessages)]) {
         return [oneSignalInAppMessages performSelector:@selector(InAppMessages)];
     } else {
@@ -222,7 +222,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 }
 
 + (Class<OSLocation>)Location {
-    let oneSignalLocationManager = NSClassFromString(@"OneSignalLocationManager");
+    let oneSignalLocationManager = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
     if (oneSignalLocationManager != nil && [oneSignalLocationManager respondsToSelector:@selector(Location)]) {
         return [oneSignalLocationManager performSelector:@selector(Location)];
     } else {
@@ -380,7 +380,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     [OneSignalTrackFirebaseAnalytics trackInfluenceOpenEvent];
     
     // Clear last location after attaching data to user state or not
-    let oneSignalLocation = NSClassFromString(@"OneSignalLocation");
+    let oneSignalLocation = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
     if (oneSignalLocation != nil && [oneSignalLocation respondsToSelector:@selector(clearLastLocation)]) {
         [oneSignalLocation performSelector:@selector(clearLastLocation)];
     }
@@ -394,7 +394,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     // The OSMessagingController is an OSPushSubscriptionObserver so that we pull IAMs once we have the sub id
     NSString *subscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
     if (subscriptionId) {
-        let oneSignalInAppMessages = NSClassFromString(@"OneSignalInAppMessages");
+        let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
         if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(getInAppMessagesFromServer:)]) {
             [oneSignalInAppMessages performSelector:@selector(getInAppMessagesFromServer:) withObject:subscriptionId];
         }
@@ -414,7 +414,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 }
 
 + (void)startInAppMessages {
-    let oneSignalInAppMessages = NSClassFromString(@"OneSignalInAppMessages");
+    let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
     if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(start)]) {
         [oneSignalInAppMessages performSelector:@selector(start)];
     }
@@ -426,7 +426,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 }
 
 + (void)startLocation {
-    let oneSignalLocation = NSClassFromString(@"OneSignalLocation");
+    let oneSignalLocation = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
     if (oneSignalLocation != nil && [oneSignalLocation respondsToSelector:@selector(start)]) {
         [oneSignalLocation performSelector:@selector(start)];
     }
@@ -619,7 +619,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
         [[OSRemoteParamController sharedController] saveRemoteParams:result];
         if ([[OSRemoteParamController sharedController] hasLocationKey]) {
             BOOL shared = [result[IOS_LOCATION_SHARED] boolValue];
-            let oneSignalLocation = NSClassFromString(@"OneSignalLocation");
+            let oneSignalLocation = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
             if (oneSignalLocation != nil && [oneSignalLocation respondsToSelector:@selector(startLocationSharedWithFlag:)]) {
                 [OneSignalCoreHelper callSelector:@selector(startLocationSharedWithFlag:) onObject:oneSignalLocation withArg:shared];
             }

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLifecycleObserver.m
@@ -81,11 +81,11 @@ static OneSignalLifecycleObserver* _instance = nil;
     
     if ([OneSignalConfigManager getAppId]) {
         [OneSignalTracker onFocus:NO];
-        let oneSignalLocation = NSClassFromString(@"OneSignalLocation");
+        let oneSignalLocation = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
         if (oneSignalLocation != nil && [oneSignalLocation respondsToSelector:@selector(onFocus:)]) {
             [OneSignalCoreHelper callSelector:@selector(onFocus:) onObject:oneSignalLocation withArg:YES];
         }
-        let oneSignalInAppMessages = NSClassFromString(@"OneSignalInAppMessages");
+        let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
         if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(onApplicationDidBecomeActive)]) {
             [oneSignalInAppMessages performSelector:@selector(onApplicationDidBecomeActive)];
         }
@@ -105,7 +105,7 @@ static OneSignalLifecycleObserver* _instance = nil;
 - (void)didEnterBackground {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"application/scene didEnterBackground"];
     if ([OneSignalConfigManager getAppId]) {
-        let oneSignalLocation = NSClassFromString(@"OneSignalLocation");
+        let oneSignalLocation = NSClassFromString(ONE_SIGNAL_LOCATION_CLASS_NAME);
         if (oneSignalLocation != nil && [oneSignalLocation respondsToSelector:@selector(onFocus:)]) {
             [OneSignalCoreHelper callSelector:@selector(onFocus:) onObject:oneSignalLocation withArg:NO];
         }


### PR DESCRIPTION
# Description
## One Line Summary
Location sharing with OneSignal now defaults to `false` regardless of device permissions, so developers must explicitly set sharing to `true`.

## Details

### Motivation
It may be a poor developer experience to be opted-in by default. Previously, as long as device has location permission, we shared location with the OneSignal server. Now, sharing must be explicitly enabled. This aligns with recent similar Android behavior changes https://github.com/OneSignal/OneSignal-Android-SDK/pull/1942. 

### Scope
**⚠️ Behavior changes:**
- Developers must now explicitly call `OneSignal.Location.isShared = true` (Swift) or  `[OneSignal.Location setShared:true]` to share location with OneSignal regardless of permission or prompting for location.

**Fix location module bug** 
- Use constants for Location and IAM module classes that are used with `NSClassFromString`: `OneSignalLocationManager` and `OneSignalInAppMessages`
- These hardcoded classes can be easily missed. When the class `OneSignalLocation` was renamed to `OneSignalLocationManager`, some of the strings were missed in `NSClassFromString` calls. One consequence of this is the location module's `start` method never ran and location not shared.

# Testing
## Unit testing
None

## Manual testing
iPhone 13 on iOS 17.1.2

- Enable and then request permission → shares location when both steps are done
- Request permission and then enable → shares location when both steps are done

Something that is not working is mid-session disabling and enabling doesn't drive location sharing until next cold start.

1. Already sharing location
2. Disable sharing - location stops being tracked and shared
3. Enable sharing - location sharing doesn't start
4. New cold start - location is shared


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Location sharing

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1352)
<!-- Reviewable:end -->
