### PR TITLE
fix: live activities uncaches correctly

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
@@ -48,8 +48,9 @@ class RequestCache {
     init(cacheKey: String, ttl: TimeInterval) {
         self.cacheKey = cacheKey
         self.ttl = ttl
-        self.items = OneSignalUserDefaults.initShared()
-            .getSavedCodeableData(forKey: cacheKey, defaultValue: nil) as? [String: OSLiveActivityRequest] ?? [String: OSLiveActivityRequest]()
+        let cached = OneSignalUserDefaults.initShared().getSavedCodeableData(forKey: cacheKey, defaultValue: nil)
+        // for safe-casting to the protocol, the intermediary cast to AnyObject is necessary
+        self.items = cached as? [String: AnyObject] as? [String: OSLiveActivityRequest] ?? [String: OSLiveActivityRequest]()
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.LiveActivities initialized token cache \(self): \(items)")
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestRemoveStartToken.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestRemoveStartToken.swift
@@ -78,14 +78,13 @@ class OSRequestRemoveStartToken: OneSignalRequest, OSLiveActivityRequest, OSLive
     required init?(coder: NSCoder) {
         guard
             let key = coder.decodeObject(forKey: "key") as? String,
-            let requestSuccessful = coder.decodeObject(forKey: "requestSuccessful") as? Bool,
             let timestamp = coder.decodeObject(forKey: "timestamp") as? Date
         else {
             // Log error
             return nil
         }
         self.key = key
-        self.requestSuccessful = requestSuccessful
+        self.requestSuccessful = coder.decodeBool(forKey: "requestSuccessful")
         super.init()
         self.timestamp = timestamp
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestRemoveUpdateToken.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestRemoveUpdateToken.swift
@@ -79,14 +79,13 @@ class OSRequestRemoveUpdateToken: OneSignalRequest, OSLiveActivityRequest, OSLiv
     required init?(coder: NSCoder) {
         guard
             let key = coder.decodeObject(forKey: "key") as? String,
-            let requestSuccessful = coder.decodeObject(forKey: "requestSuccessful") as? Bool,
             let timestamp = coder.decodeObject(forKey: "timestamp") as? Date
         else {
             // Log error
             return nil
         }
         self.key = key
-        self.requestSuccessful = requestSuccessful
+        self.requestSuccessful = coder.decodeBool(forKey: "requestSuccessful")
         super.init()
         self.timestamp = timestamp
     }


### PR DESCRIPTION
# Description
## One Line Summary
Correctly uncache live activities requests, by using an intermediary cast first as a bridge.

## Details

### Motivation
The SDK was never uncaching live activities requests, as using a safe cast directly to a protocol fails. It might be an issue with bridging from Objective-C or the compiler could not be definitely sure and errs on the side of caution. However it seems casting it to `[String: AnyObject]` before casting to `[String: OSLiveActivityRequest]` works. A force-cast also works perhaps by bypassing the first safety layer, but force-casts are dangerous. Fortunately, this alternative seems to work correctly.

### Scope
Live activities requests will now be uncached, reduce extraneous requests.

# Testing
## Unit testing
Added `testRequestsUncacheCorrectly` that caches and uncaches each live activity request type.
- test fails before and succeeds after fixe

## Manual testing
Testing on physical iPhone 13, iOS 18.6.2
- reproduced previous casting always failed
- now it works

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Live Activities

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1589)
<!-- Reviewable:end -->
