### PR TITLE
Cleanup IAM window on the main thread when failing to load

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -901,7 +901,9 @@ static BOOL _isInAppMessagingPaused = false;
 
 - (void)messageIsNotActive:(OSInAppMessageInternal *)message {
     [self deleteInactiveMessage:message];
-    [self cleanUpInAppWindow];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self cleanUpInAppWindow];
+    });
 }
 
 - (void)messageWillDisplay:(nonnull OSInAppMessageInternal *)message {


### PR DESCRIPTION
# Description
## One Line Summary
Fix crash that can occur in some cases when we fail to load an IAM

## Details
If multiple IAMs have the same trigger then we will have an IAM window that needs to be cleaned up when one of them fails to load. This fix was introduced in [this pr](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1413), but the failure is not guaranteed to return on the UI thread so it would crash in some cases.

### Motivation
Fix crash

### Scope
IAM


# Testing
## Unit testing
none

## Manual testing
Manually reproduced with break points and pausing active IAMs as they were about to load

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1447)
<!-- Reviewable:end -->
