### PR TITLE
[3.x.x] Privacy manifests - User Defaults API reason to include app groups

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/PrivacyInfo.xcprivacy
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/PrivacyInfo.xcprivacy
@@ -36,7 +36,7 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
+				<string>1C8F.1</string>
 			</array>
 		</dict>
 	</array>

--- a/iOS_SDK/OneSignalSDK/Source/PrivacyInfo.xcprivacy
+++ b/iOS_SDK/OneSignalSDK/Source/PrivacyInfo.xcprivacy
@@ -72,7 +72,7 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
+				<string>1C8F.1</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
# Description
## One Line Summary
Update Privacy Manifest for `Extension` and `OneSignal` usage of User Defaults API reason to include app groups, extensions, and app clips.

## Details

**Previously:**
`CA92.1` - Declare this reason to access user defaults to read and write information that is only accessible to the app itself.

**Now:**
`1C8F.1` - Declare this reason to access user defaults to read and write information that is only accessible to the apps, app extensions, and App Clips that are members of the same App Group as the app itself.

SDK clients are instructed to set up app groups is so that some data can be shared in the Notification Service Extension and the main app target. 


### Motivation
- Addresses https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1426
- Already done in user model https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1429

### Scope
Privacy manifests

# Testing
## Unit testing
None

## Manual testing
None

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes -  Sort Of

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1494)
<!-- Reviewable:end -->
