### PR TITLE
Detect for timezone changes and update the user

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -63,7 +63,14 @@ class OSPropertiesModel: OSModel {
         }
     }
 
-    var timezoneId = TimeZone.current.identifier
+    var timezoneId: String? = TimeZone.current.identifier {
+        didSet {
+            guard timezoneId != oldValue else {
+                return
+            }
+            self.set(property: "timezone_id", newValue: timezoneId)
+        }
+    }
 
     var tags: [String: String] = [:]
     private let tagsLock = NSRecursiveLock()
@@ -90,6 +97,7 @@ class OSPropertiesModel: OSModel {
             super.encode(with: coder)
             coder.encode(language, forKey: "language")
             coder.encode(tags, forKey: "tags")
+            coder.encode(timezoneId, forKey: "timezoneId")
             // ... and more
         }
     }
@@ -97,6 +105,7 @@ class OSPropertiesModel: OSModel {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         language = coder.decodeObject(forKey: "language") as? String
+        timezoneId = coder.decodeObject(forKey: "timezoneId") as? String
         guard let tags = coder.decodeObject(forKey: "tags") as? [String: String] else {
             // log error
             return
@@ -104,6 +113,10 @@ class OSPropertiesModel: OSModel {
         self.tags = tags
 
         // ... and more
+    }
+
+    func update() {
+        timezoneId = TimeZone.current.identifier
     }
 
     /**

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSUserInternalImpl.swift
@@ -37,6 +37,7 @@ protocol OSUserInternal {
     var pushSubscriptionModel: OSSubscriptionModel { get }
     var identityModel: OSIdentityModel { get }
     var propertiesModel: OSPropertiesModel { get }
+    func update()
     // Aliases
     func addAliases(_ aliases: [String: String])
     func removeAliases(_ labels: [String])
@@ -70,6 +71,11 @@ class OSUserInternalImpl: NSObject, OSUserInternal {
         self.identityModel = identityModel
         self.propertiesModel = propertiesModel
         self.pushSubscriptionModel = pushSubscriptionModel
+    }
+
+    func update() {
+        self.pushSubscriptionModel.update()
+        self.propertiesModel.update()
     }
 
     // MARK: - Aliases

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Support/OSPropertiesSupportedProperty.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Support/OSPropertiesSupportedProperty.swift
@@ -36,6 +36,7 @@ enum OSPropertiesSupportedProperty: String {
     case language
     case location
     case tags
+    case timezone_id
     // Created manually by User Manager, not through Models
     case session_count
     case session_time


### PR DESCRIPTION
# Description
## One Line Summary
Send up timezone ID as a one-time migration, send up timezone ID when fetching the legacy player, and start detecting timezone changes and sending it up when it changes.

## Details
* Unless users switch via logging in and out, we never update timezone (as it is only sent in the Create User request).
* Now, we cache timezone ID and detect for changes on cold starts and update the user when it changes.
* We also fix a rare issue that comes from upgrading from a very very old version of player model to user model. When we have a legacy player ID, we fetch its identity rather than creating a user. In some rare cases, this old player is already missing a timezone (version used was before we added timezone collection to the player model SDK), and the SDK never calls Create User to set a timezone. As a result, this user will be missing timezone.
* As a one-time migration, we send up the timezone in the next release for all users without considering if timezone is indeed missing or not. Note that this update will be combined in the payload of the `session_count` update. This update is driven by reading the `timezone_id` from cache, but before this PR, timezone was never cached, so it will return null, driving this one-time update.

### Motivation
Reports by customers about missing timezones on very old players after migrating to v5.
Also requests by customers to detect timezone changes.

### Scope
Sending timezone

# Testing
## Unit testing
None added

## Manual testing
iPhone 13 on iOS 18.1
**Scenario tested - player model upgrade:**
1. Upgrade from an existing player model installation
2. SDK uncaches the legacy player, fetch the identity, and sends the timezone
3. Next cold start, no timezone is sent when there is no change
4. Change timezone on phone and make a cold start
5. The new timezone is sent

**Scenario tested - user model upgrade:**
1. New install on `main`
2. Upgrade to this branch
3. See that timezone is sent up in a one-time migration. There may have been old players who were missing timezone, upgraded to user model, and still missing timezone.
4. Subsequently, no timezone is sent when there are no changes
6. If timezone does change on phone, it is sent up.

**Scenario tested - new install:**
1. New installs call Create User so timezone is sent, same as before.
2. Now moving forward, when it changes on the device, it is sent.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1542)
<!-- Reviewable:end -->
