### PR TITLE
[Feat] Use only OneSignal ID for requests

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -335,6 +335,19 @@ extension OSUserExecutor {
         OneSignalCoreImpl.sharedClient().execute(request) { _ in
             removeFromQueue(request)
 
+            guard let onesignalId = request.identityModelToIdentify.onesignalId else {
+                OneSignalLog.onesignalLog(.LL_ERROR, message: "executeIdentifyUserRequest succeeded but is now missing OneSignal ID!")
+                executePendingRequests()
+                return
+            }
+
+            // Need to hydrate the identity model for current user or past user with pending requests
+            let aliases = [
+                OS_ONESIGNAL_ID: onesignalId,
+                request.aliasLabel: request.aliasId
+            ]
+            request.identityModelToUpdate.hydrate(aliases)
+
             // the anonymous user has been identified, still need to Fetch User as we cleared local data
             // Fetch the user only if its the current user
             if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModelToUpdate) {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -230,7 +230,7 @@ extension OSUserExecutor {
                 // Fetch the user only if its the current user and non-anonymous
                 if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel),
                    let identity = request.parameters?["identity"] as? [String: String],
-                   let onesignalId = identity[OS_ONESIGNAL_ID],
+                   let onesignalId = request.identityModel.onesignalId,
                    identity[OS_EXTERNAL_ID] != nil {
                     fetchUser(aliasLabel: OS_ONESIGNAL_ID, aliasId: onesignalId, identityModel: request.identityModel)
                 } else {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -191,15 +191,10 @@ extension OSUserExecutor {
     }
 
     /**
-     This Create User call expects an Identity Model with external ID to hydrate the OneSignal ID
+     This Create User call expects an external ID and the Identity Model to hydrate with the OneSignal ID
      */
-    static func createUser(identityModel: OSIdentityModel) {
-        guard identityModel.externalId != nil else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "createUser(identityModel) called with missing external ID")
-            return
-        }
-
-        let request = OSRequestCreateUser(identityModel: identityModel, propertiesModel: nil, pushSubscriptionModel: nil, originalPushToken: nil)
+    static func createUser(aliasLabel: String, aliasId: String, identityModel: OSIdentityModel) {
+        let request = OSRequestCreateUser(aliasLabel: aliasLabel, aliasId: aliasId, identityModel: identityModel)
         appendToQueue(request)
         executePendingRequests()
     }
@@ -209,7 +204,7 @@ extension OSUserExecutor {
             return
         }
         guard request.prepareForExecution() else {
-            // Currently there are no requirements needed before sending this request
+            // Currently there are no requirements needed before sending this request, so this will set the path
             return
         }
         request.sentToClient = true
@@ -369,7 +364,7 @@ extension OSUserExecutor {
                         createUser(OneSignalUserManagerImpl.sharedInstance.user)
                     } else {
                         // This will hydrate the OneSignal ID for any pending requests
-                        createUser(identityModel: request.identityModelToUpdate)
+                        createUser(aliasLabel: request.aliasLabel, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
                     }
                 } else if responseType == .invalid || responseType == .unauthorized {
                     // Failed, no retry

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -232,11 +232,12 @@ extension OSUserExecutor {
 
                 // If this user already exists and we logged into an external_id, fetch the user data
                 // TODO: Only do this if response code is 200 or 202
-                // Fetch the user only if its the current user
+                // Fetch the user only if its the current user and non-anonymous
                 if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel),
                    let identity = request.parameters?["identity"] as? [String: String],
-                   let externalId = identity[OS_EXTERNAL_ID] {
-                    fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: externalId, identityModel: request.identityModel)
+                   let onesignalId = identity[OS_ONESIGNAL_ID],
+                   identity[OS_EXTERNAL_ID] != nil {
+                    fetchUser(aliasLabel: OS_ONESIGNAL_ID, aliasId: onesignalId, identityModel: request.identityModel)
                 } else {
                     executePendingRequests()
                 }
@@ -337,12 +338,8 @@ extension OSUserExecutor {
             // the anonymous user has been identified, still need to Fetch User as we cleared local data
             // Fetch the user only if its the current user
             if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModelToUpdate) {
-                fetchUser(aliasLabel: OS_EXTERNAL_ID, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
+                fetchUser(aliasLabel: OS_ONESIGNAL_ID, aliasId: onesignalId, identityModel: request.identityModelToUpdate)
             } else {
-                // Need to hydrate the identity model for any pending requests
-                if let osid = request.identityModelToIdentify.onesignalId {
-                    request.identityModelToUpdate.hydrate([OS_ONESIGNAL_ID: osid])
-                }
                 executePendingRequests()
             }
         } onFailure: { error in

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModel.swift
@@ -29,23 +29,7 @@ import Foundation
 import OneSignalCore
 import OneSignalOSCore
 
-// By matching the enum name to the raw value, it will always stringify correctly
-enum OSDefaultAlias: String {
-    // swiftlint:disable identifier_name
-    case onesignal_id = "onesignal_id"
-    case external_id = "external_id"
-    // swiftlint:enable identifier_name
-}
-
 class OSIdentityModel: OSModel {
-    /**
-     Set either `onesignal_id` or `external_id`, representing the alias that will be used in requests.
-     */
-    var primaryAliasLabel: OSDefaultAlias = .onesignal_id
-    var primaryAliasId: String? {
-        return if primaryAliasLabel == .external_id { externalId } else { onesignalId }
-    }
-
     var onesignalId: String? {
         return internalGetAlias(OS_ONESIGNAL_ID)
     }
@@ -73,7 +57,6 @@ class OSIdentityModel: OSModel {
         aliasesLock.withLock {
             super.encode(with: coder)
             coder.encode(aliases, forKey: "aliases")
-            coder.encode(primaryAliasLabel.rawValue, forKey: "primaryAliasLabel") // Encodes as String
         }
     }
 
@@ -82,12 +65,6 @@ class OSIdentityModel: OSModel {
         guard let aliases = coder.decodeObject(forKey: "aliases") as? [String: String] else {
             // log error
             return nil
-        }
-        if let rawType = coder.decodeObject(forKey: "primaryAliasLabel") as? String,
-           let label = OSDefaultAlias(rawValue: rawType) {
-            self.primaryAliasLabel = label
-        } else {
-            self.primaryAliasLabel = .onesignal_id
         }
         self.aliases = aliases
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -354,6 +354,14 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         return self.identityModelStore.getModel(modelId: identityModel.modelId) != nil
     }
 
+    func isCurrentUser(_ externalId: String) -> Bool {
+        guard !externalId.isEmpty else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "isCurrentUser called with empty externalId")
+            return false
+        }
+
+        return user.identityModel.externalId == externalId
+    }
     /**
      Clears the existing user's data in preparation for hydration via a fetch user call.
      */

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestAddAliases.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestAddAliases.swift
@@ -39,10 +39,9 @@ class OSRequestAddAliases: OneSignalRequest, OSUserRequest {
 
     // requires a `onesignal_id` to send this request
     func prepareForExecution() -> Bool {
-        let aliasLabel = identityModel.primaryAliasLabel
-        if let aliasId = identityModel.primaryAliasId, let appId = OneSignalConfigManager.getAppId() {
+        if let onesignalId = identityModel.onesignalId, let appId = OneSignalConfigManager.getAppId() {
             self.addJWTHeader(identityModel: identityModel)
-            self.path = "apps/\(appId)/users/by/\(aliasLabel)/\(aliasId)/identity"
+            self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity"
             return true
         } else {
             // self.path is non-nil, so set to empty string

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateSubscription.swift
@@ -44,10 +44,9 @@ class OSRequestCreateSubscription: OneSignalRequest, OSUserRequest {
 
     // Need the onesignal_id of the user
     func prepareForExecution() -> Bool {
-        let aliasLabel = identityModel.primaryAliasLabel
-        if let aliasId = identityModel.primaryAliasId, let appId = OneSignalConfigManager.getAppId() {
+        if let onesignalId = identityModel.onesignalId, let appId = OneSignalConfigManager.getAppId() {
             self.addJWTHeader(identityModel: identityModel)
-            self.path = "apps/\(appId)/users/by/\(aliasLabel)/\(aliasId)/subscriptions"
+            self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/subscriptions"
             return true
         } else {
             self.path = "" // self.path is non-nil, so set to empty string

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
@@ -66,7 +66,7 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         self.originalPushToken = pushSubscriptionModel.address
     }
 
-    init(identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel?, pushSubscriptionModel: OSSubscriptionModel?, originalPushToken: String?) {
+    init(identityModel: OSIdentityModel, propertiesModel: OSPropertiesModel, pushSubscriptionModel: OSSubscriptionModel, originalPushToken: String?) {
         self.identityModel = identityModel
         self.pushSubscriptionModel = pushSubscriptionModel
         self.originalPushToken = originalPushToken
@@ -82,18 +82,25 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         }
 
         // Properties Object
-        if let propertiesModel = propertiesModel {
-            var propertiesObject: [String: Any] = [:]
-            propertiesObject["language"] = propertiesModel.language
-            propertiesObject["timezone_id"] = propertiesModel.timezoneId
-            params["properties"] = propertiesObject
-        }
+        var propertiesObject: [String: Any] = [:]
+        propertiesObject["language"] = propertiesModel.language
+        propertiesObject["timezone_id"] = propertiesModel.timezoneId
+        params["properties"] = propertiesObject
 
         params["refresh_device_metadata"] = true
         self.parameters = params
-        if let pushSub = pushSubscriptionModel {
-            self.updatePushSubscriptionModel(pushSub)
-        }
+        self.updatePushSubscriptionModel(pushSubscriptionModel)
+        self.method = POST
+    }
+
+    init(aliasLabel: String, aliasId: String, identityModel: OSIdentityModel) {
+        self.identityModel = identityModel
+        self.stringDescription = "<OSRequestCreateUser with alias \(aliasLabel): \(aliasId)>"
+        super.init()
+        self.parameters = [
+            "identity": [aliasLabel: aliasId],
+            "refresh_device_metadata": true,
+        ]
         self.method = POST
     }
 
@@ -103,7 +110,6 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         coder.encode(originalPushToken, forKey: "originalPushToken")
         coder.encode(parameters, forKey: "parameters")
         coder.encode(method.rawValue, forKey: "method") // Encodes as String
-        coder.encode(path, forKey: "path")
         coder.encode(timestamp, forKey: "timestamp")
     }
 
@@ -112,7 +118,6 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
             let identityModel = coder.decodeObject(forKey: "identityModel") as? OSIdentityModel,
             let parameters = coder.decodeObject(forKey: "parameters") as? [String: Any],
             let rawMethod = coder.decodeObject(forKey: "method") as? UInt32,
-            let path = coder.decodeObject(forKey: "path") as? String,
             let timestamp = coder.decodeObject(forKey: "timestamp") as? Date
         else {
             // Log error
@@ -125,7 +130,6 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         super.init()
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)
-        self.path = path
         self.timestamp = timestamp
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestFetchUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestFetchUser.swift
@@ -28,8 +28,8 @@
 import OneSignalCore
 
 /**
- If an alias is passed in, it will be used to fetch the user. If not, then by default, use the `onesignal_id` in the `identityModel` to fetch the user.
- The `identityModel` is also used to reference the user that is updated with the response.
+ Fetch the user by the provided alias. This is expected to be `onesignal_id` in most cases.
+ The `identityModel` is used to reference the user that is updated with the response.
  */
 class OSRequestFetchUser: OneSignalRequest, OSUserRequest {
     var sentToClient = false

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestIdentifyUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestIdentifyUser.swift
@@ -48,15 +48,14 @@ class OSRequestIdentifyUser: OneSignalRequest, OSUserRequest {
 
     // requires a onesignal_id to send this request
     func prepareForExecution() -> Bool {
-        let aliasLabel = identityModelToIdentify.primaryAliasLabel
-        if let aliasId = identityModelToIdentify.primaryAliasId, let appId = OneSignalConfigManager.getAppId() {
+        if let onesignalId = identityModelToIdentify.onesignalId, let appId = OneSignalConfigManager.getAppId() {
             self.addJWTHeader(identityModel: identityModelToIdentify)
-            self.path = "apps/\(appId)/users/by/\(aliasLabel)/\(aliasId)/identity"
+            self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity"
             return true
         } else {
             // self.path is non-nil, so set to empty string
             self.path = ""
-            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the Identify User request due to null app ID or null \(aliasLabel) ID.")
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the Identify User request due to null app ID or null OneSignal ID.")
             return false
         }
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestRemoveAlias.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestRemoveAlias.swift
@@ -38,10 +38,9 @@ class OSRequestRemoveAlias: OneSignalRequest, OSUserRequest {
     var identityModel: OSIdentityModel
 
     func prepareForExecution() -> Bool {
-        let aliasLabel = identityModel.primaryAliasLabel
-        if let aliasId = identityModel.primaryAliasId, let appId = OneSignalConfigManager.getAppId() {
+        if let onesignalId = identityModel.onesignalId, let appId = OneSignalConfigManager.getAppId() {
             self.addJWTHeader(identityModel: identityModel)
-            self.path = "apps/\(appId)/users/by/\(aliasLabel)/\(aliasId)/identity/\(labelToRemove)"
+            self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity/\(labelToRemove)"
             return true
         } else {
             // self.path is non-nil, so set to empty string

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestTransferSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestTransferSubscription.swift
@@ -28,80 +28,36 @@
 import OneSignalCore
 
 /**
+ Deprecated as of `5.2.3`. Use CreateUser instead. This class skeleton remains due to potentially cached requests.
+ When this request is uncached, it will be translated to a CreateUser request, if appropriate.
+ -------
  Transfers the Subscription specified by the subscriptionId to the User identified by the identity in the payload.
  Only one entry is allowed, `onesignal_id` or an Alias. We will use the alias specified.
  The anticipated usage of this request is only for push subscriptions.
  */
+@available(*, deprecated, message: "Replaced by Create User")
 class OSRequestTransferSubscription: OneSignalRequest, OSUserRequest {
     var sentToClient = false
-    let stringDescription: String
-    override var description: String {
-        return stringDescription
-    }
 
-    var subscriptionModel: OSSubscriptionModel
     let aliasLabel: String
     let aliasId: String
 
-    // Need an alias and subscription_id
     func prepareForExecution() -> Bool {
-        if let subscriptionId = subscriptionModel.subscriptionId, let appId = OneSignalConfigManager.getAppId() {
-            self.path = "apps/\(appId)/subscriptions/\(subscriptionId)/owner"
-            // TODO: self.addJWTHeader(identityModel: identityModel) ??
-            return true
-        } else {
-            self.path = "" // self.path is non-nil, so set to empty string
-            return false
-        }
+        return false
     }
 
-    /**
-     Must pass an Alias pair to identify the User.
-     */
-    init(
-        subscriptionModel: OSSubscriptionModel,
-        aliasLabel: String,
-        aliasId: String
-    ) {
-        self.subscriptionModel = subscriptionModel
-        self.aliasLabel = aliasLabel
-        self.aliasId = aliasId
-        self.stringDescription = "<OSRequestTransferSubscription to \(aliasLabel): \(aliasId)>"
-        super.init()
-        self.parameters = ["identity": [aliasLabel: aliasId]]
-        self.method = PATCH
-        _ = prepareForExecution() // sets the path property
-    }
+    func encode(with coder: NSCoder) { }
 
-    func encode(with coder: NSCoder) {
-        coder.encode(subscriptionModel, forKey: "subscriptionModel")
-        coder.encode(aliasLabel, forKey: "aliasLabel")
-        coder.encode(aliasId, forKey: "aliasId")
-        coder.encode(parameters, forKey: "parameters")
-        coder.encode(method.rawValue, forKey: "method") // Encodes as String
-        coder.encode(timestamp, forKey: "timestamp")
-    }
-
+    /// All cached instances should have External ID as the alias
     required init?(coder: NSCoder) {
         guard
-            let subscriptionModel = coder.decodeObject(forKey: "subscriptionModel") as? OSSubscriptionModel,
             let aliasLabel = coder.decodeObject(forKey: "aliasLabel") as? String,
-            let aliasId = coder.decodeObject(forKey: "aliasId") as? String,
-            let rawMethod = coder.decodeObject(forKey: "method") as? UInt32,
-            let parameters = coder.decodeObject(forKey: "parameters") as? [String: Any],
-            let timestamp = coder.decodeObject(forKey: "timestamp") as? Date
+            let aliasId = coder.decodeObject(forKey: "aliasId") as? String
         else {
             // Log error
             return nil
         }
-        self.subscriptionModel = subscriptionModel
         self.aliasLabel = aliasLabel
         self.aliasId = aliasId
-        self.stringDescription = "<OSRequestTransferSubscription to \(aliasLabel): \(aliasId)>"
-        super.init()
-        self.parameters = parameters
-        self.method = HTTPMethod(rawValue: rawMethod)
-        self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
@@ -39,12 +39,11 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
     // TODO: Decide if addPushSubscriptionIdToAdditionalHeadersIfNeeded should block.
     // Note Android adds it to requests, if the push sub ID exists
     func prepareForExecution() -> Bool {
-        let aliasLabel = identityModel.primaryAliasLabel
-        if let aliasId = identityModel.primaryAliasId,
+        if let onesignalId = identityModel.onesignalId,
             let appId = OneSignalConfigManager.getAppId() {
             _ = self.addPushSubscriptionIdToAdditionalHeaders()
             self.addJWTHeader(identityModel: identityModel)
-            self.path = "apps/\(appId)/users/by/\(aliasLabel)/\(aliasId)"
+            self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)"
             return true
         } else {
             // self.path is non-nil, so set to empty string

--- a/iOS_SDK/OneSignalSDK/OneSignalUserMocks/MockUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserMocks/MockUserRequests.swift
@@ -94,7 +94,7 @@ extension MockUserRequests {
             response: userResponse
         )
         client.setMockResponseForRequest(
-            request: "<OSRequestFetchUser with external_id: \(externalId)>",
+            request: "<OSRequestFetchUser with onesignal_id: \(osid)>",
             response: userResponse
         )
     }
@@ -111,6 +111,16 @@ extension MockUserRequests {
                 request: "<OSRequestIdentifyUser with external_id: \(externalId)>",
                 error: NSError(domain: "not-important", code: 409)
             )
+            // 2. Set the response for the subsequent Create User request
+            let userResponse = MockUserRequests.testIdentityPayload(onesignalId: osid, externalId: externalId)
+            client.setMockResponseForRequest(
+                request: "<OSRequestCreateUser with externalId: \(externalId)>",
+                response: userResponse)
+            // 3. Set the response for the subsequent Fetch User request
+            client.setMockResponseForRequest(
+                request: "<OSRequestFetchUser with onesignal_id: \(osid)>",
+                response: fetchResponse
+            )
         } else {
             // The Identify User is successful, the OSID is unchanged
             osid = anonUserOSID
@@ -119,12 +129,12 @@ extension MockUserRequests {
                 request: "<OSRequestIdentifyUser with external_id: \(externalId)>",
                 response: fetchResponse
             )
+            // 2. Set the response for the subsequent Fetch User request
+            client.setMockResponseForRequest(
+                request: "<OSRequestFetchUser with onesignalId: \(osid)>",
+                response: fetchResponse
+            )
         }
-        // 2. Set the response for the subsequent Fetch User request
-        client.setMockResponseForRequest(
-            request: "<OSRequestFetchUser with external_id: \(externalId)>",
-            response: fetchResponse
-        )
     }
 
     /**
@@ -147,7 +157,7 @@ extension MockUserRequests {
             ]
         ]
         client.setMockResponseForRequest(
-            request: "<OSRequestFetchUser with external_id: \(externalId)>",
+            request: "<OSRequestFetchUser with onesignal_id: \(osid)>",
             response: fetchResponse
         )
     }
@@ -205,13 +215,6 @@ extension MockUserRequests {
         client.setMockResponseForRequest(
             request: "<OSRequestCreateSubscription with token: \(email)>",
             response: response
-        )
-    }
-
-    public static func setTransferSubscriptionResponse(with client: MockOneSignalClient, externalId: String) {
-        client.setMockResponseForRequest(
-            request: "<OSRequestTransferSubscription to external_id: \(externalId)>",
-            response: [:] // The SDK does not use the response
         )
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUserMocks/OneSignalUserMocks.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserMocks/OneSignalUserMocks.swift
@@ -43,7 +43,6 @@ public class OneSignalUserMocks: NSObject {
 
     public static func resetStaticUserExecutor() {
         OSUserExecutor.userRequestQueue.removeAll()
-        OSUserExecutor.transferSubscriptionRequestQueue.removeAll()
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
@@ -312,7 +312,7 @@ final class OneSignalUserTests: XCTestCase {
 
         // Increase flush interval to allow all the updates to batch
         OSOperationRepo.sharedInstance.pollIntervalMilliseconds = 300
-        
+
         /* When */
 
         OneSignalUserManagerImpl.sharedInstance.sendSessionTime(100)

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/SwitchUserIntegrationTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/SwitchUserIntegrationTests.swift
@@ -105,7 +105,6 @@ final class SwitchUserIntegrationTests: XCTestCase {
         MockUserRequests.setAddTagsAndLanguageResponse(with: client, tags: tagsUserA, language: "lang_a")
         MockUserRequests.setAddAliasesResponse(with: client, aliases: ["alias_a": "id_a"])
         MockUserRequests.setAddEmailResponse(with: client, email: "email_a@example.com")
-        MockUserRequests.setTransferSubscriptionResponse(with: client, externalId: userA_EUID)
         // Returns mocked user data to test hydration
         MockUserRequests.setDefaultFetchUserResponseForHydration(with: client, externalId: userA_EUID)
 
@@ -160,7 +159,6 @@ final class SwitchUserIntegrationTests: XCTestCase {
             contains: ["subscription": ["token": "email_a@example.com"]])
         )
         XCTAssertTrue(client.hasExecutedRequestOfType(OSRequestFetchUser.self))
-        XCTAssertTrue(client.hasExecutedRequestOfType(OSRequestTransferSubscription.self))
 
         // 3. Asserts for User A - local data is updated via hydration
         XCTAssertEqual("remote_language", OneSignalUserManagerImpl.sharedInstance.user.propertiesModel.language)
@@ -262,15 +260,15 @@ final class SwitchUserIntegrationTests: XCTestCase {
 
         // 2. Asserts for User A
         XCTAssertTrue(client.onlyOneRequest( // Tag + Language
-            contains: "apps/test-app-id/users/by/external_id/\(userA_EUID)",
+            contains: "apps/test-app-id/users/by/onesignal_id/\(userA_OSID)",
             contains: ["properties": ["language": "lang_a", "tags": tagsUserA]])
         )
         XCTAssertTrue(client.onlyOneRequest( // Alias
-            contains: "apps/test-app-id/users/by/external_id/\(userA_EUID)/identity",
+            contains: "apps/test-app-id/users/by/onesignal_id/\(userA_OSID)/identity",
             contains: ["identity": ["alias_a": "id_a"]])
         )
         XCTAssertTrue(client.onlyOneRequest( // Email
-            contains: "apps/test-app-id/users/by/external_id/\(userA_EUID)/subscriptions",
+            contains: "apps/test-app-id/users/by/onesignal_id/\(userA_OSID)/subscriptions",
             contains: ["subscription": ["token": "email_a@example.com"]])
         )
 
@@ -388,15 +386,15 @@ final class SwitchUserIntegrationTests: XCTestCase {
 
         // 2. Asserts for User A
         XCTAssertTrue(client.onlyOneRequest( // Tag + Language
-            contains: "apps/test-app-id/users/by/external_id/\(userA_EUID)",
+            contains: "apps/test-app-id/users/by/onesignal_id/\(userA_OSID)",
             contains: ["properties": ["language": "lang_a", "tags": tagsUserA]])
         )
         XCTAssertTrue(client.onlyOneRequest( // Alias
-            contains: "apps/test-app-id/users/by/external_id/\(userA_EUID)/identity",
+            contains: "apps/test-app-id/users/by/onesignal_id/\(userA_OSID)/identity",
             contains: ["identity": ["alias_a": "id_a"]])
         )
         XCTAssertTrue(client.onlyOneRequest( // Email
-            contains: "apps/test-app-id/users/by/external_id/\(userA_EUID)/subscriptions",
+            contains: "apps/test-app-id/users/by/onesignal_id/\(userA_OSID)/subscriptions",
             contains: ["subscription": ["token": "email_a@example.com"]])
         )
 


### PR DESCRIPTION
# Description
## One Line Summary
Use only OneSignal ID for requests, no longer using any External ID for requests.

## Details
- Fetch user will only occur with OneSignal ID, no more EUID
- Any user updates will only occur with OneSignal ID, no more EUID
- Remove Transfer Subscription Request except to uncache on upgrade only
  - Still relevant Transfer Subscription request will be converted into an equivalent Create User request
  - Cached Transfer Subscription requests should be rare - in order for this to be cached, it means the Identify User request returned 409 but the immediate Transfer Subscription did not send or resulted in a retry-able error response
- Identify User success and conflict responses result in different behavior now
  - Both will call Create User instead of marking pending requests to use EUID or fetching and transferring the push subscription

### Motivation
Move away from using External ID in request URLs, only using OneSignal ID.

### Scope
Making requests

# Testing
## Unit testing
- No new unit test are added, but existing unit tests are updated

## Manual testing
**Device:** iPhone 13 on iOS `17.5.1`




<details>
  <summary>Identify User with success (external ID applied successfully)</summary>

1. Start with anonymous user in the SDK
2. Add a tag and an email
3. Login to a new user (brand new external ID)
4. The Identify User request is successful
5. Fetch User by OSID happens
6. Local state is correct and contains the tag and email

</details>


<details>
  <summary>Identify User with 409 conflict</summary>

1. Start with anonymous user and login to an existing EUID
2. Receive 409 conflict response
3. If the user is the current user, it will make a CreateUser request with the external ID and push subscription in the payload
4. If the user is now different, it will make a CreateUser request with the external ID only for hydration of the OneSignal ID, for any pending requests for that previous user

</details>



<details>
  <summary>SDK Upgrade: There is a cached Transfer Subscription for the current user</summary>

1. Reproduce this on `main` by login to an existing EUID
2. The Identify User happens and receives 409 conflict response
3. The subsequent Fetch User by EUID and Transfer Subscription are generated and cached, but do not get sent
4. Upgrade SDK to this version
5. During uncaching, the Fetch User is dropped and the Transfer Subscription is converted to a CreateUser containing the external ID and push subscription.
6. User observer fires and everything looks correct.

</details>

<details>
  <summary>SDK Upgrade: There is a cached Transfer Subscription for a previous user</summary>

1. Reproduce this on `main` by login to an existing EUID `userA`
2. The Identify User happens and receives 409 conflict response
3. The subsequent Fetch User by EUID and Transfer Subscription are generated and cached, but do not get sent
4. Now login to another user `userB`, which enqueues a CreateUser request
5. Upgrade SDK to this version
6. During uncaching, the Fetch User is dropped and the Transfer Subscription is dropped, only the CreateUser remains
7. The CreateUser is sent and the state in the SDK seems correct for `userB`.

</details>

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1464)
<!-- Reviewable:end -->
