### PR TITLE
fix(badges): drop deprecated applicationIconBadgeNumber usage

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		3C277D7E2BD76E0000857606 /* OSIdentityModelRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C277D7D2BD76E0000857606 /* OSIdentityModelRepo.swift */; };
 		3C2C7DC8288F3C020020F9AE /* OSSubscriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2C7DC7288F3C020020F9AE /* OSSubscriptionModel.swift */; };
 		3C2D8A5928B4C4E300BE41F6 /* OSDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */; };
+		3C2DB2F12DE6CB5E0006B905 /* OneSignalBadgeHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C2DB2EF2DE6CB5E0006B905 /* OneSignalBadgeHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C2DB2F22DE6CB5E0006B905 /* OneSignalBadgeHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2DB2F02DE6CB5E0006B905 /* OneSignalBadgeHelpers.m */; };
 		3C44673E296D099D0039A49E /* OneSignalMobileProvision.m in Sources */ = {isa = PBXBuildFile; fileRef = 912411FD1E73342200E41FD7 /* OneSignalMobileProvision.m */; };
 		3C44673F296D09CC0039A49E /* OneSignalMobileProvision.h in Headers */ = {isa = PBXBuildFile; fileRef = 912411FC1E73342200E41FD7 /* OneSignalMobileProvision.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C448B9D2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C448B9B2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h */; };
@@ -1251,6 +1253,8 @@
 		3C2C7DC2288E007E0020F9AE /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3C2C7DC7288F3C020020F9AE /* OSSubscriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSubscriptionModel.swift; sourceTree = "<group>"; };
 		3C2D8A5828B4C4E300BE41F6 /* OSDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDelta.swift; sourceTree = "<group>"; };
+		3C2DB2EF2DE6CB5E0006B905 /* OneSignalBadgeHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalBadgeHelpers.h; sourceTree = "<group>"; };
+		3C2DB2F02DE6CB5E0006B905 /* OneSignalBadgeHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneSignalBadgeHelpers.m; sourceTree = "<group>"; };
 		3C448B9B2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSBackgroundTaskHandlerImpl.h; sourceTree = "<group>"; };
 		3C448B9C2936ADFD002F96BC /* OSBackgroundTaskHandlerImpl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSBackgroundTaskHandlerImpl.m; sourceTree = "<group>"; };
 		3C448BA12936B474002F96BC /* OSBackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBackgroundTaskManager.swift; sourceTree = "<group>"; };
@@ -2596,6 +2600,8 @@
 				DE7D182C270273B0002D3A5D /* OSNotification.h */,
 				454F94F41FAD2E5A00D74CCF /* OSNotification.m */,
 				454F94F61FAD2EC300D74CCF /* OSNotification+Internal.h */,
+				3C2DB2EF2DE6CB5E0006B905 /* OneSignalBadgeHelpers.h */,
+				3C2DB2F02DE6CB5E0006B905 /* OneSignalBadgeHelpers.m */,
 				3CE8CC4C2911ADD1000DB0D3 /* OSDeviceUtils.h */,
 				3C47A972292642B100312125 /* OneSignalConfigManager.h */,
 				3C47A973292642B100312125 /* OneSignalConfigManager.m */,
@@ -3138,6 +3144,7 @@
 				DE7D182F270275FF002D3A5D /* OneSignalTrackFirebaseAnalytics.h in Headers */,
 				DEF7845C2912E89200A1F3A5 /* OSObservable.h in Headers */,
 				DE7D1875270375FF002D3A5D /* OSReattemptRequest.h in Headers */,
+				3C2DB2F12DE6CB5E0006B905 /* OneSignalBadgeHelpers.h in Headers */,
 				DEF784652912FB2200A1F3A5 /* OSDialogInstanceManager.h in Headers */,
 				DEF78493291479B200A1F3A5 /* OneSignalSelectorHelpers.h in Headers */,
 				DE7D1862270374EE002D3A5D /* OSJSONHandling.h in Headers */,
@@ -4427,6 +4434,7 @@
 				DEF784642912FA5100A1F3A5 /* OSDialogInstanceManager.m in Sources */,
 				DE7D183B27027EFC002D3A5D /* NSURL+OneSignal.m in Sources */,
 				DE7D186B270374EE002D3A5D /* OneSignalRequest.m in Sources */,
+				3C2DB2F22DE6CB5E0006B905 /* OneSignalBadgeHelpers.m in Sources */,
 				3C44673E296D099D0039A49E /* OneSignalMobileProvision.m in Sources */,
 				3CCF44BF299B17290021964D /* OneSignalWrapper.m in Sources */,
 				DEF78492291479B200A1F3A5 /* OneSignalSelectorHelpers.m in Sources */,

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.h
@@ -28,5 +28,5 @@
 #import <Foundation/Foundation.h>
 
 @interface OneSignalBadgeHelpers : NSObject
-+ (void)updateCachedBadgeValue:(NSInteger)value;
++ (void)updateCachedBadgeValue:(NSInteger)value usePreviousBadgeCount:(BOOL)usePrevious;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.h
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2025 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,10 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UserNotifications/UserNotifications.h>
-#import <OneSignalCore/OneSignalCore.h>
 
-@interface OneSignalExtensionBadgeHandler : NSObject
-+ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotification:(OSNotification *)notification withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
-+ (NSInteger)currentCachedBadgeValue;
+@interface OneSignalBadgeHelpers : NSObject
++ (void)updateCachedBadgeValue:(NSInteger)value;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.m
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2025 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,11 +25,14 @@
  * THE SOFTWARE.
  */
 
-#import <Foundation/Foundation.h>
-#import <UserNotifications/UserNotifications.h>
-#import <OneSignalCore/OneSignalCore.h>
+#import "OneSignalBadgeHelpers.h"
+#import "OneSignalUserDefaults.h"
+#import "OneSignalCommonDefines.h"
 
-@interface OneSignalExtensionBadgeHandler : NSObject
-+ (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotification:(OSNotification *)notification withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
-+ (NSInteger)currentCachedBadgeValue;
+@implementation OneSignalBadgeHelpers
++ (void)updateCachedBadgeValue:(NSInteger)value {
+    // Since badge logic can be executed in an extension, we need to use app groups to get
+    // a shared NSUserDefaults from the app group suite name
+    [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:value];
+}
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalBadgeHelpers.m
@@ -30,9 +30,23 @@
 #import "OneSignalCommonDefines.h"
 
 @implementation OneSignalBadgeHelpers
-+ (void)updateCachedBadgeValue:(NSInteger)value {
+
+/**
+ Store a previous badge count so that we can revert to this cached value when a notification display is cancelled.
+ When `usePreviousBadgeCount` is `true`, the `value` passed to this method will be unused.
+ */
++ (void)updateCachedBadgeValue:(NSInteger)value usePreviousBadgeCount:(BOOL)usePrevious {
     // Since badge logic can be executed in an extension, we need to use app groups to get
     // a shared NSUserDefaults from the app group suite name
-    [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:value];
+    if (usePrevious) {
+        // Keep the PREVIOUS_ONESIGNAL_BADGE_KEY value unchanged
+        NSInteger previousBadgeCount = [OneSignalUserDefaults.initShared getSavedIntegerForKey:PREVIOUS_ONESIGNAL_BADGE_KEY defaultValue:0];
+        [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:previousBadgeCount];
+    } else {
+        NSInteger previousBadgeCount = [OneSignalUserDefaults.initShared getSavedIntegerForKey:ONESIGNAL_BADGE_KEY defaultValue:0];
+        [OneSignalUserDefaults.initShared saveIntegerForKey:PREVIOUS_ONESIGNAL_BADGE_KEY withValue:previousBadgeCount];
+        [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:value];
+    }
 }
+
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -159,6 +159,8 @@
 #define ONESIGNAL_DISABLE_BADGE_CLEARING @"OneSignal_disable_badge_clearing"
 #define ONESIGNAL_APP_GROUP_NAME_KEY @"OneSignal_app_groups_key"
 #define ONESIGNAL_BADGE_KEY @"onesignalBadgeCount"
+/// Store the previous badge count to read for a cancelled notification display event
+#define PREVIOUS_ONESIGNAL_BADGE_KEY @"previousOnesignalBadgeCount"
 
 // Firebase
 #define ONESIGNAL_FB_ENABLE_FIREBASE @"OS_ENABLE_FIREBASE_ANALYTICS"

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCore.h
@@ -58,6 +58,7 @@
 #import <OneSignalCore/OSLocation.h>
 #import <OneSignalCore/OSBundleUtils.h>
 #import <OneSignalCore/OneSignalClientError.h>
+#import <OneSignalCore/OneSignalBadgeHelpers.h>
 
 // TODO: Testing: Should this class be defined in this file?
 @interface OneSignalCoreImpl : NSObject

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.h
@@ -31,5 +31,4 @@
 
 @interface OneSignalExtensionBadgeHandler : NSObject
 + (void)handleBadgeCountWithNotificationRequest:(UNNotificationRequest *)request withNotification:(OSNotification *)notification withMutableNotificationContent:(UNMutableNotificationContent *)replacementContent;
-+ (NSInteger)currentCachedBadgeValue;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.m
@@ -35,7 +35,7 @@
     //make sure the OneSignal cached value is updated to this value
     if (!notification.badgeIncrement) {
         if (notification.hasBadge)
-            [OneSignalBadgeHelpers updateCachedBadgeValue:notification.badge];
+            [OneSignalBadgeHelpers updateCachedBadgeValue:notification.badge usePreviousBadgeCount:false];
         
         return;
     }
@@ -50,7 +50,7 @@
     
     replacementContent.badge = @(currentValue);
     
-    [OneSignalBadgeHelpers updateCachedBadgeValue:currentValue];
+    [OneSignalBadgeHelpers updateCachedBadgeValue:currentValue usePreviousBadgeCount:false];
 }
 
 + (NSInteger)currentCachedBadgeValue {

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtensionBadgeHandler.m
@@ -35,7 +35,7 @@
     //make sure the OneSignal cached value is updated to this value
     if (!notification.badgeIncrement) {
         if (notification.hasBadge)
-            [OneSignalExtensionBadgeHandler updateCachedBadgeValue:notification.badge];
+            [OneSignalBadgeHelpers updateCachedBadgeValue:notification.badge];
         
         return;
     }
@@ -50,17 +50,11 @@
     
     replacementContent.badge = @(currentValue);
     
-    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:currentValue];
+    [OneSignalBadgeHelpers updateCachedBadgeValue:currentValue];
 }
 
 + (NSInteger)currentCachedBadgeValue {
     return [OneSignalUserDefaults.initShared getSavedIntegerForKey:ONESIGNAL_BADGE_KEY defaultValue:0];
-}
-
-+ (void)updateCachedBadgeValue:(NSInteger)value {
-    // Since badge logic can be executed in an extension, we need to use app groups to get
-    //  a shared NSUserDefaults from the app group suite name
-    [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:value];
 }
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
@@ -179,7 +179,7 @@ static UNNotificationSettings* cachedUNNotificationSettings;
  necessary as there is no equivalent "getBadgeCount" method available.
  */
 - (void)onesignalSetBadgeCount:(NSInteger)badge withCompletionHandler:(void(^)(NSError *error))completionHandler {
-    [OneSignalBadgeHelpers updateCachedBadgeValue:badge];
+    [OneSignalBadgeHelpers updateCachedBadgeValue:badge usePreviousBadgeCount:false];
     [self onesignalSetBadgeCount:badge withCompletionHandler:completionHandler];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotification+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotification+OneSignal.m
@@ -77,7 +77,7 @@ BOOL _wantsToDisplay = true;
      */
     if (!notification) {
         NSInteger previousBadgeCount = [UIApplication sharedApplication].applicationIconBadgeNumber;
-        [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:previousBadgeCount];
+        [OneSignalBadgeHelpers updateCachedBadgeValue:previousBadgeCount];
     }
     if (_completion) {
         _completion(notification);

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotification+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotification+OneSignal.m
@@ -76,8 +76,8 @@ BOOL _wantsToDisplay = true;
      reset the badge count to the value prior to receipt of this notif
      */
     if (!notification) {
-        NSInteger previousBadgeCount = [UIApplication sharedApplication].applicationIconBadgeNumber;
-        [OneSignalBadgeHelpers updateCachedBadgeValue:previousBadgeCount];
+        // The badge count value of -99 will not be used, the previous badge count will be set
+        [OneSignalBadgeHelpers updateCachedBadgeValue:-99 usePreviousBadgeCount:true];
     }
     if (_completion) {
         _completion(notification);

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -114,7 +114,7 @@ NS_SWIFT_NAME(onClick(event:));
 
 + (void)handleWillShowInForegroundForNotification:(OSNotification *_Nonnull)notification completion:(OSNotificationDisplayResponse _Nonnull)completion;
 + (void)handleNotificationActionWithUrl:(NSString* _Nullable)url actionID:(NSString* _Nonnull)actionID;
-+ (BOOL)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll;
++ (void)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll;
 
 + (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
 + (void)notificationReceived:(NSDictionary* _Nonnull)messageDict wasOpened:(BOOL)opened;

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -794,25 +794,22 @@ static NSString *_lastnonActiveMessageId;
         _disableBadgeClearing = NO;
     
     if (_disableBadgeClearing && !fromClearAll) {
-        // The customer could have manually changed the badge value. We must ensure our cached value will match the current state.
-        [OneSignalBadgeHelpers updateCachedBadgeValue:[UIApplication sharedApplication].applicationIconBadgeNumber];
+        // The developer could have manually changed the badge value but we cannot read the current state.
+        // We swizzle badge count setters, which should be sufficient to ensure the cached value matches the current state.
+        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"clearBadgeCount called but badge clearing is disabled, not updating cached badge count"];
         return;
     }
     
-    bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;
-    
-    if (fromNotifOpened || wasBadgeSet) {
-        if (@available(iOS 16.0, *)) {
-            [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {
-                if (error) {
-                    [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"clearBadgeCount encountered error setting badge count: %@", error]];
-                }
-            }];
-        } else {
-            [OneSignalCoreHelper runOnMainThread:^{
-                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-            }];
-        }
+    if (@available(iOS 16.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {
+            if (error) {
+                [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"clearBadgeCount encountered error setting badge count: %@", error]];
+            }
+        }];
+    } else {
+        [OneSignalCoreHelper runOnMainThread:^{
+            [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        }];
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -802,9 +802,17 @@ static NSString *_lastnonActiveMessageId;
     bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;
     
     if (fromNotifOpened || wasBadgeSet) {
-        [OneSignalCoreHelper runOnMainThread:^{
-            [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-        }];
+        if (@available(iOS 16.0, *)) {
+            [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {
+                if (error) {
+                    [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"clearBadgeCount encountered error setting badge count: %@", error]];
+                }
+            }];
+        } else {
+            [OneSignalCoreHelper runOnMainThread:^{
+                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+            }];
+        }
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -795,7 +795,7 @@ static NSString *_lastnonActiveMessageId;
     
     if (_disableBadgeClearing && !fromClearAll) {
         // The customer could have manually changed the badge value. We must ensure our cached value will match the current state.
-        [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:[UIApplication sharedApplication].applicationIconBadgeNumber];
+        [OneSignalBadgeHelpers updateCachedBadgeValue:[UIApplication sharedApplication].applicationIconBadgeNumber];
         return;
     }
     

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -784,7 +784,7 @@ static NSString *_lastnonActiveMessageId;
     openUrlBlock(true);
 }
 
-+ (BOOL)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll {
++ (void)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll {
     
     NSNumber *disableBadgeNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_BADGE_CLEARING];
     
@@ -796,7 +796,7 @@ static NSString *_lastnonActiveMessageId;
     if (_disableBadgeClearing && !fromClearAll) {
         // The customer could have manually changed the badge value. We must ensure our cached value will match the current state.
         [OneSignalUserDefaults.initShared saveIntegerForKey:ONESIGNAL_BADGE_KEY withValue:[UIApplication sharedApplication].applicationIconBadgeNumber];
-        return false;
+        return;
     }
     
     bool wasBadgeSet = [UIApplication sharedApplication].applicationIconBadgeNumber > 0;
@@ -806,8 +806,6 @@ static NSString *_lastnonActiveMessageId;
             [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
         }];
     }
-
-    return wasBadgeSet;
 }
 
 + (BOOL)handleIAMPreview:(OSNotification *)notification {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -809,7 +809,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     We swizzle the 'setApplicationIconBadgeNumber()' to intercept these calls so we always know the latest count
 */
 - (void)onesignalSetApplicationIconBadgeNumber:(NSInteger)badge {
-    [OneSignalExtensionBadgeHandler updateCachedBadgeValue:badge];
+    [OneSignalBadgeHelpers updateCachedBadgeValue:badge];
     [self onesignalSetApplicationIconBadgeNumber:badge];
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -809,7 +809,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     We swizzle the 'setApplicationIconBadgeNumber()' to intercept these calls so we always know the latest count
 */
 - (void)onesignalSetApplicationIconBadgeNumber:(NSInteger)badge {
-    [OneSignalBadgeHelpers updateCachedBadgeValue:badge];
+    [OneSignalBadgeHelpers updateCachedBadgeValue:badge usePreviousBadgeCount:false];
     [self onesignalSetApplicationIconBadgeNumber:badge];
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Drop usage of deprecated `applicationIconBadgeNumber` API, and support usage of replacement `setBadgeCount` API (with no getter).

## Details

### Motivation
Reports of the SDK's usage of `applicationIconBadgeNumber` is causing apps to hang: https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1452

### Scope
Note the biggest change is we lose **some** ability to get the most accurate badge count at any moment. This should be mitigated overall as we swizzle both badge setting methods that developers would call (old and new) to update our cached value. Additionally, we will store a previous badge count as well for cases where a notification display event is cancelled, so we can revert our cached badge count to be accurate.

**New class** `OneSignalBadgeHelpers` in OneSignalCore and move a method to cache badge count out of OneSignalExtension and into that class
- Moving to Core means the functionality can be shared across different frameworks

**Support new `setBadgeCount` API on iOS 16+.** 
- The method `applicationIconBadgeNumber` is deprecated in iOS 17 - see https://developer.apple.com/documentation/uikit/uiapplication/applicationiconbadgenumber. Its replacement is `setBadgeCount:withCompletionHandler:` (https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/setbadgecount(_:withcompletionhandler:)?language=objc) but there is no equivalent getter.
- Use this new API on ios 16+ and swizzle it just like we do for applicationIconBadgeNumber to get the most accurate badge count.

**Remove all usages of deprecated applicationIconBadgeNumber**
- Keep a previous badge count as well as current. When a notification foreground display is cancelled, the badge count in that notification (if any) does not apply. We have to revert our cached badge count back to the previous badge count. Thus, we store the previous badge when a new one is set as we cannot use a getter for badge count anymore.

# Testing
## Unit testing
None

## Manual testing
iPhone 13 iOS 18.5
- manually called `setBadgeCount` and check SDK swizzling and caching
- Display notifications in foreground as well as cancel displaying notifications in foreground, and check caching
- Sending notifications with different combinations of "SetTo" and "Increase" badge count values and checking behavior is correct

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [x] Badges
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1568)
<!-- Reviewable:end -->
