### PR TITLE
[Bug] Fix warning about decoding a boolean

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestSetStartToken.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestSetStartToken.swift
@@ -89,7 +89,6 @@ class OSRequestSetStartToken: OneSignalRequest, OSLiveActivityRequest, OSLiveAct
         guard
             let key = coder.decodeObject(forKey: "key") as? String,
             let token = coder.decodeObject(forKey: "token") as? String,
-            let requestSuccessful = coder.decodeObject(forKey: "requestSuccessful") as? Bool,
             let timestamp = coder.decodeObject(forKey: "timestamp") as? Date
         else {
             // Log error
@@ -97,7 +96,7 @@ class OSRequestSetStartToken: OneSignalRequest, OSLiveActivityRequest, OSLiveAct
         }
         self.key = key
         self.token = token
-        self.requestSuccessful = requestSuccessful
+        self.requestSuccessful = coder.decodeBool(forKey: "requestSuccessful")
         super.init()
         self.timestamp = timestamp
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestSetUpdateToken.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestSetUpdateToken.swift
@@ -91,7 +91,6 @@ class OSRequestSetUpdateToken: OneSignalRequest, OSLiveActivityRequest, OSLiveAc
         guard
             let key = coder.decodeObject(forKey: "key") as? String,
             let token = coder.decodeObject(forKey: "token") as? String,
-            let requestSuccessful = coder.decodeObject(forKey: "requestSuccessful") as? Bool,
             let timestamp = coder.decodeObject(forKey: "timestamp") as? Date
         else {
             // Log error
@@ -99,7 +98,7 @@ class OSRequestSetUpdateToken: OneSignalRequest, OSLiveActivityRequest, OSLiveAc
         }
         self.key = key
         self.token = token
-        self.requestSuccessful = requestSuccessful
+        self.requestSuccessful = coder.decodeBool(forKey: "requestSuccessful")
         super.init()
         self.timestamp = timestamp
     }


### PR DESCRIPTION
# Description
## One Line Summary
Fixes a warning about decoding an object as a boolean by using the decode boolean method.

## Details
Use decodeBool instead of decodeObject as Bool, for the flag indicating if a live activities request is successful.

This was added in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1377, and we didn't catch the warnings.

### Motivation
Xcode warning about future errors.
```
*** -[NSKeyedUnarchiver decodeObjectForKey:]: value for key (requestSuccessful) is not an object. 
This will become an error in the future.

*** -[NSKeyedUnarchiver decodeObjectForKey:]: value for key (requestSuccessful) is not an object. 
This will become an error in the future.
```

### Scope
Decoding a boolean from cache, which defaults to `false` if not there, which is unlikely to happen as there are guards ensuring other properties are successfully decoded.

# Testing

## Manual testing
Encountered this purple warning message in the Xcode log, then went away.
![Screenshot 2024-05-15 at 2 29 39 PM](https://github.com/OneSignal/OneSignal-iOS-SDK/assets/4022291/2eb7697f-68be-4451-8ada-beda537f6100)


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1436)
<!-- Reviewable:end -->
