### PR TITLE
Sign the zipped xcframeworks for swift package manager

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,12 +49,6 @@ jobs:
           chmod +x ./build_all_frameworks.sh
           ./build_all_frameworks.sh
         shell: bash
-      - name: Update Swift Package
-        run: |
-          cd iOS_SDK/OneSignalSDK
-          chmod +x ./update_swift_package.sh
-          ./update_swift_package.sh ${{github.event.inputs.version}}
-        shell: bash
       - name: Code Sign
         run: |
           cd iOS_SDK/OneSignalSDK
@@ -67,6 +61,12 @@ jobs:
           codesign --timestamp -v --sign "Apple Distribution: OneSignal, Inc. (J3J28YJX9L)" OneSignal_Outcomes/OneSignalOutcomes.xcframework
           codesign --timestamp -v --sign "Apple Distribution: OneSignal, Inc. (J3J28YJX9L)" OneSignal_User/OneSignalUser.xcframework
           codesign --timestamp -v --sign "Apple Distribution: OneSignal, Inc. (J3J28YJX9L)" OneSignal_XCFramework/OneSignalFramework.xcframework
+        shell: bash
+      - name: Update Swift Package
+        run: |
+          cd iOS_SDK/OneSignalSDK
+          chmod +x ./update_swift_package.sh
+          ./update_swift_package.sh ${{github.event.inputs.version}}
         shell: bash
       - name: Commit Changes
         run: |


### PR DESCRIPTION
# Description
## One Line Summary
Fix our CD action to sign the XCFrameworks prior to zipping them for SwiftPM

## Details
Reorders the signing and swift package update steps in the CD script

### Motivation
code signing for swiftpm

### Scope
cd


# Testing
## Unit testing
n/a

## Manual testing


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1423)
<!-- Reviewable:end -->
