### PR TITLE
[JWT] Handle when jwt_required is not returned in remote params

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -663,6 +663,20 @@ extension OneSignalUserManagerImpl {
         jwtConfig.isRequired = required
     }
 
+    /**
+     This is called when remote params does not return the property `IOS_JWT_REQUIRED`.
+     It is likely this feature is not enabled for the app, so we will assume it is off.
+     However, don't overwrite the value if this has already been set.
+     */
+    @objc
+    public func remoteParamsReturnedUnknownRequiresUserAuth() {
+        guard jwtConfig.isRequired == nil else {
+            return
+        }
+        OneSignalLog.onesignalLog(.LL_DEBUG, message: "remoteParamsReturnedUnknownRequiresUserAuth called")
+        jwtConfig.isRequired = false
+    }
+
     @objc
     public func subscribeToJwtConfig(_ listener: OSUserJwtConfigListener, key: String) {
         jwtConfig.subscribe(listener, key: key)

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -650,6 +650,9 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     [OneSignalCoreImpl.sharedClient executeRequest:[OSRequestGetIosParams withUserId:userId appId:appId] onSuccess:^(NSDictionary *result) {
         if (result[IOS_JWT_REQUIRED]) {
             OneSignalUserManagerImpl.sharedInstance.requiresUserAuth = [result[IOS_JWT_REQUIRED] boolValue];
+        } else {
+            // Remote params did not return IOS_JWT_REQUIRED
+            [OneSignalUserManagerImpl.sharedInstance remoteParamsReturnedUnknownRequiresUserAuth];
         }
 
         if (result[IOS_USES_PROVISIONAL_AUTHORIZATION] != (id)[NSNull null]) {


### PR DESCRIPTION
# Description
## One Line Summary
When remote params did not return IOS_JWT_REQUIRED, assume off, unless this value has already been set.

## Details
- remote params may not return the property `IOS_JWT_REQUIRED`.
- It is likely this feature is not enabled for the app, so we will assume it is off.
- However, don't overwrite the value if this has already been set.

### Motivation
Identity Verification support should work with existing apps with no change.

### Scope
Reading remote params and assuming a value

# Testing
## Unit testing
None

## Manual testing
iOS 15 simulator on 17.2
Tested production and faking it receiving jwt_required and not receiving it.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1491)
<!-- Reviewable:end -->
