### PR TITLE
Omit misleading fatal-level log for wrappers

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -293,7 +293,10 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 
 + (BOOL)isValidAppId:(NSString*)appId {
     if (!appId || ![[NSUUID alloc] initWithUUIDString:appId]) {
-        [OneSignalLog onesignalLog:ONE_S_LL_FATAL message:[NSString stringWithFormat:@"OneSignal AppId: %@ - AppId is null or format is invalid, stopping initialization.\nExample usage: 'b2f7f966-d8cc-11e4-bed1-df8f05be55ba'\n", appId]];
+        if (!OneSignalWrapper.sdkType) {
+            // Fatal log if not a wrapper SDK, wrappers will call init with null App Id
+            [OneSignalLog onesignalLog:ONE_S_LL_FATAL message:[NSString stringWithFormat:@"OneSignal AppId: %@ - AppId is null or format is invalid, stopping initialization.\nExample usage: 'b2f7f966-d8cc-11e4-bed1-df8f05be55ba'\n", appId]];
+        }
         return false;
     }
     return true;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -76,7 +76,6 @@ NS_SWIFT_NAME(login(externalId:token:));
 + (Class<OSNotifications>)Notifications NS_REFINED_FOR_SWIFT;
 
 #pragma mark Initialization
-+ (void)setLaunchOptions:(nullable NSDictionary*)newLaunchOptions; // meant for use by wrappers
 + (void)initialize:(nonnull NSString*)newAppId withLaunchOptions:(nullable NSDictionary*)launchOptions;
 + (void)setProvidesNotificationSettingsView:(BOOL)providesView;
 


### PR DESCRIPTION
# Description
## One Line Summary
Omit misleading fatal-level log for wrappers that always happens and is alarming, and is regularly reported by SDK users.

## Details
**Log Fatal log for null app ID only on native SDK**
* Wrapper SDKs will automatically initialize with null app ID.
* On wrappers, this fatal log is very misleading, so only log if this happens on the native SDK.
* Most wrappers also have type signatures indicating app ID should be non-null for the public initialize API
* Note all wrappers except Flutter set the wrapper sdkType before initializing with null app ID. Requires Flutter update.

**Remove `setLaunchOptions` from OneSignal header**
* This was added to the OneSignalFramework header file to expose to wrappers.
* However, wrappers do not actually use this because they must initialize the SDK (not sufficient to only set launch options) so cold start click listeners can be triggered.
* Remove from header so it is not misleading, which suggests wrappers behave differently than how they are. 

### Motivation
Wrapper SDK users regularly report the alarming `FATAL: OneSignal AppId: (null) - AppId is null or format is invalid, stopping initialization`, and it is misleading, and hides the real issue they have, if any.

### Scope
An error log

# Testing
## Unit testing

## Manual testing
Iphone 13 on iOS 17.5.1
- Tested setting and not setting a `OneSignalWrapper.sdkType` before calling init with null app ID and seeing logs

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ x Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1468)
<!-- Reviewable:end -->
