### PR TITLE
Feat: Add option to disable swizzling

### DIFF
--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.h
@@ -29,9 +29,10 @@
 // This project exisits to make testing OneSignal SDK changes.
 
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 #import <OneSignalFramework/OneSignalFramework.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener, OSUserStateObserver, OSLogListener>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate, OSNotificationPermissionObserver, OSInAppMessageLifecycleListener, OSPushSubscriptionObserver, OSNotificationLifecycleListener, OSInAppMessageClickListener, OSNotificationClickListener, OSUserStateObserver, OSLogListener>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/AppDelegate.m
@@ -59,6 +59,7 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     
 //    [FIRApp configure];
+    [UNUserNotificationCenter currentNotificationCenter].delegate = self;
     
     NSLog(@"Bundle URL: %@", [[NSBundle mainBundle] bundleURL]);
     // Uncomment to test LogListener
@@ -197,17 +198,66 @@ OneSignalNotificationCenterDelegate *_notificationDelegate;
 - (void)applicationWillTerminate:(UIApplication *)application {
 }
 
-// Remote
-- (void)application:(UIApplication *)application
-didReceiveRemoteNotification:(NSDictionary *)userInfo
-fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-    
-    NSLog(@"application:didReceiveRemoteNotification:fetchCompletionHandler: %@", userInfo);
-    completionHandler(UIBackgroundFetchResultNoData);
-}
-
 - (void)onLogEvent:(OneSignalLogEvent * _Nonnull)event {
     NSLog(@"Dev App onLogEvent: %@", event.entry);
+}
+
+#pragma mark - Manual Integration APIs (for use when swizzling is disabled)
+
+// Forward the APNs device token to OneSignal so it can register the device for push
+- (void)application:(UIApplication *)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    NSLog(@"Dev App application:didRegisterForRemoteNotificationsWithDeviceToken %@", deviceToken);
+    [OneSignal.Notifications didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+// Forward APNs registration failures so OneSignal can log and retry appropriately
+- (void)application:(UIApplication *)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    NSLog(@"Dev App application:didFailToRegisterForRemoteNotificationsWithError %@", error);
+    [OneSignal.Notifications didFailToRegisterForRemoteNotificationsWithError:error];
+}
+
+// Forward background / silent notifications for content-available processing
+- (void)application:(UIApplication *)application
+    didReceiveRemoteNotification:(NSDictionary *)userInfo
+    fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    NSLog(@"Dev App application:didReceiveRemoteNotification %@", userInfo);
+    [OneSignal.Notifications didReceiveRemoteNotification:userInfo
+                                       completionHandler:completionHandler];
+}
+
+// Forward foreground notifications so the SDK can invoke onWillDisplayNotification listeners
+// and determine whether to show a banner. Completion returns nil for IAM previews.
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    NSLog(@"Dev App userNotificationCenter:willPresentNotification %@", notification);
+    [OneSignal.Notifications
+        willPresentNotificationWithPayload:notification.request.content.userInfo
+        completion:^(OSNotification *notif) {
+            if (notif) {
+                if (@available(iOS 14.0, *)) {
+                    completionHandler(UNNotificationPresentationOptionBanner |
+                                      UNNotificationPresentationOptionList |
+                                      UNNotificationPresentationOptionSound);
+                } else {
+                    completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound);
+                }
+            } else {
+                completionHandler(UNNotificationPresentationOptionNone);
+            }
+        }];
+}
+
+// Forward notification tap / action so the SDK can fire onClickNotification listeners
+// and handle deep links and action buttons
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+    didReceiveNotificationResponse:(UNNotificationResponse *)response
+             withCompletionHandler:(void (^)(void))completionHandler {
+    NSLog(@"Dev App userNotificationCenter:didReceiveNotificationResponse %@", response);
+    [OneSignal.Notifications didReceiveNotificationResponse:response];
+    completionHandler();
 }
 
 @end

--- a/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
+++ b/iOS_SDK/OneSignalDevApp/OneSignalDevApp/Info.plist
@@ -82,5 +82,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>OneSignal_disable_swizzling</key>
+	<true/>
 </dict>
 </plist>

--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalCommonDefines.h
@@ -155,6 +155,9 @@
 #define GDPR_CONSENT_GRANTED @"GDPR_CONSENT_GRANTED"
 #define ONESIGNAL_REQUIRE_PRIVACY_CONSENT @"OneSignal_require_privacy_consent"
 
+// Swizzling
+#define ONESIGNAL_DISABLE_SWIZZLING @"OneSignal_disable_swizzling"
+
 // Badge handling
 #define ONESIGNAL_DISABLE_BADGE_CLEARING @"OneSignal_disable_badge_clearing"
 #define ONESIGNAL_APP_GROUP_NAME_KEY @"OneSignal_app_groups_key"

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UIApplicationDelegate+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UIApplicationDelegate+OneSignalNotifications.m
@@ -111,10 +111,10 @@ static NSMutableSet<Class>* swizzledClasses;
     return false;
 }
 
-- (void)oneSignalDidRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken {
+- (void)oneSignalDidRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)deviceToken {
     [OneSignalNotificationsAppDelegate traceCall:@"oneSignalDidRegisterForRemoteNotifications:deviceToken:"];
     
-    [OSNotificationsManager didRegisterForRemoteNotificationsWithDeviceToken:inDeviceToken];
+    [OSNotificationsManager processRegisteredDeviceToken:deviceToken];
     
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
         initWithTarget:self
@@ -125,14 +125,14 @@ static NSMutableSet<Class>* swizzledClasses;
             application:didRegisterForRemoteNotificationsWithDeviceToken:
         )
     ];
-    [forwarder invokeWithArgs:@[app, inDeviceToken]];
+    [forwarder invokeWithArgs:@[app, deviceToken]];
 }
 
 - (void)oneSignalDidFailRegisterForRemoteNotification:(UIApplication*)app error:(NSError*)err {
     [OneSignalNotificationsAppDelegate traceCall:@"oneSignalDidFailRegisterForRemoteNotification:error:"];
     
     if ([OneSignalConfigManager getAppId])
-        [OSNotificationsManager didFailToRegisterForRemoteNotificationsWithError:err];
+        [OSNotificationsManager processFailedRemoteNotificationsRegistration:err];
     
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
         initWithTarget:self
@@ -180,7 +180,7 @@ static NSMutableSet<Class>* swizzledClasses;
         else if (appState == UIApplicationStateActive && isVisibleNotification)
             [OSNotificationsManager notificationReceived:userInfo wasOpened:NO];
         else
-            startedBackgroundJob = [OSNotificationsManager didReceiveRemoteNotification:userInfo completionHandler:forwarder.hasReceiver ? nil : completionHandler];
+            startedBackgroundJob = [OSNotificationsManager processReceivedRemoteNotification:userInfo completionHandler:forwarder.hasReceiver ? nil : completionHandler];
     }
     
     if (forwarder.hasReceiver) {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UIApplicationDelegate+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UIApplicationDelegate+OneSignalNotifications.m
@@ -114,7 +114,7 @@ static NSMutableSet<Class>* swizzledClasses;
 - (void)oneSignalDidRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken {
     [OneSignalNotificationsAppDelegate traceCall:@"oneSignalDidRegisterForRemoteNotifications:deviceToken:"];
     
-    [OSNotificationsManager didRegisterForRemoteNotifications:app deviceToken:inDeviceToken];
+    [OSNotificationsManager didRegisterForRemoteNotificationsWithDeviceToken:inDeviceToken];
     
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
         initWithTarget:self
@@ -132,7 +132,7 @@ static NSMutableSet<Class>* swizzledClasses;
     [OneSignalNotificationsAppDelegate traceCall:@"oneSignalDidFailRegisterForRemoteNotification:error:"];
     
     if ([OneSignalConfigManager getAppId])
-        [OSNotificationsManager handleDidFailRegisterForRemoteNotification:err];
+        [OSNotificationsManager didFailToRegisterForRemoteNotificationsWithError:err];
     
     SwizzlingForwarder *forwarder = [[SwizzlingForwarder alloc]
         initWithTarget:self
@@ -180,7 +180,7 @@ static NSMutableSet<Class>* swizzledClasses;
         else if (appState == UIApplicationStateActive && isVisibleNotification)
             [OSNotificationsManager notificationReceived:userInfo wasOpened:NO];
         else
-            startedBackgroundJob = [OSNotificationsManager receiveRemoteNotification:application UserInfo:userInfo completionHandler:forwarder.hasReceiver ? nil : completionHandler];
+            startedBackgroundJob = [OSNotificationsManager didReceiveRemoteNotification:userInfo completionHandler:forwarder.hasReceiver ? nil : completionHandler];
     }
     
     if (forwarder.hasReceiver) {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UIApplicationDelegate+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UIApplicationDelegate+OneSignalNotifications.m
@@ -169,15 +169,7 @@ static NSMutableSet<Class>* swizzledClasses;
         let appState = [UIApplication sharedApplication].applicationState;
         let isVisibleNotification = userInfo[@"aps"][@"alert"] != nil;
         
-        // iOS 9 - Notification was tapped on
-        // https://medium.com/posts-from-emmerge/ios-push-notification-background-fetch-demystified-7090358bb66e
-        //   - NOTE: We do not have the extra logic for the notifiation center or double tap home button cases
-        //           of "inactive" on notification received the link above describes.
-        //           Omiting that complex logic as iOS 9 usage stats are very low (12/11/2020) and these are rare cases.
-        if ([OSDeviceUtils isIOSVersionLessThan:@"10.0"] && appState == UIApplicationStateInactive && isVisibleNotification) {
-            [OSNotificationsManager notificationReceived:userInfo wasOpened:YES];
-        }
-        else if (appState == UIApplicationStateActive && isVisibleNotification)
+        if (appState == UIApplicationStateActive && isVisibleNotification)
             [OSNotificationsManager notificationReceived:userInfo wasOpened:NO];
         else
             startedBackgroundJob = [OSNotificationsManager processReceivedRemoteNotification:userInfo completionHandler:forwarder.hasReceiver ? nil : completionHandler];

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
@@ -293,7 +293,7 @@ static NSMutableSet<Class>* swizzledClasses;
 
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler: Fired! %@", notification.request.content.body]];
     
-    [OSNotificationsManager handleWillPresentNotificationInForegroundWithPayload:notification.request.content.userInfo withCompletion:^(OSNotification *responseNotif) {
+    [OSNotificationsManager willPresentNotificationWithPayload:notification.request.content.userInfo completion:^(OSNotification *responseNotif) {
         UNNotificationPresentationOptions displayType = responseNotif != nil ? (UNNotificationPresentationOptions)7 : (UNNotificationPresentationOptions)0;
         finishProcessingNotification(notification, center, displayType, completionHandler, self);
     }];
@@ -377,19 +377,7 @@ void finishProcessingNotification(UNNotification *notification,
 }
 
 + (void)processiOS10Open:(UNNotificationResponse*)response {
-    if (![OneSignalConfigManager getAppId])
-        return;
-    
-    if ([OneSignalNotificationsUNUserNotificationCenter isDismissEvent:response])
-        return;
-    
-    if (![OneSignalCoreHelper isOneSignalPayload:response.notification.request.content.userInfo])
-        return;
-    
-    let userInfo = [OneSignalCoreHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo
-                                                      identifier:response.actionIdentifier];
-
-    [OSNotificationsManager notificationReceived:userInfo wasOpened:YES];
+    [OSNotificationsManager didReceiveNotificationResponse:response];
 }
 
 // Calls depercated pre-iOS 10 selector if one is set on the AppDelegate.

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/Categories/UNUserNotificationCenter+OneSignalNotifications.m
@@ -293,7 +293,7 @@ static NSMutableSet<Class>* swizzledClasses;
 
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler: Fired! %@", notification.request.content.body]];
     
-    [OSNotificationsManager willPresentNotificationWithPayload:notification.request.content.userInfo completion:^(OSNotification *responseNotif) {
+    [OSNotificationsManager processWillPresentNotificationWithPayload:notification.request.content.userInfo completion:^(OSNotification *responseNotif) {
         UNNotificationPresentationOptions displayType = responseNotif != nil ? (UNNotificationPresentationOptions)7 : (UNNotificationPresentationOptions)0;
         finishProcessingNotification(notification, center, displayType, completionHandler, self);
     }];
@@ -377,7 +377,7 @@ void finishProcessingNotification(UNNotification *notification,
 }
 
 + (void)processiOS10Open:(UNNotificationResponse*)response {
-    [OSNotificationsManager didReceiveNotificationResponse:response];
+    [OSNotificationsManager processNotificationResponse:response];
 }
 
 // Calls depercated pre-iOS 10 selector if one is set on the AppDelegate.

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -65,6 +65,18 @@ NS_SWIFT_NAME(onClick(event:));
 + (void)addPermissionObserver:(NSObject<OSNotificationPermissionObserver>*_Nonnull)observer NS_REFINED_FOR_SWIFT;
 + (void)removePermissionObserver:(NSObject<OSNotificationPermissionObserver>*_Nonnull)observer NS_REFINED_FOR_SWIFT;
 + (void)clearAll;
+// Manual integration APIs (for use when swizzling is disabled via Info.plist)
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *_Nonnull)deviceToken
+    NS_SWIFT_NAME(didRegisterForRemoteNotifications(deviceToken:));
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *_Nonnull)error
+    NS_SWIFT_NAME(didFailToRegisterForRemoteNotifications(error:));
++ (BOOL)didReceiveRemoteNotification:(NSDictionary *_Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler
+    NS_SWIFT_NAME(didReceiveRemoteNotification(userInfo:completionHandler:));
++ (void)willPresentNotificationWithPayload:(NSDictionary *_Nonnull)payload completion:(OSNotificationDisplayResponse _Nonnull)completion
+    NS_SWIFT_NAME(willPresentNotification(payload:completion:));
++ (void)didReceiveNotificationResponse:(UNNotificationResponse *_Nonnull)response
+    NS_SWIFT_NAME(didReceiveNotificationResponse(_:));
++ (void)setBadgeCount:(NSInteger)badgeCount;
 @end
 
 
@@ -116,10 +128,8 @@ NS_SWIFT_NAME(onClick(event:));
 + (void)handleNotificationActionWithUrl:(NSString* _Nullable)url actionID:(NSString* _Nonnull)actionID;
 + (void)clearBadgeCount:(BOOL)fromNotifOpened fromClearAll:(BOOL)fromClearAll;
 
-+ (BOOL)receiveRemoteNotification:(UIApplication* _Nonnull)application UserInfo:(NSDictionary* _Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
 + (void)notificationReceived:(NSDictionary* _Nonnull)messageDict wasOpened:(BOOL)opened;
-+ (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary * _Nonnull)payload withCompletion:(OSNotificationDisplayResponse _Nonnull)completion;
-+ (void)didRegisterForRemoteNotifications:(UIApplication *_Nonnull)app deviceToken:(NSData *_Nonnull)inDeviceToken;
-+ (void)handleDidFailRegisterForRemoteNotification:(NSError*_Nonnull)err;
 + (void)checkProvisionalAuthorizationStatus;
++ (void)registerLifecycleObserver;
+
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -94,7 +94,7 @@ NS_SWIFT_NAME(onClick(event:));
 @property (class, weak, nonatomic, nullable) id<OneSignalNotificationsDelegate> delegate;
 
 + (Class<OSNotifications> _Nonnull)Notifications;
-+ (void)start;
++ (void)startSwizzling;
 + (void)setColdStartFromTapOnNotification:(BOOL)coldStartFromTapOnNotification;
 + (BOOL)getColdStartFromTapOnNotification;
 

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -131,5 +131,14 @@ NS_SWIFT_NAME(onClick(event:));
 + (void)notificationReceived:(NSDictionary* _Nonnull)messageDict wasOpened:(BOOL)opened;
 + (void)checkProvisionalAuthorizationStatus;
 + (void)registerLifecycleObserver;
++ (BOOL)isSwizzlingDisabled;
+
+// Internal entry points called by swizzled delegate paths
+// These bypass the swizzling-active guard so the SDK doesn't block its own calls
++ (void)processRegisteredDeviceToken:(NSData *_Nonnull)deviceToken;
++ (void)processFailedRemoteNotificationsRegistration:(NSError *_Nonnull)error;
++ (BOOL)processReceivedRemoteNotification:(NSDictionary *_Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
++ (void)processWillPresentNotificationWithPayload:(NSDictionary *_Nonnull)payload completion:(OSNotificationDisplayResponse _Nonnull)completion;
++ (void)processNotificationResponse:(UNNotificationResponse *_Nonnull)response;
 
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.h
@@ -70,7 +70,7 @@ NS_SWIFT_NAME(onClick(event:));
     NS_SWIFT_NAME(didRegisterForRemoteNotifications(deviceToken:));
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *_Nonnull)error
     NS_SWIFT_NAME(didFailToRegisterForRemoteNotifications(error:));
-+ (BOOL)didReceiveRemoteNotification:(NSDictionary *_Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler
++ (void)didReceiveRemoteNotification:(NSDictionary *_Nonnull)userInfo completionHandler:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler
     NS_SWIFT_NAME(didReceiveRemoteNotification(userInfo:completionHandler:));
 + (void)willPresentNotificationWithPayload:(NSDictionary *_Nonnull)payload completion:(OSNotificationDisplayResponse _Nonnull)completion
     NS_SWIFT_NAME(willPresentNotification(payload:completion:));

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -252,9 +252,6 @@ static NSString *_pushSubscriptionId;
         @selector(onesignalSetApplicationIconBadgeNumber:)
     );
     [OneSignalNotificationsUNUserNotificationCenter setup];
-    
-    [self registerLifecycleObserver];
-    
 }
 #pragma clang diagnostic pop
 
@@ -444,8 +441,7 @@ static NSString *_pushSubscriptionId;
     return true;
 }
 
-+ (void)didRegisterForRemoteNotifications:(UIApplication *)app
-                              deviceToken:(NSData *)inDeviceToken {
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)inDeviceToken {
     let parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
 
     [OneSignalLog onesignalLog:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];
@@ -465,7 +461,7 @@ static NSString *_pushSubscriptionId;
     [self sendPushTokenToDelegate];
 }
 
-+ (void)handleDidFailRegisterForRemoteNotification:(NSError*)err {
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError*)err {
     OSNotificationsManager.waitingForApnsResponse = false;
     
     if (err.code == 3000) {
@@ -651,9 +647,10 @@ static NSString *_lastnonActiveMessageId;
     return nil;
 }
 
-+ (void)handleWillPresentNotificationInForegroundWithPayload:(NSDictionary *)payload withCompletion:(OSNotificationDisplayResponse)completion {
++ (void)willPresentNotificationWithPayload:(NSDictionary *)payload completion:(OSNotificationDisplayResponse)completion {
     // check to make sure the app is in focus and it's a OneSignal notification
-    if (![OneSignalCoreHelper isOneSignalPayload:payload]
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil]
+        || ![OneSignalCoreHelper isOneSignalPayload:payload]
         || UIApplication.sharedApplication.applicationState == UIApplicationStateBackground) {
         completion([OSNotification new]);
         return;
@@ -662,10 +659,16 @@ static NSString *_lastnonActiveMessageId;
 
     OSDisplayableNotification *osNotification = [OSDisplayableNotification parseWithApns:payload];
     if ([osNotification additionalData][ONESIGNAL_IAM_PREVIEW]) {
+        [self notificationReceived:payload wasOpened:NO];
         completion(nil);
         return;
     }
-    [self handleWillShowInForegroundForNotification:osNotification completion:completion];
+
+    OSNotificationDisplayResponse wrappedCompletion = ^(OSNotification *notification) {
+        [self notificationReceived:payload wasOpened:NO];
+        completion(notification);
+    };
+    [self handleWillShowInForegroundForNotification:osNotification completion:wrappedCompletion];
 }
 
 + (void)handleWillShowInForegroundForNotification:(OSDisplayableNotification *)notification completion:(OSNotificationDisplayResponse)completion {
@@ -801,19 +804,7 @@ static NSString *_lastnonActiveMessageId;
         return;
     }
     
-    [OneSignalBadgeHelpers updateCachedBadgeValue:0 usePreviousBadgeCount:false];
-    
-    if (@available(iOS 16.0, *)) {
-        [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {
-            if (error) {
-                [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"clearBadgeCount encountered error setting badge count: %@", error]];
-            }
-        }];
-    } else {
-        [OneSignalCoreHelper runOnMainThread:^{
-            [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-        }];
-    }
+    [self setBadgeCount:0];
 }
 
 + (BOOL)handleIAMPreview:(OSNotification *)notification {
@@ -910,7 +901,7 @@ static NSString *_lastnonActiveMessageId;
     _unprocessedClickEvents = [NSMutableArray new];
 }
 
-+ (BOOL)receiveRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
++ (BOOL)didReceiveRemoteNotification:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
    var startedBackgroundJob = false;
    
    NSDictionary* richData = nil;
@@ -929,7 +920,7 @@ static NSString *_lastnonActiveMessageId;
        }
    }
    // Method was called due to a tap on a notification - Fire open notification
-   else if (application.applicationState == UIApplicationStateActive) {
+   else if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
        _lastMessageReceived = userInfo;
 
        if ([OneSignalCoreHelper isDisplayableNotification:userInfo]) {
@@ -1000,6 +991,37 @@ static NSString *_lastnonActiveMessageId;
     let trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:0.25 repeats:NO];
     let identifier = [OneSignalCoreHelper randomStringWithLength:16];
     return [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
+}
+
+#pragma mark - Manual Integration APIs (for use when swizzling is disabled)
+
++ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response {
+    if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
+        return;
+    if (![OneSignalConfigManager getAppId])
+        return;
+    if ([@"com.apple.UNNotificationDismissActionIdentifier" isEqual:response.actionIdentifier])
+        return;
+    if (![OneSignalCoreHelper isOneSignalPayload:response.notification.request.content.userInfo])
+        return;
+    NSDictionary *userInfo = [OneSignalCoreHelper formatApsPayloadIntoStandard:response.notification.request.content.userInfo
+                                                                    identifier:response.actionIdentifier];
+    [self notificationReceived:userInfo wasOpened:YES];
+}
+
++ (void)setBadgeCount:(NSInteger)badgeCount {
+    [OneSignalBadgeHelpers updateCachedBadgeValue:badgeCount usePreviousBadgeCount:false];
+    if (@available(iOS 16.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:badgeCount withCompletionHandler:^(NSError * _Nullable error) {
+            if (error) {
+                [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"setBadgeCount encountered error setting badge count: %@", error]];
+            }
+        }];
+    } else {
+        [OneSignalCoreHelper runOnMainThread:^{
+            [UIApplication sharedApplication].applicationIconBadgeNumber = badgeCount;
+        }];
+    }
 }
 
 - (void)dealloc {

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -162,13 +162,12 @@ static UIBackgroundTaskIdentifier _mediaBackgroundTask;
 static BOOL _disableBadgeClearing = NO;
 
 + (BOOL)isSwizzlingDisabled {
-    static BOOL _cached = NO;
     static BOOL _disabled = NO;
-    if (!_cached) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         id plistValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_SWIZZLING];
         _disabled = plistValue != nil && [plistValue boolValue];
-        _cached = YES;
-    }
+    });
     return _disabled;
 }
 
@@ -245,7 +244,7 @@ static NSString *_pushSubscriptionId;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-+ (void)start {
++ (void)startSwizzling {
     // Swizzle - UIApplication delegate
     //TODO: do the equivalent in the notificaitons module
     injectSelector(

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -161,6 +161,16 @@ static NSString *_lastMessageIdFromAction;
 static UIBackgroundTaskIdentifier _mediaBackgroundTask;
 static BOOL _disableBadgeClearing = NO;
 
++ (BOOL)isSwizzlingDisabled {
+    static BOOL _cached = NO;
+    static BOOL _disabled = NO;
+    if (!_cached) {
+        id plistValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_SWIZZLING];
+        _disabled = plistValue != nil && [plistValue boolValue];
+        _cached = YES;
+    }
+    return _disabled;
+}
 
 static BOOL _coldStartFromTapOnNotification = NO;
 // Set to false as soon as it's read.
@@ -441,8 +451,16 @@ static NSString *_pushSubscriptionId;
     return true;
 }
 
-+ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)inDeviceToken {
-    let parsedDeviceToken = [NSString hexStringFromData:inDeviceToken];
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    if (![self isSwizzlingDisabled]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal: didRegisterForRemoteNotificationsWithDeviceToken: ignored because swizzling is active. Remove the manual call or set OneSignal_disable_swizzling to true in Info.plist."];
+        return;
+    }
+    [self processRegisteredDeviceToken:deviceToken];
+}
+
++ (void)processRegisteredDeviceToken:(NSData *)deviceToken {
+    let parsedDeviceToken = [NSString hexStringFromData:deviceToken];
 
     [OneSignalLog onesignalLog:ONE_S_LL_INFO message: [NSString stringWithFormat:@"Device Registered with Apple: %@", parsedDeviceToken]];
 
@@ -462,6 +480,14 @@ static NSString *_pushSubscriptionId;
 }
 
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError*)err {
+    if (![self isSwizzlingDisabled]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal: didFailToRegisterForRemoteNotificationsWithError: ignored because swizzling is active. Remove the manual call or set OneSignal_disable_swizzling to true in Info.plist."];
+        return;
+    }
+    [self processFailedRemoteNotificationsRegistration:err];
+}
+
++ (void)processFailedRemoteNotificationsRegistration:(NSError*)err {
     OSNotificationsManager.waitingForApnsResponse = false;
     
     if (err.code == 3000) {
@@ -648,6 +674,15 @@ static NSString *_lastnonActiveMessageId;
 }
 
 + (void)willPresentNotificationWithPayload:(NSDictionary *)payload completion:(OSNotificationDisplayResponse)completion {
+    if (![self isSwizzlingDisabled]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal: willPresentNotificationWithPayload:completion: ignored because swizzling is active. Remove the manual call or set OneSignal_disable_swizzling to true in Info.plist."];
+        completion([OSNotification new]);
+        return;
+    }
+    [self processWillPresentNotificationWithPayload:payload completion:completion];
+}
+
++ (void)processWillPresentNotificationWithPayload:(NSDictionary *)payload completion:(OSNotificationDisplayResponse)completion {
     // check to make sure the app is in focus and it's a OneSignal notification
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil]
         || ![OneSignalCoreHelper isOneSignalPayload:payload]
@@ -902,6 +937,14 @@ static NSString *_lastnonActiveMessageId;
 }
 
 + (BOOL)didReceiveRemoteNotification:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    if (![self isSwizzlingDisabled]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal: didReceiveRemoteNotification:completionHandler: ignored because swizzling is active. Remove the manual call or set OneSignal_disable_swizzling to true in Info.plist."];
+        return NO;
+    }
+    return [self processReceivedRemoteNotification:userInfo completionHandler:completionHandler];
+}
+
++ (BOOL)processReceivedRemoteNotification:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
    var startedBackgroundJob = false;
    
    NSDictionary* richData = nil;
@@ -996,6 +1039,14 @@ static NSString *_lastnonActiveMessageId;
 #pragma mark - Manual Integration APIs (for use when swizzling is disabled)
 
 + (void)didReceiveNotificationResponse:(UNNotificationResponse *)response {
+    if (![self isSwizzlingDisabled]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal: didReceiveNotificationResponse: ignored because swizzling is active. Remove the manual call or set OneSignal_disable_swizzling to true in Info.plist."];
+        return;
+    }
+    [self processNotificationResponse:response];
+}
+
++ (void)processNotificationResponse:(UNNotificationResponse *)response {
     if ([OSPrivacyConsentController shouldLogMissingPrivacyConsentErrorWithMethodName:nil])
         return;
     if (![OneSignalConfigManager getAppId])

--- a/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotifications/OSNotificationsManager.m
@@ -935,17 +935,18 @@ static NSString *_lastnonActiveMessageId;
     _unprocessedClickEvents = [NSMutableArray new];
 }
 
-+ (BOOL)didReceiveRemoteNotification:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
++ (void)didReceiveRemoteNotification:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     if (![self isSwizzlingDisabled]) {
         [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal: didReceiveRemoteNotification:completionHandler: ignored because swizzling is active. Remove the manual call or set OneSignal_disable_swizzling to true in Info.plist."];
-        return NO;
+        return;
     }
-    return [self processReceivedRemoteNotification:userInfo completionHandler:completionHandler];
+    BOOL startedBackgroundJob = [self processReceivedRemoteNotification:userInfo completionHandler:completionHandler];
+    if (!startedBackgroundJob) {
+        completionHandler(UIBackgroundFetchResultNewData);
+    }
 }
 
 + (BOOL)processReceivedRemoteNotification:(NSDictionary*)userInfo completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
-   var startedBackgroundJob = false;
-   
    NSDictionary* richData = nil;
    // TODO: Look into why the userInfo payload would be different here for displaying vs opening....
    // Check for buttons or attachments pre-2.4.0 version
@@ -955,11 +956,8 @@ static NSString *_lastnonActiveMessageId;
    // Generate local notification for action button and/or attachments.
    if (richData) {
        let osNotification = [OSNotification parseWithApns:userInfo];
-       
-       if ([OSDeviceUtils isIOSVersionGreaterThanOrEqual:@"10.0"]) {
-           startedBackgroundJob = true;
-           [self addNotificationRequest:osNotification completionHandler:completionHandler];
-       }
+       [self addNotificationRequest:osNotification completionHandler:completionHandler];
+       return YES;
    }
    // Method was called due to a tap on a notification - Fire open notification
    else if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
@@ -968,14 +966,13 @@ static NSString *_lastnonActiveMessageId;
        if ([OneSignalCoreHelper isDisplayableNotification:userInfo]) {
             [self notificationReceived:userInfo wasOpened:YES];
        }
-       return startedBackgroundJob;
    }
    // content-available notification received in the background
    else {
        _lastMessageReceived = userInfo;
    }
-   
-   return startedBackgroundJob;
+
+   return NO;
 }
 
 + (void)addNotificationRequest:(OSNotification*)notification

--- a/iOS_SDK/OneSignalSDK/OneSignalNotificationsTests/OneSignalNotificationsTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalNotificationsTests/OneSignalNotificationsTests.swift
@@ -63,7 +63,7 @@ final class OneSignalNotificationsTests: XCTestCase {
 
     func testClearBadgesWhenAppEntersForeground() throws {
         // NotificationManager Start to register lifecycle listener
-        OSNotificationsManager.start()
+        OSNotificationsManager.startSwizzling()
         // Set badge count > 0
         let expectation = self.expectation(description: "Badge set")
         setBadgeCount(1) {
@@ -88,7 +88,7 @@ final class OneSignalNotificationsTests: XCTestCase {
 
     func testDontclearBadgesWhenAppBecomesActive() throws {
         // NotificationManager Start to register lifecycle listener
-        OSNotificationsManager.start()
+        OSNotificationsManager.startSwizzling()
         // Set badge count > 0
         let expectation = self.expectation(description: "Badge set")
         setBadgeCount(1) {
@@ -113,7 +113,7 @@ final class OneSignalNotificationsTests: XCTestCase {
 
     func testUpdateNotificationTypesOnAppEntersForeground() throws {
         // NotificationManager Start to register lifecycle listener
-        OSNotificationsManager.start()
+        OSNotificationsManager.startSwizzling()
 
         OSNotificationsManager.delegate = self
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -749,9 +749,11 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
 #pragma clang diagnostic ignored "-Wincomplete-implementation"
 @implementation UIApplication (OneSignal)
 + (void)load {
+    [OSDialogInstanceManager setSharedOSDialogInstance:[OneSignalDialogController sharedInstance]];
+    [OSNotificationsManager registerLifecycleObserver];
     
-    if ([self shouldDisableBasedOnProcessArguments]) {
-        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal method swizzling is disabled. Make sure the feature is enabled for production."];
+    if ([self shouldDisableSwizzling]) {
+        [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal method swizzling is disabled via Info.plist. Developers must manually forward notification delegate methods to OneSignal."];
         return;
     }
     [OneSignalLog onesignalLog:ONE_S_LL_VERBOSE message:@"UIApplication(OneSignal) LOADED!"];
@@ -784,8 +786,6 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     [[OSMigrationController new] migrate];
 //    sessionLaunchTime = [NSDate date];
     // TODO: sessionLaunchTime used to always be set in load
-    
-    [OSDialogInstanceManager setSharedOSDialogInstance:[OneSignalDialogController sharedInstance]];
 }
 
 /*
@@ -797,8 +797,9 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     [self onesignalSetApplicationIconBadgeNumber:badge];
 }
 
-+(BOOL) shouldDisableBasedOnProcessArguments {
-    if ([NSProcessInfo.processInfo.arguments containsObject:@"DISABLE_ONESIGNAL_SWIZZLING"]) {
++ (BOOL)shouldDisableSwizzling {
+    id plistValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_SWIZZLING];
+    if (plistValue != nil && [plistValue boolValue]) {
         return YES;
     }
     return NO;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -752,7 +752,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     [OSDialogInstanceManager setSharedOSDialogInstance:[OneSignalDialogController sharedInstance]];
     [OSNotificationsManager registerLifecycleObserver];
     
-    if ([self shouldDisableSwizzling]) {
+    if ([OSNotificationsManager isSwizzlingDisabled]) {
         [OneSignalLog onesignalLog:ONE_S_LL_WARN message:@"OneSignal method swizzling is disabled via Info.plist. Developers must manually forward notification delegate methods to OneSignal."];
         return;
     }
@@ -797,13 +797,6 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     [self onesignalSetApplicationIconBadgeNumber:badge];
 }
 
-+ (BOOL)shouldDisableSwizzling {
-    id plistValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:ONESIGNAL_DISABLE_SWIZZLING];
-    if (plistValue != nil && [plistValue boolValue]) {
-        return YES;
-    }
-    return NO;
-}
 @end
 
 #pragma clang diagnostic pop

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -781,7 +781,7 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
         return;
     }
 
-    [OSNotificationsManager start];
+    [OSNotificationsManager startSwizzling];
 
     [[OSMigrationController new] migrate];
 //    sessionLaunchTime = [NSDate date];

--- a/iOS_SDK/OneSignalSwiftUIExample/OneSignalSwiftUIExample/App/OneSignalSwiftUIExampleApp.swift
+++ b/iOS_SDK/OneSignalSwiftUIExample/OneSignalSwiftUIExample/App/OneSignalSwiftUIExampleApp.swift
@@ -26,6 +26,7 @@
  */
 
 import SwiftUI
+import UserNotifications
 import OneSignalFramework
 
 @main
@@ -47,7 +48,7 @@ struct OneSignalSwiftUIExampleApp: App {
 
 // MARK: - App Delegate
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     // Keys for caching SDK state in UserDefaults
     private let cachedIAMPausedKey = "CachedInAppMessagesPaused"
@@ -59,6 +60,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+
         // Set consent required before init (must be set before initWithContext)
         let consentRequired = UserDefaults.standard.bool(forKey: cachedConsentRequiredKey)
         let privacyConsent = UserDefaults.standard.bool(forKey: cachedPrivacyConsentKey)
@@ -89,6 +92,49 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         TooltipService.shared.initialize()
 
         return true
+    }
+
+    // MARK: - Manual Integration APIs (for use when swizzling is disabled)
+
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        OneSignal.Notifications.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+    }
+
+    func application(_ application: UIApplication,
+                     didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        OneSignal.Notifications.didFailToRegisterForRemoteNotifications(error: error as NSError)
+    }
+
+    func application(_ application: UIApplication,
+                     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        OneSignal.Notifications.didReceiveRemoteNotification(userInfo: userInfo,
+                                                             completionHandler: completionHandler)
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        OneSignal.Notifications.willPresentNotification(
+            payload: notification.request.content.userInfo) { notif in
+                if notif != nil {
+                    if #available(iOS 14.0, *) {
+                        completionHandler([.banner, .list, .sound])
+                    } else {
+                        completionHandler([.alert, .sound])
+                    }
+                } else {
+                    completionHandler([])
+                }
+            }
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        OneSignal.Notifications.didReceiveNotificationResponse(response)
+        completionHandler()
     }
 
     private func setupLogListener() {

--- a/iOS_SDK/OneSignalSwiftUIExample/OneSignalSwiftUIExample/Info.plist
+++ b/iOS_SDK/OneSignalSwiftUIExample/OneSignalSwiftUIExample/Info.plist
@@ -54,5 +54,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>OneSignal_disable_swizzling</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
# Description
## One Line Summary
Add option to disable swizzling and add manual integration APIs, when disabled.

## Details

### Motivation
Allow disabling swizzling for developers to have more control over notification delegate methods.

### New Manual Integration APIs

If swizzling is enabled but the new forwarding APIs are used, those APIs would no-op and log a warning.

All new manual integration APIs are called on the `OneSignal.Notifications namespace`:


|Objective-C | Swift (NS_SWIFT_NAME) | Purpose|
|-- | -- | --|
|didRegisterForRemoteNotificationsWithDeviceToken: | didRegisterForRemoteNotifications(deviceToken:) | Forward APNs token|
|didFailToRegisterForRemoteNotificationsWithError: | didFailToRegisterForRemoteNotifications(error:) | Forward registration failure|
|didReceiveRemoteNotification:completionHandler: | didReceiveRemoteNotification(userInfo:completionHandler:) | Forward background/silent notification|
|willPresentNotificationWithPayload:completion: | willPresentNotification(payload:completion:) | Forward foreground notification|
|didReceiveNotificationResponse: | didReceiveNotificationResponse(_:) | Forward tap/action
setBadgeCount: | setBadgeCount(_:) | Set badge count|

### How to test
Commit [dev app: setup to test swizzle disabled](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1650/commits/3e444886ad40f7301fb140b42129d9ae18a12882) is setup to allow testing

### Scope
Swizzling disable option

# Testing
## Unit testing
None

## Manual testing
iPhone on iOS 26.3 with sizzling disabled via Info.plist for:
- init, APNS token, notification displays, listeners, click handling, permissions, badge count, NSE, etc

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-iOS-SDK/1650)
<!-- Reviewable:end -->
