### PR TITLE
[Bug] Add Dispatch Queues to all executors

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOSDispatchQueue.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOSDispatchQueue.swift
@@ -30,7 +30,7 @@ import OneSignalOSCore
 public class MockDispatchQueue: OSDispatchQueue {
     let requestDispatch = DispatchQueue(label: "MockDispatchQueue")
     var numDispatches = 0
-    
+
     public init() {}
 
     public func async(execute work: @escaping @convention(block) () -> Void) {
@@ -46,8 +46,8 @@ public class MockDispatchQueue: OSDispatchQueue {
             self.numDispatches += 1
         }
     }
-    
-    public func waitForDispatches(_ numDispatches: Int) -> Void {
+
+    public func waitForDispatches(_ numDispatches: Int) {
         while self.numDispatches < numDispatches {
             requestDispatch.sync {
                 Thread.sleep(forTimeInterval: TimeInterval(1))

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
@@ -37,6 +37,8 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
     public var networkRequestCount = 0
     public var executedRequests: [OneSignalRequest] = []
     public var executeInstantaneously = false
+    /// Set to true to make it unnecessary to setup mock responses for every request possible
+    public var fireSuccessForAllRequests = false
 
     var remoteParamsResponse: [String: Any]?
     var shouldUseProvisionalAuthorization = false // new in iOS 12 (aka Direct to History)
@@ -138,6 +140,9 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
             successBlock(mockResponses[stringifiedRequest])
         } else if (mockFailureResponses[stringifiedRequest]) != nil {
             failureBlock(mockFailureResponses[stringifiedRequest])
+        } else if fireSuccessForAllRequests {
+            allRequestsHandled = false
+            successBlock([:])
         } else {
             allRequestsHandled = false
             print("🧪 cannot find a mock response for request: \(stringifiedRequest)")

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
@@ -28,7 +28,8 @@ import OneSignalCore
  */
 @objc
 public class MockOneSignalClient: NSObject, IOneSignalClient {
-    public let executionQueue: DispatchQueue = DispatchQueue(label: "com.onesignal.execution")
+    public let executionQueue: DispatchQueue = DispatchQueue(label: "com.onesignal.execution", attributes: .concurrent)
+    let lock = NSLock()
 
     var mockResponses: [String: [String: Any]] = [:]
     var mockFailureResponses: [String: NSError] = [:]
@@ -90,7 +91,9 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
     public func execute(_ request: OneSignalRequest, onSuccess successBlock: @escaping OSResultSuccessBlock, onFailure failureBlock: @escaping OSFailureBlock) {
         print("🧪 MockOneSignalClient execute called")
 
-        executedRequests.append(request)
+        lock.withLock {
+            executedRequests.append(request)
+        }
 
         if executeInstantaneously {
             finishExecutingRequest(request, onSuccess: successBlock, onFailure: failureBlock)

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/OneSignalCoreMocks.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/OneSignalCoreMocks.swift
@@ -51,9 +51,9 @@ public class OneSignalCoreMocks: NSObject {
         let expectation = XCTestExpectation(description: "Wait for \(seconds) seconds")
         _ = XCTWaiter.wait(for: [expectation], timeout: seconds)
     }
-    
+
     @objc public static func backgroundApp() {
-        if (OSBundleUtils.isAppUsingUIScene()) {
+        if OSBundleUtils.isAppUsingUIScene() {
             if #available(iOS 13.0, *) {
                 NotificationCenter.default.post(name: UIScene.willDeactivateNotification, object: nil)
                 NotificationCenter.default.post(name: UIScene.didEnterBackgroundNotification, object: nil)
@@ -63,9 +63,9 @@ public class OneSignalCoreMocks: NSObject {
             NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
         }
     }
-    
+
     @objc public static func foregroundApp() {
-        if (OSBundleUtils.isAppUsingUIScene()) {
+        if OSBundleUtils.isAppUsingUIScene() {
             if #available(iOS 13.0, *) {
                 NotificationCenter.default.post(name: UIScene.willEnterForegroundNotification, object: nil)
                 NotificationCenter.default.post(name: UIScene.didActivateNotification, object: nil)
@@ -75,9 +75,9 @@ public class OneSignalCoreMocks: NSObject {
             NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
         }
     }
-    
+
     @objc public static func resignActive() {
-        if (OSBundleUtils.isAppUsingUIScene()) {
+        if OSBundleUtils.isAppUsingUIScene() {
             if #available(iOS 13.0, *) {
                 NotificationCenter.default.post(name: UIScene.willDeactivateNotification, object: nil)
             }
@@ -85,9 +85,9 @@ public class OneSignalCoreMocks: NSObject {
             NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
         }
     }
-    
+
     @objc public static func becomeActive() {
-        if (OSBundleUtils.isAppUsingUIScene()) {
+        if OSBundleUtils.isAppUsingUIScene() {
             if #available(iOS 13.0, *) {
                 NotificationCenter.default.post(name: UIScene.didActivateNotification, object: nil)
             }

--- a/iOS_SDK/OneSignalSDK/OneSignalNotificationsTests/OneSignalNotificationsTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotificationsTests/OneSignalNotificationsTests.swift
@@ -12,7 +12,7 @@ import OneSignalCoreMocks
 import UIKit
 
 final class OneSignalNotificationsTests: XCTestCase {
-    
+
     var notifTypes: Int32 = 0
     var token: String = ""
 
@@ -38,7 +38,7 @@ final class OneSignalNotificationsTests: XCTestCase {
         // Ensure that badge count == 0
         XCTAssertEqual(UIApplication.shared.applicationIconBadgeNumber, 0)
     }
-    
+
     func testDontclearBadgesWhenAppBecomesActive() throws {
         // NotificationManager Start to register lifecycle listener
         OSNotificationsManager.start()
@@ -51,25 +51,24 @@ final class OneSignalNotificationsTests: XCTestCase {
         // Ensure that badge count == 0
         XCTAssertEqual(UIApplication.shared.applicationIconBadgeNumber, 1)
     }
-    
+
     func testUpdateNotificationTypesOnAppEntersForeground() throws {
         // NotificationManager Start to register lifecycle listener
         OSNotificationsManager.start()
-        
+
         OSNotificationsManager.delegate = self
-        
+
         XCTAssertEqual(self.notifTypes, 0)
-        
+
         // Then background the app
         OneSignalCoreMocks.backgroundApp()
-        
+
         // Foreground the app for within 30 seconds
         OneSignalCoreMocks.foregroundApp()
-        
+
         // Ensure that the delegate is updated with the new notification type
         XCTAssertEqual(self.notifTypes, ERROR_PUSH_NEVER_PROMPTED)
     }
-    
 
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -196,7 +196,10 @@ class OSUserExecutor {
             }
         }
     }
+}
 
+// MARK: - Execution
+extension OSUserExecutor {
     // We will pass minimal properties to this request
     static func createUser(_ user: OSUserInternal) {
         let originalPushToken = user.pushSubscriptionModel.address

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -37,84 +37,90 @@ class OSUserExecutor {
     static var userRequestQueue: [OSUserRequest] = []
     static var transferSubscriptionRequestQueue: [OSRequestTransferSubscription] = []
 
+    // The User executor dispatch queue, serial. This synchronizes access to the request queues.
+    private static let dispatchQueue = DispatchQueue(label: "OneSignal.OSUserExecutor", target: .global())
+
     // Read in requests from the cache, do not read in FetchUser requests as this is not needed.
     static func start() {
-        var userRequestQueue: [OSUserRequest] = []
+        self.dispatchQueue.async {
+            var userRequestQueue: [OSUserRequest] = []
 
-        // Read unfinished Create User + Identify User + Get Identity By Subscription requests from cache, if any...
-        if let cachedRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSUserRequest] {
-            // Hook each uncached Request to the right model reference
-            for request in cachedRequestQueue {
-                if request.isKind(of: OSRequestFetchIdentityBySubscription.self), let req = request as? OSRequestFetchIdentityBySubscription {
-                    if let identityModel = getIdentityModel(req.identityModel.modelId) {
-                        // 1. The model exist in the repo, set it to be the Request's model
-                        // It is the current user or the model has already been processed
-                        req.identityModel = identityModel
-                    } else {
-                        // 2. The model do not exist, use the model on the request, and add to repo.
-                        addIdentityModel(req.identityModel)
-                    }
-                    userRequestQueue.append(req)
-
-                } else if request.isKind(of: OSRequestCreateUser.self), let req = request as? OSRequestCreateUser {
-                    if let identityModel = getIdentityModel(req.identityModel.modelId) {
-                        // 1. The model exist in the repo, set it to be the Request's model
-                        req.identityModel = identityModel
-                    } else {
-                        // 2. The models do not exist, use the model on the request, and add to repo.
-                        addIdentityModel(req.identityModel)
-                    }
-                    userRequestQueue.append(req)
-
-                } else if request.isKind(of: OSRequestIdentifyUser.self), let req = request as? OSRequestIdentifyUser {
-
-                    if let identityModelToIdentify = getIdentityModel(req.identityModelToIdentify.modelId),
-                       let identityModelToUpdate = getIdentityModel(req.identityModelToUpdate.modelId) {
-                        // 1. Both models exist in the repo, set it to be the Request's models
-                        req.identityModelToIdentify = identityModelToIdentify
-                        req.identityModelToUpdate = identityModelToUpdate
-                    } else if let identityModelToIdentify = getIdentityModel(req.identityModelToIdentify.modelId),
-                              getIdentityModel(req.identityModelToUpdate.modelId) == nil {
-                        // 2. A model is in the repo, the other model does not exist
-                        req.identityModelToIdentify = identityModelToIdentify
-                        addIdentityModel(req.identityModelToUpdate)
-                    } else {
-                        // 3. Both models don't exist yet
-                        // Drop the request if the identityModelToIdentify does not already exist AND the request is missing OSID
-                        // Otherwise, this request will forever fail `prepareForExecution` and block pending requests such as recovery calls to `logout` or `login`
-                        guard request.prepareForExecution() else {
-                            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor.start() dropped: \(request)")
-                            continue
+            // Read unfinished Create User + Identify User + Get Identity By Subscription requests from cache, if any...
+            if let cachedRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSUserRequest] {
+                // Hook each uncached Request to the right model reference
+                for request in cachedRequestQueue {
+                    if request.isKind(of: OSRequestFetchIdentityBySubscription.self), let req = request as? OSRequestFetchIdentityBySubscription {
+                        if let identityModel = getIdentityModel(req.identityModel.modelId) {
+                            // 1. The model exist in the repo, set it to be the Request's model
+                            // It is the current user or the model has already been processed
+                            req.identityModel = identityModel
+                        } else {
+                            // 2. The model do not exist, use the model on the request, and add to repo.
+                            addIdentityModel(req.identityModel)
                         }
-                        addIdentityModel(req.identityModelToIdentify)
-                        addIdentityModel(req.identityModelToUpdate)
+                        userRequestQueue.append(req)
+
+                    } else if request.isKind(of: OSRequestCreateUser.self), let req = request as? OSRequestCreateUser {
+                        if let identityModel = getIdentityModel(req.identityModel.modelId) {
+                            // 1. The model exist in the repo, set it to be the Request's model
+                            req.identityModel = identityModel
+                        } else {
+                            // 2. The models do not exist, use the model on the request, and add to repo.
+                            addIdentityModel(req.identityModel)
+                        }
+                        userRequestQueue.append(req)
+
+                    } else if request.isKind(of: OSRequestIdentifyUser.self), let req = request as? OSRequestIdentifyUser {
+
+                        if let identityModelToIdentify = getIdentityModel(req.identityModelToIdentify.modelId),
+                           let identityModelToUpdate = getIdentityModel(req.identityModelToUpdate.modelId) {
+                            // 1. Both models exist in the repo, set it to be the Request's models
+                            req.identityModelToIdentify = identityModelToIdentify
+                            req.identityModelToUpdate = identityModelToUpdate
+                        } else if let identityModelToIdentify = getIdentityModel(req.identityModelToIdentify.modelId),
+                                  getIdentityModel(req.identityModelToUpdate.modelId) == nil {
+                            // 2. A model is in the repo, the other model does not exist
+                            req.identityModelToIdentify = identityModelToIdentify
+                            addIdentityModel(req.identityModelToUpdate)
+                        } else {
+                            // 3. Both models don't exist yet
+                            // Drop the request if the identityModelToIdentify does not already exist AND the request is missing OSID
+                            // Otherwise, this request will forever fail `prepareForExecution` and block pending requests such as recovery calls to `logout` or `login`
+                            guard request.prepareForExecution() else {
+                                OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor.start() dropped: \(request)")
+                                continue
+                            }
+                            addIdentityModel(req.identityModelToIdentify)
+                            addIdentityModel(req.identityModelToUpdate)
+                        }
+                        userRequestQueue.append(req)
                     }
-                    userRequestQueue.append(req)
                 }
             }
-        }
-        self.userRequestQueue = userRequestQueue
-        OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
-        // Read unfinished Transfer Subscription requests from cache, if any...
-        if let transferSubscriptionRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestTransferSubscription] {
-            // We only care about the last transfer subscription request
-            if let request = transferSubscriptionRequestQueue.last {
-                // Hook the uncached Request to the model in the store
-                if request.subscriptionModel.modelId == OneSignalUserManagerImpl.sharedInstance.user.pushSubscriptionModel.modelId {
-                    // The model exist, set it to be the Request's model
-                    request.subscriptionModel = OneSignalUserManagerImpl.sharedInstance.user.pushSubscriptionModel
-                    self.transferSubscriptionRequestQueue = [request]
-                } else if !request.prepareForExecution() {
-                    // The model do not exist AND this request cannot be sent, drop this Request
-                    OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor.start() dropped: \(request)")
-                    self.transferSubscriptionRequestQueue = []
+            self.userRequestQueue = userRequestQueue
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
+            // Read unfinished Transfer Subscription requests from cache, if any...
+            if let transferSubscriptionRequestQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSRequestTransferSubscription] {
+                // We only care about the last transfer subscription request
+                if let request = transferSubscriptionRequestQueue.last {
+                    // Hook the uncached Request to the model in the store
+                    if request.subscriptionModel.modelId == OneSignalUserManagerImpl.sharedInstance.user.pushSubscriptionModel.modelId {
+                        // The model exist, set it to be the Request's model
+                        request.subscriptionModel = OneSignalUserManagerImpl.sharedInstance.user.pushSubscriptionModel
+                        self.transferSubscriptionRequestQueue = [request]
+                    } else if !request.prepareForExecution() {
+                        // The model do not exist AND this request cannot be sent, drop this Request
+                        OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor.start() dropped: \(request)")
+                        self.transferSubscriptionRequestQueue = []
+                    }
                 }
+            } else {
+                OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor error encountered reading from cache for \(OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY)")
             }
-        } else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor error encountered reading from cache for \(OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY)")
+            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
+
+            executePendingRequests()
         }
-        OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
-        executePendingRequests()
     }
 
     static private func getIdentityModel(_ modelId: String) -> OSIdentityModel? {
@@ -126,61 +132,67 @@ class OSUserExecutor {
     }
 
     static func appendToQueue(_ request: OSUserRequest) {
-        if request.isKind(of: OSRequestTransferSubscription.self), let req = request as? OSRequestTransferSubscription {
-            self.transferSubscriptionRequestQueue.append(req)
-            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
-        } else {
-            self.userRequestQueue.append(request)
-            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
+        self.dispatchQueue.async {
+            if request.isKind(of: OSRequestTransferSubscription.self), let req = request as? OSRequestTransferSubscription {
+                self.transferSubscriptionRequestQueue.append(req)
+                OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
+            } else {
+                self.userRequestQueue.append(request)
+                OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
+            }
         }
     }
 
     static func removeFromQueue(_ request: OSUserRequest) {
-        if request.isKind(of: OSRequestTransferSubscription.self), let req = request as? OSRequestTransferSubscription {
-            transferSubscriptionRequestQueue.removeAll(where: { $0 == req})
-            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
-        } else {
-            userRequestQueue.removeAll(where: { $0 == request})
-            OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
+        self.dispatchQueue.async {
+            if request.isKind(of: OSRequestTransferSubscription.self), let req = request as? OSRequestTransferSubscription {
+                transferSubscriptionRequestQueue.removeAll(where: { $0 == req})
+                OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_TRANSFER_SUBSCRIPTION_REQUEST_QUEUE_KEY, withValue: self.transferSubscriptionRequestQueue)
+            } else {
+                userRequestQueue.removeAll(where: { $0 == request})
+                OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
+            }
         }
     }
 
     static func executePendingRequests() {
-        let requestQueue: [OSUserRequest] = userRequestQueue + transferSubscriptionRequestQueue
-        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSUserExecutor.executePendingRequests called with queue \(requestQueue)")
+        self.dispatchQueue.async {
+            let requestQueue: [OSUserRequest] = userRequestQueue + transferSubscriptionRequestQueue
+            OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSUserExecutor.executePendingRequests called with queue \(requestQueue)")
 
-        if requestQueue.isEmpty {
-            return
-        }
-
-        // Sort the requestQueue by timestamp
-        for request in requestQueue.sorted(by: { first, second in
-            return first.timestamp < second.timestamp
-        }) {
-            // Return as soon as we reach an un-executable request
-            if !request.prepareForExecution() {
-                OneSignalLog.onesignalLog(.LL_WARN, message: "OSUserExecutor.executePendingRequests() is blocked by unexecutable request \(request)")
+            if requestQueue.isEmpty {
                 return
             }
 
-            if request.isKind(of: OSRequestFetchIdentityBySubscription.self), let fetchIdentityRequest = request as? OSRequestFetchIdentityBySubscription {
-                executeFetchIdentityBySubscriptionRequest(fetchIdentityRequest)
-                return
-            } else if request.isKind(of: OSRequestCreateUser.self), let createUserRequest = request as? OSRequestCreateUser {
-                executeCreateUserRequest(createUserRequest)
-                return
-            } else if request.isKind(of: OSRequestIdentifyUser.self), let identifyUserRequest = request as? OSRequestIdentifyUser {
-                executeIdentifyUserRequest(identifyUserRequest)
-                return
-            } else if request.isKind(of: OSRequestTransferSubscription.self), let transferSubscriptionRequest = request as? OSRequestTransferSubscription {
-                executeTransferPushSubscriptionRequest(transferSubscriptionRequest)
-                return
-            } else if request.isKind(of: OSRequestFetchUser.self), let fetchUserRequest = request as? OSRequestFetchUser {
-                executeFetchUserRequest(fetchUserRequest)
-                return
-            } else {
-                // Log Error
-                OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor met incompatible Request type that cannot be executed.")
+            // Sort the requestQueue by timestamp
+            for request in requestQueue.sorted(by: { first, second in
+                return first.timestamp < second.timestamp
+            }) {
+                // Return as soon as we reach an un-executable request
+                if !request.prepareForExecution() {
+                    OneSignalLog.onesignalLog(.LL_WARN, message: "OSUserExecutor.executePendingRequests() is blocked by unexecutable request \(request)")
+                    return
+                }
+
+                if request.isKind(of: OSRequestFetchIdentityBySubscription.self), let fetchIdentityRequest = request as? OSRequestFetchIdentityBySubscription {
+                    executeFetchIdentityBySubscriptionRequest(fetchIdentityRequest)
+                    return
+                } else if request.isKind(of: OSRequestCreateUser.self), let createUserRequest = request as? OSRequestCreateUser {
+                    executeCreateUserRequest(createUserRequest)
+                    return
+                } else if request.isKind(of: OSRequestIdentifyUser.self), let identifyUserRequest = request as? OSRequestIdentifyUser {
+                    executeIdentifyUserRequest(identifyUserRequest)
+                    return
+                } else if request.isKind(of: OSRequestTransferSubscription.self), let transferSubscriptionRequest = request as? OSRequestTransferSubscription {
+                    executeTransferPushSubscriptionRequest(transferSubscriptionRequest)
+                    return
+                } else if request.isKind(of: OSRequestFetchUser.self), let fetchUserRequest = request as? OSRequestFetchUser {
+                    executeFetchUserRequest(fetchUserRequest)
+                    return
+                } else {
+                    // Log Error
+                    OneSignalLog.onesignalLog(.LL_ERROR, message: "OSUserExecutor met incompatible Request type that cannot be executed.")
+                }
             }
         }
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestDeleteSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestDeleteSubscription.swift
@@ -55,7 +55,7 @@ class OSRequestDeleteSubscription: OneSignalRequest, OSUserRequest {
 
     init(subscriptionModel: OSSubscriptionModel) {
         self.subscriptionModel = subscriptionModel
-        self.stringDescription = "OSRequestDeleteSubscription with subscriptionModel: \(subscriptionModel.address ?? "nil")"
+        self.stringDescription = "<OSRequestDeleteSubscription with subscriptionModel: \(subscriptionModel.address ?? "nil")>"
         super.init()
         self.method = DELETE
         _ = prepareForExecution() // sets the path property
@@ -77,7 +77,7 @@ class OSRequestDeleteSubscription: OneSignalRequest, OSUserRequest {
             return nil
         }
         self.subscriptionModel =  subscriptionModel
-        self.stringDescription = "OSRequestDeleteSubscription with subscriptionModel: \(subscriptionModel.address ?? "nil")"
+        self.stringDescription = "<OSRequestDeleteSubscription with subscriptionModel: \(subscriptionModel.address ?? "nil")>"
         super.init()
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp


### PR DESCRIPTION
# Description
## One Line Summary
Improve synchronization in the remaining executors (Identity, Subscription, User) to prevent concurrent access crashes.

## Details
In #1376, a `DispatchQueue` was added to the Operation Repo and the Property Executor to serialize access to shared data. These two components encounter the most updates and frequent mutations by different threads. Though rare, the other executors can also encounter concurrent access.

The changes for the Operation Repo and Property Executor appear to be mitigating crashes, so we are adding the same to all executors in this PR:
- Identity Executor
- Subscription Executor
- User Executor (for creates, fetches, etc)

### Motivation
We received a report of a crash that I believe is due to one of these remaining executors experiencing a concurrent state access / mutation.

### Scope
Executors synchronize array access, mutation, and caching through a Dispatch Queue.

# Testing
## Unit testing
* Added tests reproducing crashes
  * testSubscriptionExecutorConcurrency - add test to reproduce crash in Subscription Executor
  * testIdentityExecutorConcurrency - add test to reproduce crash in Identity Executor
  * testUserExecutorConcurrency - add test to reproduce crash in User Executor
  * testPropertyExecutorConcurrency - add test to confirm Property Executor does have have concurrency crashes

## Manual testing
Unable to reproduce

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1454)
<!-- Reviewable:end -->
