### PR TITLE
[Fix] Prevent deadlocks when user manager runs its startup tasks

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -119,8 +119,9 @@ class OSUserExecutor {
 
             // Translate the last request into a Create User request, if the current user is the same
             if let request = transferSubscriptionRequestQueue.last,
+               let userInstance = OneSignalUserManagerImpl.sharedInstance._user,
                OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.aliasId) {
-                createUser(OneSignalUserManagerImpl.sharedInstance.user)
+                createUser(userInstance)
             }
         }
     }
@@ -396,9 +397,10 @@ extension OSUserExecutor {
 
                 self.removeFromQueue(request)
 
-                if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModelToUpdate) {
+                if let userInstance = OneSignalUserManagerImpl.sharedInstance._user,
+                    OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModelToUpdate) {
                     // Generate a Create User request, if it's still the current user
-                    self.createUser(OneSignalUserManagerImpl.sharedInstance.user)
+                    self.createUser(userInstance)
                 } else {
                     // This will hydrate the OneSignal ID for any pending requests
                     self.createUser(aliasLabel: request.aliasLabel, aliasId: request.aliasId, identityModel: request.identityModelToUpdate)
@@ -544,7 +546,7 @@ extension OSUserExecutor {
         }
 
         if let propertiesObject = parsePropertiesObjectResponse(response) {
-            OneSignalUserManagerImpl.sharedInstance.user.propertiesModel.hydrate(propertiesObject)
+            OneSignalUserManagerImpl.sharedInstance._user?.propertiesModel.hydrate(propertiesObject)
         }
 
         // Now parse email and sms subscriptions

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModelStoreListener.swift
@@ -45,14 +45,15 @@ class OSPropertiesModelStoreListener: OSModelStoreListener {
     }
 
     func getUpdateModelDelta(_ args: OSModelChangedArgs) -> OSDelta? {
-        guard let _ = OSPropertiesSupportedProperty(rawValue: args.property) else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSPropertiesModelStoreListener.getUpdateModelDelta encountered unsupported property: \(args.property)")
+        guard let _ = OSPropertiesSupportedProperty(rawValue: args.property),
+              let userInstance = OneSignalUserManagerImpl.sharedInstance._user
+        else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSPropertiesModelStoreListener.getUpdateModelDelta encountered unsupported property: \(args.property) or no user instance")
             return nil
         }
-
         return OSDelta(
             name: OS_UPDATE_PROPERTIES_DELTA,
-            identityModelId: OneSignalUserManagerImpl.sharedInstance.user.identityModel.modelId,
+            identityModelId: userInstance.identityModel.modelId,
             model: args.model,
             property: args.property,
             value: args.newValue

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModelStoreListener.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSSubscriptionModelStoreListener.swift
@@ -37,9 +37,13 @@ class OSSubscriptionModelStoreListener: OSModelStoreListener {
     }
 
     func getAddModelDelta(_ model: OSSubscriptionModel) -> OSDelta? {
+        guard let userInstance = OneSignalUserManagerImpl.sharedInstance._user else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionModelStoreListener.getAddModelDelta has no user instance")
+            return nil
+        }
         return OSDelta(
             name: OS_ADD_SUBSCRIPTION_DELTA,
-            identityModelId: OneSignalUserManagerImpl.sharedInstance.user.identityModel.modelId,
+            identityModelId: userInstance.identityModel.modelId,
             model: model,
             property: model.type.rawValue, // push, email, sms
             value: model.address ?? ""
@@ -50,9 +54,13 @@ class OSSubscriptionModelStoreListener: OSModelStoreListener {
      The `property` and `value` is not needed for a remove operation, so just pass in some model data as placeholders.
      */
     func getRemoveModelDelta(_ model: OSSubscriptionModel) -> OSDelta? {
+        guard let userInstance = OneSignalUserManagerImpl.sharedInstance._user else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionModelStoreListener.getRemoveModelDelta has no user instance")
+            return nil
+        }
         return OSDelta(
             name: OS_REMOVE_SUBSCRIPTION_DELTA,
-            identityModelId: OneSignalUserManagerImpl.sharedInstance.user.identityModel.modelId,
+            identityModelId: userInstance.identityModel.modelId,
             model: model,
             property: model.type.rawValue, // push, email, sms
             value: model.address ?? ""
@@ -66,14 +74,18 @@ class OSSubscriptionModelStoreListener: OSModelStoreListener {
         // The user update call increases the session_count while the subscription update would update
         // something like the app_version. If the app_version hasn't changed since the last session, there
         // wouldn't be an update needed (among other system-level properties).
-        if let onesignalId = OneSignalUserManagerImpl.sharedInstance.user.identityModel.onesignalId {
+        guard let userInstance = OneSignalUserManagerImpl.sharedInstance._user else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionModelStoreListener.getUpdateModelDelta has no user instance")
+            return nil
+        }
+        if let onesignalId = userInstance.identityModel.onesignalId {
             let condition = OSIamFetchReadyCondition.sharedInstance(withId: onesignalId)
             condition.setSubscriptionUpdatePending(value: true)
         }
 
         return OSDelta(
             name: OS_UPDATE_SUBSCRIPTION_DELTA,
-            identityModelId: OneSignalUserManagerImpl.sharedInstance.user.identityModel.modelId,
+            identityModelId: userInstance.identityModel.modelId,
             model: args.model,
             property: args.property,
             value: args.newValue

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OneSignalUserManagerImpl.swift
@@ -384,12 +384,12 @@ public class OneSignalUserManagerImpl: NSObject, OneSignalUserManager {
     }
 
     func isCurrentUser(_ externalId: String) -> Bool {
-        guard !externalId.isEmpty else {
-            OneSignalLog.onesignalLog(.LL_ERROR, message: "isCurrentUser called with empty externalId")
+        guard let userInstance = _user, !externalId.isEmpty else {
+            OneSignalLog.onesignalLog(.LL_ERROR, message: "isCurrentUser called with empty externalId or no user instance")
             return false
         }
 
-        return user.identityModel.externalId == externalId
+        return userInstance.identityModel.externalId == externalId
     }
     /**
      Clears the existing user's data in preparation for hydration via a fetch user call.


### PR DESCRIPTION
# Description
## One Line Summary
Prevent deadlocks in the user module after making synchronization changes.

## Details

### Motivation
- #1554 introduced deadlocks from the `OneSignalUserManagerImpl.start()` method
- See example report at https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/1028.

### Scope
- When the SDK is upgraded, an sdk version change is detected in the `start()` method which triggers the model > store > listener flow. Eventually, it was triggering the `start()` method again, resulting in a deadlock.
- The changes made are that the model store minimize amount of locking needed (no reported issues for this but this change is made as an improvement)
- The second set of changes are falling to more no-ops if there is no user instance to operate on, rather than triggering `start()` to generate a user instance. Currently, only the properties model and subscription model may have update enqueued at the end of the start() method to enqueue any changes such as timezone and app version for the user instance, which exists by this point. The other no-op refactors are for safety / improvement.

# Testing
## Unit testing
None

## Manual testing
iPhone 13 on iOS 18.4.1
Tested version upgrade, timezone upgrade, other normal flows

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1559)
<!-- Reviewable:end -->
