### PR TITLE
Fix crash in OneSignalAttachmentHandler trimURLSpacing

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		3C14E39F2AFAE39B006ED053 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3C14E39E2AFAE39B006ED053 /* PrivacyInfo.xcprivacy */; };
 		3C14E3A12AFAE461006ED053 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3C14E3A02AFAE461006ED053 /* PrivacyInfo.xcprivacy */; };
 		3C14E3A42AFAE54C006ED053 /* OneSignalSwiftInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC08AFF2947D4E900C81DA3 /* OneSignalSwiftInterface.swift */; };
+		3C24B0EC2BD09D7A0052E771 /* OneSignalCoreObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C24B0EB2BD09D7A0052E771 /* OneSignalCoreObjCTests.m */; };
 		3C2C7DC8288F3C020020F9AE /* OSSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSSubscriptionModel.swift */; };
 		3C2D8A5928B4C4E300BE41F6 /* OSDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */; };
 		3C44673E296D099D0039A49E /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
@@ -956,6 +957,8 @@
 		3C11518C289AF5E800565C41 /* OSModelChangedHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSModelChangedHandler.swift; sourceTree = "<group>"; };
 		3C14E39E2AFAE39B006ED053 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3C14E3A02AFAE461006ED053 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3C24B0EA2BD09D790052E771 /* OneSignalCoreTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OneSignalCoreTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		3C24B0EB2BD09D7A0052E771 /* OneSignalCoreObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalCoreObjCTests.m; sourceTree = "<group>"; };
 		3C2C7DC2288E007E0020F9AE /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3C2C7DC7288F3C020020F9AE /* OSSubscriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSubscriptionModel.swift; sourceTree = "<group>"; };
 		3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDelta.swift; sourceTree = "<group>"; };
@@ -1720,6 +1723,8 @@
 			isa = PBXGroup;
 			children = (
 				3CC063A62B6D7A8E002BB07F /* OneSignalCoreTests.swift */,
+				3C24B0EB2BD09D7A0052E771 /* OneSignalCoreObjCTests.m */,
+				3C24B0EA2BD09D790052E771 /* OneSignalCoreTests-Bridging-Header.h */,
 			);
 			path = OneSignalCoreTests;
 			sourceTree = "<group>";
@@ -3015,6 +3020,7 @@
 					3CC063A02B6D7A8D002BB07F = {
 						CreatedOnToolsVersion = 15.2;
 						DevelopmentTeam = 99SW8E36CT;
+						LastSwiftMigration = 1520;
 						ProvisioningStyle = Automatic;
 						TestTargetID = DEF5CCF02539321A0003E9CC;
 					};
@@ -3358,6 +3364,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3CC063A72B6D7A8E002BB07F /* OneSignalCoreTests.swift in Sources */,
+				3C24B0EC2BD09D7A0052E771 /* OneSignalCoreObjCTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4245,6 +4252,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalCoreTests/OneSignalCoreTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/UnitTestApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/UnitTestApp";
@@ -4299,6 +4307,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalCoreTests/OneSignalCoreTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4348,6 +4357,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalCoreTests/OneSignalCoreTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/UnitTestApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/UnitTestApp";

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCoreHelper.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCoreHelper.m
@@ -279,9 +279,10 @@ API_AVAILABLE(macos(10.4), ios(2.0));
 }
 
 + (NSString*)trimURLSpacing:(NSString*)url {
-    if (!url)
-        return url;
-    
+    if (!url || [url isEqual:[NSNull null]]) {
+        return nil;
+    }
+
     return [url stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreTests/OneSignalCoreObjCTests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreTests/OneSignalCoreObjCTests.m
@@ -1,0 +1,55 @@
+/*
+ Modified MIT License
+ 
+ Copyright 2024 OneSignal
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ 2. All copies of substantial portions of the Software may only be used in connection
+ 
+ with services provided by OneSignal.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import <XCTest/XCTest.h>
+#import <OneSignalCore/OneSignalCore.h>
+
+@interface OneSignalCoreObjCTests : XCTestCase
+
+@end
+
+@implementation OneSignalCoreObjCTests
+
+- (void)setUp {
+}
+
+- (void)tearDown {
+}
+
+// See https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1400
+- (void)testOneSignalCoreHelper_trimURLSpacing_handlesNullishValues {
+    NSString *nsNullResult = [OneSignalCoreHelper trimURLSpacing:[NSNull null]];
+    XCTAssertNil(nsNullResult);
+    
+    NSString *nilResult = [OneSignalCoreHelper trimURLSpacing:nil];
+    XCTAssertNil(nilResult);
+    
+    NSString *stringResult = [OneSignalCoreHelper trimURLSpacing:@"  test  "];
+    XCTAssertEqualObjects(@"test", stringResult);
+}
+
+@end

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreTests/OneSignalCoreTests-Bridging-Header.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreTests/OneSignalCoreTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalAttachmentHandler.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalAttachmentHandler.m
@@ -209,7 +209,7 @@
     let unAttachments = [NSMutableArray new];
     
     for(NSString* key in notification.attachments) {
-        let URI = [OneSignalAttachmentHandler trimURLSpacing:[notification.attachments valueForKey:key]];
+        let URI = [OneSignalCoreHelper trimURLSpacing:[notification.attachments valueForKey:key]];
         
         let nsURL = [NSURL URLWithString:URI];
         
@@ -305,14 +305,6 @@
                                                   options:UNNotificationActionOptionForeground];
     }
 }
-
-+ (NSString*)trimURLSpacing:(NSString*)url {
-    if (!url)
-        return url;
-    
-    return [url stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-}
-
 
 /*
  Synchroneously downloads an attachment


### PR DESCRIPTION
# Description
## One Line Summary
Fix crash in `OneSignalAttachmentHandler` `trimURLSpacing` by checking for `NSNull` in addition to `nil` checking that is already existent.

## Details

The attachment handler can have values in a dictionary be `NSNull` since is used to represent nil objects in collections, and we typically see `NSNull` when we convert JSON to Objective-C objects and the JSON contained null values.

### Motivation
- Fixes https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1400

### Scope
Checking for nullness


# Testing
## Unit testing
Added one unit test

## Manual testing
Reproduced the crash by passing in `NSNull` manually.
Tested on iPhone 13 ios 17.4 by attaching an image and seeing method triggered.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1411)
<!-- Reviewable:end -->
