### PR TITLE
Pausing IAMs dismisses any currently showing IAM

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -177,8 +177,13 @@ static BOOL _isInAppMessagingPaused = false;
     _isInAppMessagingPaused = pause;
     
     // If IAM are not paused, try to evaluate and show IAMs
-    if (!pause)
+    if (!pause) {
         [self evaluateMessages];
+    } else if (self.isInAppMessageShowing) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.viewController dismissCurrentInAppMessage];
+        });
+    }
 }
 
 + (BOOL)doesDeviceSupportIAM {


### PR DESCRIPTION
# Description
## One Line Summary
Setting in app messages to paused while there is currently an IAM being displayed dismisses the IAM.

## Details
This is a fairly simple change that just detects if there is currently an IAM being displayed when paused is set to true. If so we dismiss the IAM. 



### Motivation
Add the ability to programmatically close an IAM. This could be used in response to the IAM click listener, or some other event happening in the application

### Scope
In App Messages

# Testing

## Manual testing
Tested that queued IAMs don't show and that lifecycle callback listeners fire.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1480)
<!-- Reviewable:end -->
