### PR TITLE
[User Model] Add plist option to override gray overlay to In App Messages

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -141,6 +141,7 @@
 #define FALLBACK_TO_SETTINGS_MESSAGE @"Onesignal_settings_fallback_message"
 #define ONESIGNAL_SUPRESS_LAUNCH_URLS @"OneSignal_suppress_launch_urls"
 #define ONESIGNAL_IN_APP_HIDE_DROP_SHADOW @"OneSignal_in_app_message_hide_drop_shadow"
+#define ONESIGNAL_IN_APP_HIDE_GRAY_OVERLAY @"OneSignal_in_app_message_hide_gray_overlay"
 
 // GDPR Privacy Consent
 #define GDPR_CONSENT_GRANTED @"GDPR_CONSENT_GRANTED"

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
@@ -184,8 +184,17 @@ OSInAppMessageInternal *_dismissingMessage = nil;
     // Only the center modal and full screen (both centered) IAM should have a dark background
     // So get the alpha based on the IAM being a banner or not
     double alphaBackground = [self.message isBanner] ? 0.0 : 0.5;
-    [UIView animateWithDuration:0.3 animations:^{
+    
+    // the plist value specifies whether the user wants to add a gray overlay to the In App Message
+    NSDictionary *bundleDict = [[NSBundle mainBundle] infoDictionary];
+    BOOL hideGrayOverlay = [bundleDict[ONESIGNAL_IN_APP_HIDE_GRAY_OVERLAY] boolValue];
+    if (hideGrayOverlay) {
+        self.view.backgroundColor = [UIColor clearColor];
+    } else {
         self.view.backgroundColor = [UIColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:alphaBackground];
+    }
+    
+    [UIView animateWithDuration:0.3 animations:^{
         self.view.alpha = 1.0;
     } completion:^(BOOL finished) {
         if (!finished)


### PR DESCRIPTION
# Description
## One Line Summary
Add plist option to override gray overlay to In App Messages

## Details
In center modal and full screen (both centered) IAMs, a dark gray background is applied. Customers would like the option to disable this overlay.

With this PR developers can now use boolean plist setting `OneSignal_in_app_message_hide_gray_overlay` to toggle if they wish to remove the overlay from center modal and full screen IAMs. 

**Examples with the overlay**

<img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/46546946/08139526-853e-4df7-9781-a0af82fa47b6"> <img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/46546946/d00580c7-aff8-4d2f-8f87-de656579ba58">

**Examples without the overlay**
<img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/46546946/6cea6cf7-dc06-4755-825d-2014380333fe"> <img src="https://github.com/OneSignal/OneSignal-iOS-SDK/assets/46546946/f1f855bd-bd39-4dfb-8b92-a2743d592d9c">

### Scope
New and existing In App Message visual behavior

# Testing
## Manual testing
Tested on center and full IAM types with a iPhone 15 simulator running iOS 17.2 without plist, with plist option to `YES`, and with plist option to `NO`.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1396)
<!-- Reviewable:end -->
