### PR TITLE
Fixed typo in verbose logging from 'occured' to 'occurred'

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m
@@ -734,9 +734,9 @@ OSInAppMessageInternal *_dismissingMessage = nil;
 - (void)jsEventOccurredWithBody:(NSData *)body {
     let event = [OSInAppMessageBridgeEvent instanceWithData:body];
     
-    NSString *eventMessage = [NSString stringWithFormat:@"Action Occured with Event: %@", event];
+    NSString *eventMessage = [NSString stringWithFormat:@"Action Occurred with Event: %@", event];
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:eventMessage];
-    NSString *eventTypeMessage = [NSString stringWithFormat:@"Action Occured with Event Type: %lu", (unsigned long)event.type];
+    NSString *eventTypeMessage = [NSString stringWithFormat:@"Action Occurred with Event Type: %lu", (unsigned long)event.type];
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:eventTypeMessage];
 
     if (event) {


### PR DESCRIPTION
# Description
## One Line Summary
**REQUIRED** - Very short description that summaries the changes in this PR.
- Fixed a [typo](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/91ad5e69bcb72284d2290deb6c923d69622b0ee0/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageViewController.m#L731C1-L741C1) in the verbose logging shown when an IAM is shown to the end user 

## Details

### Motivation
**REQUIRED -** Why is this code change being made? Or what is the goal of this PR? Examples: Fixes a specific bug, provides additional logging to debug future issues, feature to allow X.
- This is being made to adjust incorrect spelling from an old change made years ago that has since been left in the source

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

- This change adds a single letter to the logging when an In App Message with custom HTML is shown

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

- I've tested that this does in fact change the logging output when building the branch locally using the OneSignalDevApp build
![image](https://github.com/user-attachments/assets/d6929ee6-546e-4d38-bca6-c29dbd3f612a)


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1500)
<!-- Reviewable:end -->
