### PR TITLE
fix(badges): Fix bug when notification has badge set to zero

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification.h
@@ -59,6 +59,9 @@
 @property(readonly, nullable)NSString* category;
 
 /* The badge assigned to the application icon */
+/// Indicates if badge count is set on this notification; this flag is needed as the `badge` property is an
+/// integer primitive and cannot be used to differentiate between null badge vs badge count of 0.
+@property(readonly)BOOL hasBadge;
 @property(readonly)NSInteger badge;
 @property(readonly)NSInteger badgeIncrement;
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OSNotification.m
@@ -124,6 +124,7 @@
 
 - (void)parseApnsFields {
     [self parseAlertField:_rawPayload[@"aps"][@"alert"]];
+    _hasBadge = _rawPayload[@"aps"][@"badge"] ? true : false;
     _badge = [_rawPayload[@"aps"][@"badge"] intValue];
     _sound = _rawPayload[@"aps"][@"sound"];
 }
@@ -257,7 +258,9 @@
     if (self.templateId)
         [obj setObject:self.templateId forKeyedSubscript: @"templateId"];
     
-    if (self.badge)
+    [obj setObject:@(self.hasBadge) forKeyedSubscript: @"hasBadge"];
+
+    if (self.hasBadge)
         [obj setObject:@(self.badge) forKeyedSubscript: @"badge"];
     
     if (self.badgeIncrement)

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.m
@@ -34,7 +34,7 @@
     //if the user is setting the badge directly instead of incrementing/decrementing,
     //make sure the OneSignal cached value is updated to this value
     if (!notification.badgeIncrement) {
-        if (notification.badge)
+        if (notification.hasBadge)
             [OneSignalExtensionBadgeHandler updateCachedBadgeValue:notification.badge];
         
         return;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -985,7 +985,7 @@ static NSString *_lastnonActiveMessageId;
     else
         content.sound = UNNotificationSound.defaultSound;
     
-    if (notification.badge != 0)
+    if (notification.hasBadge)
         content.badge = [NSNumber numberWithInteger:notification.badge];
     
     // Check if media attached


### PR DESCRIPTION
# Description
## One Line Summary
Add additional flag to `OSNotification` called `hasBadge` to let us differentiate between null vs 0 badge count by checking this flag.

## Details

### Motivation
* This fixes a bug when a notification had "SetTo" = 0 would no-op; our check for the existence of `notification.badge` could not differentiate null vs 0, and we detected 0 as lack of existence.
* Using a flag let's us differentiate between null vs 0 badge count. The payload from APNS will be already be an NSNumber: https://developer.apple.com/documentation/usernotifications/unnotificationcontent/badge?language=objc and we will set the flag if there is a badge

<details>
<summary>Click to see the before and after clips</summary>

https://github.com/user-attachments/assets/97ae3191-8afc-4690-91f3-8c64d24abdd3

https://github.com/user-attachments/assets/1945b72c-8c37-41ff-8121-e32d6e3d88f4

</details>


### Scope
Adds additional boolean property to OSNotification, leaving previous `badge` property unchanged.

# Testing
## Unit testing
None

## Manual testing
iphone 13 on iOS 18.5 testing different notifications sent with 
- no badge
- "SetTo" badge count by various values including 0
- "Increase" badge count by various values including 0

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [x] Badges
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1565)
<!-- Reviewable:end -->
