### PR TITLE
[3.x.x] Replace deprecated openURL method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build and Test using any available iPhone simulator
-    runs-on: macos-latest
+    runs-on: macos-latest-large
 
     steps:
       - name: Checkout OneSignal-iOS-SDK

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalHelper.m
@@ -544,7 +544,7 @@ static OneSignal* singleInstance = nil;
                     [webVC showInApp];
                 } else {
                     // Keep dispatch_async. Without this the url can take an extra 2 to 10 secounds to open.
-                    [[UIApplication sharedApplication] openURL:url];
+                    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
                 }
             });
         }];

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalLocation.m
@@ -293,10 +293,7 @@ static OneSignalLocation* singleInstance = nil;
     [[OneSignalDialogController sharedInstance] presentDialogWithTitle:@"Location Not Available" withMessage:@"You have previously denied sharing your device location. Please go to settings to enable." withActions:@[@"Open Settings"] cancelTitle:@"Cancel" withActionCompletion:^(int tappedActionIndex) {
         if (tappedActionIndex > -1) {
             [OneSignal onesignalLog:ONE_S_LL_DEBUG message:@"CLLocationManage open settings option click"];
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wdeprecated"
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-            #pragma clang diagnostic pop
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString] options:@{} completionHandler:nil];
         }
         [OneSignalLocation sendAndClearLocationListener:false];
         return;


### PR DESCRIPTION
# Description
## One Line Summary
The method `openURL:` ([doc](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl?language=objc)) appears to be completely deprecated on ios 18, so replace with the updated `openURL:options:completionHandler:` ([doc](https://developer.apple.com/documentation/uikit/uiapplication/1648685-openurl)).

## Details

### Motivation
Tapping on launch URLs fails with iOS 18 when using the deprecated method.
The user model SDK already uses the newer API.

### Scope
Update a deprecated method with its replacement in 2 places (both are tested).

# Testing
## Unit testing
None

## Manual testing
iPhone 16 simulator on iOS 18.0
- Reproduced the issue that the method is no-op
- Works after updating the method
- Tested both changes

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1493)
<!-- Reviewable:end -->
