### PR TITLE
[Fix] Don't evaluate in app messages when paused

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -683,6 +683,10 @@ static BOOL _isInAppMessagingPaused = false;
  Checks to see if any messages should be shown now
  */
 - (void)evaluateMessages {
+    if (_isInAppMessagingPaused) {
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Not evaluating in app messages while paused"];
+        return;
+    }
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"Evaluating in app messages"];
     for (OSInAppMessageInternal *message in self.messages) {
         if ([self.triggerController messageMatchesTriggers:message]) {


### PR DESCRIPTION
# Description
## One Line Summary
Don't evaluate in app messages when paused to improve accuracy once they are unpaused.

## Details

### Motivation
A SDK consumer reached out with the following issue:
1. Set up a regular IAM and a duration since last IAM
2. Pause IAMs and open app
3. Now unpause IAMs
4. The first IAM will show, then the duration IAM will show immediately after, ignoring the duration

* This is caused by message evaluation after fetching.
* Since no IAM has shown yet in the paused state, the duration IAM passes the duration check and is queued for display
* Thus, evaluating IAMs while paused will lead to inaccuracies once IAMs are unpaused.
* In this case, duration-since-last IAMs will be evaluated incorrectly and then queue for display once unpaused.
* When IAMs are unpaused, IAM evaluation is re-triggered anyway and will queue the messages for display at that time. There is no need to evaluate while paused.

### Scope
More accurate In App Message evaluation

# Testing
## Unit testing
Will be part of a subsequent task to build IAM tests.

## Manual testing
iPhone simulator 18.1
- Reproduced issue with 2 IAMs (a display on app open, and a 30 second duration since last)
- In app messaging starts out paused
- Then unpause
- First IAM should display then 30 seconds later the next one should display

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1524)
<!-- Reviewable:end -->
