### PR TITLE
[cd] update xcode version to 15.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
       - name: setup xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.1'
+          xcode-version: '15.2'
       - name: Checkout OneSignal-iOS-SDK
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Description
## One Line Summary
Update our CD script to use xcode 15.2, necessary to build now with Live Activities and xcode 15 being the minimum.

## Details

### Motivation
Release 5.2.0 CD failed then [passed](https://github.com/OneSignal/OneSignal-iOS-SDK/actions/runs/9038402027) after these changes

The CI is already using 15.2.

### Scope
CD

# Testing
## Unit testing

## Manual testing

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1433)
<!-- Reviewable:end -->
