### PR TITLE
[Fix] Handle incorrect `404`, delay making requests to new IDs

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,1 +1,4 @@
 line_length: 150
+disabled_rules:
+  # Track https://github.com/realm/SwiftLint/pull/5521
+  - opening_brace

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		3CEE93542B7C78EC008440BD /* OneSignalUser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3CEE93572B7C78FD008440BD /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
 		3CEE93582B7C78FE008440BD /* OneSignalCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3CF1A5632C669EA40056B3AA /* OSNewRecordsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF1A5622C669EA40056B3AA /* OSNewRecordsState.swift */; };
 		3CF8629E28A183F900776CA4 /* OSIdentityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */; };
 		3CF862A028A1964F00776CA4 /* OSPropertiesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */; };
 		3CF862A228A197D200776CA4 /* OSPropertiesModelStoreListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF862A128A197D200776CA4 /* OSPropertiesModelStoreListener.swift */; };
@@ -1294,6 +1295,7 @@
 		3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModelStoreListener.swift; sourceTree = "<group>"; };
 		3CEE90A62BFE6ABD00B0FB5B /* OSPropertiesSupportedProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesSupportedProperty.swift; sourceTree = "<group>"; };
 		3CEE90A82C000BD500B0FB5B /* OneSignalRequest+UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OneSignalRequest+UnitTests.swift"; sourceTree = "<group>"; };
+		3CF1A5622C669EA40056B3AA /* OSNewRecordsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSNewRecordsState.swift; sourceTree = "<group>"; };
 		3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModel.swift; sourceTree = "<group>"; };
 		3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesModel.swift; sourceTree = "<group>"; };
 		3CF862A128A197D200776CA4 /* OSPropertiesModelStoreListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesModelStoreListener.swift; sourceTree = "<group>"; };
@@ -2051,6 +2053,7 @@
 				3C115188289ADEA300565C41 /* OSModelStore.swift */,
 				3C115186289ADE7700565C41 /* OSModelStoreListener.swift */,
 				3C115184289ADE4F00565C41 /* OSModel.swift */,
+				3CF1A5622C669EA40056B3AA /* OSNewRecordsState.swift */,
 				3C11518A289ADEEB00565C41 /* OSEventProducer.swift */,
 				3C11518C289AF5E800565C41 /* OSModelChangedHandler.swift */,
 				3C4F9E4328A4466C009F453A /* OSOperationRepo.swift */,
@@ -4038,6 +4041,7 @@
 				3C115165289A259500565C41 /* OneSignalOSCore.docc in Sources */,
 				3C115189289ADEA300565C41 /* OSModelStore.swift in Sources */,
 				3C115185289ADE4F00565C41 /* OSModel.swift in Sources */,
+				3CF1A5632C669EA40056B3AA /* OSNewRecordsState.swift in Sources */,
 				3C448BA22936B474002F96BC /* OSBackgroundTaskManager.swift in Sources */,
 				3C115187289ADE7700565C41 /* OSModelStoreListener.swift in Sources */,
 				3CE5F9E3289D88DC004A156E /* OSModelStoreChangedHandler.swift in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -177,6 +177,8 @@
 		3CEE93542B7C78EC008440BD /* OneSignalUser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3CEE93572B7C78FD008440BD /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
 		3CEE93582B7C78FE008440BD /* OneSignalCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3CF11E3D2C6D6155002856F5 /* UserExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF11E3C2C6D6155002856F5 /* UserExecutorTests.swift */; };
+		3CF11E402C6E6DE2002856F5 /* MockNewRecordsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF11E3F2C6E6DE2002856F5 /* MockNewRecordsState.swift */; };
 		3CF1A5632C669EA40056B3AA /* OSNewRecordsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF1A5622C669EA40056B3AA /* OSNewRecordsState.swift */; };
 		3CF8629E28A183F900776CA4 /* OSIdentityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */; };
 		3CF862A028A1964F00776CA4 /* OSPropertiesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */; };
@@ -1295,6 +1297,8 @@
 		3CE92279289FA88B001B1062 /* OSIdentityModelStoreListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModelStoreListener.swift; sourceTree = "<group>"; };
 		3CEE90A62BFE6ABD00B0FB5B /* OSPropertiesSupportedProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesSupportedProperty.swift; sourceTree = "<group>"; };
 		3CEE90A82C000BD500B0FB5B /* OneSignalRequest+UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OneSignalRequest+UnitTests.swift"; sourceTree = "<group>"; };
+		3CF11E3C2C6D6155002856F5 /* UserExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserExecutorTests.swift; sourceTree = "<group>"; };
+		3CF11E3F2C6E6DE2002856F5 /* MockNewRecordsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNewRecordsState.swift; sourceTree = "<group>"; };
 		3CF1A5622C669EA40056B3AA /* OSNewRecordsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSNewRecordsState.swift; sourceTree = "<group>"; };
 		3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModel.swift; sourceTree = "<group>"; };
 		3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesModel.swift; sourceTree = "<group>"; };
@@ -2073,6 +2077,7 @@
 			children = (
 				3C8544B82C5AEFF700F542A9 /* OneSignalOSCoreMocks.h */,
 				3C8544C22C5AF18B00F542A9 /* OSCoreMocks.swift */,
+				3CF11E3F2C6E6DE2002856F5 /* MockNewRecordsState.swift */,
 			);
 			path = OneSignalOSCoreMocks;
 			sourceTree = "<group>";
@@ -2153,6 +2158,7 @@
 			isa = PBXGroup;
 			children = (
 				3CDE664A2BFC2A55006DA114 /* OneSignalUserTests-Bridging-Header.h */,
+				3CF11E3E2C6D61AC002856F5 /* Executors */,
 				3CC063ED2B6D7FE8002BB07F /* OneSignalUserTests.swift */,
 				3CC890342C5BF9A7002CB4CC /* UserConcurrencyTests.swift */,
 				3C67F7792BEB2B710085A0F0 /* SwitchUserIntegrationTests.swift */,
@@ -2167,6 +2173,14 @@
 				3CEE90A62BFE6ABD00B0FB5B /* OSPropertiesSupportedProperty.swift */,
 			);
 			path = Support;
+			sourceTree = "<group>";
+		};
+		3CF11E3E2C6D61AC002856F5 /* Executors */ = {
+			isa = PBXGroup;
+			children = (
+				3CF11E3C2C6D6155002856F5 /* UserExecutorTests.swift */,
+			);
+			path = Executors;
 			sourceTree = "<group>";
 		};
 		3E2400391D4FFC31008BDE70 /* OneSignalFramework */ = {
@@ -4058,6 +4072,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C8544C32C5AF18B00F542A9 /* OSCoreMocks.swift in Sources */,
+				3CF11E402C6E6DE2002856F5 /* MockNewRecordsState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4096,6 +4111,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3CF11E3D2C6D6155002856F5 /* UserExecutorTests.swift in Sources */,
 				3C67F77A2BEB2B710085A0F0 /* SwitchUserIntegrationTests.swift in Sources */,
 				3CC063EE2B6D7FE8002BB07F /* OneSignalUserTests.swift in Sources */,
 				3CC890352C5BF9A7002CB4CC /* UserConcurrencyTests.swift in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -259,6 +259,13 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE, PATCH} HTTP
 
     // Flush interval for operation repo in milliseconds
     #define POLL_INTERVAL_MS 5000
+
+    /**
+     The number of seconds to delay after an operation completes that creates or changes IDs.
+     This is a "cold down" period to avoid a caveat with OneSignal's backend replication, where you may
+     incorrectlyget a 404 when attempting a GET or PATCH REST API call on something just after it is created.
+     */
+    #define OP_REPO_POST_CREATE_DELAY_SECONDS 3
 #else
     // Test defines for API Client
     #define REATTEMPT_DELAY 0.004
@@ -279,6 +286,8 @@ typedef enum {GET, POST, HEAD, PUT, DELETE, OPTIONS, CONNECT, TRACE, PATCH} HTTP
     // Reduce flush interval for operation repo in tests
     #define POLL_INTERVAL_MS 100
 
+    // Reduce delay in tests
+    #define OP_REPO_POST_CREATE_DELAY_SECONDS 0
 #endif
 
 // A max timeout for a request, which might include multiple reattempts

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
@@ -93,10 +93,6 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
     public func execute(_ request: OneSignalRequest, onSuccess successBlock: @escaping OSResultSuccessBlock, onFailure failureBlock: @escaping OSFailureBlock) {
         print("🧪 MockOneSignalClient execute called")
 
-        lock.withLock {
-            executedRequests.append(request)
-        }
-
         if executeInstantaneously {
             finishExecutingRequest(request, onSuccess: successBlock, onFailure: failureBlock)
         } else {
@@ -127,6 +123,9 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
         print("🧪 completing HTTP request: \(request)")
 
         // TODO: Check for existence of app_id in the request and fail if not.
+        lock.withLock {
+            executedRequests.append(request)
+        }
 
         self.didCompleteRequest(request)
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSNewRecordsState.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSNewRecordsState.swift
@@ -54,11 +54,9 @@ public class OSNewRecordsState {
         }
     }
 
-    public func canAccess(_ key: String?) -> Bool {
+    public func canAccess(_ key: String) -> Bool {
         lock.withLock {
-            guard let key = key,
-                  let timeLastMovedOrCreated = records[key]
-            else {
+            guard let timeLastMovedOrCreated = records[key] else {
                 return true
             }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreMocks/MockNewRecordsState.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreMocks/MockNewRecordsState.swift
@@ -1,0 +1,60 @@
+/*
+ Modified MIT License
+
+ Copyright 2024 OneSignal
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ 2. All copies of substantial portions of the Software may only be used in connection
+ with services provided by OneSignal.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+@testable import OneSignalOSCore
+
+public class MockNewRecordsState: OSNewRecordsState {
+    public struct MockNewRecord {
+        let key: String
+        let overwrite: Bool
+    }
+
+    public var records: [MockNewRecord] = []
+
+    override public func add(_ key: String, _ overwrite: Bool = false) {
+        let record = MockNewRecord(key: key, overwrite: overwrite)
+        records.append(record)
+
+        super.add(key, overwrite)
+    }
+
+    override public func canAccess(_ key: String) -> Bool {
+        return super.canAccess(key)
+    }
+
+    public func get(_ key: String?) -> [MockNewRecord] {
+        return records.filter { $0.key == key }
+    }
+
+    public func contains(_ key: String?) -> Bool {
+        return get(key).count > 0
+    }
+
+    public func wasOverwritten(_ key: String?) -> Bool {
+        return records.filter { $0.key == key && $0.overwrite }.count > 0
+    }
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -442,7 +442,7 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     /**
      Creates and sets a blank new SDK user with the provided externalId, if any.
      */
-    private func setNewInternalUser(externalId: String?, pushSubscriptionModel: OSSubscriptionModel?) -> OSUserInternal {
+    func setNewInternalUser(externalId: String?, pushSubscriptionModel: OSSubscriptionModel?) -> OSUserInternal {
         let aliases: [String: String]?
         if let externalIdToUse = externalId {
             aliases = [OS_EXTERNAL_ID: externalIdToUse]

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -120,6 +120,8 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
     var identityModelRepo = OSIdentityModelRepo()
 
+    let newRecordsState = OSNewRecordsState()
+
     var hasCalledStart = false
 
     private var jwtExpiredHandler: OSJwtExpiredHandler?
@@ -222,13 +224,13 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
         // Setup the executors
         // The OSUserExecutor has to run first, before other executors
-        self.userExecutor = OSUserExecutor()
+        self.userExecutor = OSUserExecutor(newRecordsState: newRecordsState)
         OSOperationRepo.sharedInstance.start()
 
         // Cannot initialize these executors in `init` as they reference the sharedInstance
-        let propertyExecutor = OSPropertyOperationExecutor()
-        let identityExecutor = OSIdentityOperationExecutor()
-        let subscriptionExecutor = OSSubscriptionOperationExecutor()
+        let propertyExecutor = OSPropertyOperationExecutor(newRecordsState: newRecordsState)
+        let identityExecutor = OSIdentityOperationExecutor(newRecordsState: newRecordsState)
+        let subscriptionExecutor = OSSubscriptionOperationExecutor(newRecordsState: newRecordsState)
         self.propertyExecutor = propertyExecutor
         self.identityExecutor = identityExecutor
         self.subscriptionExecutor = subscriptionExecutor

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestAddAliases.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestAddAliases.swift
@@ -42,7 +42,7 @@ class OSRequestAddAliases: OneSignalRequest, OSUserRequest {
     func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
         if let onesignalId = identityModel.onesignalId,
            newRecordsState.canAccess(onesignalId),
-           let appId = OneSignalConfigManager.getAppId() 
+           let appId = OneSignalConfigManager.getAppId()
         {
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity"

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestAddAliases.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestAddAliases.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 class OSRequestAddAliases: OneSignalRequest, OSUserRequest {
     var sentToClient = false
@@ -37,15 +38,16 @@ class OSRequestAddAliases: OneSignalRequest, OSUserRequest {
     var identityModel: OSIdentityModel
     let aliases: [String: String]
 
-    // requires a `onesignal_id` to send this request
-    func prepareForExecution() -> Bool {
-        if let onesignalId = identityModel.onesignalId, let appId = OneSignalConfigManager.getAppId() {
+    /// requires a `onesignal_id` to send this request
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        if let onesignalId = identityModel.onesignalId,
+           newRecordsState.canAccess(onesignalId),
+           let appId = OneSignalConfigManager.getAppId() 
+        {
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity"
             return true
         } else {
-            // self.path is non-nil, so set to empty string
-            self.path = ""
             return false
         }
     }
@@ -57,7 +59,6 @@ class OSRequestAddAliases: OneSignalRequest, OSUserRequest {
         super.init()
         self.parameters = ["identity": aliases]
         self.method = PATCH
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -86,6 +87,5 @@ class OSRequestAddAliases: OneSignalRequest, OSUserRequest {
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateSubscription.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 /**
  Primary uses of this request are for adding Email and SMS subscriptions. Push subscriptions typically won't be created using
@@ -43,13 +44,15 @@ class OSRequestCreateSubscription: OneSignalRequest, OSUserRequest {
     var identityModel: OSIdentityModel
 
     // Need the onesignal_id of the user
-    func prepareForExecution() -> Bool {
-        if let onesignalId = identityModel.onesignalId, let appId = OneSignalConfigManager.getAppId() {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        if let onesignalId = identityModel.onesignalId,
+           newRecordsState.canAccess(onesignalId),
+           let appId = OneSignalConfigManager.getAppId()
+        {
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/subscriptions"
             return true
         } else {
-            self.path = "" // self.path is non-nil, so set to empty string
             return false
         }
     }
@@ -61,7 +64,6 @@ class OSRequestCreateSubscription: OneSignalRequest, OSUserRequest {
         super.init()
         self.parameters = ["subscription": subscriptionModel.jsonRepresentation()]
         self.method = POST
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -90,6 +92,5 @@ class OSRequestCreateSubscription: OneSignalRequest, OSUserRequest {
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 /**
  This request will be made with the minimum information needed. The payload will contain an externalId or no identities.
@@ -44,9 +45,12 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
     var pushSubscriptionModel: OSSubscriptionModel?
     var originalPushToken: String?
 
-    func prepareForExecution() -> Bool {
-        guard let appId = OneSignalConfigManager.getAppId() else {
-            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the create user request due to null app ID.")
+    /// Checks if the subscription ID can be accessed, if a subscription is being included in the request
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        guard let appId = OneSignalConfigManager.getAppId(),
+              newRecordsState.canAccess(pushSubscriptionModel?.subscriptionId)
+        else {
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the create user request yet.")
             return false
         }
         _ = self.addPushSubscriptionIdToAdditionalHeaders()
@@ -99,7 +103,7 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
         super.init()
         self.parameters = [
             "identity": [aliasLabel: aliasId],
-            "refresh_device_metadata": true,
+            "refresh_device_metadata": true
         ]
         self.method = POST
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestCreateUser.swift
@@ -47,16 +47,21 @@ class OSRequestCreateUser: OneSignalRequest, OSUserRequest {
 
     /// Checks if the subscription ID can be accessed, if a subscription is being included in the request
     func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
-        guard let appId = OneSignalConfigManager.getAppId(),
-              newRecordsState.canAccess(pushSubscriptionModel?.subscriptionId)
-        else {
+        guard let appId = OneSignalConfigManager.getAppId() else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "Cannot generate the create user request due to null app ID.")
+            return false
+        }
+
+        if let subscriptionId = pushSubscriptionModel?.subscriptionId,
+           !newRecordsState.canAccess(subscriptionId)
+        {
             OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the create user request yet.")
             return false
         }
+
         _ = self.addPushSubscriptionIdToAdditionalHeaders()
         self.addJWTHeader(identityModel: identityModel)
         self.path = "apps/\(appId)/users"
-        // The pushSub doesn't need to have a token.
         return true
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestDeleteSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestDeleteSubscription.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 /**
  Delete the subscription specified by the `subscriptionId` in the `subscriptionModel`.
@@ -42,13 +43,14 @@ class OSRequestDeleteSubscription: OneSignalRequest, OSUserRequest {
     var subscriptionModel: OSSubscriptionModel
 
     // Need the subscription_id
-    func prepareForExecution() -> Bool {
-        if let subscriptionId = subscriptionModel.subscriptionId, let appId = OneSignalConfigManager.getAppId() {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        if let subscriptionId = subscriptionModel.subscriptionId,
+           newRecordsState.canAccess(subscriptionId),
+           let appId = OneSignalConfigManager.getAppId()
+        {
             self.path = "apps/\(appId)/subscriptions/\(subscriptionId)"
             return true
         } else {
-            // self.path is non-nil, so set to empty string
-            self.path = ""
             return false
         }
     }
@@ -58,7 +60,6 @@ class OSRequestDeleteSubscription: OneSignalRequest, OSUserRequest {
         self.stringDescription = "<OSRequestDeleteSubscription with subscriptionModel: \(subscriptionModel.address ?? "nil")>"
         super.init()
         self.method = DELETE
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -81,6 +82,5 @@ class OSRequestDeleteSubscription: OneSignalRequest, OSUserRequest {
         super.init()
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestFetchIdentityBySubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestFetchIdentityBySubscription.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 class OSRequestFetchIdentityBySubscription: OneSignalRequest, OSUserRequest {
     var sentToClient = false
@@ -38,7 +39,8 @@ class OSRequestFetchIdentityBySubscription: OneSignalRequest, OSUserRequest {
     var identityModel: OSIdentityModel
     var pushSubscriptionModel: OSSubscriptionModel
 
-    func prepareForExecution() -> Bool {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        // newRecordsState is unused for this request
         guard let appId = OneSignalConfigManager.getAppId() else {
             OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the FetchIdentityBySubscription request due to null app ID.")
             return false

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestFetchUser.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestFetchUser.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 /**
  Fetch the user by the provided alias. This is expected to be `onesignal_id` in most cases.
@@ -43,9 +44,11 @@ class OSRequestFetchUser: OneSignalRequest, OSUserRequest {
     let aliasId: String
     let onNewSession: Bool
 
-    func prepareForExecution() -> Bool {
-        guard let appId = OneSignalConfigManager.getAppId() else {
-            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the fetch user request due to null app ID.")
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        guard let appId = OneSignalConfigManager.getAppId(),
+              newRecordsState.canAccess(aliasId)
+        else {
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot generate the fetch user request for \(aliasLabel): \(aliasId) yet.")
             return false
         }
         self.addJWTHeader(identityModel: identityModel)
@@ -61,7 +64,6 @@ class OSRequestFetchUser: OneSignalRequest, OSUserRequest {
         self.stringDescription = "<OSRequestFetchUser with \(aliasLabel): \(aliasId)>"
         super.init()
         self.method = GET
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -92,6 +94,5 @@ class OSRequestFetchUser: OneSignalRequest, OSUserRequest {
         super.init()
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestRemoveAlias.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestRemoveAlias.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 class OSRequestRemoveAlias: OneSignalRequest, OSUserRequest {
     var sentToClient = false
@@ -37,14 +38,15 @@ class OSRequestRemoveAlias: OneSignalRequest, OSUserRequest {
     let labelToRemove: String
     var identityModel: OSIdentityModel
 
-    func prepareForExecution() -> Bool {
-        if let onesignalId = identityModel.onesignalId, let appId = OneSignalConfigManager.getAppId() {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        if let onesignalId = identityModel.onesignalId,
+           newRecordsState.canAccess(onesignalId),
+           let appId = OneSignalConfigManager.getAppId() 
+        {
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity/\(labelToRemove)"
             return true
         } else {
-            // self.path is non-nil, so set to empty string
-            self.path = ""
             return false
         }
     }
@@ -55,7 +57,6 @@ class OSRequestRemoveAlias: OneSignalRequest, OSUserRequest {
         self.stringDescription = "OSRequestRemoveAlias with aliasLabel: \(labelToRemove)"
         super.init()
         self.method = DELETE
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -81,6 +82,5 @@ class OSRequestRemoveAlias: OneSignalRequest, OSUserRequest {
         super.init()
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestRemoveAlias.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestRemoveAlias.swift
@@ -41,7 +41,7 @@ class OSRequestRemoveAlias: OneSignalRequest, OSUserRequest {
     func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
         if let onesignalId = identityModel.onesignalId,
            newRecordsState.canAccess(onesignalId),
-           let appId = OneSignalConfigManager.getAppId() 
+           let appId = OneSignalConfigManager.getAppId()
         {
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)/identity/\(labelToRemove)"

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestTransferSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestTransferSubscription.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 /**
  Deprecated as of `5.2.3`. Use CreateUser instead. This class skeleton remains due to potentially cached requests.
@@ -42,7 +43,7 @@ class OSRequestTransferSubscription: OneSignalRequest, OSUserRequest {
     let aliasLabel: String
     let aliasId: String
 
-    func prepareForExecution() -> Bool {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
         return false
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateProperties.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
     var sentToClient = false
@@ -38,16 +39,16 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
 
     // TODO: Decide if addPushSubscriptionIdToAdditionalHeadersIfNeeded should block.
     // Note Android adds it to requests, if the push sub ID exists
-    func prepareForExecution() -> Bool {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
         if let onesignalId = identityModel.onesignalId,
-            let appId = OneSignalConfigManager.getAppId() {
+           newRecordsState.canAccess(onesignalId),
+           let appId = OneSignalConfigManager.getAppId()
+        {
             _ = self.addPushSubscriptionIdToAdditionalHeaders()
             self.addJWTHeader(identityModel: identityModel)
             self.path = "apps/\(appId)/users/by/\(OS_ONESIGNAL_ID)/\(onesignalId)"
             return true
         } else {
-            // self.path is non-nil, so set to empty string
-            self.path = ""
             return false
         }
     }
@@ -58,7 +59,6 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         super.init()
         self.parameters = params
         self.method = PATCH
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -84,6 +84,5 @@ class OSRequestUpdateProperties: OneSignalRequest, OSUserRequest {
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateSubscription.swift
@@ -26,6 +26,7 @@
  */
 
 import OneSignalCore
+import OneSignalOSCore
 
 /**
  Currently, only the Push Subscription will make this Update Request.
@@ -40,12 +41,14 @@ class OSRequestUpdateSubscription: OneSignalRequest, OSUserRequest {
     var subscriptionModel: OSSubscriptionModel
 
     // Need the subscription_id
-    func prepareForExecution() -> Bool {
-        if let subscriptionId = subscriptionModel.subscriptionId, let appId = OneSignalConfigManager.getAppId() {
+    func prepareForExecution(newRecordsState: OSNewRecordsState) -> Bool {
+        if let subscriptionId = subscriptionModel.subscriptionId,
+           newRecordsState.canAccess(subscriptionId),
+           let appId = OneSignalConfigManager.getAppId()
+        {
             self.path = "apps/\(appId)/subscriptions/\(subscriptionId)"
             return true
         } else {
-            self.path = "" // self.path is non-nil, so set to empty string
             return false
         }
     }
@@ -77,7 +80,6 @@ class OSRequestUpdateSubscription: OneSignalRequest, OSUserRequest {
 
         self.parameters = ["subscription": subscriptionParams]
         self.method = PATCH
-        _ = prepareForExecution() // sets the path property
     }
 
     func encode(with coder: NSCoder) {
@@ -103,6 +105,5 @@ class OSRequestUpdateSubscription: OneSignalRequest, OSUserRequest {
         self.parameters = parameters
         self.method = HTTPMethod(rawValue: rawMethod)
         self.timestamp = timestamp
-        _ = prepareForExecution()
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUserMocks/MockUserRequests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserMocks/MockUserRequests.swift
@@ -20,7 +20,7 @@ public class MockUserRequests: NSObject {
 
     public static func testDefaultPushSubPayload(id: String) -> [String: Any] {
         return [
-            "id": testPushSubId,
+            "id": id,
             "app_id": "test-app-id",
             "type": "iOSPush",
             "token": "",
@@ -43,7 +43,7 @@ public class MockUserRequests: NSObject {
 
     public static func testDefaultFullCreateUserResponse(onesignalId: String, externalId: String?, subscriptionId: String?) -> [String: Any] {
         let identity = testIdentityPayload(onesignalId: onesignalId, externalId: externalId)
-        let subscription = testDefaultPushSubPayload(id: testPushSubId)
+        let subscription = testDefaultPushSubPayload(id: subscriptionId ?? testPushSubId)
         let properties = [
             "language": "en",
             "timezone_id": "America/Los_Angeles",
@@ -84,11 +84,10 @@ extension MockUserRequests {
             response: anonCreateResponse)
     }
 
-    public static func setDefaultCreateUserResponses(with client: MockOneSignalClient, externalId: String) {
+    public static func setDefaultCreateUserResponses(with client: MockOneSignalClient, externalId: String, subscriptionId: String? = nil) {
         let osid = getOneSignalId(for: externalId)
 
-        let userResponse = MockUserRequests.testIdentityPayload(onesignalId: osid, externalId: externalId)
-
+        let userResponse = testDefaultFullCreateUserResponse(onesignalId: osid, externalId: externalId, subscriptionId: subscriptionId)
         client.setMockResponseForRequest(
             request: "<OSRequestCreateUser with external_id: \(externalId)>",
             response: userResponse

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/UserExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/UserExecutorTests.swift
@@ -1,0 +1,197 @@
+/*
+ Modified MIT License
+ 
+ Copyright 2024 OneSignal
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ 1. The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ 2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+import XCTest
+import OneSignalCore
+import OneSignalOSCore
+import OneSignalCoreMocks
+import OneSignalOSCoreMocks
+import OneSignalUserMocks
+@testable import OneSignalUser
+
+/// This class has helpers that can be used in other tests and can be extracted out, as they are used
+private class Mocks {
+    let client = MockOneSignalClient()
+    let newRecordsState = MockNewRecordsState()
+    let userExecutor: OSUserExecutor
+
+    init() {
+        OneSignalCoreImpl.setSharedClient(client)
+        userExecutor = OSUserExecutor(newRecordsState: newRecordsState)
+    }
+
+    func createUserInstance(externalId: String) -> OSUserInternal {
+        let identityModel = OSIdentityModel(aliases: [OS_EXTERNAL_ID: externalId], changeNotifier: OSEventProducer())
+        let propertiesModel = OSPropertiesModel(changeNotifier: OSEventProducer())
+        let pushModel = OSSubscriptionModel(type: .push, address: "", subscriptionId: nil, reachable: false, isDisabled: false, changeNotifier: OSEventProducer())
+        return OSUserInternalImpl(identityModel: identityModel, propertiesModel: propertiesModel, pushSubscriptionModel: pushModel)
+    }
+
+    func setUserManagerInternalUser(externalId: String) -> OSUserInternal {
+        return OneSignalUserManagerImpl.sharedInstance.setNewInternalUser(
+            externalId: externalId,
+            pushSubscriptionModel: OSSubscriptionModel(type: .push, address: "", subscriptionId: testPushSubId, reachable: false, isDisabled: false, changeNotifier: OSEventProducer())
+        )
+    }
+}
+
+final class UserExecutorTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        OneSignalCoreMocks.clearUserDefaults()
+        OneSignalUserMocks.reset()
+        // App ID is set because requests have guards against null App ID
+        OneSignalConfigManager.setAppId("test-app-id")
+        // Temp. logging to help debug during testing
+        OneSignalLog.setLogLevel(.LL_VERBOSE)
+    }
+
+    override func tearDownWithError() throws { }
+
+    func testCreateUser_withPushSubscription_addsToNewRecords() {
+        /* Setup */
+        let mocks = Mocks()
+        MockUserRequests.setDefaultCreateUserResponses(with: mocks.client, externalId: userA_EUID, subscriptionId: "push-sub-id")
+
+        /* When */
+        mocks.userExecutor.createUser(mocks.createUserInstance(externalId: userA_EUID))
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.newRecordsState.contains(userA_OSID))
+        XCTAssertTrue(mocks.newRecordsState.contains("push-sub-id"))
+    }
+
+    func testCreateUser_withoutPushSubscription_doesNot_addToNewRecords() {
+        /* Setup */
+        let mocks = Mocks()
+        MockUserRequests.setDefaultCreateUserResponses(with: mocks.client, externalId: userA_EUID)
+
+        /* When */
+        let identityModel = OSIdentityModel(aliases: [OS_EXTERNAL_ID: userA_EUID], changeNotifier: OSEventProducer())
+        mocks.userExecutor.createUser(aliasLabel: OS_EXTERNAL_ID, aliasId: userA_EUID, identityModel: identityModel)
+
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestCreateUser.self))
+        XCTAssertTrue(mocks.newRecordsState.records.isEmpty)
+    }
+
+    /**
+     When an external ID is successfully applied to an anonymous user, its Onesignal ID should be force re-added to
+     the new records state with an updated timestamp. This is to prevent an immediate fetch where the external ID
+     can be missing from the fetch response, as it has not finished being applied to the user on the backend.
+     */
+    func testIdentifyUser_successfully_forcesAddToNewRecords() {
+        /* Setup */
+        let mocks = Mocks()
+        MockUserRequests.setDefaultIdentifyUserResponses(with: mocks.client, externalId: userA_EUID, conflicted: false)
+
+        /* When */
+        let anonIdentityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: userA_OSID], changeNotifier: OSEventProducer())
+        let newIdentityModel = OSIdentityModel(aliases: [OS_EXTERNAL_ID: userA_EUID], changeNotifier: OSEventProducer())
+
+        // The current user needs to be the same, set it in the user manager
+        OneSignalUserManagerImpl.sharedInstance.identityModelStore.add(id: OS_IDENTITY_MODEL_KEY, model: newIdentityModel, hydrating: false)
+        mocks.userExecutor.identifyUser(externalId: userA_EUID, identityModelToIdentify: anonIdentityModel, identityModelToUpdate: newIdentityModel)
+
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestIdentifyUser.self))
+        XCTAssertTrue(mocks.newRecordsState.contains(userA_OSID))
+        XCTAssertTrue(mocks.newRecordsState.wasOverwritten(userA_OSID))
+    }
+
+    /**
+     When an external ID is successfully applied to an anonymous user, but the current user is no longer the same,
+     nothing is added to the new records state.
+     */
+    func testIdentifyUserSuccessful_butUserHasChangedSince_doesNotAddToNewRecords() {
+        /* Setup */
+        let mocks = Mocks()
+        MockUserRequests.setDefaultIdentifyUserResponses(with: mocks.client, externalId: userA_EUID, conflicted: false)
+
+        /* When */
+        let anonIdentityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: userA_OSID], changeNotifier: OSEventProducer())
+        let newIdentityModel = OSIdentityModel(aliases: [OS_EXTERNAL_ID: userA_EUID], changeNotifier: OSEventProducer())
+
+        mocks.userExecutor.identifyUser(externalId: userA_EUID, identityModelToIdentify: anonIdentityModel, identityModelToUpdate: newIdentityModel)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestIdentifyUser.self))
+        XCTAssertTrue(mocks.newRecordsState.records.isEmpty)
+    }
+
+    /**
+     When Identify User encounters a 409 conflict, a Create User call will be made.
+     The response from that request will add its Onesignal ID to the new records state.
+     */
+    func testIdentifyUser_withConflict_addsToNewRecords() {
+        /* Setup */
+        let mocks = Mocks()
+        let user = mocks.setUserManagerInternalUser(externalId: userB_EUID)
+
+        let anonIdentityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: userA_OSID], changeNotifier: OSEventProducer())
+        let newIdentityModel = user.identityModel
+
+        MockUserRequests.setDefaultIdentifyUserResponses(with: mocks.client, externalId: userB_EUID, conflicted: true)
+
+        /* When */
+        mocks.userExecutor.identifyUser(externalId: userB_EUID, identityModelToIdentify: anonIdentityModel, identityModelToUpdate: newIdentityModel)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestIdentifyUser.self))
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestCreateUser.self))
+        XCTAssertEqual(mocks.newRecordsState.records.count, 1)
+        XCTAssertTrue(mocks.newRecordsState.contains(userB_OSID))
+    }
+
+    func testIdentifyUserWithConflict_butUserHasChangedSince_doesNot_addToNewRecords() {
+        /* Setup */
+        let mocks = Mocks()
+
+        let user = mocks.setUserManagerInternalUser(externalId: "new-eid")
+        let anonIdentityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: userA_OSID], changeNotifier: OSEventProducer())
+        let newIdentityModel = OSIdentityModel(aliases: [OS_EXTERNAL_ID: userB_EUID], changeNotifier: OSEventProducer())
+
+        MockUserRequests.setDefaultIdentifyUserResponses(with: mocks.client, externalId: userB_EUID, conflicted: true)
+
+        /* When */
+        mocks.userExecutor.identifyUser(externalId: userB_EUID, identityModelToIdentify: anonIdentityModel, identityModelToUpdate: newIdentityModel)
+
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestIdentifyUser.self))
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestCreateUser.self))
+        XCTAssertTrue(mocks.newRecordsState.records.isEmpty)
+    }
+}

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/SwitchUserIntegrationTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/SwitchUserIntegrationTests.swift
@@ -321,7 +321,7 @@ final class SwitchUserIntegrationTests: XCTestCase {
         // Increase flush interval to allow all the updates to batch
         OSOperationRepo.sharedInstance.pollIntervalMilliseconds = 300
         // Wait to let any pending flushes in the Operation Repo to run
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.1)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.3)
 
         // 1. Set up mock responses for the first anonymous user
         let tagsUserAnon = ["tag_anon": "value_anon"]
@@ -369,7 +369,7 @@ final class SwitchUserIntegrationTests: XCTestCase {
         OneSignalUserManagerImpl.sharedInstance.addEmail("email_b@example.com")
 
         // 3. Run background threads
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 2)
 
         /* Then */
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/UserConcurrencyTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/UserConcurrencyTests.swift
@@ -92,7 +92,7 @@ final class UserConcurrencyTests: XCTestCase {
         )
         OneSignalCoreImpl.setSharedClient(client)
 
-        let executor = OSSubscriptionOperationExecutor()
+        let executor = OSSubscriptionOperationExecutor(newRecordsState: OSNewRecordsState())
         OSOperationRepo.sharedInstance.addExecutor(executor)
 
         /* When */
@@ -131,7 +131,7 @@ final class UserConcurrencyTests: XCTestCase {
         OneSignalCoreImpl.setSharedClient(client)
         MockUserRequests.setAddAliasesResponse(with: client, aliases: aliases)
 
-        let executor = OSIdentityOperationExecutor()
+        let executor = OSIdentityOperationExecutor(newRecordsState: OSNewRecordsState())
         OSOperationRepo.sharedInstance.addExecutor(executor)
 
         /* When */
@@ -172,7 +172,7 @@ final class UserConcurrencyTests: XCTestCase {
         let identityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: UUID().uuidString], changeNotifier: OSEventProducer())
         OneSignalUserManagerImpl.sharedInstance.addIdentityModelToRepo(identityModel)
 
-        let executor = OSPropertyOperationExecutor()
+        let executor = OSPropertyOperationExecutor(newRecordsState: OSNewRecordsState())
         OSOperationRepo.sharedInstance.addExecutor(executor)
 
         /* When */
@@ -213,7 +213,7 @@ final class UserConcurrencyTests: XCTestCase {
         let identityModel1 = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: UUID().uuidString], changeNotifier: OSEventProducer())
         let identityModel2 = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: UUID().uuidString], changeNotifier: OSEventProducer())
 
-        let userExecutor = OSUserExecutor()
+        let userExecutor = OSUserExecutor(newRecordsState: OSNewRecordsState())
 
         /* When */
 


### PR DESCRIPTION
# Description
## One Line Summary
Handle incorrect 404 responses from the OneSignal's backend by adding a delay after creates, when new subscription IDs or OneSignal IDs can be created on the backend.

## Details
See [Android Implementation here](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059)

### Backend Issue
OneSignal sometimes returns a `404` on `GET` and `PATCH` requests if you are accessing something immediately after it was created. Normally the OneSignal backend can accept fetch/updates right way, but it all depends on it's server load and replication process. There isn't a guaranteed amount of time a client can wait, so SDKs has to work around this problem.

### SDK's work around strategy
Add a minimum delay after creating records (User or Subscription) before allowing any requests to fetch or update that specific record, based on the `onesignalId` or `subscriptionId`.
   * We picked **3 seconds** as this "cool down" period. This is a best guess, we are balancing SDK responsiveness with the chance of running into this issue, as well as timing for Operation Repo's 5 second flush interval.
   * Also noting that backend team said _"it looks like we can have peaks of up to 300ms for database replication lag. If you added 0.5s delay between each network request, that would likely resolve some of these issues"_


### Motivation
404/410 responses are being handled by recreating the missing record (User or Subscription), however this isn't always the right way to handle these, give the backend caveat noted above. Recreating these records can create side-effects and extra load we want to avoid.

### Scope
Add a delay processing user-based or subscription-based requests.

### Future Considerations
* We want to refactor Operation Repo and Executors relationship down the line, so this PR is minimal to prevent the primary errors. The 3 second delay should be sufficient to address the overwhelming majority of incorrect 404 cases, especially as backend team mentioned a delay of 0.5 seconds should be sufficient.
* As the 404/410 may still happen when the backend is under unusual load (a 3 second delay may not always be enough) we can also retry on 404/410 within a longer but still short window.
* Calls that do not go through the Operation Repo and Executors could have this same logic applied.
    - Live Activities requests, Fetch IAM, and Outcomes requests.
* The new parameter for the delay interval could be read from remote params, so it can be tweaked later.

# Testing
## Unit testing
### 🚧 New unit tests are WIP

## Manual testing
Physical iPhone 13 on iOS 17.4
- New install
- New install with immediate login to **new** user
- New install with immediate login to **existing** user

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1470)
<!-- Reviewable:end -->
