### PR TITLE
Rename internal method to workaround false App Store flagging

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSDialogInstanceManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSDialogInstanceManager.h
@@ -35,6 +35,6 @@ typedef void (^OSDialogActionCompletion)(int tappedActionIndex);
 @end
 
 @interface OSDialogInstanceManager : NSObject
-+ (void)setSharedInstance:(NSObject<OSDialogPresenter> *_Nonnull)instance;
++ (void)setSharedOSDialogInstance:(NSObject<OSDialogPresenter> *_Nonnull)instance;
 + (NSObject<OSDialogPresenter> *_Nullable)sharedInstance;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSDialogInstanceManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSDialogInstanceManager.m
@@ -30,7 +30,7 @@
 @implementation OSDialogInstanceManager
 
 static NSObject<OSDialogPresenter> *_sharedInstance;
-+ (void)setSharedInstance:(NSObject<OSDialogPresenter> *_Nonnull)instance {
++ (void)setSharedOSDialogInstance:(NSObject<OSDialogPresenter> *_Nonnull)instance {
     _sharedInstance = instance;
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -789,7 +789,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 //    sessionLaunchTime = [NSDate date];
     // TODO: sessionLaunchTime used to always be set in load
     
-    [OSDialogInstanceManager setSharedInstance:[OneSignalDialogController sharedInstance]];
+    [OSDialogInstanceManager setSharedOSDialogInstance:[OneSignalDialogController sharedInstance]];
 }
 
 /*


### PR DESCRIPTION
# Description
## One Line Summary
Rename an internal method `setSharedInstance` to `setSharedOSDialogInstance` due to App Store Connect rejecting builds with the previous method name.

## Details
* App Store Connect is flagging our method `setSharedInstance` in a false negative manner
* https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1374 says changing this method name they were able to successfully submit the build.

### Motivation
- Fixes https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1370

### Scope
Just a rename of internal method, no implementation changes

# Testing

## Manual testing
App builds and runs

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1375)
<!-- Reviewable:end -->
