### PR TITLE
Fix RYW retry-count first attempt sending 0

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Requests/OSInAppMessagingRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Requests/OSInAppMessagingRequests.m
@@ -43,8 +43,10 @@
         headers[@"OneSignal-Session-Duration" ] = [sessionDuration stringValue];
     }
     headers[@"OneSignal-RYW-Token"] = rywToken;
-    headers[@"OneSignal-Retry-Count"] = [retryCount stringValue];
-    
+    if ([retryCount intValue] > 0) {
+        headers[@"OneSignal-Retry-Count"] = [retryCount stringValue];
+    }
+
     request.additionalHeaders = headers;
 
     NSString *appId = [OneSignalConfigManager getAppId];


### PR DESCRIPTION
# Description
## One Line Summary
Bugfix: should not be sending retry-count = 0 on first attempt / bring into parity with Android.

## Details
### Motivation
The retry count header for IAM fetch specifying retries should start at 1 to be in line with Android.

# Testing
## Manual testing
Ran the example app and inspected the first request to confirm the header is not being included for the first attempt.

1st:
![Screenshot 2024-10-31 at 11 04 14 AM](https://github.com/user-attachments/assets/19904eca-a142-4a54-962e-6bc7a33f05e1)

2nd:
![Screenshot 2024-10-31 at 11 04 30 AM](https://github.com/user-attachments/assets/cf9c7c22-9587-48f6-918a-accfd8841ce0)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1509)
<!-- Reviewable:end -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208665137727399