### PR TITLE
Chore: fix Xcode project navigator files reference

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -190,6 +190,17 @@
 		3CF8629E28A183F900776CA4 /* OSIdentityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */; };
 		3CF862A028A1964F00776CA4 /* OSPropertiesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */; };
 		3CF862A228A197D200776CA4 /* OSPropertiesModelStoreListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF862A128A197D200776CA4 /* OSPropertiesModelStoreListener.swift */; };
+		3CFA8F4F2E9087DB00201FE5 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F492E9087DB00201FE5 /* AnyCodable.swift */; };
+		3CFA8F502E9087DB00201FE5 /* OSLiveActivitiesExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F412E9087DB00201FE5 /* OSLiveActivitiesExecutor.swift */; };
+		3CFA8F512E9087DB00201FE5 /* DefaultLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F4A2E9087DB00201FE5 /* DefaultLiveActivityAttributes.swift */; };
+		3CFA8F522E9087DB00201FE5 /* OSRequestSetStartToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F462E9087DB00201FE5 /* OSRequestSetStartToken.swift */; };
+		3CFA8F532E9087DB00201FE5 /* OSRequestRemoveStartToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F442E9087DB00201FE5 /* OSRequestRemoveStartToken.swift */; };
+		3CFA8F542E9087DB00201FE5 /* OSLiveActivitiesExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F4D2E9087DB00201FE5 /* OSLiveActivitiesExtension.swift */; };
+		3CFA8F552E9087DB00201FE5 /* OneSignalLiveActivitiesManagerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F4B2E9087DB00201FE5 /* OneSignalLiveActivitiesManagerImpl.swift */; };
+		3CFA8F562E9087DB00201FE5 /* OSRequestSetUpdateToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F472E9087DB00201FE5 /* OSRequestSetUpdateToken.swift */; };
+		3CFA8F572E9087DB00201FE5 /* OSRequestRemoveUpdateToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F452E9087DB00201FE5 /* OSRequestRemoveUpdateToken.swift */; };
+		3CFA8F582E9087DB00201FE5 /* OSLiveActivityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F432E9087DB00201FE5 /* OSLiveActivityRequest.swift */; };
+		3CFA8F592E9087DB00201FE5 /* OneSignalLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFA8F4C2E9087DB00201FE5 /* OneSignalLiveActivityAttributes.swift */; };
 		3E464ED71D88ED1F00DCF7E9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E6B2BA19D9CAF300D0C601 /* UIKit.framework */; };
 		3E66F5821D90A2C600E45A01 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */; };
 		4529DED21FA81EA800CEAB1D /* NSObjectOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4529DED11FA81EA800CEAB1D /* NSObjectOverrider.m */; };
@@ -207,7 +218,6 @@
 		4710EA562B8FD08F00435356 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		4710EA572B8FD08F00435356 /* OneSignalOSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4710EA5A2B8FD18800435356 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
-		47278E452BD7E62B00562820 /* DefaultLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47278E442BD7E62B00562820 /* DefaultLiveActivityAttributes.swift */; };
 		47278E472BD92B4B00562820 /* DefaultLiveActivityAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47278E462BD92B4B00562820 /* DefaultLiveActivityAttributesTests.swift */; };
 		4735424D2B8F93340016DB4C /* OSLiveActivitiesExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4735424C2B8F93340016DB4C /* OSLiveActivitiesExecutorTests.swift */; };
 		473542552B8F93760016DB4C /* OneSignalCoreMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CC0639A2B6D7A8C002BB07F /* OneSignalCoreMocks.framework */; };
@@ -227,19 +237,9 @@
 		475F47252B8E398E00EC05B3 /* OneSignalLiveActivities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 475F471E2B8E398D00EC05B3 /* OneSignalLiveActivities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		475F472A2B8E399F00EC05B3 /* OneSignalCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE7D17E627026B95002D3A5D /* OneSignalCore.framework */; };
 		475F472E2B8E399F00EC05B3 /* OneSignalUser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE69E19B282ED8060090BB3D /* OneSignalUser.framework */; };
-		475F47362B8E39DD00EC05B3 /* OSLiveActivitiesExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F47352B8E39DD00EC05B3 /* OSLiveActivitiesExecutor.swift */; };
-		475F473A2B8E39F300EC05B3 /* OneSignalLiveActivitiesManagerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F47372B8E39F300EC05B3 /* OneSignalLiveActivitiesManagerImpl.swift */; };
-		475F473B2B8E39F300EC05B3 /* OneSignalLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F47382B8E39F300EC05B3 /* OneSignalLiveActivityAttributes.swift */; };
-		475F473C2B8E39F300EC05B3 /* OSLiveActivitiesExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F47392B8E39F300EC05B3 /* OSLiveActivitiesExtension.swift */; };
-		475F47422B8E3A0A00EC05B3 /* OSRequestRemoveUpdateToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F473D2B8E3A0900EC05B3 /* OSRequestRemoveUpdateToken.swift */; };
-		475F47432B8E3A0A00EC05B3 /* OSRequestSetStartToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F473E2B8E3A0900EC05B3 /* OSRequestSetStartToken.swift */; };
-		475F47442B8E3A0A00EC05B3 /* OSRequestSetUpdateToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F473F2B8E3A0A00EC05B3 /* OSRequestSetUpdateToken.swift */; };
-		475F47452B8E3A0A00EC05B3 /* OSLiveActivityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F47402B8E3A0A00EC05B3 /* OSLiveActivityRequest.swift */; };
-		475F47462B8E3A0A00EC05B3 /* OSRequestRemoveStartToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475F47412B8E3A0A00EC05B3 /* OSRequestRemoveStartToken.swift */; };
 		475F474A2B8E3B4600EC05B3 /* OneSignalLiveActivities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 475F471E2B8E398D00EC05B3 /* OneSignalLiveActivities.framework */; platformFilter = ios; };
 		475F474F2B8E3B5400EC05B3 /* OneSignalLiveActivities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 475F471E2B8E398D00EC05B3 /* OneSignalLiveActivities.framework */; };
 		475F47502B8E3B5400EC05B3 /* OneSignalLiveActivities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 475F471E2B8E398D00EC05B3 /* OneSignalLiveActivities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		47A885CD2BB317B300ED91FA /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A885CC2BB317B300ED91FA /* AnyCodable.swift */; };
 		5B053FBC2CAE07EB002F30C4 /* OneSignalOSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C115161289A259500565C41 /* OneSignalOSCore.framework */; };
 		5B053FC32CAE0843002F30C4 /* OSConsistencyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1DE672C90C23E00CA8807 /* OSConsistencyManagerTests.swift */; };
 		5B58E4F8237CE7B4009401E0 /* UIDeviceOverrider.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B58E4F6237CE7B4009401E0 /* UIDeviceOverrider.m */; };
@@ -1339,6 +1339,17 @@
 		3CF8629D28A183F900776CA4 /* OSIdentityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSIdentityModel.swift; sourceTree = "<group>"; };
 		3CF8629F28A1964F00776CA4 /* OSPropertiesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesModel.swift; sourceTree = "<group>"; };
 		3CF862A128A197D200776CA4 /* OSPropertiesModelStoreListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPropertiesModelStoreListener.swift; sourceTree = "<group>"; };
+		3CFA8F412E9087DB00201FE5 /* OSLiveActivitiesExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLiveActivitiesExecutor.swift; sourceTree = "<group>"; };
+		3CFA8F432E9087DB00201FE5 /* OSLiveActivityRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLiveActivityRequest.swift; sourceTree = "<group>"; };
+		3CFA8F442E9087DB00201FE5 /* OSRequestRemoveStartToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSRequestRemoveStartToken.swift; sourceTree = "<group>"; };
+		3CFA8F452E9087DB00201FE5 /* OSRequestRemoveUpdateToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSRequestRemoveUpdateToken.swift; sourceTree = "<group>"; };
+		3CFA8F462E9087DB00201FE5 /* OSRequestSetStartToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSRequestSetStartToken.swift; sourceTree = "<group>"; };
+		3CFA8F472E9087DB00201FE5 /* OSRequestSetUpdateToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSRequestSetUpdateToken.swift; sourceTree = "<group>"; };
+		3CFA8F492E9087DB00201FE5 /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		3CFA8F4A2E9087DB00201FE5 /* DefaultLiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLiveActivityAttributes.swift; sourceTree = "<group>"; };
+		3CFA8F4B2E9087DB00201FE5 /* OneSignalLiveActivitiesManagerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneSignalLiveActivitiesManagerImpl.swift; sourceTree = "<group>"; };
+		3CFA8F4C2E9087DB00201FE5 /* OneSignalLiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneSignalLiveActivityAttributes.swift; sourceTree = "<group>"; };
+		3CFA8F4D2E9087DB00201FE5 /* OSLiveActivitiesExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLiveActivitiesExtension.swift; sourceTree = "<group>"; };
 		3E08E2701D49A5C8002176DE /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		3E2400381D4FFC31008BDE70 /* OneSignalFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OneSignalFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E24003B1D4FFC31008BDE70 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1375,7 +1386,6 @@
 		454F94F61FAD2EC300D74CCF /* OSNotification+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OSNotification+Internal.h"; sourceTree = "<group>"; };
 		4710EA522B8FCFB200435356 /* OSDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDispatchQueue.swift; sourceTree = "<group>"; };
 		4710EA542B8FD04400435356 /* MockOSDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOSDispatchQueue.swift; sourceTree = "<group>"; };
-		47278E442BD7E62B00562820 /* DefaultLiveActivityAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DefaultLiveActivityAttributes.swift; path = Source/DefaultLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		47278E462BD92B4B00562820 /* DefaultLiveActivityAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLiveActivityAttributesTests.swift; sourceTree = "<group>"; };
 		4735424A2B8F93330016DB4C /* OneSignalLiveActivitiesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneSignalLiveActivitiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4735424C2B8F93340016DB4C /* OSLiveActivitiesExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLiveActivitiesExecutorTests.swift; sourceTree = "<group>"; };
@@ -1383,17 +1393,7 @@
 		4746E2AA2B8775C400D6324C /* LiveActivitiesObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LiveActivitiesObjcTests.m; sourceTree = "<group>"; };
 		475F471E2B8E398D00EC05B3 /* OneSignalLiveActivities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OneSignalLiveActivities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		475F47202B8E398E00EC05B3 /* OneSignalLiveActivities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignalLiveActivities.h; sourceTree = "<group>"; };
-		475F47352B8E39DD00EC05B3 /* OSLiveActivitiesExecutor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSLiveActivitiesExecutor.swift; path = Source/Executors/OSLiveActivitiesExecutor.swift; sourceTree = "<group>"; };
-		475F47372B8E39F300EC05B3 /* OneSignalLiveActivitiesManagerImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OneSignalLiveActivitiesManagerImpl.swift; path = Source/OneSignalLiveActivitiesManagerImpl.swift; sourceTree = "<group>"; };
-		475F47382B8E39F300EC05B3 /* OneSignalLiveActivityAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OneSignalLiveActivityAttributes.swift; path = Source/OneSignalLiveActivityAttributes.swift; sourceTree = "<group>"; };
-		475F47392B8E39F300EC05B3 /* OSLiveActivitiesExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSLiveActivitiesExtension.swift; path = Source/OSLiveActivitiesExtension.swift; sourceTree = "<group>"; };
-		475F473D2B8E3A0900EC05B3 /* OSRequestRemoveUpdateToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSRequestRemoveUpdateToken.swift; path = Source/Requests/OSRequestRemoveUpdateToken.swift; sourceTree = "<group>"; };
-		475F473E2B8E3A0900EC05B3 /* OSRequestSetStartToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSRequestSetStartToken.swift; path = Source/Requests/OSRequestSetStartToken.swift; sourceTree = "<group>"; };
-		475F473F2B8E3A0A00EC05B3 /* OSRequestSetUpdateToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSRequestSetUpdateToken.swift; path = Source/Requests/OSRequestSetUpdateToken.swift; sourceTree = "<group>"; };
-		475F47402B8E3A0A00EC05B3 /* OSLiveActivityRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSLiveActivityRequest.swift; path = Source/Requests/OSLiveActivityRequest.swift; sourceTree = "<group>"; };
-		475F47412B8E3A0A00EC05B3 /* OSRequestRemoveStartToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OSRequestRemoveStartToken.swift; path = Source/Requests/OSRequestRemoveStartToken.swift; sourceTree = "<group>"; };
 		475F47482B8E3A4400EC05B3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		47A885CC2BB317B300ED91FA /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnyCodable.swift; path = Source/AnyCodable.swift; sourceTree = "<group>"; };
 		5B053FB82CAE07EB002F30C4 /* OneSignalOSCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneSignalOSCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B58E4F3237CE7B3009401E0 /* UIDeviceOverrider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIDeviceOverrider.h; sourceTree = "<group>"; };
 		5B58E4F6237CE7B4009401E0 /* UIDeviceOverrider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIDeviceOverrider.m; sourceTree = "<group>"; };
@@ -2239,6 +2239,40 @@
 			path = Executors;
 			sourceTree = "<group>";
 		};
+		3CFA8F422E9087DB00201FE5 /* Executors */ = {
+			isa = PBXGroup;
+			children = (
+				3CFA8F412E9087DB00201FE5 /* OSLiveActivitiesExecutor.swift */,
+			);
+			path = Executors;
+			sourceTree = "<group>";
+		};
+		3CFA8F482E9087DB00201FE5 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				3CFA8F432E9087DB00201FE5 /* OSLiveActivityRequest.swift */,
+				3CFA8F462E9087DB00201FE5 /* OSRequestSetStartToken.swift */,
+				3CFA8F442E9087DB00201FE5 /* OSRequestRemoveStartToken.swift */,
+				3CFA8F472E9087DB00201FE5 /* OSRequestSetUpdateToken.swift */,
+				3CFA8F452E9087DB00201FE5 /* OSRequestRemoveUpdateToken.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		3CFA8F4E2E9087DB00201FE5 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				3CFA8F422E9087DB00201FE5 /* Executors */,
+				3CFA8F482E9087DB00201FE5 /* Requests */,
+				3CFA8F4B2E9087DB00201FE5 /* OneSignalLiveActivitiesManagerImpl.swift */,
+				3CFA8F4C2E9087DB00201FE5 /* OneSignalLiveActivityAttributes.swift */,
+				3CFA8F4D2E9087DB00201FE5 /* OSLiveActivitiesExtension.swift */,
+				3CFA8F492E9087DB00201FE5 /* AnyCodable.swift */,
+				3CFA8F4A2E9087DB00201FE5 /* DefaultLiveActivityAttributes.swift */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
 		3E2400391D4FFC31008BDE70 /* OneSignalFramework */ = {
 			isa = PBXGroup;
 			children = (
@@ -2319,37 +2353,11 @@
 		475F471F2B8E398E00EC05B3 /* OneSignalLiveActivities */ = {
 			isa = PBXGroup;
 			children = (
-				475F47342B8E39B700EC05B3 /* Executors */,
-				475F47332B8E39B100EC05B3 /* Requests */,
-				475F47372B8E39F300EC05B3 /* OneSignalLiveActivitiesManagerImpl.swift */,
-				475F47382B8E39F300EC05B3 /* OneSignalLiveActivityAttributes.swift */,
-				475F47392B8E39F300EC05B3 /* OSLiveActivitiesExtension.swift */,
+				3CFA8F4E2E9087DB00201FE5 /* Source */,
 				475F47202B8E398E00EC05B3 /* OneSignalLiveActivities.h */,
-				47A885CC2BB317B300ED91FA /* AnyCodable.swift */,
-				47278E442BD7E62B00562820 /* DefaultLiveActivityAttributes.swift */,
 				3C6299A22BEEA3CC00649187 /* PrivacyInfo.xcprivacy */,
 			);
 			path = OneSignalLiveActivities;
-			sourceTree = "<group>";
-		};
-		475F47332B8E39B100EC05B3 /* Requests */ = {
-			isa = PBXGroup;
-			children = (
-				475F47402B8E3A0A00EC05B3 /* OSLiveActivityRequest.swift */,
-				475F473E2B8E3A0900EC05B3 /* OSRequestSetStartToken.swift */,
-				475F47412B8E3A0A00EC05B3 /* OSRequestRemoveStartToken.swift */,
-				475F473F2B8E3A0A00EC05B3 /* OSRequestSetUpdateToken.swift */,
-				475F473D2B8E3A0900EC05B3 /* OSRequestRemoveUpdateToken.swift */,
-			);
-			name = Requests;
-			sourceTree = "<group>";
-		};
-		475F47342B8E39B700EC05B3 /* Executors */ = {
-			isa = PBXGroup;
-			children = (
-				475F47352B8E39DD00EC05B3 /* OSLiveActivitiesExecutor.swift */,
-			);
-			name = Executors;
 			sourceTree = "<group>";
 		};
 		475F47472B8E3A1C00EC05B3 /* OneSignalLiveActivitiesFramework */ = {
@@ -4292,17 +4300,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				475F473C2B8E39F300EC05B3 /* OSLiveActivitiesExtension.swift in Sources */,
-				47278E452BD7E62B00562820 /* DefaultLiveActivityAttributes.swift in Sources */,
-				475F47432B8E3A0A00EC05B3 /* OSRequestSetStartToken.swift in Sources */,
-				475F473B2B8E39F300EC05B3 /* OneSignalLiveActivityAttributes.swift in Sources */,
-				475F47362B8E39DD00EC05B3 /* OSLiveActivitiesExecutor.swift in Sources */,
-				475F473A2B8E39F300EC05B3 /* OneSignalLiveActivitiesManagerImpl.swift in Sources */,
-				475F47422B8E3A0A00EC05B3 /* OSRequestRemoveUpdateToken.swift in Sources */,
-				475F47452B8E3A0A00EC05B3 /* OSLiveActivityRequest.swift in Sources */,
-				47A885CD2BB317B300ED91FA /* AnyCodable.swift in Sources */,
-				475F47462B8E3A0A00EC05B3 /* OSRequestRemoveStartToken.swift in Sources */,
-				475F47442B8E3A0A00EC05B3 /* OSRequestSetUpdateToken.swift in Sources */,
+				3CFA8F4F2E9087DB00201FE5 /* AnyCodable.swift in Sources */,
+				3CFA8F502E9087DB00201FE5 /* OSLiveActivitiesExecutor.swift in Sources */,
+				3CFA8F512E9087DB00201FE5 /* DefaultLiveActivityAttributes.swift in Sources */,
+				3CFA8F522E9087DB00201FE5 /* OSRequestSetStartToken.swift in Sources */,
+				3CFA8F532E9087DB00201FE5 /* OSRequestRemoveStartToken.swift in Sources */,
+				3CFA8F542E9087DB00201FE5 /* OSLiveActivitiesExtension.swift in Sources */,
+				3CFA8F552E9087DB00201FE5 /* OneSignalLiveActivitiesManagerImpl.swift in Sources */,
+				3CFA8F562E9087DB00201FE5 /* OSRequestSetUpdateToken.swift in Sources */,
+				3CFA8F572E9087DB00201FE5 /* OSRequestRemoveUpdateToken.swift in Sources */,
+				3CFA8F582E9087DB00201FE5 /* OSLiveActivityRequest.swift in Sources */,
+				3CFA8F592E9087DB00201FE5 /* OneSignalLiveActivityAttributes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
# Description
## One Line Summary
Clean up file references in Xcode workspace to make it easier to maintain, add, and remove files.

## Details

### Motivation
For example, most of the files within `OneSignalLiveActivities` directory are under a sub directory called `Source`. However, you could not see this in the project navigator. It becomes confusing when you add/remove files via the project navigator as they do not go where you think they should. Also did this for UnitTests and OneSignalLiveActivitiesFramework.

### Real Folder Structure
<img width="479" height="350" alt="real_folder_structure" src="https://github.com/user-attachments/assets/cc59920c-4837-48dc-acff-a404397f9fbd" />

### Xcode project navigator BEFORE
<img width="461" height="384" alt="before_changes" src="https://github.com/user-attachments/assets/b5b3d83e-6d8b-4eef-8e2d-2979720c06cd" />

### Xcode project navigator AFTER
<img width="461" height="384" alt="after_changes" src="https://github.com/user-attachments/assets/e19daf26-41f1-48e1-b786-6b97d0c09ae9" />

### Scope
Clean up Xcode files structure so every file and folder in the project navigator matches the actual file/folder structure. Make all files that are a "reference" be the "real" file.

# Testing

## Manual testing
Builds and runs on iphone 13, iOS 18.6.2

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1591)
<!-- Reviewable:end -->
