### PR TITLE
Fix requiring privacy consent blocks confirmed deliveries indefinitely

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 
 @interface OSPrivacyConsentController : NSObject
++ (void)migrate;
 + (BOOL)requiresUserPrivacyConsent;
 + (void)consentGranted:(BOOL)granted;
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName;

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.h
@@ -29,7 +29,6 @@ THE SOFTWARE.
 @interface OSPrivacyConsentController : NSObject
 + (BOOL)requiresUserPrivacyConsent;
 + (void)consentGranted:(BOOL)granted;
-+ (BOOL)getPrivacyConsent;
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName;
 + (void)setRequiresPrivacyConsent:(BOOL)required;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.m
@@ -35,6 +35,29 @@ THE SOFTWARE.
 
 @implementation OSPrivacyConsentController
 
++ (void)migrate {
+    [self migrateConsentGranted];
+}
+
+/// `GDPR_CONSENT_GRANTED` had previously been saved to the standard user defaults.
+/// However, this value is also read from the NSE (for example, to send confirmed deliveries).
+/// Migrate this value to the shared user defaults, if it exists.
++ (void)migrateConsentGranted {
+    long consentGrantedCacheFixVersion = 50210;
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_CORE defaultValue:0];
+
+    if (sdkVersion >= consentGrantedCacheFixVersion) {
+        return;
+    }
+    
+    if ([OneSignalUserDefaults.initStandard keyExists:GDPR_CONSENT_GRANTED]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSPrivacyConsentController migrating consent granted from version: %ld", sdkVersion]];
+        // The default value should never be used, however the getSavedBoolForKey method requires it
+        BOOL granted = [OneSignalUserDefaults.initStandard getSavedBoolForKey:GDPR_CONSENT_GRANTED defaultValue:false];
+        [OneSignalUserDefaults.initShared saveBoolForKey:GDPR_CONSENT_GRANTED withValue:granted];
+    }
+}
+
 + (void)setRequiresPrivacyConsent:(BOOL)required {
     OSRemoteParamController *remoteParamController = [OSRemoteParamController sharedController];
 
@@ -56,13 +79,13 @@ THE SOFTWARE.
     // if required and consent has not been previously granted, return false
     BOOL requiresConsent = [[[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_REQUIRE_PRIVACY_CONSENT] boolValue] ?: false;
     if (requiresConsent || shouldRequireUserConsent)
-        return ![OneSignalUserDefaults.initStandard getSavedBoolForKey:GDPR_CONSENT_GRANTED defaultValue:false];
+        return ![OneSignalUserDefaults.initShared getSavedBoolForKey:GDPR_CONSENT_GRANTED defaultValue:false];
     
     return false;
 }
 
 + (void)consentGranted:(BOOL)granted {
-    [OneSignalUserDefaults.initStandard saveBoolForKey:GDPR_CONSENT_GRANTED withValue:granted];
+    [OneSignalUserDefaults.initShared saveBoolForKey:GDPR_CONSENT_GRANTED withValue:granted];
 }
 
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName {

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSPrivacyConsentController.m
@@ -65,12 +65,6 @@ THE SOFTWARE.
     [OneSignalUserDefaults.initStandard saveBoolForKey:GDPR_CONSENT_GRANTED withValue:granted];
 }
 
-+ (BOOL)getPrivacyConsent {
-    // The default is the inverse of privacy consent required
-    BOOL defaultValue = ![OneSignalUserDefaults.initShared getSavedBoolForKey:OSUD_REQUIRES_USER_PRIVACY_CONSENT defaultValue:NO];
-    return [OneSignalUserDefaults.initStandard getSavedBoolForKey:GDPR_CONSENT_GRANTED defaultValue:defaultValue];
-}
-
 + (BOOL)shouldLogMissingPrivacyConsentErrorWithMethodName:(NSString *)methodName {
     if ([self requiresUserPrivacyConsent]) {
         if (methodName) {

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -96,8 +96,15 @@
 #define OSUD_CACHED_RECEIVED_IAM_IDS                                        @"OSUD_CACHED_RECEIVED_IAM_IDS"
 #define OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT                 @"CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT"                   // * OSUD_CACHED_UNATTRIBUTED_UNIQUE_OUTCOME_EVENTS_SENT
 #define OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT   @"CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT"     // * OSUD_CACHED_ATTRIBUTED_UNIQUE_OUTCOME_EVENT_NOTIFICATION_IDS_SENT
+
 // Migration
-#define OSUD_CACHED_SDK_VERSION                                             @"OSUD_CACHED_SDK_VERSION"
+/// Value used by all modules prior to 5.2.10
+#define OSUD_LEGACY_CACHED_SDK_VERSION_FOR_MIGRATION                @"OSUD_CACHED_SDK_VERSION"
+/// Values added in 5.2.10 for each module to own its own migration
+#define OSUD_CACHED_SDK_VERSION_FOR_CORE                            @"OSUD_CACHED_SDK_VERSION_FOR_CORE"
+#define OSUD_CACHED_SDK_VERSION_FOR_OUTCOMES                        @"OSUD_CACHED_SDK_VERSION_FOR_OUTCOMES"
+#define OSUD_CACHED_SDK_VERSION_FOR_IAM                             @"OSUD_CACHED_SDK_VERSION_FOR_IAM"
+
 // Time Tracking
 #define OSUD_APP_LAST_CLOSED_TIME                                           @"GT_LAST_CLOSED_TIME"                                              // * OSUD_APP_LAST_CLOSED_TIME
 #define OSUD_UNSENT_ACTIVE_TIME                                             @"GT_UNSENT_ACTIVE_TIME"                                            // * OSUD_UNSENT_ACTIVE_TIME

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
@@ -62,6 +62,7 @@
 // TODO: Testing: Should this class be defined in this file?
 @interface OneSignalCoreImpl : NSObject
 
++ (void)migrate;
 + (void)setSharedClient:(nonnull id<IOneSignalClient>)client;
 + (nonnull id<IOneSignalClient>)sharedClient;
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.m
@@ -30,6 +30,34 @@
 
 @implementation OneSignalCoreImpl
 
++ (void)migrate {
+    [self migrateCachedSdkVersion];
+    [self saveCurrentSDKVersion];
+}
+
+/// Every module should be responsible for its own migration, as it is possible for one module
+/// to finish migrating without another undergoing migration yet.
+/// See https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1541
++ (void)migrateCachedSdkVersion {
+    if (![OneSignalUserDefaults.initShared keyExists:OSUD_LEGACY_CACHED_SDK_VERSION_FOR_MIGRATION]) {
+        return;
+    }
+    
+    // The default value should never be used, however the getSavedIntegerForKey method requires it
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_LEGACY_CACHED_SDK_VERSION_FOR_MIGRATION defaultValue:0];
+    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OneSignalCoreImpl migrating cached SDK versions from version: %ld", sdkVersion]];
+
+    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_CORE withValue:sdkVersion];
+    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_OUTCOMES withValue:sdkVersion];
+    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_IAM withValue:sdkVersion];
+    [OneSignalUserDefaults.initShared removeValueForKey:OSUD_LEGACY_CACHED_SDK_VERSION_FOR_MIGRATION];
+}
+
++ (void)saveCurrentSDKVersion {
+    int currentVersion = [ONESIGNAL_VERSION intValue];
+    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_CORE withValue:currentVersion];
+}
+
 static id<IOneSignalClient> _sharedClient;
 + (id<IOneSignalClient>)sharedClient {
     if (!_sharedClient) {

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.m
@@ -32,6 +32,7 @@
 
 + (void)migrate {
     [self migrateCachedSdkVersion];
+    [OSPrivacyConsentController migrate];
     [self saveCurrentSDKVersion];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalNotificationServiceExtensionHandler.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalNotificationServiceExtensionHandler.m
@@ -132,6 +132,7 @@
 + (void)onNotificationReceived:(NSString *)receivedNotificationId withBlockingTask:(dispatch_semaphore_t)semaphore {
     if (receivedNotificationId && ![receivedNotificationId isEqualToString:@""]) {
         // If update was made without app being initialized/launched before -> migrate
+        [OneSignalCoreImpl migrate];
         [OSOutcomes migrate];
         [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"NSE request received, sessionManager: %@", [OSSessionManager sharedSessionManager]]];
         // Save received notification id

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSInAppMessageMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSInAppMessageMigrationController.m
@@ -34,6 +34,7 @@
 +(void)migrate {
     [self migrateIAMRedisplayCache];
     [self migrateToOSInAppMessageInternal];
+    [self saveCurrentSDKVersion];
 }
 
 // Devices could potentially have bad data in the OS_IAM_REDISPLAY_DICTIONARY
@@ -41,7 +42,7 @@
 // and save it is as CodeableData instead.
 + (void)migrateIAMRedisplayCache {
     let iamRedisplayCacheFixVersion = 30203;
-    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_IAM defaultValue:0];
     if (sdkVersion >= iamRedisplayCacheFixVersion)
         return;
 
@@ -71,7 +72,7 @@
 // We must set the new class name to the unarchiver to avoid crashing
 + (void)migrateToOSInAppMessageInternal {
     let nameChangeVersion = 30700;
-    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_IAM defaultValue:0];
     [NSKeyedUnarchiver setClass:[OSInAppMessageInternal class] forClassName:@"OSInAppMessage"];
     if (sdkVersion < nameChangeVersion) {
         [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSInAppMessage from version: %ld", sdkVersion]];
@@ -88,5 +89,9 @@
     }
 }
 
++ (void)saveCurrentSDKVersion {
+    int currentVersion = [ONESIGNAL_VERSION intValue];
+    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_IAM withValue:currentVersion];
+}
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalOutcomes/OSOutcomes.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalOutcomes/OSOutcomes.m
@@ -60,7 +60,7 @@ static OneSignalOutcomeEventsController *_sharedController;
 + (void)migrateToVersion_02_14_00_AndGreater {
     let influenceVersion = 21400;
     let uniqueCacheOutcomeVersion = 21403;
-    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
+    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_OUTCOMES defaultValue:0];
     if (sdkVersion < influenceVersion) {
         [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSIndirectNotification from version: %ld", sdkVersion]];
 
@@ -85,7 +85,7 @@ static OneSignalOutcomeEventsController *_sharedController;
 }
 + (void)saveCurrentSDKVersion {
     let currentVersion = [ONESIGNAL_VERSION intValue];
-    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION withValue:currentVersion];
+    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION_FOR_OUTCOMES withValue:currentVersion];
 }
 
 #pragma mark Session namespace

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -40,6 +40,7 @@ THE SOFTWARE.
 @implementation OSMigrationController
 
 - (void)migrate {
+    [OneSignalCoreImpl migrate];
     [OSOutcomes migrate];
     let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
     if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(migrate)]) {

--- a/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSMigrationController.m
@@ -40,47 +40,11 @@ THE SOFTWARE.
 @implementation OSMigrationController
 
 - (void)migrate {
-    [self migrateToVersion_02_14_00_AndGreater];
+    [OSOutcomes migrate];
     let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
     if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(migrate)]) {
         [oneSignalInAppMessages performSelector:@selector(migrate)];
     }
-    [self saveCurrentSDKVersion];
-}
-
-/**
- * Support renaming of decodable classes for cached data
- */
-- (void)migrateToVersion_02_14_00_AndGreater {
-    let influenceVersion = 21400;
-    let uniqueCacheOutcomeVersion = 21403;
-    long sdkVersion = [OneSignalUserDefaults.initShared getSavedIntegerForKey:OSUD_CACHED_SDK_VERSION defaultValue:0];
-    if (sdkVersion < influenceVersion) {
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSIndirectNotification from version: %ld", sdkVersion]];
-
-        [NSKeyedUnarchiver setClass:[OSIndirectInfluence class] forClassName:@"OSIndirectNotification"];
-        NSArray<OSIndirectInfluence *> * indirectInfluenceData = [[OSInfluenceDataRepository sharedInfluenceDataRepository] lastNotificationsReceivedData];
-        if (indirectInfluenceData) {
-            [NSKeyedArchiver setClassName:@"OSIndirectInfluence" forClass:[OSIndirectInfluence class]];
-            [[OSInfluenceDataRepository sharedInfluenceDataRepository] saveNotifications:indirectInfluenceData];
-        }
-    }
-    
-    if (sdkVersion < uniqueCacheOutcomeVersion) {
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"Migrating OSUniqueOutcomeNotification from version: %ld", sdkVersion]];
-        
-        [NSKeyedUnarchiver setClass:[OSCachedUniqueOutcome class] forClassName:@"OSUniqueOutcomeNotification"];
-        NSArray<OSCachedUniqueOutcome *> * attributedCacheUniqueOutcomeEvents = [[OSOutcomeEventsCache sharedOutcomeEventsCache] getAttributedUniqueOutcomeEventSent];
-        if (attributedCacheUniqueOutcomeEvents) {
-            [NSKeyedArchiver setClassName:@"OSCachedUniqueOutcome" forClass:[OSCachedUniqueOutcome class]];
-            [[OSOutcomeEventsCache sharedOutcomeEventsCache] saveAttributedUniqueOutcomeEventNotificationIds:attributedCacheUniqueOutcomeEvents];
-        }
-    }
-}
-
-- (void)saveCurrentSDKVersion {
-    let currentVersion = [[OneSignal sdkVersionRaw] intValue];
-    [OneSignalUserDefaults.initShared saveIntegerForKey:OSUD_CACHED_SDK_VERSION withValue:currentVersion];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -605,10 +605,6 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     _delayedInitParameters = nil;
 }
 
-+ (BOOL)getPrivacyConsent {
-    return [OSPrivacyConsentController getPrivacyConsent];
-}
-
 + (void)downloadIOSParamsWithAppId:(NSString *)appId {
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"Downloading iOS parameters for this application"];
     _didCallDownloadParameters = true;


### PR DESCRIPTION
# Description
## One Line Summary
Setting consent required and then providing consent still blocked confirmed deliveries from being sent - this PR fixes that.

## Details
The consent required value was being written to / read from the shared user defaults but the consent granted value was written to / read from standard user defaults (which is not accessible to the NSE). 
- Looking at the history, the consent granted logic was added in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/361 in 2018 when few things were shared with the NSE. 
- In 2020, the requires consent value started to get cached from remote params in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/707, which saved this to shared user defaults.

This PR also fixes a migration bug (and creates more migrations to fix that and fix the bug in this PR) that arose after modularizing the SDK.

### Motivation
Reported by customers, and we should send confirmed deliveries once consent is granted.

### Scope
- where consent is set and read
- migrations changes including fixing a migration bug after modularization

# Testing
## Unit testing
None added, little infrastructure

## Manual testing
iPhone 13 with iOS 18.1
**Fix the bug in this PR**
1. On `main`, set consent required, and then provide consent
2. Confirmed deliveries fail due to not detecting consent in the extension
3. Upgrade to this PR, and confirmed deliveries succeed, and other requests, such as for the user, succeed too (the migration was necessary to maintain behavior in the app).

**Fix the existing migration bug**
1. Mock an SDK version upgrade but don't open the app. 
2. Let's say the previous version was `2.0.0` and the new version is `5.2.10`.
3. Send a notification
4. The NSE receives notification and calls a migration in `OSOutcomes`
5. The old SDK version of `2.0.0` is read from cache to determine if migration is needed, and the new SDK version is cached. Outcomes is migrated now.
6. Next time the app is launched, the Migration Controller reads the new version from cache `5.2.10` and does not do a migration, even if it is necessary. The migration controller invokes in app messages to migrate.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [x] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1541)
<!-- Reviewable:end -->
