### PR TITLE
Fix: Prevent exception when copying an error's localizedDescription

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -318,7 +318,7 @@ static BOOL _isInAppMessagingPaused = false;
     onFailure:^(OneSignalClientError *error) {
         NSDictionary* responseHeaders = error.responseHeaders;
         
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"getInAppMessagesFromServer failure: %@", error.underlyingError.localizedDescription]];
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"getInAppMessagesFromServer failure: %@", error.description]];
         
         if (error.code == 425 || error.code == 429) { // 425 Too Early or 429 Too Many Requests
             NSInteger retryAfter = [responseHeaders[@"Retry-After"] integerValue] ?: DEFAULT_RETRY_AFTER_SECONDS;
@@ -387,7 +387,7 @@ static BOOL _isInAppMessagingPaused = false;
             }
         });
     } onFailure:^(OneSignalClientError *error) {
-        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"getInAppMessagesFromServer failure: %@", error.underlyingError.localizedDescription]];
+        [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"getInAppMessagesFromServer failure: %@", error.description]];
     }];
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/OneSignalLiveActivitiesManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/OneSignalLiveActivitiesManagerImpl.swift
@@ -171,7 +171,7 @@ public class OneSignalLiveActivitiesManagerImpl: NSObject, OSLiveActivities {
                     contentState: contentState,
                     pushType: .token)
         } catch let error {
-            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot start default live activity: " + error.localizedDescription)
+            OneSignalLog.onesignalLog(.LL_DEBUG, message: "Cannot start default live activity: \(error)")
         }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
To log an error, use its `description` rather than `localizedDescription`, which can cause exceptions.

## Details
* It seems that when creating a new string with `NSString stringWithFormat`, copying the `localizedDescription` can raise an `NSInvalidArgumentException`. Not reproducible, but reported by users. Those reports were from a non-Americas locale.
* This usage of **description** rather than **localizedDescription** matches other calls to the client where we log the error returned. This is likely why we did not received reports of crashes in those calls.
* In addition, `localizedDescription` was never used on player model, it logged the error directly which internally calls the error's `description`.

Example stacktrace:
```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x... __exceptionPreprocess
1  libobjc.A.dylib                0x... objc_exception_throw
2  CoreFoundation                 0x... +[NSObject(NSObject) _copyDescription]
3  CoreFoundation                 0x... ___forwarding___
4  CoreFoundation                 0x... _CF_forwarding_prep_0
5  OneSignalInAppMessages         0x... __77-[OSMessagingController attemptFetchWithRetries:rywData:attempts:retryLimit:]_block_invoke.90 + 320 (OSMessagingController.m:320)
6  OneSignalCore                  0x... -[OneSignalClient handleJSONNSURLResponse:data:error:isAsync:withRequest:onSuccess:onFailure:] + 214 (OneSignalClient.m:214)
7  OneSignalCore                  0x... __54-[OneSignalClient executeRequest:onSuccess:onFailure:]_block_invoke + 110 (OneSignalClient.m:110)
```

### Motivation
Fix reported crash

### Scope
- Logging only

# Testing
## Unit testing
None added

## Manual testing
None, unable to reproduce by attempting:
- GET https://onesignal.com/foo (returns invalid JSON, and 404 response) and GET https://onesignal.com/ (returns invalid JSON and 200 response)
- Change my phone’s region and language to various locales and make the above GETs
- No crash experienced. The localizedDescription always printed “The data couldn’t be read because it isn’t in the correct format.”

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible - LOCALLY
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1594)
<!-- Reviewable:end -->
