### PR TITLE
[Bug] Remove IAM window when an in app message is inactive

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -901,6 +901,7 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)messageIsNotActive:(OSInAppMessageInternal *)message {
     [self deleteInactiveMessage:message];
+    [self cleanUpInAppWindow];
 }
 
 - (void)messageWillDisplay:(nonnull OSInAppMessageInternal *)message {


### PR DESCRIPTION
# Description
## One Line Summary
Fix a case where failing to load message content due to the IAM being inactive can freeze the app

## Details
If we fail to load message content we were not removing the IAM window resulting in a "frozen" app with an un-interactable clear window overtop of the app.

The fix is to simply clean up the window if the message is inactive

### Motivation
bug fix

### Scope
IAMs that fail to load content

# Testing
## Unit testing
n/a

## Manual testing
manually tested by forcing the IAM content load to fail
Also experienced it when testing another fix

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1413)
<!-- Reviewable:end -->
