### PR TITLE
Fix user executor's requests from being blocked

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDelta.swift
@@ -39,7 +39,7 @@ open class OSDelta: NSObject, NSCoding {
     public let value: Any
 
     override open var description: String {
-        return "OSDelta \(name) with property: \(property) value: \(value)"
+        return "<OSDelta \(name) with property: \(property) value: \(value)>"
     }
 
     public init(name: String, model: OSModel, property: String, value: Any) {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationExecutor.swift
@@ -27,8 +27,9 @@
 
 import OneSignalCore
 
-// TODO: Concrete executors drop OSDeltas and Requests when initializing from the cache, when they cannot be connected to their respective models anymore. Revisit this behavior of dropping.
-
+/**
+ Concrete executors drop OSDeltas and Requests when initializing from the cache, when they cannot be connected to their respective models anymore. These cannot be sent, so they are dropped..
+ */
 public protocol OSOperationExecutor {
     var supportedDeltas: [String] { get }
     var deltaQueue: [OSDelta] { get }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -71,8 +71,9 @@ public class OSOperationRepo: NSObject {
         // Read the Deltas from cache, if any...
         if let deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_OPERATION_REPO_DELTA_QUEUE_KEY, defaultValue: []) as? [OSDelta] {
             self.deltaQueue = deltaQueue
+            OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSOperationRepo.start() with deltaQueue: \(deltaQueue)")
         } else {
-            // log error
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSOperationRepo.start() is unable to uncache the OSDelta queue.")
         }
 
         pollFlushQueue()

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSIdentityOperationExecutor.swift
@@ -49,6 +49,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
                 }
             }
             self.deltaQueue = deltaQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_IDENTITY_EXECUTOR_DELTA_QUEUE_KEY, withValue: self.deltaQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSIdentityOperationExecutor error encountered reading from cache for \(OS_IDENTITY_EXECUTOR_DELTA_QUEUE_KEY)")
         }
@@ -70,6 +71,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
                 }
             }
             self.addRequestQueue = addRequestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_IDENTITY_EXECUTOR_ADD_REQUEST_QUEUE_KEY, withValue: self.addRequestQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSIdentityOperationExecutor error encountered reading from cache for \(OS_IDENTITY_EXECUTOR_ADD_REQUEST_QUEUE_KEY)")
         }
@@ -89,6 +91,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
                 }
             }
             self.removeRequestQueue = removeRequestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_IDENTITY_EXECUTOR_REMOVE_REQUEST_QUEUE_KEY, withValue: self.removeRequestQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSIdentityOperationExecutor error encountered reading from cache for \(OS_IDENTITY_EXECUTOR_REMOVE_REQUEST_QUEUE_KEY)")
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
@@ -47,6 +47,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
                     delta.model = modelInStore
                 } else {
                     // 2. The model does not exist, drop this Delta
+                    OneSignalLog.onesignalLog(.LL_WARN, message: "OSPropertyOperationExecutor.init dropped: \(delta)")
                     deltaQueue.remove(at: index)
                 }
             }
@@ -71,6 +72,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
                     request.identityModel = identityModel
                 } else if !request.prepareForExecution() {
                     // 3. The identitymodel do not exist AND this request cannot be sent, drop this Request
+                    OneSignalLog.onesignalLog(.LL_WARN, message: "OSPropertyOperationExecutor.init dropped: \(request)")
                     updateRequestQueue.remove(at: index)
                 }
             }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
@@ -52,6 +52,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
                 }
             }
             self.deltaQueue = deltaQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_DELTA_QUEUE_KEY, withValue: self.deltaQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSPropertyOperationExecutor error encountered reading from cache for \(OS_PROPERTIES_EXECUTOR_DELTA_QUEUE_KEY)")
         }
@@ -77,6 +78,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
                 }
             }
             self.updateRequestQueue = updateRequestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSPropertyOperationExecutor error encountered reading from cache for \(OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY)")
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
@@ -51,6 +51,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                 }
             }
             self.deltaQueue = deltaQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_DELTA_QUEUE_KEY, withValue: self.deltaQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionOperationExecutor error encountered reading from cache for \(OS_SUBSCRIPTION_EXECUTOR_DELTA_QUEUE_KEY)")
         }
@@ -87,6 +88,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                 requestQueue.append(request)
             }
             self.addRequestQueue = requestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY, withValue: self.addRequestQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionOperationExecutor error encountered reading from cache for \(OS_SUBSCRIPTION_EXECUTOR_ADD_REQUEST_QUEUE_KEY)")
         }
@@ -106,6 +108,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                 }
             }
             self.removeRequestQueue = removeRequestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_REMOVE_REQUEST_QUEUE_KEY, withValue: self.removeRequestQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionOperationExecutor error encountered reading from cache for \(OS_SUBSCRIPTION_EXECUTOR_REMOVE_REQUEST_QUEUE_KEY)")
         }
@@ -125,6 +128,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                 }
             }
             self.updateRequestQueue = updateRequestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionOperationExecutor error encountered reading from cache for \(OS_SUBSCRIPTION_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY)")
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -91,6 +91,12 @@ class OSUserExecutor {
                         identityModels[req.identityModelToUpdate.modelId] = req.identityModelToUpdate
                     } else {
                         // 4. Both models don't exist yet
+                        // Drop the request if the identityModelToIdentify does not already exist AND the request is missing OSID
+                        // Otherwise, this request will forever fail `prepareForExecution` and block pending requests such as recovery calls to `logout` or `login`
+                        guard request.prepareForExecution() else {
+                            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor.start() dropped: \(request)")
+                            continue
+                        }
                         identityModels[req.identityModelToIdentify.modelId] = req.identityModelToIdentify
                         identityModels[req.identityModelToUpdate.modelId] = req.identityModelToUpdate
                     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -105,7 +105,7 @@ class OSUserExecutor {
             }
         }
         self.userRequestQueue = userRequestQueue
-
+        OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
         // Read unfinished Transfer Subscription requests from cache, if any...
         if let transferSubscriptionRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestTransferSubscription] {
             // We only care about the last transfer subscription request
@@ -124,7 +124,7 @@ class OSUserExecutor {
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor error encountered reading from cache for \(OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY)")
         }
-
+        OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
         executePendingRequests()
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -549,9 +549,12 @@ extension OneSignalUserManagerImpl {
         updateSession(sessionCount: 1, sessionTime: nil, refreshDeviceMetadata: true)
 
         // Fetch the user's data if there is a onesignal_id
-        // TODO: What if onesignal_id is missing, because we may init a user from cache but it may be missing onesignal_id. Is this ok.
         if let onesignalId = onesignalId {
             OSUserExecutor.fetchUser(aliasLabel: OS_ONESIGNAL_ID, aliasId: onesignalId, identityModel: user.identityModel, onNewSession: true)
+        } else {
+            // It is possible to init a user from cache who is missing the onesignalId
+            // This can happen if any createUser or identifyUser requests are cached
+            OneSignalLog.onesignalLog(.LL_WARN, message: "OneSignalUserManagerImpl.startNewSession() is unable to fetch user with External ID \(externalId ?? "nil") due to null OneSignal ID")
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -260,7 +260,7 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         }
         start()
         guard externalId != "" else {
-            // Log error
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OneSignal.User login called with empty externalId. This is not allowed.")
             return
         }
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.User login called with externalId: \(externalId)")
@@ -539,7 +539,7 @@ extension OneSignalUserManagerImpl {
     @objc
     public func startNewSession() {
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignalUserManagerImpl starting new session")
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: nil) else {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "_startNewSession") else {
             return
         }
         start()

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
@@ -66,7 +66,7 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         self.identityModel = identityModel
         self.pushSubscriptionModel = pushSubscriptionModel
         self.originalPushToken = originalPushToken
-        self.stringDescription = "OSRequestCreateUser"
+        self.stringDescription = "<OSRequestCreateUser with externalId: \(identityModel.externalId ?? "nil")>"
         super.init()
 
         var params: [String: Any] = [:]
@@ -114,7 +114,7 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         self.identityModel = identityModel
         self.pushSubscriptionModel = pushSubscriptionModel
         self.originalPushToken = coder.decodeObject(forKey: "originalPushToken") as? String
-        self.stringDescription = "OSRequestCreateUser"
+        self.stringDescription = "<OSRequestCreateUser with externalId: \(identityModel.externalId ?? "nil")>"
         super.init()
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestIdentifyUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestIdentifyUser.swift
@@ -55,6 +55,7 @@ class OSRequestIdentifyUser: OneSignalRequest, OSUserRequest {
         } else {
             // self.path is non-nil, so set to empty string
             self.path = ""
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the Identify User request due to null app ID or null OneSignal ID.")
             return false
         }
     }
@@ -71,7 +72,7 @@ class OSRequestIdentifyUser: OneSignalRequest, OSUserRequest {
         self.identityModelToUpdate = identityModelToUpdate
         self.aliasLabel = aliasLabel
         self.aliasId = aliasId
-        self.stringDescription = "OSRequestIdentifyUser with aliasLabel: \(aliasLabel) aliasId: \(aliasId)"
+        self.stringDescription = "<OSRequestIdentifyUser with aliasLabel: \(aliasLabel) aliasId: \(aliasId)>"
         super.init()
         self.parameters = ["identity": [aliasLabel: aliasId]]
         self.method = PATCH
@@ -105,7 +106,7 @@ class OSRequestIdentifyUser: OneSignalRequest, OSUserRequest {
         self.identityModelToUpdate = identityModelToUpdate
         self.aliasLabel = aliasLabel
         self.aliasId = aliasId
-        self.stringDescription = "OSRequestIdentifyUser with aliasLabel: \(aliasLabel) aliasId: \(aliasId)"
+        self.stringDescription = "<OSRequestIdentifyUser with aliasLabel: \(aliasLabel) aliasId: \(aliasId)>"
         super.init()
         self.timestamp = timestamp
         self.parameters = parameters

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
@@ -58,7 +58,7 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
     init(properties: [String: Any], deltas: [String: Any]?, refreshDeviceMetadata: Bool?, modelToUpdate: OSPropertiesModel, identityModel: OSIdentityModel) {
         self.modelToUpdate = modelToUpdate
         self.identityModel = identityModel
-        self.stringDescription = "OSRequestUpdateProperties with properties: \(properties) deltas: \(String(describing: deltas)) refreshDeviceMetadata: \(String(describing: refreshDeviceMetadata))"
+        self.stringDescription = "<OSRequestUpdateProperties with properties: \(properties) deltas: \(String(describing: deltas)) refreshDeviceMetadata: \(String(describing: refreshDeviceMetadata))>"
         super.init()
 
         var propertiesObject = properties
@@ -99,7 +99,7 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         }
         self.modelToUpdate = modelToUpdate
         self.identityModel = identityModel
-        self.stringDescription = "OSRequestUpdateProperties with parameters: \(parameters)"
+        self.stringDescription = "<OSRequestUpdateProperties with parameters: \(parameters)>"
         super.init()
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -357,7 +357,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
         return;
     }
     
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"startNewSession"];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OneSignal.startNewSession"];
     
     // Run on the main queue as it is possible for this to be called from multiple queues.
     // Also some of the code in the method is not thread safe such as _outcomeEventsController.
@@ -367,7 +367,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 }
 
 + (void)startNewSessionInternal {
-    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"startNewSessionInternal"];
+    [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"OneSignal.startNewSessionInternal"];
     
     // return if the user has not granted privacy permissions
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])


### PR DESCRIPTION
# Description
## One Line Summary
Drop any cached Identify User requests that can never go through in order to prevent blocking of other pending requests and allow recovery.

## Details

The logic of this PR is a small change in this commit: [Drop insurmountable cached requests in the user executor](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1398/commits/c83dbb1696808816284d4d1724dfb07e9a1885a0)

### Motivation
An app developer through testing and usage of a debugging proxy ended up in a scenario where the SDK called `login` from an anonymous state, but is forever missing the onesignal ID to complete the Identify User call.

- No user updates or fetches can be made without an OSID.
- The Identify User request forever sits first in queue waiting for an OSID.
- There is no pending Create User request before it that will update the missing OSID.
- Calls to `logout` or `login("another_user")` don't work as they are added to the executor queue but the queue is still blocked by the first request.

### Scope
- Dropping Identify User requests that can never go through to fulfill pending user requests and allow recovery.
- I considered other options but this was most preferable
- Also missed some User Defaults persistence in the executors.
- Add more logs.

# Testing
## Unit testing
None

## Manual testing
Physical iPhone 13 with iOS 17.4

I was **not** able to naturally reproduce this state by a combination:
- Making the anonymous user's create user call fail
- Making the Identify User call fail

I reproduced this state by:
1. The anonymous Create User call succeeds but don't hydrate which doesn't give the SDK an OSID
2. Then call `login("a")`, then `logout()`, `login("a")`, `logout()`, `login("a")`
3. See there are 5 pending requests in the User Executor, along with some other pending requests in other executors
4. On the next cold start, those 5 pending requests are still there and nothing can move forward
5. Make the changes in this PR
6. On the next cold start, the first Identify User request is dropped, so that `logout()`, `login("a")`, `logout()`, `login("a")` are the pending requests
7. Those go successfully and the SDK ends up in a state with the correct user `"a"` and correct data for user `"a"`

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1398)
<!-- Reviewable:end -->
