### PR TITLE
Rename `OneSignalCore` class to prevent conflict with the framework name

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
@@ -58,7 +58,7 @@
 #import <OneSignalCore/OSLocation.h>
 
 // TODO: Testing: Should this class be defined in this file?
-@interface OneSignalCore : NSObject
+@interface OneSignalCoreImpl : NSObject
 
 + (void)setSharedClient:(nonnull id<IOneSignalClient>)client;
 + (nonnull id<IOneSignalClient>)sharedClient;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.m
@@ -28,7 +28,7 @@
 #import <Foundation/Foundation.h>
 #import "OneSignalCore.h"
 
-@implementation OneSignalCore
+@implementation OneSignalCoreImpl
 
 static id<IOneSignalClient> _sharedClient;
 + (id<IOneSignalClient>)sharedClient {

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalReceiveReceiptsController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalReceiveReceiptsController.m
@@ -97,7 +97,7 @@
     dispatch_time_t dispatchTime = dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC);
     dispatch_after(dispatchTime, dispatch_get_main_queue(), ^{
         [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal sendReceiveReceiptWithPlayerId now sending confirmed delievery after: %i second delay", delay]];
-        [OneSignalCore.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
+        [OneSignalCoreImpl.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
             if (success) {
                 success(result);
             }

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSInAppMessageController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSInAppMessageController.m
@@ -46,13 +46,13 @@
     
     let request = [OSRequestLoadInAppMessageContent withAppId:[OneSignalConfigManager getAppId] withMessageId:self.messageId withVariantId:variantId];
     
-    [OneSignalCore.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
+    [OneSignalCoreImpl.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
 }
 
 - (void)loadPreviewMessageHTMLContentWithUUID:(NSString * _Nonnull)previewUUID success:(OSResultSuccessBlock _Nullable)successBlock failure:(OSFailureBlock _Nullable)failureBlock {
     let request = [OSRequestLoadInAppMessagePreviewContent withAppId:[OneSignalConfigManager getAppId] previewUUID:previewUUID];
     
-    [OneSignalCore.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
+    [OneSignalCoreImpl.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
 }
 
 /**

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -245,7 +245,7 @@ static BOOL _isInAppMessagingPaused = false;
     }
     
     OSRequestGetInAppMessages *request = [OSRequestGetInAppMessages withSubscriptionId:subscriptionId];
-    [OneSignalCore.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
+    [OneSignalCoreImpl.sharedClient executeRequest:request onSuccess:^(NSDictionary *result) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"getInAppMessagesFromServer success"];
             if (result[@"in_app_messages"]) { // when there are no IAMs, will this still be there?
@@ -510,7 +510,7 @@ static BOOL _isInAppMessagingPaused = false;
                                                          withPageId:pageId
                                                        forVariantId:message.variantId];
 
-    [OneSignalCore.sharedClient executeRequest:metricsRequest
+    [OneSignalCoreImpl.sharedClient executeRequest:metricsRequest
                                        onSuccess:^(NSDictionary *result) {
         NSString *successMessage = [NSString stringWithFormat:@"In App Message with message id: %@ and page id: %@, successful POST page impression update with result: %@", message.messageId, pageId, result];
                                            [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
@@ -549,7 +549,7 @@ static BOOL _isInAppMessagingPaused = false;
                                                   withMessageId:message.messageId
                                                    forVariantId:message.variantId];
     
-    [OneSignalCore.sharedClient executeRequest:metricsRequest
+    [OneSignalCoreImpl.sharedClient executeRequest:metricsRequest
                                        onSuccess:^(NSDictionary *result) {
                                            NSString *successMessage = [NSString stringWithFormat:@"In App Message with id: %@, successful POST impression update with result: %@", message.messageId, result];
                                            [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];
@@ -951,7 +951,7 @@ static BOOL _isInAppMessagingPaused = false;
                                                     forVariantId:message.variantId
                                                       withAction:action];
 
-   [OneSignalCore.sharedClient executeRequest:metricsRequest
+   [OneSignalCoreImpl.sharedClient executeRequest:metricsRequest
                                       onSuccess:^(NSDictionary *result) {
                                           NSString *successMessage = [NSString stringWithFormat:@"In App Message with id: %@, successful POST click update for click id: %@, with result: %@", message.messageId, action.clickId,  result];
                                           [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:successMessage];

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -716,7 +716,7 @@ static NSString *_lastnonActiveMessageId;
     NSString* lastMessageId = [standardUserDefaults getSavedStringForKey:OSUD_LAST_MESSAGE_OPENED defaultValue:nil];
     //Only submit request if messageId not nil and: (lastMessage is nil or not equal to current one)
     if(messageId && (!lastMessageId || ![lastMessageId isEqualToString:messageId])) {
-        [OneSignalCore.sharedClient executeRequest:[OSRequestSubmitNotificationOpened withUserId:[self pushSubscriptionId]
+        [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestSubmitNotificationOpened withUserId:[self pushSubscriptionId]
                                                                                              appId:[OneSignalConfigManager getAppId]
                                                                                          wasOpened:YES
                                                                                          messageId:messageId

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/Controller/V1/OSOutcomeEventsV1Repository.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/Controller/V1/OSOutcomeEventsV1Repository.m
@@ -65,7 +65,7 @@ THE SOFTWARE.
             return;
     }
 
-    [OneSignalCore.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
+    [OneSignalCoreImpl.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/Controller/V2/OSOutcomeEventsV2Repository.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/Controller/V2/OSOutcomeEventsV2Repository.m
@@ -43,7 +43,7 @@ THE SOFTWARE.
                                                                  appId:appId
                                                             deviceType:deviceType];
 
-    [OneSignalCore.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
+    [OneSignalCoreImpl.sharedClient executeRequest:request onSuccess:successBlock onFailure:failureBlock];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OneSignalOutcomeEventsController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/Source/OutcomeEvents/OneSignalOutcomeEventsController.m
@@ -111,7 +111,7 @@ NSMutableSet *unattributedUniqueOutcomeEventsSentSet;
                influenceParams:(NSArray<OSFocusInfluenceParam *> * _Nonnull)influenceParams
                      onSuccess:(OSResultSuccessBlock _Nonnull)successBlock
                      onFailure:(OSFailureBlock _Nonnull)failureBlock {
-    [OneSignalCore.sharedClient executeRequest:[OSRequestSendSessionEndOutcomes
+    [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestSendSessionEndOutcomes
                                                   withActiveTime:timeElapsed
                                                   appId:appId
                                                   pushSubscriptionId:pushSubscriptionId

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSIdentityOperationExecutor.swift
@@ -179,7 +179,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
             OSBackgroundTaskManager.beginBackgroundTask(backgroundTaskIdentifier)
         }
 
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             // No hydration from response
             // On success, remove request from cache
             self.addRequestQueue.removeAll(where: { $0 == request})
@@ -234,7 +234,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
             OSBackgroundTaskManager.beginBackgroundTask(backgroundTaskIdentifier)
         }
 
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             // There is nothing to hydrate
             // On success, remove request from cache
             self.removeRequestQueue.removeAll(where: { $0 == request})

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
@@ -148,7 +148,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
             OSBackgroundTaskManager.beginBackgroundTask(backgroundTaskIdentifier)
         }
 
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             // On success, remove request from cache, and we do need to hydrate
             // TODO: We need to hydrate after all ? What why ?
             self.dispatchQueue.async {
@@ -205,7 +205,7 @@ extension OSPropertyOperationExecutor {
 
         if sendImmediately {
             // Bypass the request queues
-            OneSignalCore.sharedClient().execute(request) { _ in
+            OneSignalCoreImpl.sharedClient().execute(request) { _ in
                 if let onSuccess = onSuccess {
                     onSuccess()
                 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
@@ -246,7 +246,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
         }
 
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSSubscriptionOperationExecutor: executeCreateSubscriptionRequest making request: \(request)")
-        OneSignalCore.sharedClient().execute(request) { result in
+        OneSignalCoreImpl.sharedClient().execute(request) { result in
             // On success, remove request from cache (even if not hydrating model), and hydrate model
             self.addRequestQueue.removeAll(where: { $0 == request})
             OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY, withValue: self.addRequestQueue)
@@ -308,7 +308,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
 
         // This request can be executed as-is.
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSSubscriptionOperationExecutor: executeDeleteSubscriptionRequest making request: \(request)")
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             // On success, remove request from cache. No model hydration occurs.
             // For example, if app restarts and we read in operations between sending this off and getting the response
             self.removeRequestQueue.removeAll(where: { $0 == request})
@@ -347,7 +347,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
             OSBackgroundTaskManager.beginBackgroundTask(backgroundTaskIdentifier)
         }
 
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             // On success, remove request from cache. No model hydration occurs.
             // For example, if app restarts and we read in operations between sending this off and getting the response
             self.updateRequestQueue.removeAll(where: { $0 == request})

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -206,7 +206,7 @@ class OSUserExecutor {
             request.updatePushSubscriptionModel(pushSubscriptionModel)
         }
 
-        OneSignalCore.sharedClient().execute(request) { response in
+        OneSignalCoreImpl.sharedClient().execute(request) { response in
             removeFromQueue(request)
 
             // TODO: Differentiate if we need to fetch the user based on response code of 200, 201, 202
@@ -263,7 +263,7 @@ class OSUserExecutor {
         }
         request.sentToClient = true
 
-        OneSignalCore.sharedClient().execute(request) { response in
+        OneSignalCoreImpl.sharedClient().execute(request) { response in
             removeFromQueue(request)
 
             if let identityObject = parseIdentityObjectResponse(response),
@@ -316,7 +316,7 @@ class OSUserExecutor {
         }
         request.sentToClient = true
 
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             removeFromQueue(request)
 
             // the anonymous user has been identified, still need to Fetch User as we cleared local data
@@ -386,7 +386,7 @@ class OSUserExecutor {
             return
         }
         request.sentToClient = true
-        OneSignalCore.sharedClient().execute(request) { _ in
+        OneSignalCoreImpl.sharedClient().execute(request) { _ in
             removeFromQueue(request)
 
             // TODO: ... hydrate with returned identity object?
@@ -422,7 +422,7 @@ class OSUserExecutor {
             return
         }
         request.sentToClient = true
-        OneSignalCore.sharedClient().execute(request) { response in
+        OneSignalCoreImpl.sharedClient().execute(request) { response in
             removeFromQueue(request)
 
             if let response = response {

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
@@ -51,7 +51,7 @@ final class OneSignalUserTests: XCTestCase {
     // Comparable to Android test: "externalId is backed by the identity model"
     func testLoginSetsExternalId() throws {
         /* Setup */
-        OneSignalCore.setSharedClient(MockOneSignalClient())
+        OneSignalCoreImpl.setSharedClient(MockOneSignalClient())
 
         /* When */
         OneSignalUserManagerImpl.sharedInstance.login(externalId: "my-external-id", token: nil)
@@ -71,7 +71,7 @@ final class OneSignalUserTests: XCTestCase {
      */
     func testOperationRepoFlushingConcurrency() throws {
         /* Setup */
-        OneSignalCore.setSharedClient(MockOneSignalClient())
+        OneSignalCoreImpl.setSharedClient(MockOneSignalClient())
 
         /* When */
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -601,7 +601,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     // NSString *userId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId;
     NSString *userId = nil;
 
-    [OneSignalCore.sharedClient executeRequest:[OSRequestGetIosParams withUserId:userId appId:appId] onSuccess:^(NSDictionary *result) {
+    [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestGetIosParams withUserId:userId appId:appId] onSuccess:^(NSDictionary *result) {
 
         if (result[IOS_REQUIRES_USER_ID_AUTHENTICATION]) {
             OneSignalUserManagerImpl.sharedInstance.requiresUserAuth = [result[IOS_REQUIRES_USER_ID_AUTHENTICATION] boolValue];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLiveActivityController.m
@@ -126,7 +126,7 @@ static dispatch_once_t once;
     }
 
     if(subscriptionId) {
-        [OneSignalCore.sharedClient executeRequest:[OSRequestLiveActivityEnter withSubscriptionId:subscriptionId appId:appId activityId:activityId token:token]
+        [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestLiveActivityEnter withSubscriptionId:subscriptionId appId:appId activityId:activityId token:token]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:successBlock withResult:result];
         } onFailure:^(NSError *error) {
@@ -169,7 +169,7 @@ static dispatch_once_t once;
     }
     
     if(subscriptionId) {
-        [OneSignalCore.sharedClient executeRequest:[OSRequestLiveActivityExit withSubscriptionId:subscriptionId appId:appId activityId:activityId]
+        [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestLiveActivityExit withSubscriptionId:subscriptionId appId:appId activityId:activityId]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:successBlock withResult:result];
         } onFailure:^(NSError *error) {
@@ -221,7 +221,7 @@ static dispatch_once_t once;
     OSPendingLiveActivityUpdate * updateToProcess = [pendingLiveActivityUpdates objectAtIndex:0];
     [pendingLiveActivityUpdates removeObjectAtIndex: 0];
     if (updateToProcess.isEnter) {
-        [OneSignalCore.sharedClient executeRequest:[OSRequestLiveActivityEnter withSubscriptionId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId token:updateToProcess.token]
+        [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestLiveActivityEnter withSubscriptionId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId token:updateToProcess.token]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:updateToProcess.successBlock withResult:result];
             [self executePendingLiveActivityUpdates];
@@ -230,7 +230,7 @@ static dispatch_once_t once;
             [self executePendingLiveActivityUpdates];
         }];
     } else {
-        [OneSignalCore.sharedClient executeRequest:[OSRequestLiveActivityExit withSubscriptionId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId]
+        [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestLiveActivityExit withSubscriptionId:subscriptionId appId:updateToProcess.appId activityId:updateToProcess.activityId]
                                            onSuccess:^(NSDictionary *result) {
             [self callSuccessBlockOnMainThread:updateToProcess.successBlock withResult:result];
             [self executePendingLiveActivityUpdates];


### PR DESCRIPTION
# Description
## One Line Summary
Rename `OneSignalCore` class to prevent conflict with the framework name, which was causing Swift apps to have build errors.

## Details

### Motivation
After we released `v5.1.1` with the new CD action and then `v5.1.2` manually (thinking the error was due to the CD process), both releases caused Swift build errors in apps that looked like this.

![Screenshot 2024-03-06 at 11 31 06 AM](https://github.com/OneSignal/OneSignal-iOS-SDK/assets/4022291/59ed64f0-39e1-4d0a-8279-00180b8f9a23)

I noticed only `OneSignalFramework` import was erroring. Using OneSignalUser or OneSignalCore directly was ok.

It is because of adding a class called `OneSignalCore` in the `OneSignalCore` framework in #1371. The Swift interface in `OneSignalFramework` had a conflict between the **class name** and **framework name.** No other modules have a Swift interface.

![Screenshot 2024-03-06 at 11 31 31 AM](https://github.com/OneSignal/OneSignal-iOS-SDK/assets/4022291/300203ad-df3d-4f7e-80ed-fe354691b1ce)

Renamed the class to `OneSignalCoreImpl` but considered other choices like "manager", "controller", etc.

### Scope
Renaming internal class

# Testing
## Unit testing
None

## Manual testing
- I tested this on my iphone 13 with ios 17.2
- I added the `OneSignalXCFramework` pod to a project using the local path to the iOS SDK and confirmed the error went away and the app built and ran successfully.
- I also confirmed I was using the correct version by testing a behavior change in #1373

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1382)
<!-- Reviewable:end -->
