### PR TITLE
Synchronize to fix crashes in the user module

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSModel.swift
@@ -52,11 +52,11 @@ open class OSModel: NSObject, NSCoding {
     }
 
     // We can add operation name to this... , such as enum of "updated", "deleted", "added"
-    public func set<T>(property: String, newValue: T) {
+    public func set<T>(property: String, newValue: T, preventServerUpdate: Bool = false) {
         let changeArgs = OSModelChangedArgs(model: self, property: property, newValue: newValue)
 
         changeNotifier.fire { modelChangeHandler in
-            modelChangeHandler.onModelUpdated(args: changeArgs, hydrating: self.hydrating)
+            modelChangeHandler.onModelUpdated(args: changeArgs, hydrating: self.hydrating || preventServerUpdate)
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModel.swift
@@ -117,13 +117,19 @@ class OSSubscriptionModel: OSModel {
         }
     }
 
-    // Set via server response
+    /**
+     Typically, the subscription ID is set via server response, so don't trigger a server update call when it changes.
+     It can also be set to null by the SDK when the user or subscription is detected as missing.
+     Setting the subscription ID to null will serve as a "reset" and will later hydrate a value from a user create rquest.
+     */
     var subscriptionId: String? {
         didSet {
             guard subscriptionId != oldValue else {
                 return
             }
-            self.set(property: "subscriptionId", newValue: subscriptionId)
+
+            // If the ID has changed, don't trigger a server call, since it can be set to null
+            self.set(property: "subscriptionId", newValue: subscriptionId, preventServerUpdate: true)
 
             guard self.type == .push else {
                 return

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -408,6 +408,9 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
      */
     @objc
     public func logout() {
+        guard !OneSignalConfigManager.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: "logout") else {
+            return
+        }
         guard user.identityModel.externalId != nil else {
             OneSignalLog.onesignalLog(.LL_DEBUG, message: "OneSignal.User logout called, but the user is currently anonymous, so not logging out.")
             return

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserObjcTests.m
@@ -33,6 +33,9 @@
 
     MockOneSignalClient* client = [MockOneSignalClient new];
 
+    // 0. Purchases will be dropped if there is no user instance.
+    [OneSignalUserManagerImpl.sharedInstance start];
+
     // 1. Set up mock responses for the anonymous user
     [MockUserRequests setDefaultCreateAnonUserResponsesWith:client];
     [OneSignalCoreImpl setSharedClient:client];

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
@@ -74,6 +74,8 @@ final class OneSignalUserTests: XCTestCase {
     func testBasicCombiningUserUpdateDeltas_resultsInOneRequest() throws {
         /* Setup */
 
+        OneSignalUserManagerImpl.sharedInstance.start()
+
         let client = MockOneSignalClient()
         MockUserRequests.setDefaultCreateAnonUserResponses(with: client)
         OneSignalCoreImpl.setSharedClient(client)

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/UserConcurrencyTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/UserConcurrencyTests.swift
@@ -278,4 +278,13 @@ final class UserConcurrencyTests: XCTestCase {
             identityModel.clearData()
         }
     }
+
+    func testConcurrentStart() throws {
+        DispatchQueue.concurrentPerform(iterations: 5_000) { _ in
+            OneSignalUserManagerImpl.sharedInstance.start()
+        }
+        DispatchQueue.concurrentPerform(iterations: 5_000) { _ in
+            _ = OneSignalUserManagerImpl.sharedInstance.user
+        }
+    }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Make changes to synchronize and prevent crashes that have been reported.

## Details

### Motivation
Address synchronization, race conditions, and user-submitted crash reports.

### Scope
1. Add lock to OSModelStore models dictionary, and confirmed codes paths would not result in deadlock.
2. Make a change to prevent generating an update subscription server call when the SDK nullifies the push subscription ID in 404 scenarios. It will be received from the server on the expected subsequent User Create call.
3. Synchronize the User Manager start up process, and confirm codes paths do not result in deadlock. 
4. To avoid deadlock from changes above, there is one side effect that `purchases` and `session_time` will be dropped if the user manager has not started up by that point, which is a scenario that should not be happening anyway.

# Testing
## Unit testing
Added one test to reproduce a crash via multiple concurrent threads.

## Manual testing
Tested on iPhone 13 running iOS 18.4.1
- The User Manager `start()` method essentially has 3 paths: has cached user, has legacy player to migrate, and new install. Test all code paths to ensure correctness and no deadlocking.
- Manual testing involved triggering concurrent threads doing variety of things.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Initialization

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1554)
<!-- Reviewable:end -->
