### PR TITLE
Fix: Prevent crash with nil HTTPResponse headers

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalClient.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/API/OneSignalClient.m
@@ -197,7 +197,7 @@
     
     NSHTTPURLResponse* HTTPResponse = (NSHTTPURLResponse*)response;
     NSInteger statusCode = [HTTPResponse statusCode];
-    NSDictionary *headers = [HTTPResponse allHeaderFields];
+    NSDictionary *headers = [HTTPResponse allHeaderFields] ?: @{};
     NSError* jsonError = nil;
     NSMutableDictionary* innerJson;
     


### PR DESCRIPTION
# Description
## One Line Summary
Prevent crash with nil `HTTPResponse` headers by adding fallback to empty dictionary.

## Details
This PR addresses customer-reported issues regarding the `NSInvalidArgumentException` crash [[1](https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1517)] [[2](https://github.com/OneSignal/OneSignal-XCFramework/issues/105)].

[Changes](https://github.com/OneSignal/OneSignal-iOS-SDK/commit/4f7a9dd21f67a41fde68b0ba1d3f815c4e33979c) made in [Release 5.2.6](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.6) introduced response headers getting stored in a dictionary. However, when these headers are nil (for example, due to no internet connection), the request is never actually made, leading to the reported crash.

This PR prevents the crash by adding a fallback to an empty dictionary.

### Scope
Changes are limited to the `handleJSONNSURLResponse` method.

# Testing
## Manual testing
Tested turning off wifi on an iPhone 16 Pro simulator running iOS 18.0. With the changes in this PR, the crash is prevented.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [X] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1518)
<!-- Reviewable:end -->
