### PR TITLE
Fix crash when handling a dialog result

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalDialogController.m
@@ -67,9 +67,8 @@
             //if so, we shouldn't present on top of existing dialog
             if (self.queue.count > 1)
                 return;
-            
-            [self displayDialog:request];
         }
+        [self displayDialog:request];
     });
 }
 
@@ -102,6 +101,7 @@
 
 - (void)delayResult:(int)result {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        OSDialogRequest *nextDialog = nil;
         @synchronized (self.queue) {
             if (self.queue.count > 0) {
                 let currentDialog = self.queue.firstObject;
@@ -116,8 +116,9 @@
             if (self.queue.count == 0)
                 return;
             
-            let nextDialog = self.queue.firstObject;
-            
+            nextDialog = self.queue.firstObject;
+        }
+        if (nextDialog != nil) {
             [self displayDialog:nextDialog];
         }
     });


### PR DESCRIPTION
# Description
## One Line Summary
Fix a crash when handling a dialog result (often from requesting location or notification permission when permission has already been denied.)

## Details
The stack traces point to crashing when calling `[self.queue removeObjectAtIndex:0];` in `delayResult`. This was never reproducible as the queue should never be empty when calling delayResult, but this PR adds thread safety and a sanity check to protect and this crash.

- Synchronize queue reads and writes on self.queue

- Additionally verify that queue.count > 0 prior to removing object at index 0

### Motivation
Fix crash

### Scope
iOS dialogs

# Testing
## Unit testing
no infrastructure in place yet for mocking handling prompting actions

## Manual testing
Tested by spamming the permission dialog actions 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1417)
<!-- Reviewable:end -->
