### PR TITLE
[JWT] Handle logout when Identity verification is on

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -91,8 +91,8 @@ typedef void (^JwtExpiredBlock)(NSString *, JwtCompletionBlock);
     return YES;
 }
 
-#define ONESIGNAL_APP_ID_DEFAULT @"0139bd6f-451f-438c-8886-4e0f0fe3a085"
-#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"0139bd6f-451f-438c-8886-4e0f0fe3a085"
+#define ONESIGNAL_APP_ID_DEFAULT @"77e32082-ea27-42e3-a898-c72e141824ef"
+#define ONESIGNAL_APP_ID_KEY_FOR_TESTING @"77e32082-ea27-42e3-a898-c72e141824ef"
 
 + (NSString*)getOneSignalAppId {
     NSString* userDefinedAppId = [[NSUserDefaults standardUserDefaults] objectForKey:ONESIGNAL_APP_ID_KEY_FOR_TESTING];

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/ViewController.m
@@ -197,14 +197,14 @@
 - (IBAction)loginExternalUserId:(UIButton *)sender {
     NSString* externalUserId = self.externalUserIdTextField.text;
     NSString* token = self.tokenTextField.text;
-    NSLog(@"❌ Dev App: Logging in to external user ID %@ and token %@", externalUserId, token);
+    NSLog(@"Dev App: Logging in to external user ID %@ and token %@", externalUserId, token);
     [OneSignal login:externalUserId withToken:token];
 }
 
 - (IBAction)updateJwt:(id)sender {
     NSString* externalUserId = self.externalUserIdTextField.text;
     NSString* token = self.tokenTextField.text;
-    NSLog(@"❌ Dev App: updating JWT for external user ID %@ and token %@", externalUserId, token);
+    NSLog(@"Dev App: updating JWT for external user ID %@ and token %@", externalUserId, token);
     [OneSignal updateUserJwt:externalUserId withToken:token];
 }
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalExample.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalDevApp/OneSignalExample.xcodeproj/project.pbxproj
@@ -47,6 +47,32 @@
 		DE12F3F8289B2B7F002F63AA /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE12F3F6289B2B7F002F63AA /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE61E483294810B900CD12F1 /* OneSignalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E482294810B900CD12F1 /* OneSignalFramework.framework */; };
 		DE61E484294810B900CD12F1 /* OneSignalFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E482294810B900CD12F1 /* OneSignalFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E4852948117000CD12F1 /* OneSignalExampleClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = DE68DA5724C7695900FC95A8 /* OneSignalExampleClip.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DE61E48A2948117A00CD12F1 /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4892948117A00CD12F1 /* OneSignalCore.framework */; };
+		DE61E48B2948117A00CD12F1 /* OneSignalCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4892948117A00CD12F1 /* OneSignalCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E48E2948117D00CD12F1 /* OneSignalExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E48D2948117D00CD12F1 /* OneSignalExtension.framework */; };
+		DE61E48F2948117D00CD12F1 /* OneSignalExtension.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E48D2948117D00CD12F1 /* OneSignalExtension.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E4912948118200CD12F1 /* OneSignalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4902948118200CD12F1 /* OneSignalFramework.framework */; };
+		DE61E4922948118200CD12F1 /* OneSignalFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4902948118200CD12F1 /* OneSignalFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E4942948118500CD12F1 /* OneSignalNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4932948118500CD12F1 /* OneSignalNotifications.framework */; };
+		DE61E4952948118500CD12F1 /* OneSignalNotifications.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4932948118500CD12F1 /* OneSignalNotifications.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E4972948118900CD12F1 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4962948118900CD12F1 /* OneSignalOSCore.framework */; };
+		DE61E4982948118900CD12F1 /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4962948118900CD12F1 /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E49A2948118C00CD12F1 /* OneSignalOutcomes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4992948118C00CD12F1 /* OneSignalOutcomes.framework */; };
+		DE61E49B2948118D00CD12F1 /* OneSignalOutcomes.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E4992948118C00CD12F1 /* OneSignalOutcomes.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE61E49D2948119100CD12F1 /* OneSignalUser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E49C2948119100CD12F1 /* OneSignalUser.framework */; };
+		DE61E49E2948119100CD12F1 /* OneSignalUser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE61E49C2948119100CD12F1 /* OneSignalUser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE68DA5B24C7695900FC95A8 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DE68DA5A24C7695900FC95A8 /* AppDelegate.m */; };
+		DE68DA5E24C7695900FC95A8 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DE68DA5D24C7695900FC95A8 /* SceneDelegate.m */; };
+		DE68DA6124C7695900FC95A8 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DE68DA6024C7695900FC95A8 /* ViewController.m */; };
+		DE68DA6424C7695900FC95A8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE68DA6224C7695900FC95A8 /* Main.storyboard */; };
+		DE68DA6624C7695A00FC95A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE68DA6524C7695A00FC95A8 /* Assets.xcassets */; };
+		DE68DA6924C7695A00FC95A8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE68DA6724C7695A00FC95A8 /* LaunchScreen.storyboard */; };
+		DE68DA6C24C7695A00FC95A8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DE68DA6B24C7695A00FC95A8 /* main.m */; };
+		DE68DA7724C769F200FC95A8 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03432CDB1EBD426A0071FC48 /* CoreLocation.framework */; };
+		DE68DA7824C769F900FC95A8 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9112E8A61E724EE00022A1CB /* SystemConfiguration.framework */; };
+		DE68DA7924C76A0300FC95A8 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91B6EA051E83215000B5CF01 /* UserNotifications.framework */; };
+		DE68DA7A24C76A1800FC95A8 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CACBAAB5218A7136000ACAA5 /* WebKit.framework */; };
 		DE7D180727026BB5002D3A5D /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D180627026BB5002D3A5D /* OneSignalCore.framework */; };
 		DE7D180827026BB5002D3A5D /* OneSignalCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D180627026BB5002D3A5D /* OneSignalCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE7D180927026BC5002D3A5D /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D180627026BB5002D3A5D /* OneSignalCore.framework */; };
@@ -81,6 +107,13 @@
 			remoteGlobalIDString = 945C59DB296CF2A00097041D;
 			remoteInfo = OneSignalWidgetExtensionExtension;
 		};
+		DE61E4862948117000CD12F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9112E87A1E724C320022A1CB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DE68DA5624C7695900FC95A8;
+			remoteInfo = OneSignalExampleClip;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -102,8 +135,26 @@
 			dstPath = "$(CONTENTS_FOLDER_PATH)/AppClips";
 			dstSubfolderSpec = 16;
 			files = (
+				DE61E4852948117000CD12F1 /* OneSignalExampleClip.app in Embed App Clips */,
 			);
 			name = "Embed App Clips";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE61E48C2948117A00CD12F1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				DE61E4952948118500CD12F1 /* OneSignalNotifications.framework in Embed Frameworks */,
+				DE61E49E2948119100CD12F1 /* OneSignalUser.framework in Embed Frameworks */,
+				DE61E4922948118200CD12F1 /* OneSignalFramework.framework in Embed Frameworks */,
+				DE61E48B2948117A00CD12F1 /* OneSignalCore.framework in Embed Frameworks */,
+				DE61E48F2948117D00CD12F1 /* OneSignalExtension.framework in Embed Frameworks */,
+				DE61E49B2948118D00CD12F1 /* OneSignalOutcomes.framework in Embed Frameworks */,
+				DE61E4982948118900CD12F1 /* OneSignalOSCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DEA226FA261F74060092FF58 /* Embed Frameworks */ = {
@@ -181,6 +232,7 @@
 		DE61E4962948118900CD12F1 /* OneSignalOSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OneSignalOSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE61E4992948118C00CD12F1 /* OneSignalOutcomes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OneSignalOutcomes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE61E49C2948119100CD12F1 /* OneSignalUser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OneSignalUser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE68DA5724C7695900FC95A8 /* OneSignalExampleClip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OneSignalExampleClip.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE68DA5924C7695900FC95A8 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DE68DA5A24C7695900FC95A8 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		DE68DA5C24C7695900FC95A8 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
@@ -257,6 +309,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DE68DA5424C7695900FC95A8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE61E48A2948117A00CD12F1 /* OneSignalCore.framework in Frameworks */,
+				DE61E4912948118200CD12F1 /* OneSignalFramework.framework in Frameworks */,
+				DE61E4972948118900CD12F1 /* OneSignalOSCore.framework in Frameworks */,
+				DE61E48E2948117D00CD12F1 /* OneSignalExtension.framework in Frameworks */,
+				DE61E49A2948118C00CD12F1 /* OneSignalOutcomes.framework in Frameworks */,
+				DE61E49D2948119100CD12F1 /* OneSignalUser.framework in Frameworks */,
+				DE68DA7A24C76A1800FC95A8 /* WebKit.framework in Frameworks */,
+				DE61E4942948118500CD12F1 /* OneSignalNotifications.framework in Frameworks */,
+				DE68DA7924C76A0300FC95A8 /* UserNotifications.framework in Frameworks */,
+				DE68DA7724C769F200FC95A8 /* CoreLocation.framework in Frameworks */,
+				DE68DA7824C769F900FC95A8 /* SystemConfiguration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -279,6 +349,7 @@
 			children = (
 				9112E8821E724C320022A1CB /* OneSignalExample.app */,
 				9150E7721E73BEDC00C5D46A /* OneSignalNotificationServiceExtension.appex */,
+				DE68DA5724C7695900FC95A8 /* OneSignalExampleClip.app */,
 				945C59DC296CF2A00097041D /* OneSignalWidgetExtensionExtension.appex */,
 			);
 			name = Products;
@@ -420,6 +491,7 @@
 			);
 			dependencies = (
 				9150E7791E73BEDD00C5D46A /* PBXTargetDependency */,
+				DE61E4872948117000CD12F1 /* PBXTargetDependency */,
 				945C59EF296CF2A10097041D /* PBXTargetDependency */,
 			);
 			name = OneSignalExample;
@@ -465,6 +537,26 @@
 			productReference = 945C59DC296CF2A00097041D /* OneSignalWidgetExtensionExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		DE68DA5624C7695900FC95A8 /* OneSignalExampleClip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DE68DA7424C7695A00FC95A8 /* Build configuration list for PBXNativeTarget "OneSignalExampleClip" */;
+			buildPhases = (
+				DE68DA5324C7695900FC95A8 /* Sources */,
+				DE68DA5424C7695900FC95A8 /* Frameworks */,
+				DE68DA5524C7695900FC95A8 /* Resources */,
+				DE61E48C2948117A00CD12F1 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OneSignalExampleClip;
+			packageProductDependencies = (
+			);
+			productName = OneSignalDevAppClip;
+			productReference = DE68DA5724C7695900FC95A8 /* OneSignalExampleClip.app */;
+			productType = "com.apple.product-type.application.on-demand-install-capable";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -477,6 +569,7 @@
 				TargetAttributes = {
 					9112E8811E724C320022A1CB = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 99SW8E36CT;
 						LastSwiftMigration = 1320;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -504,6 +597,9 @@
 					945C59DB296CF2A00097041D = {
 						CreatedOnToolsVersion = 14.1;
 					};
+					DE68DA5624C7695900FC95A8 = {
+						CreatedOnToolsVersion = 12.0;
+					};
 				};
 			};
 			buildConfigurationList = 9112E87D1E724C320022A1CB /* Build configuration list for PBXProject "OneSignalExample" */;
@@ -524,6 +620,7 @@
 			targets = (
 				9112E8811E724C320022A1CB /* OneSignalExample */,
 				9150E7711E73BEDC00C5D46A /* OneSignalNotificationServiceExtension */,
+				DE68DA5624C7695900FC95A8 /* OneSignalExampleClip */,
 				945C59DB296CF2A00097041D /* OneSignalWidgetExtensionExtension */,
 			);
 		};
@@ -556,6 +653,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				945C59EA296CF2A10097041D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE68DA5524C7695900FC95A8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE68DA6924C7695A00FC95A8 /* LaunchScreen.storyboard in Resources */,
+				DE68DA6624C7695A00FC95A8 /* Assets.xcassets in Resources */,
+				DE68DA6424C7695900FC95A8 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -596,6 +703,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DE68DA5324C7695900FC95A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE68DA6124C7695900FC95A8 /* ViewController.m in Sources */,
+				DE68DA5B24C7695900FC95A8 /* AppDelegate.m in Sources */,
+				DE68DA6C24C7695A00FC95A8 /* main.m in Sources */,
+				DE68DA5E24C7695900FC95A8 /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -609,6 +727,12 @@
 			platformFilter = ios;
 			target = 945C59DB296CF2A00097041D /* OneSignalWidgetExtensionExtension */;
 			targetProxy = 945C59EE296CF2A10097041D /* PBXContainerItemProxy */;
+		};
+		DE61E4872948117000CD12F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = DE68DA5624C7695900FC95A8 /* OneSignalExampleClip */;
+			targetProxy = DE61E4862948117000CD12F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -763,7 +887,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = OneSignalExample;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalDevApp/OneSignalExample-Bridging-Header.h";
@@ -795,7 +919,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = OneSignalExample;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "OneSignalDevApp/OneSignalExample-Bridging-Header.h";
@@ -823,7 +947,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.OneSignalNotificationServiceExtensionA;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
@@ -851,7 +975,7 @@
 				);
 				MARKETING_VERSION = 1.4.4;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.OneSignalNotificationServiceExtensionA;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalNotificationServiceExtensionA;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
@@ -894,7 +1018,7 @@
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.OneSignalWidgetExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
@@ -941,7 +1065,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.staging.OneSignalWidgetExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.OneSignalWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
@@ -949,6 +1073,88 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		DE68DA7224C7695A00FC95A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = OneSignalDevAppClip/OneSignalDevAppClip.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1.4.4;
+				DEVELOPMENT_TEAM = 99SW8E36CT;
+				"DYLIB_INSTALL_NAME_BASE[arch=*]" = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					OS_APP_CLIP,
+				);
+				INFOPLIST_FILE = OneSignalDevAppClip/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.4.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.Clip;
+				PRODUCT_NAME = OneSignalExampleClip;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DE68DA7324C7695A00FC95A8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = OneSignalDevAppClip/OneSignalDevAppClip.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1.4.4;
+				DEVELOPMENT_TEAM = 99SW8E36CT;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = OS_APP_CLIP;
+				INFOPLIST_FILE = OneSignalDevAppClip/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.4.4;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.Clip;
+				PRODUCT_NAME = OneSignalExampleClip;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -988,6 +1194,15 @@
 			buildConfigurations = (
 				945C59F2296CF2A20097041D /* Debug */,
 				945C59F3296CF2A20097041D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DE68DA7424C7695A00FC95A8 /* Build configuration list for PBXNativeTarget "OneSignalExampleClip" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DE68DA7224C7695A00FC95A8 /* Debug */,
+				DE68DA7324C7695A00FC95A8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -33,8 +33,8 @@
 // Networking
 #define OS_API_VERSION @"1"
 #define OS_API_ACCEPT_HEADER @"application/vnd.onesignal.v" OS_API_VERSION @"+json"
-#define OS_API_SERVER_URL @"https://api.staging.onesignal.com/"
-#define OS_IAM_WEBVIEW_BASE_URL @"https://staging.onesignal.com/"
+#define OS_API_SERVER_URL @"https://api.onesignal.com/"
+#define OS_IAM_WEBVIEW_BASE_URL @"https://onesignal.com/"
 
 // OneSignalUserDefault keys
 // String values start with "OSUD_" to maintain a level of uniqueness from other libs and app code

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalMobileProvision.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalMobileProvision.m
@@ -87,7 +87,7 @@
     NSDictionary *entitlements = nil;
     NSDictionary *provision = [self getProvision];
     if (provision) {
-        // [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"provision: %@", provision]];
+        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"provision: %@", provision]];
         entitlements = [provision objectForKey:@"Entitlements"];
     }
     else

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -1154,7 +1154,6 @@ static BOOL _isInAppMessagingPaused = false;
 
 #pragma mark OSUserStateObserver Methods
 - (void)onUserStateDidChangeWithState:(OSUserChangedState * _Nonnull)state {
-    NSLog(@"❌ OSMessagingController onUserStateDidChangeWithState: %@", [state jsonRepresentation]);
     if (state.current.onesignalId && shouldRetryGetInAppMessagesOnUserChange) {
         shouldRetryGetInAppMessagesOnUserChange = false;
         [self getInAppMessagesFromServer];
@@ -1167,7 +1166,6 @@ static BOOL _isInAppMessagingPaused = false;
 }
 
 - (void)onJwtUpdatedWithExternalId:(NSString *)externalId token:(NSString *)token {
-    NSLog(@"❌ OSMessagingController onJwtUpdatedWithExternalId: %@ token: %@", externalId, token);
     if (![token  isEqual: OS_JWT_TOKEN_INVALID] && shouldRetryGetInAppMessagesOnJwtUpdated) {
         shouldRetryGetInAppMessagesOnJwtUpdated = false;
         [self getInAppMessagesFromServer];

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Jwt/OSUserJwtConfig.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Jwt/OSUserJwtConfig.swift
@@ -64,8 +64,7 @@ public class OSUserJwtConfig {
                 return
             }
 
-            print("❌ OSUserJwtConfig.requiresUserAuth: changing from \(oldValue) to \(requiresUserAuth), firing \(changeNotifier)")
-
+            OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSUserJwtConfig.requiresUserAuth: changing from \(oldValue) to \(requiresUserAuth), firing listeners")
             // Persist new value
             OneSignalUserDefaults.initShared().saveInteger(forKey: OSUD_USE_IDENTITY_VERIFICATION, withValue: requiresUserAuth.rawValue)
 
@@ -93,9 +92,6 @@ public class OSUserJwtConfig {
 
     public init() {
         let rawValue = OneSignalUserDefaults.initShared().getSavedInteger(forKey: OSUD_USE_IDENTITY_VERIFICATION, defaultValue: OSRequiresUserAuth.unknown.rawValue)
-
-        print("❌ OSUserJwtConfig init(): \(String(describing: OSRequiresUserAuth(rawValue: rawValue))))")
-
         requiresUserAuth = OSRequiresUserAuth(rawValue: rawValue) ?? OSRequiresUserAuth.unknown
     }
 
@@ -104,7 +100,7 @@ public class OSUserJwtConfig {
     }
 
     public func onJwtTokenChanged(externalId: String, token: String?) {
-        print("❌ OSUserJwtConfig.onJwtTokenChanged \(externalId): \(token)")
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSUserJwtConfig.onJwtTokenChanged for \(externalId) with token \(token ?? "nil"), firing listeners")
         changeNotifier.fire { listener in
             listener.onJwtUpdated(externalId: externalId, token: token)
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSOperationRepo.swift
@@ -54,8 +54,6 @@ public class OSOperationRepo {
     public init(jwtConfig: OSUserJwtConfig) {
         self.jwtConfig = jwtConfig
         self.jwtConfig.subscribe(self, key: OS_OPERATION_REPO)
-        print("❌ OSOperationRepo init(\(String(describing: jwtConfig.isRequired))) called")
-
         // Read the Deltas from cache, if any...
         guard let deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_OPERATION_REPO_DELTA_QUEUE_KEY, defaultValue: []) as? [OSDelta] else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSOperationRepo is unable to uncache the OSDelta queue.")
@@ -73,7 +71,7 @@ public class OSOperationRepo {
         }
 
         guard jwtConfig.isRequired != nil else {
-            print("❌ OSOperationRepo.start() returning early due to unknown Identity Verification status.")
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "OSOperationRepo.start() returning early due to unknown Identity Verification status")
             return
         }
 
@@ -185,7 +183,6 @@ public class OSOperationRepo {
 
 extension OSOperationRepo: OSUserJwtConfigListener {
     public func onRequiresUserAuthChanged(from: OSRequiresUserAuth, to: OSRequiresUserAuth) {
-        print("❌ OSOperationRepo onRequiresUserAuthChanged from \(String(describing: from)) to \(String(describing: to))")
         // If auth changed from false or unknown to true, process deltas
         if to == .on {
             removeInvalidDeltas()
@@ -194,7 +191,7 @@ extension OSOperationRepo: OSUserJwtConfigListener {
     }
 
     public func onJwtUpdated(externalId: String, token: String?) {
-        print("❌ OSOperationRepo onJwtUpdated for \(externalId) to \(String(describing: token))")
+        // Not used for now
     }
 
     /**
@@ -203,14 +200,19 @@ extension OSOperationRepo: OSUserJwtConfigListener {
      Executors will handle this.
      */
     func removeInvalidDeltas() {
-        print("❌ OSOperationRepo removeInvalidDeltas TODO!")
+        // Not used for now
     }
 }
 
 extension OSOperationRepo: OSLoggable {
     public func logSelf() {
-        print("💛 Operation Repo: deltaQueue: \(self.deltaQueue )")
-        print("💛 Operation Repo: executors that are subscribed:")
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
+            """
+            Operation Repo: deltaQueue: \(self.deltaQueue)
+
+            Operation Repo: executors that are subscribed:
+            """
+        )
         for executor in self.executors {
             executor.logSelf()
         }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSIdentityOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSIdentityOperationExecutor.swift
@@ -45,7 +45,6 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
         self.newRecordsState = newRecordsState
         self.jwtConfig = jwtConfig
         self.jwtConfig.subscribe(self, key: OS_IDENTITY_EXECUTOR)
-        print("❌ OSIdentityOperationExecutor init(\(jwtConfig.isRequired))")
         // Read unfinished deltas and requests from cache, if any...
         uncacheDeltas()
         uncacheRequests()
@@ -206,7 +205,7 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
 
                 // If JWT is on but the external ID does not exist, drop this Delta
                 if self.jwtConfig.isRequired == true, model.externalId == nil {
-                    print("❌ \(delta) is Invalid with JWT, being dropped")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSIdentityOperationExecutor.processDeltaQueue dropped \(delta)")
                 }
 
                 switch delta.name {
@@ -401,7 +400,6 @@ class OSIdentityOperationExecutor: OSOperationExecutor {
 
 extension OSIdentityOperationExecutor: OSUserJwtConfigListener {
     func onRequiresUserAuthChanged(from: OSRequiresUserAuth, to: OSRequiresUserAuth) {
-        print("❌ OSIdentityOperationExecutor onUserAuthChanged from \(String(describing: from)) to \(String(describing: to))")
         // If auth changed from false or unknown to true, process requests
         if to == .on {
             removeInvalidDeltasAndRequests()
@@ -409,7 +407,6 @@ extension OSIdentityOperationExecutor: OSUserJwtConfigListener {
     }
 
     func onJwtUpdated(externalId: String, token: String?) {
-        print("❌ OSIdentityOperationExecutor onJwtUpdated for \(externalId) to \(String(describing: token))")
         reQueuePendingRequestsForExternalId(externalId: externalId)
     }
 
@@ -435,10 +432,9 @@ extension OSIdentityOperationExecutor: OSUserJwtConfigListener {
 
     private func removeInvalidDeltasAndRequests() {
         self.dispatchQueue.async {
-            print("❌ OSIdentityOperationExecutor.removeInvalidDeltasAndRequests called")
             for (index, delta) in self.deltaQueue.enumerated().reversed() {
                 if (delta.model as? OSIdentityModel)?.externalId == nil {
-                    print(" \(delta) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSIdentityOperationExecutor.removeInvalidDeltasAndRequests dropped \(delta)")
                     self.deltaQueue.remove(at: index)
                 }
             }
@@ -446,7 +442,7 @@ extension OSIdentityOperationExecutor: OSUserJwtConfigListener {
 
             for (index, request) in self.addRequestQueue.enumerated().reversed() {
                 if request.identityModel.externalId == nil {
-                    print(" \(request) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSIdentityOperationExecutor.removeInvalidDeltasAndRequests dropped \(request)")
                     self.addRequestQueue.remove(at: index)
                 }
             }
@@ -454,7 +450,7 @@ extension OSIdentityOperationExecutor: OSUserJwtConfigListener {
 
             for (index, request) in self.removeRequestQueue.enumerated().reversed() {
                 if request.identityModel.externalId == nil {
-                    print(" \(request) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSIdentityOperationExecutor.removeInvalidDeltasAndRequests dropped \(request)")
                     self.removeRequestQueue.remove(at: index)
                 }
             }
@@ -465,13 +461,14 @@ extension OSIdentityOperationExecutor: OSUserJwtConfigListener {
 
 extension OSIdentityOperationExecutor: OSLoggable {
     func logSelf() {
-        print(
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
             """
-            💛 OSIdentityOperationExecutor has the following queues:
+            OSIdentityOperationExecutor has the following queues:
                 addRequestQueue: \(self.addRequestQueue)
                 removeRequestQueue: \(self.removeRequestQueue)
                 deltaQueue: \(self.deltaQueue)
                 pendingAuthRequests: \(self.pendingAuthRequests)
+
             """
         )
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
@@ -75,8 +75,6 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         self.newRecordsState = newRecordsState
         self.jwtConfig = jwtConfig
         self.jwtConfig.subscribe(self, key: OS_PROPERTIES_EXECUTOR)
-        print("❌ OSPropertyOperationExecutor init(\(String(describing: jwtConfig.isRequired)))")
-
         // Read unfinished deltas and requests from cache, if any...
         // Note that we should only have deltas for the current user as old ones are flushed..
         uncacheDeltas()
@@ -84,8 +82,6 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
     }
 
     private func uncacheDeltas() {
-        print("❌ OSPropertyOperationExecutor uncacheDeltas called")
-
         if var deltaQueue = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_PROPERTIES_EXECUTOR_DELTA_QUEUE_KEY, defaultValue: []) as? [OSDelta] {
             for (index, delta) in deltaQueue.enumerated().reversed() {
                 guard let model = OneSignalUserManagerImpl.sharedInstance.getIdentityModel(delta.identityModelId) else {
@@ -97,7 +93,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
 
                 // If JWT is on but the external ID does not exist, drop this Delta
                 if jwtConfig.isRequired == true, model.externalId == nil {
-                    print("❌ removing \(delta)")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSPropertyOperationExecutor.uncacheDeltas dropped \(delta)")
                     deltaQueue.remove(at: index)
                 }
             }
@@ -106,7 +102,6 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         } else {
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSPropertyOperationExecutor error encountered reading from cache for \(OS_PROPERTIES_EXECUTOR_DELTA_QUEUE_KEY)")
         }
-        print("❌ OSPropertyOperationExecutor uncacheDeltas done, \(self.deltaQueue)")
     }
 
     private func uncacheUpdateRequests() {
@@ -117,15 +112,13 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         }
 
         if let pendingRequests = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_PROPERTIES_EXECUTOR_PENDING_QUEUE_KEY, defaultValue: [:]) as? [String: [OSRequestUpdateProperties]] {
-            print("❌ prop executor uncached pending \(pendingRequests)")
-
             for requests in pendingRequests.values {
                 for request in requests {
                     updateRequestQueue.append(request)
                 }
             }
         }
-        print("❌ prop executor uncached requests \(updateRequestQueue)")
+
         // Hook each uncached Request to the model in the store
         for (index, request) in updateRequestQueue.enumerated().reversed() {
             if jwtConfig.isRequired == true,
@@ -172,7 +165,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
      */
     func processDeltaQueue(inBackground: Bool) {
         guard jwtConfig.isRequired != nil else {
-            print("❌ OSPropertyOperationExecutor processDeltaQueue returning early due to requiresAuth: \(String(describing: jwtConfig.isRequired))")
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "OSPropertyOperationExecutor processDeltaQueue returning early due to requiresAuth: \(String(describing: jwtConfig.isRequired))")
             return
         }
 
@@ -198,7 +191,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
 
                 // If JWT is on but the external ID does not exist, drop this Delta
                 if self.jwtConfig.isRequired == true, identityModel.externalId == nil {
-                    print("❌ \(delta) is Invalid with JWT, being dropped")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSPropertyOperationExecutor.processDeltaQueue dropped \(delta)")
                 }
 
                 let combinedSoFar: OSCombinedProperties? = combinedProperties[identityModel.modelId]
@@ -317,7 +310,6 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
             return
         }
 
-        print("ECM executing properties request: %@", request.identityModel.externalId)
         request.sentToClient = true
 
         let backgroundTaskIdentifier = PROPERTIES_EXECUTOR_BACKGROUND_TASK + UUID().uuidString
@@ -375,7 +367,6 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
 
 extension OSPropertyOperationExecutor: OSUserJwtConfigListener {
     func onRequiresUserAuthChanged(from: OSRequiresUserAuth, to: OSRequiresUserAuth) {
-        print("❌ OSPropertyOperationExecutor onUserAuthChanged from \(String(describing: from)) to \(String(describing: to))")
         // If auth changed from false or unknown to true, process requests
         if to == .on {
             removeInvalidDeltasAndRequests()
@@ -383,7 +374,6 @@ extension OSPropertyOperationExecutor: OSUserJwtConfigListener {
     }
 
     func onJwtUpdated(externalId: String, token: String?) {
-        print("❌ OSPropertyOperationExecutor onJwtUpdated for \(externalId) to \(String(describing: token))")
         reQueuePendingRequestsForExternalId(externalId: externalId)
     }
 
@@ -404,13 +394,11 @@ extension OSPropertyOperationExecutor: OSUserJwtConfigListener {
 
     private func removeInvalidDeltasAndRequests() {
         self.dispatchQueue.async {
-            print("❌ OSPropertyOperationExecutor.removeInvalidDeltasAndRequests called")
-
             for (index, delta) in self.deltaQueue.enumerated().reversed() {
                 if let identityModel = OneSignalUserManagerImpl.sharedInstance.getIdentityModel(delta.identityModelId),
                    identityModel.externalId == nil
                 {
-                    print(" \(delta) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSPropertyOperationExecutor.removeInvalidDeltasAndRequests dropped \(delta)")
                     self.deltaQueue.remove(at: index)
                 }
             }
@@ -418,7 +406,7 @@ extension OSPropertyOperationExecutor: OSUserJwtConfigListener {
 
             for (index, request) in self.updateRequestQueue.enumerated().reversed() {
                 if request.identityModel.externalId == nil {
-                    print(" \(request) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSPropertyOperationExecutor.removeInvalidDeltasAndRequests dropped \(request)")
                     self.updateRequestQueue.remove(at: index)
                 }
             }
@@ -429,12 +417,13 @@ extension OSPropertyOperationExecutor: OSUserJwtConfigListener {
 
 extension OSPropertyOperationExecutor: OSLoggable {
     func logSelf() {
-        print(
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
             """
-            💛 OSPropertyOperationExecutor has the following queues:
+            OSPropertyOperationExecutor has the following queues:
                 updateRequestQueue: \(self.updateRequestQueue)
                 deltaQueue: \(self.deltaQueue)
                 pendingAuthRequests: \(self.pendingAuthRequests)
+
             """
         )
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
@@ -257,7 +257,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
 
                     // If JWT is on but the external ID does not exist, drop this Delta
                     if self.jwtConfig.isRequired == true, identityModel.externalId == nil {
-                        print("❌ \(delta) is Invalid with JWT, being dropped")
+                        OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSSubscriptionOperationExecutor.processDeltaQueue dropped \(delta)")
                     }
 
                     let request = OSRequestCreateSubscription(
@@ -275,7 +275,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
 
                     // If JWT is on but the external ID does not exist, drop this Delta
                     if self.jwtConfig.isRequired == true, identityModel.externalId == nil {
-                        print("❌ \(delta) is Invalid with JWT, being dropped")
+                        OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSSubscriptionOperationExecutor.processDeltaQueue dropped \(delta)")
                     }
 
                     let request = OSRequestDeleteSubscription(
@@ -514,14 +514,12 @@ extension OSSubscriptionOperationExecutor {
 
 extension OSSubscriptionOperationExecutor: OSUserJwtConfigListener {
     func onRequiresUserAuthChanged(from: OneSignalOSCore.OSRequiresUserAuth, to: OneSignalOSCore.OSRequiresUserAuth) {
-        print("❌ OSSubscriptionOperationExecutor onUserAuthChanged from \(String(describing: from)) to \(String(describing: to))")
         if to == .on {
             removeInvalidDeltasAndRequests()
         }
     }
 
     func onJwtUpdated(externalId: String, token: String?) {
-        print("❌ OSSubscriptionOperationExecutor onJwtUpdated for \(externalId) to \(String(describing: token))")
         reQueuePendingRequestsForExternalId(externalId: externalId)
     }
 
@@ -575,14 +573,12 @@ extension OSSubscriptionOperationExecutor: OSUserJwtConfigListener {
      */
     private func removeInvalidDeltasAndRequests() {
         self.dispatchQueue.async {
-            print("❌ OSSubscriptionOperationExecutor.removeInvalidDeltasAndRequests called")
-
             for (index, delta) in self.deltaQueue.enumerated().reversed() {
                 if delta.name != OS_UPDATE_SUBSCRIPTION_DELTA,
                    let identityModel = OneSignalUserManagerImpl.sharedInstance.getIdentityModel(delta.identityModelId),
                    identityModel.externalId == nil
                 {
-                    print(" \(delta) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSSubscriptionOperationExecutor.removeInvalidDeltasAndRequests dropped \(delta)")
                     self.deltaQueue.remove(at: index)
                 }
             }
@@ -590,7 +586,7 @@ extension OSSubscriptionOperationExecutor: OSUserJwtConfigListener {
 
             for (index, request) in self.addRequestQueue.enumerated().reversed() {
                 if request.identityModel.externalId == nil {
-                    print(" \(request) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSSubscriptionOperationExecutor.removeInvalidDeltasAndRequests dropped \(request)")
                     self.addRequestQueue.remove(at: index)
                 }
             }
@@ -598,7 +594,7 @@ extension OSSubscriptionOperationExecutor: OSUserJwtConfigListener {
 
             for (index, request) in self.removeRequestQueue.enumerated().reversed() {
                 if request.identityModel.externalId == nil {
-                    print(" \(request) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSSubscriptionOperationExecutor.removeInvalidDeltasAndRequests dropped \(request)")
                     self.removeRequestQueue.remove(at: index)
                 }
             }
@@ -609,14 +605,15 @@ extension OSSubscriptionOperationExecutor: OSUserJwtConfigListener {
 
 extension OSSubscriptionOperationExecutor: OSLoggable {
     func logSelf() {
-        print(
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
             """
-            💛 OSSubscriptionOperationExecutor has the following queues:
+            OSSubscriptionOperationExecutor has the following queues:
                 addRequestQueue: \(self.addRequestQueue)
                 removeRequestQueue: \(self.removeRequestQueue)
                 updateRequestQueue: \(self.updateRequestQueue)
                 deltaQueue: \(self.deltaQueue)
                 pendingAuthRequests: \(self.pendingAuthRequests)
+
             """
         )
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -49,8 +49,6 @@ class OSUserExecutor {
         self.newRecordsState = newRecordsState
         self.jwtConfig = jwtConfig
         self.jwtConfig.subscribe(self, key: OS_USER_EXECUTOR)
-        print("❌ OSUserExecutor init requiresAuth: \(jwtConfig.isRequired)")
-
         uncacheUserRequests()
         migrateTransferSubscriptionRequests()
         executePendingRequests()
@@ -60,7 +58,7 @@ class OSUserExecutor {
     private func uncacheUserRequests() {
         var userRequestQueue: [OSUserRequest] = []
         var cachedRequestQueue: [OSUserRequest] = []
-        print(" OSUserExecutor uncacheUserRequests called")
+
         // Read unfinished Create User + Identify User + Get Identity By Subscription requests from cache, if any...
         if let cache = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, defaultValue: []) as? [OSUserRequest] {
             cachedRequestQueue = cache
@@ -79,7 +77,7 @@ class OSUserExecutor {
             if request.isKind(of: OSRequestFetchIdentityBySubscription.self), let req = request as? OSRequestFetchIdentityBySubscription {
                 // Remove this request if JWT is enabled
                 guard jwtConfig.isRequired != true else {
-                    print(" uncacheUserRequests dropping request \(req)")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSUserExecutor.uncacheUserRequests dropped \(req)")
                     continue
                 }
                 if let identityModel = getIdentityModel(req.identityModel.modelId) {
@@ -98,7 +96,7 @@ class OSUserExecutor {
                    req.identityModel.externalId == nil
                 {
                     // Remove this request if there is no EUID
-                    print(" uncacheUserRequests dropping request \(req)")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSUserExecutor.uncacheUserRequests dropped \(req)")
                     continue
                 }
 
@@ -115,7 +113,6 @@ class OSUserExecutor {
 
                 // If JWT is enabled, we migrate this request into a Create User request
                 guard jwtConfig.isRequired != true else {
-                    print(" uncacheUserRequests converting \(req) to createUser")
                     convertIdentifyUserToCreateUser(req)
                     continue
                 }
@@ -146,7 +143,6 @@ class OSUserExecutor {
         }
         self.userRequestQueue = userRequestQueue
         OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
-        print(" OSUserExecutor uncacheUserRequests done, now has queue: \(self.userRequestQueue)")
     }
 
     /**
@@ -166,6 +162,7 @@ class OSUserExecutor {
     }
 
     private func convertIdentifyUserToCreateUser(_ request: OSRequestIdentifyUser) {
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSUserExecutor.convertIdentifyUserToCreateUser for \(request)")
         if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.aliasId) {
             self.createUser(OneSignalUserManagerImpl.sharedInstance.user)
         } else {
@@ -239,7 +236,7 @@ class OSUserExecutor {
      */
     func executePendingRequests(withDelay: Bool = false) {
         guard jwtConfig.isRequired != nil else {
-            print("❌ OSUserExecutor.executePendingRequests returning early due to unknown Identity Verification status.")
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "OSUserExecutor.executePendingRequests returning early due to unknown Identity Verification status")
             return
         }
 
@@ -766,7 +763,6 @@ extension OSUserExecutor {
 
 extension OSUserExecutor: OSUserJwtConfigListener {
     func onRequiresUserAuthChanged(from: OSRequiresUserAuth, to: OSRequiresUserAuth) {
-        print("❌ OSUserExecutor onUserAuthChanged from \(String(describing: from)) to \(String(describing: to))")
         // If auth changed from false or unknown to true, process requests
         if to == .on {
             removeInvalidRequests()
@@ -776,7 +772,6 @@ extension OSUserExecutor: OSUserJwtConfigListener {
 
     func onJwtUpdated(externalId: String, token: String?) {
         reQueuePendingRequestsForExternalId(externalId: externalId)
-        print("❌ OSUserExecutor onJwtUpdated for \(externalId) to \(String(describing: token))")
     }
 
     private func reQueuePendingRequestsForExternalId(externalId: String) {
@@ -796,24 +791,20 @@ extension OSUserExecutor: OSUserJwtConfigListener {
 
     private func removeInvalidRequests() {
         self.dispatchQueue.async {
-            print("❌ OSUserExecutor.removeInvalidRequests called")
-
             for request in self.userRequestQueue {
                 guard self.isRequestValidWithAuth(request) else {
-                    print(" \(request) is Invalid, being removed")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: OSUserExecutor.removeInvalidRequests dropped \(request)")
                     self.userRequestQueue.removeAll(where: { $0 == request})
                     continue
                 }
 
                 if request.isKind(of: OSRequestIdentifyUser.self), let req = request as? OSRequestIdentifyUser {
-                    print(" \(request) is IdentifyUser, being converted")
+                    OneSignalLog.onesignalLog(.LL_DEBUG, message: "Invalid with JWT: \(request) is IdentifyUser, being converted")
                     self.userRequestQueue.removeAll(where: { $0 == request})
                     self.convertIdentifyUserToCreateUser(req)
                 }
             }
-
             OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_USER_EXECUTOR_USER_REQUEST_QUEUE_KEY, withValue: self.userRequestQueue)
-            print(" OSUserExecutor.removeInvalidRequests done, \(self.userRequestQueue)")
         }
     }
 
@@ -839,11 +830,12 @@ extension OSUserExecutor: OSUserJwtConfigListener {
 
 extension OSUserExecutor: OSLoggable {
     func logSelf() {
-        print(
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
             """
-            💛 OSUserExecutor has the following queues:
+            OSUserExecutor has the following queues:
                 userRequestQueue: \(self.userRequestQueue)
                 pendingAuthRequests: \(self.pendingAuthRequests)
+
             """
         )
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Modeling/OSIdentityModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Modeling/OSIdentityModel.swift
@@ -134,26 +134,6 @@ class OSIdentityModel: OSModel {
         let newExternalId = remoteAliases[OS_EXTERNAL_ID]
 
         internalAddAliases(remoteAliases)
-        fireUserStateChanged(newOnesignalId: newOnesignalId, newExternalId: newExternalId)
-    }
-
-    /**
-     Fires the user observer if `onesignal_id` OR `external_id` has changed from the previous snapshot (previous hydration).
-     */
-    private func fireUserStateChanged(newOnesignalId: String?, newExternalId: String?) {
-        let prevOnesignalId  = OneSignalUserDefaults.initShared().getSavedString(forKey: OS_SNAPSHOT_ONESIGNAL_ID, defaultValue: nil)
-        let prevExternalId = OneSignalUserDefaults.initShared().getSavedString(forKey: OS_SNAPSHOT_EXTERNAL_ID, defaultValue: nil)
-
-        guard prevOnesignalId != newOnesignalId || prevExternalId != newExternalId else {
-            return
-        }
-
-        OneSignalUserDefaults.initShared().saveString(forKey: OS_SNAPSHOT_ONESIGNAL_ID, withValue: newOnesignalId)
-        OneSignalUserDefaults.initShared().saveString(forKey: OS_SNAPSHOT_EXTERNAL_ID, withValue: newExternalId)
-
-        let curUserState = OSUserState(onesignalId: newOnesignalId, externalId: newExternalId)
-        let changedState = OSUserChangedState(current: curUserState)
-
-        OneSignalUserManagerImpl.sharedInstance.userStateChangesObserver.notifyChange(changedState)
+        OSUserUtils.fireUserStateChanged(newOnesignalId: newOnesignalId, newExternalId: newExternalId)
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Modeling/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Modeling/OSSubscriptionModel.swift
@@ -98,6 +98,10 @@ enum OSSubscriptionType: String {
  Internal subscription model.
  */
 class OSSubscriptionModel: OSModel {
+    struct Constants {
+      static let isDisabledInternallyKey = "isDisabledInternallyKey"
+    }
+
     var type: OSSubscriptionType
 
     var address: String? { // This is token on push subs so must remain Optional
@@ -191,6 +195,21 @@ class OSSubscriptionModel: OSModel {
             }
             firePushSubscriptionChanged(.isDisabled(oldValue))
             notificationTypes = -2
+        }
+    }
+
+    /**
+     Set to `true` by the SDK when logout is called with Identity Verification turned on.
+     The properties of `_isDisabled` and `notificationTypes` remain unchanged, to maintain correct data.
+     When a subscription update is made, this value will be read and `enabled = false` and `notification_types = -2` will be sent.
+     When a user logs in, this property will be set to `false` and the subscription will be included in the User Create request..
+     */
+    var _isDisabledInternally = false {
+        didSet {
+            guard _isDisabledInternally != oldValue else {
+                return
+            }
+            self.set(property: Constants.isDisabledInternallyKey, newValue: _isDisabledInternally)
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Modeling/OSSubscriptionModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Modeling/OSSubscriptionModelStoreListener.swift
@@ -62,6 +62,14 @@ class OSSubscriptionModelStoreListener: OSModelStoreListener {
     }
 
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta? {
+        /*
+         Don't generate a Delta if setting internal disable to false, which will generate a subscription update.
+         This means a user is logging in and a create user will be sent with the updated subscription included.
+         */
+        if args.property == OSSubscriptionModel.Constants.isDisabledInternallyKey && args.newValue as? Bool == false {
+            return nil
+        }
+
         return OSDelta(
             name: OS_UPDATE_SUBSCRIPTION_DELTA,
             identityModelId: OneSignalUserManagerImpl.sharedInstance.user.identityModel.modelId,

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelRepo.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSIdentityModelRepo.swift
@@ -102,16 +102,17 @@ extension OSIdentityModelRepo: OSModelChangedHandler {
         else {
             return
         }
-        print("❌ OSIdentityModelRepo onModelUpdated for \(externalId): \(token)")
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSIdentityModelRepo onModelUpdated for \(externalId) with token \(token)")
         OneSignalUserManagerImpl.sharedInstance.jwtConfig.onJwtTokenChanged(externalId: externalId, token: token)
     }
 }
 
 extension OSIdentityModelRepo: OSLoggable {
     func logSelf() {
-        print("🥭 OSIdentityModelRepo has the following models: ")
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OSIdentityModelRepo has the following models:")
+
         for model in models.values {
-            print("     modelID: \(model.modelId), alises: \(model.aliases) token: \(model.jwtBearerToken ?? "nil")")
+            OneSignalLog.onesignalLog(.LL_VERBOSE, message: "    modelID: \(model.modelId), alises: \(model.aliases) token: \(model.jwtBearerToken ?? "nil")")
         }
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl+OSLoggable.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl+OSLoggable.swift
@@ -30,50 +30,53 @@ import OneSignalOSCore
 
 extension OneSignalUserManagerImpl: OSLoggable {
     @objc public func logSelf() {
-        print("💛 _user: \(String(describing: _user))")
-        print(
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
             """
-            💛 identityModel:
+            OneSignalUserManagerImpl:
+            _user: \(String(describing: _user))
+
+            identityModel:
                 aliases: \(String(describing: _user?.identityModel.aliases))
                 jwt: \(String(describing: _user?.identityModel.jwtBearerToken))
                 modelId: \(String(describing: _user?.identityModel.modelId))
-            """
-        )
-        print(
-            """
-            💛 propertiesModel:
+
+            propertiesModel:
                 tags: \(String(describing: _user?.propertiesModel.tags))
                 language: \(String(describing: _user?.propertiesModel.language))
                 modelId: \(String(describing: _user?.propertiesModel.modelId))
+
             """
         )
+
         let subscriptionModels = subscriptionModelStore.getModels().values
         for sub in subscriptionModels {
-            print(
+            OneSignalLog.onesignalLog(.LL_VERBOSE, message:
                 """
-                💛 subscription model from store
+                subscription model from store
                     addess: \(String(describing: sub.address))
                     subscriptionId: \(String(describing: sub.subscriptionId))
                     enabled: \(sub.enabled)
                     modelId: \(sub.modelId)
+
                 """
             )
         }
+
         let pushSubModel = pushSubscriptionModelStore.getModel(key: OS_PUSH_SUBSCRIPTION_MODEL_KEY)
-        print(
+        OneSignalLog.onesignalLog(.LL_VERBOSE, message:
             """
-            💛 push sub model from store
+            push sub model from store
                 token: \(String(describing: pushSubModel?.address))
                 subscriptionId: \(String(describing: pushSubModel?.subscriptionId))
                 enabled: \(String(describing: pushSubModel?.enabled))
                 notification_types: \(String(describing: pushSubModel?.notificationTypes))
                 optedIn: \(String(describing: pushSubModel?.optedIn))
                 modelId: \(String(describing: pushSubModel?.modelId))
+
             """
         )
         operationRepo.logSelf()
         userExecutor?.logSelf()
         identityModelRepo.logSelf()
-        print("")
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -447,9 +447,13 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
 
         /*
          If Identity Verification is on, disable the push subscription.
+         Since the anonymous placeholder user will not be created to the backend,
+         fire the user observer here to represent "no user" in the SDK.
+         This is necessary so internal user observers can know when a user logs out and then back in.
          */
         if jwtConfig.isRequired == true {
             user.pushSubscriptionModel._isDisabledInternally = true
+            OSUserUtils.fireUserStateChanged(newOnesignalId: nil, newExternalId: nil)
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -576,16 +576,6 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         }
         updatePropertiesDeltas(property: .purchases, value: purchases)
     }
-
-    @objc
-    public func updateUserJwt(externalId: String, token: String) {
-        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "updateUserJwt") else {
-            return
-        }
-        OneSignalLog.onesignalLog(ONE_S_LOG_LEVEL.LL_VERBOSE, message: "Update User JWT called with externalId: \(externalId) and token: \(token)")
-
-        identityModelRepo.updateJwtToken(externalId: externalId, token: token)
-    }
 }
 
 // MARK: - Sessions
@@ -676,6 +666,16 @@ extension OneSignalUserManagerImpl {
     @objc
     public func subscribeToJwtConfig(_ listener: OSUserJwtConfigListener, key: String) {
         jwtConfig.subscribe(listener, key: key)
+    }
+
+    @objc
+    public func updateUserJwt(externalId: String, token: String) {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "updateUserJwt") else {
+            return
+        }
+        OneSignalLog.onesignalLog(ONE_S_LOG_LEVEL.LL_VERBOSE, message: "Update User JWT called with externalId: \(externalId) and token: \(token)")
+
+        identityModelRepo.updateJwtToken(externalId: externalId, token: token)
     }
 
     @objc

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -400,6 +400,10 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         }
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignalUserManager internal _login called with externalId: \(externalId ?? "nil")")
 
+        if externalId != nil {
+            pushSubscriptionModel?._isDisabledInternally = false
+        }
+
         /*
          Logging in to a "new-to-the-sdk" externalId from an anonymous user, if JWT is OFF or UNKNOWN.
          
@@ -440,6 +444,13 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
         prepareForNewUser()
         _user = nil
         createUserIfNil()
+
+        /*
+         If Identity Verification is on, disable the push subscription.
+         */
+        if jwtConfig.isRequired == true {
+            user.pushSubscriptionModel._isDisabledInternally = true
+        }
     }
 
     @objc

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateSubscription.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Requests/OSRequestUpdateSubscription.swift
@@ -65,17 +65,23 @@ class OSRequestUpdateSubscription: OneSignalRequest, OSUserRequest {
         var subscriptionParams = subscriptionObject
         subscriptionParams.removeValue(forKey: "address")
         subscriptionParams.removeValue(forKey: "notificationTypes")
+        subscriptionParams.removeValue(forKey: OSSubscriptionModel.Constants.isDisabledInternallyKey)
         subscriptionParams["token"] = subscriptionModel.address
         subscriptionParams["device_os"] = subscriptionModel.deviceOs
         subscriptionParams["sdk"] = subscriptionModel.sdk
         subscriptionParams["app_version"] = subscriptionModel.appVersion
 
-        // notificationTypes defaults to -1 instead of nil, don't send if it's -1
-        if subscriptionModel.notificationTypes != -1 {
-            subscriptionParams["notification_types"] = subscriptionModel.notificationTypes
+        if subscriptionModel._isDisabledInternally {
+            subscriptionParams["enabled"] = false
+            subscriptionParams["notification_types"] = -2
+        } else {
+            // notificationTypes defaults to -1 instead of nil, don't send if it's -1
+            if subscriptionModel.notificationTypes != -1 {
+                subscriptionParams["notification_types"] = subscriptionModel.notificationTypes
+            }
+            subscriptionParams["enabled"] = subscriptionModel.enabled
         }
 
-        subscriptionParams["enabled"] = subscriptionModel.enabled
         // TODO: The above is not quite right. If we hydrate, we will over-write any pending updates
         // May use subscriptionObject, but enabled and notification_types should be sent together...
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Support/OSUserUtils.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Support/OSUserUtils.swift
@@ -71,4 +71,24 @@ class OSUserUtils {
         }
         return headers
     }
+
+    /**
+     Fires the user observer if `onesignal_id` OR `external_id` has changed from the previous snapshot (previous hydration).
+     */
+    static func fireUserStateChanged(newOnesignalId: String?, newExternalId: String?) {
+        let prevOnesignalId  = OneSignalUserDefaults.initShared().getSavedString(forKey: OS_SNAPSHOT_ONESIGNAL_ID, defaultValue: nil)
+        let prevExternalId = OneSignalUserDefaults.initShared().getSavedString(forKey: OS_SNAPSHOT_EXTERNAL_ID, defaultValue: nil)
+
+        guard prevOnesignalId != newOnesignalId || prevExternalId != newExternalId else {
+            return
+        }
+
+        OneSignalUserDefaults.initShared().saveString(forKey: OS_SNAPSHOT_ONESIGNAL_ID, withValue: newOnesignalId)
+        OneSignalUserDefaults.initShared().saveString(forKey: OS_SNAPSHOT_EXTERNAL_ID, withValue: newExternalId)
+
+        let curUserState = OSUserState(onesignalId: newOnesignalId, externalId: newExternalId)
+        let changedState = OSUserChangedState(current: curUserState)
+
+        OneSignalUserManagerImpl.sharedInstance.userStateChangesObserver.notifyChange(changedState)
+    }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Handle logout when JWT is on by disabling the push subscription and still create an anonymous local user to prevent data updates.

## Details

### Motivation
When JWT is on, logout needs to be handled differently. This is a small PR, so logout is handled simply.

### Scope
- Logout will mostly be the same: an anonymous user is created locally but user creation will be blocked from sending to the server and this anonymous user's requests are dropped. Changing users in the SDK prevents mixing up data or making updates to the old user incorrectly.
- Additionally, disable push sub when logout called with JWT on by using a local flag, which will send a subscription update request.
- When login is next called, this flag will revert and the push subscription will maintain its original state.

# Testing
## Unit testing
❗️TODO

## Manual testing
To fill out
Tested on iPhone 13 on iOS 17 
1. Be logged in and push permission granted
2. Call logout and see the push subscription is disabled on server
3. Kill and re-open app to drive a new session
4. No IAM is fetched due to no viable alias
5. Log back into the same user and IAM is now fetched (driven by user change)
6. The login generates a user create request that sends the correct push subscription state from before disabling

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1488)
<!-- Reviewable:end -->
