### PR TITLE
Add `OneSignal-Subscription-Id` to Create User request

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
@@ -48,6 +48,7 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
             OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the create user request due to null app ID.")
             return false
         }
+        let _ = self.addPushSubscriptionIdToAdditionalHeaders()
         self.addJWTHeader(identityModel: identityModel)
         self.path = "apps/\(appId)/users"
         // The pushSub doesn't need to have a token.

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
@@ -43,8 +43,8 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
     // Note Android adds it to requests, if the push sub ID exists
     func prepareForExecution() -> Bool {
         if let onesignalId = identityModel.onesignalId,
-            let appId = OneSignalConfigManager.getAppId(),
-           addPushSubscriptionIdToAdditionalHeaders() {
+            let appId = OneSignalConfigManager.getAppId() {
+            let _ = self.addPushSubscriptionIdToAdditionalHeaders()
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)"
             return true

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
@@ -55,17 +55,6 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         }
     }
 
-    func addPushSubscriptionIdToAdditionalHeaders() -> Bool {
-        if let pushSubscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId {
-            var additionalHeaders = self.additionalHeaders ?? [String: String]()
-            additionalHeaders["OneSignal-Subscription-Id"] = pushSubscriptionId
-            self.additionalHeaders = additionalHeaders
-            return true
-        } else {
-            return false
-        }
-    }
-
     init(properties: [String: Any], deltas: [String: Any]?, refreshDeviceMetadata: Bool?, modelToUpdate: OSPropertiesModel, identityModel: OSIdentityModel) {
         self.modelToUpdate = modelToUpdate
         self.identityModel = identityModel

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSUserRequest.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSUserRequest.swift
@@ -41,4 +41,16 @@ internal extension OneSignalRequest {
 //        additionalHeaders["Authorization"] = "Bearer \(token)"
 //        self.additionalHeaders = additionalHeaders
     }
+    
+    /** Returns if the `OneSignal-Subscription-Id` header was added successfully. */
+    func addPushSubscriptionIdToAdditionalHeaders() -> Bool {
+        if let pushSubscriptionId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId {
+            var additionalHeaders = self.additionalHeaders ?? [String: String]()
+            additionalHeaders["OneSignal-Subscription-Id"] = pushSubscriptionId
+            self.additionalHeaders = additionalHeaders
+            return true
+        } else {
+            return false
+        }
+    }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Add the `OneSignal-Subscription-Id` header to Create User requests.

## Details

### Motivation
- This was an ask of the SDK to support improved `last_active` tracking subscriptions that were actually active
- What is currently happening is all subscriptions for this user were getting `last_active` updated.
- Now, only the subscription that made the create user request is updated.
- Also, changed a detail of User Update request to not be blocked if subscription ID header could not be added (may be missing subscription ID for example)

### Scope
- Changed the Update User requests to not be blocked if missing subscription-ID
- A header in Create User requests for backend to process
- I tested with server changes that only the device making the call has `last_active` updated.

# Testing
## Unit testing
None, we can add in future to make sure headers are included.

## Manual testing
1. Building and running on iPhone 13 with iOS 17.2.
2. Change SDK version and call login while already logged into an identified user (this will send a Create User request)
3. With debug on, confirm the subscription ID is added to the request
4. Checked dashboard that only this subscription is updated

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1372)
<!-- Reviewable:end -->
