### PR TITLE
Add `OneSignal-Subscription-Id` to all Update User requests

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
@@ -44,7 +44,7 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
     func prepareForExecution() -> Bool {
         if let onesignalId = identityModel.onesignalId,
             let appId = OneSignalConfigManager.getAppId(),
-           addPushSubscriptionIdToAdditionalHeadersIfNeeded() {
+           addPushSubscriptionIdToAdditionalHeaders() {
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)"
             return true
@@ -55,21 +55,15 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         }
     }
 
-    func addPushSubscriptionIdToAdditionalHeadersIfNeeded() -> Bool {
-        guard let parameters = self.parameters else {
+    func addPushSubscriptionIdToAdditionalHeaders() -> Bool {
+        if let pushSubscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId {
+            var additionalHeaders = self.additionalHeaders ?? [String: String]()
+            additionalHeaders["OneSignal-Subscription-Id"] = pushSubscriptionId
+            self.additionalHeaders = additionalHeaders
             return true
+        } else {
+            return false
         }
-        if parameters["deltas"] != nil { // , !parameters["deltas"].isEmpty
-            if let pushSubscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId {
-                var additionalHeaders = self.additionalHeaders ?? [String: String]()
-                additionalHeaders["OneSignal-Subscription-Id"] = pushSubscriptionId
-                self.additionalHeaders = additionalHeaders
-                return true
-            } else {
-                return false
-            }
-        }
-        return true
     }
 
     init(properties: [String: Any], deltas: [String: Any]?, refreshDeviceMetadata: Bool?, modelToUpdate: OSPropertiesModel, identityModel: OSIdentityModel) {


### PR DESCRIPTION
# Description
## One Line Summary
Add the `OneSignal-Subscription-Id` header to all Update User requests, not just the ones with `deltas`.

## Details

### Motivation
- Previously, we added the `OneSignal-Subscription-Id` header to update user requests that had `deltas` in the body.
- Now, we will add this header to all update user requests. This endpoint may have expected this all along, but this was a recent ask of the SDK.

### Scope
A header in Update User requests for backend to process.

# Testing
## Unit testing
None

## Manual testing
Building and running on iPhone 13 with iOS 17.1.2.
1. Change SDK version and Sent a bunch of tags
2. Check honeycomb to see a bunch of requests with the header and that SDK version

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1353)
<!-- Reviewable:end -->
