### PR TITLE
chore(ci): Update runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Select Xcode Version
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.2.app
+          sudo xcode-select -s /Applications/Xcode_16.3.0.app
       - name: Checkout OneSignal-iOS-SDK
         uses: actions/checkout@v3
       - name: Set Default Scheme


### PR DESCRIPTION
# Description
## One Line Summary
On `macos-latest-largest`, use xcode 16.3+.

## Details

### Motivation
Fix CI
<img width="500" alt="Failing CI example" src="https://github.com/user-attachments/assets/2d3052d7-acb2-4e09-8134-d34453ef8258" />

### Scope
CI

# Testing
## Manual testing
Confirmed CI works after this

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs - NONE

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed - NOT NEEDED
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1596)
<!-- Reviewable:end -->
