### PR TITLE
[User Model] Add back the dropshadow to In App Messages with a plist option to disable it

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -140,6 +140,7 @@
 // Info.plist key
 #define FALLBACK_TO_SETTINGS_MESSAGE @"Onesignal_settings_fallback_message"
 #define ONESIGNAL_SUPRESS_LAUNCH_URLS @"OneSignal_suppress_launch_urls"
+#define ONESIGNAL_IN_APP_HIDE_DROP_SHADOW @"OneSignal_in_app_message_hide_drop_shadow"
 
 // GDPR Privacy Consent
 #define GDPR_CONSENT_GRANTED @"GDPR_CONSENT_GRANTED"

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
@@ -195,6 +195,19 @@ OSInAppMessageInternal *_dismissingMessage = nil;
     }];
 }
 
+- (void)updateDropShadow {
+    // the plist value specifies whether the user wants to add drop shadow to the In App Message
+    NSDictionary *bundleDict = [[NSBundle mainBundle] infoDictionary];
+    BOOL hideDropShadow = [bundleDict[ONESIGNAL_IN_APP_HIDE_DROP_SHADOW] boolValue];
+    if (hideDropShadow) {
+        return;
+    }
+    self.messageView.layer.shadowOffset = CGSizeMake(0, 3);
+    self.messageView.layer.shadowColor = [[UIColor blackColor] CGColor];
+    self.messageView.layer.shadowRadius = 3.0f;
+    self.messageView.layer.shadowOpacity = 0.55f;
+}
+
 - (void)displayMessage {
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Displaying In-App Message"];
     
@@ -233,9 +246,11 @@ OSInAppMessageInternal *_dismissingMessage = nil;
             if (self.waitForTags) {
                 return;
             }
+            [self updateDropShadow];
             [self.delegate messageWillDisplay:self.message];
             [self.messageView loadedHtmlContent:self.pendingHTMLContent withBaseURL:baseUrl];
             self.pendingHTMLContent = nil;
+            
         }];
     };
 }


### PR DESCRIPTION
# Description
## One Line Summary
Add back the dropshadow to In App Messages with a plist option to disable it

## Details
The drop shadow was [removed](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1078) from iOS In App Messages to support transparent In App Messages. However this results in banner IAMs not looking correct if the background color of the message matches the color of the app underneath it.

To solve both use cases developers can now use boolean plist setting `OneSignal_in_app_message_hide_drop_shadow` to toggle if they want a drop shadow or not. Note that this is a setting that would apply to all in app messages. 

**Examples without the dropshadow**

<img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/13123372/49b8aec4-c262-4a0a-990a-d6ac04521373" width=30% height=30%>
<img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/13123372/ff577e45-183d-4525-972c-990a869f78e6" width=30% height=30%>

**Examples with the dropshadow**

<img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/13123372/4a71735f-e3a5-4568-b763-99c8f2153c03" width=30% height=30%>
<img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/13123372/0e602231-8a9d-49c4-9eaa-a31de9798d65" width=30% height=30%>


### Motivation
Banner IAMs look incorrect when matching the background color of the app

### Scope
New and existing In App Messsage visual behavior


# Testing
## Unit testing
n/a

## Manual testing
tested on multiple IAM types with a simulator without plist, with plist option to yes, and with plist option to no

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1395)
<!-- Reviewable:end -->
