### PR TITLE
Change OSPushSubscriptionState's `"nil"` json values to be `""`

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -53,8 +53,8 @@ public class OSPushSubscriptionState: NSObject {
     }
 
     @objc public func jsonRepresentation() -> NSDictionary {
-        let id = self.id ?? "nil"
-        let token = self.token ?? "nil"
+        let id = self.id ?? ""
+        let token = self.token ?? ""
         return [
             "id": id,
             "token": token,


### PR DESCRIPTION
# Description
## One Line Summary
Change `OSPushSubscriptionState`'s json representation to have values of `""` (empty string) instead of `"nil"` (a string literal of `nil`).

## Details

### Motivation
* The dictionary representation would be better as empty strings instead of the string literal "nil".
* This way, it is easier to check for the emptiness of these properties.
* This method is likely consumed by wrappers and the `"nil"` value is passed along all this time?

### Scope
- Do we want to make this change? It simplifies wrapper consumption of this method but **could** be a breaking change if any developers are using this method directly and checking against `"nil"`.
- Affects dictionary representation

# Testing
## Unit testing
None

## Manual testing
iPhone 13 on iOS 17.2

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1373)
<!-- Reviewable:end -->
