### PR TITLE
fix: update unattributed outcomes to match attributed outcomes and Android SDK

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
@@ -61,11 +61,8 @@ static let DELAY_TIME = 30;
     let totalTimeActive = unsentActive + params.timeElapsed;
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG
                      message:[NSString stringWithFormat:@"sendOnFocusCall attributed with totalTimeActive %f", totalTimeActive]];
-    
+
     [super saveUnsentActiveTime:totalTimeActive];
-    
-    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSAttributedFocusTimeProcessor:sendSessionTime of %@", @(params.timeElapsed)]];
-    [OneSignalUserManagerImpl.sharedInstance sendSessionTime:@(params.timeElapsed)];
 
     [self sendOnFocusCallWithParams:params totalTimeActive:totalTimeActive];
 }
@@ -109,6 +106,9 @@ static let DELAY_TIME = 30;
 
 - (void)sendBackgroundAttributedSessionTimeWithParams:(OSFocusCallParams *)params withTotalTimeActive:(NSNumber*)totalTimeActive {
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"OSAttributedFocusTimeProcessor:sendBackgroundAttributedSessionTimeWithParams start"];
+
+    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSAttributedFocusTimeProcessor:sendSessionTime of %@", totalTimeActive]];
+    [OneSignalUserManagerImpl.sharedInstance sendSessionTime:totalTimeActive];
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [OneSignal sendSessionEndOutcomes:totalTimeActive params:params onSuccess:^(NSDictionary *result) {

--- a/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSAttributedFocusTimeProcessor.m
@@ -39,17 +39,12 @@
     NSTimer* restCallTimer;
 }
 
-static let ATTRIBUTED_MIN_SESSION_TIME_SEC = 1;
 static let DELAY_TIME = 30;
 
 - (instancetype)init {
     self = [super init];
     [OSBackgroundTaskManager setTaskInvalid:SESSION_OUTCOMES_TASK];
     return self;
-}
-
-- (int)getMinSessionTime {
-    return ATTRIBUTED_MIN_SESSION_TIME_SEC;
 }
 
 - (NSString*)unsentActiveTimeUserDefaultsKey {

--- a/iOS_SDK/OneSignalSDK/Source/OSBaseFocusTimeProcessor.h
+++ b/iOS_SDK/OneSignalSDK/Source/OSBaseFocusTimeProcessor.h
@@ -34,9 +34,7 @@
 
 @property (nonatomic, readonly) BOOL onFocusCallEnabled;
 
-- (int)getMinSessionTime;
 - (NSString*)unsentActiveTimeUserDefaultsKey;
-- (BOOL)hasMinSyncTime:(NSTimeInterval)activeTime;
 
 - (void)resetUnsentActiveTime;
 - (void)sendOnFocusCall:(OSFocusCallParams *)params;

--- a/iOS_SDK/OneSignalSDK/Source/OSBaseFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSBaseFocusTimeProcessor.m
@@ -33,17 +33,6 @@
     NSNumber* unsentActiveTime;
 }
 
-// Must override
-- (int)getMinSessionTime {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-      reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)] userInfo:nil];
-}
-
-- (BOOL)hasMinSyncTime:(NSTimeInterval)activeTime {
-    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSBaseFocusTimeProcessor hasMinSyncTime getMinSessionTime: %d activeTime: %f", [self getMinSessionTime], activeTime]];
-    return activeTime >= [self getMinSessionTime];
-}
-
 - (void)resetUnsentActiveTime {
     unsentActiveTime = nil;
 }

--- a/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
@@ -36,9 +36,12 @@
 + (void)sendSessionEndOutcomes:(NSNumber*)totalTimeActive params:(OSFocusCallParams *)params onSuccess:(OSResultSuccessBlock _Nonnull)successBlock onFailure:(OSFailureBlock _Nonnull)failureBlock;
 @end
 
-@implementation OSUnattributedFocusTimeProcessor
+@implementation OSUnattributedFocusTimeProcessor {
+    NSTimer* restCallTimer;
+}
 
-static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 60;
+static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 1;
+static let DELAY_TIME = 30;
 
 - (instancetype)init {
     self = [super init];
@@ -57,12 +60,12 @@ static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 60;
 - (void)sendOnFocusCall:(OSFocusCallParams *)params {
     let unsentActive = [super getUnsentActiveTime];
     let totalTimeActive = unsentActive + params.timeElapsed;
-    
+
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"sendOnFocusCall unattributed with totalTimeActive %f", totalTimeActive]];
-    
+
+    [super saveUnsentActiveTime:totalTimeActive];
+
     if (![super hasMinSyncTime:totalTimeActive]) {
-        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"unattributed influence saveUnsentActiveTime %f", totalTimeActive]];
-        [super saveUnsentActiveTime:totalTimeActive];
         return;
     }
 
@@ -72,31 +75,59 @@ static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 60;
 - (void)sendUnsentActiveTime:(OSFocusCallParams *)params {
     let unsentActive = [super getUnsentActiveTime];
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"sendUnsentActiveTime unattributed with unsentActive %f", unsentActive]];
-    
+
     [self sendOnFocusCallWithParams:params totalTimeActive:unsentActive];
 }
 
 - (void)sendOnFocusCallWithParams:(OSFocusCallParams *)params totalTimeActive:(NSTimeInterval)totalTimeActive {
-    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSUnattributedFocusTimeProcessor:sendSessionTime of %@", @(totalTimeActive)]];
-    [OneSignalUserManagerImpl.sharedInstance sendSessionTime:@(totalTimeActive)];
-    [super saveUnsentActiveTime:0];
-
     [OSBackgroundTaskManager beginBackgroundTask:SESSION_OUTCOMES_TASK];
+
+    if (params.onSessionEnded) {
+        [self sendBackgroundUnattributedSessionTimeWithParams:params withTotalTimeActive:@(totalTimeActive)];
+        return;
+    }
+
+    restCallTimer = [NSTimer
+        scheduledTimerWithTimeInterval:DELAY_TIME
+                               target:self
+                             selector:@selector(sendBackgroundUnattributedSessionTimeWithNSTimer:)
+                             userInfo:@{@"params": params, @"time": @(totalTimeActive)}
+                              repeats:false];
+}
+
+- (void)sendBackgroundUnattributedSessionTimeWithNSTimer:(NSTimer*)timer {
+    let userInfo = (NSDictionary<NSString*, id>*)timer.userInfo;
+    let params = (OSFocusCallParams*)userInfo[@"params"];
+    let totalTimeActive = (NSNumber*)userInfo[@"time"];
+    [self sendBackgroundUnattributedSessionTimeWithParams:params withTotalTimeActive:totalTimeActive];
+}
+
+- (void)sendBackgroundUnattributedSessionTimeWithParams:(OSFocusCallParams *)params withTotalTimeActive:(NSNumber*)totalTimeActive {
+    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"OSUnattributedFocusTimeProcessor:sendBackgroundUnattributedSessionTimeWithParams start"];
+
+    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OSUnattributedFocusTimeProcessor:sendSessionTime of %@", totalTimeActive]];
+    [OneSignalUserManagerImpl.sharedInstance sendSessionTime:totalTimeActive];
+
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [OneSignal sendSessionEndOutcomes:@(totalTimeActive) params:params onSuccess:^(NSDictionary *result) {
+        [OneSignal sendSessionEndOutcomes:totalTimeActive params:params onSuccess:^(NSDictionary *result) {
             [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"sendUnattributed session end outcomes succeed"];
+            [super saveUnsentActiveTime:0];
             [OSBackgroundTaskManager endBackgroundTask:SESSION_OUTCOMES_TASK];
         } onFailure:^(NSError *error) {
-            [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"sendUnattributed session end outcomes failed"];
+            [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:@"sendUnattributed session end outcomes failed, will retry on next open"];
             [OSBackgroundTaskManager endBackgroundTask:SESSION_OUTCOMES_TASK];
         }];
     });
 }
 
 - (void)cancelDelayedJob {
-    // No job to cancel, network call is made right away.
-}
+    if (!restCallTimer)
+        return;
 
+    [restCallTimer invalidate];
+    restCallTimer = nil;
+    [OSBackgroundTaskManager endBackgroundTask:SESSION_OUTCOMES_TASK];
+}
 
 @end
 

--- a/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
+++ b/iOS_SDK/OneSignalSDK/Source/OSUnattributedFocusTimeProcessor.m
@@ -40,17 +40,12 @@
     NSTimer* restCallTimer;
 }
 
-static let UNATTRIBUTED_MIN_SESSION_TIME_SEC = 1;
 static let DELAY_TIME = 30;
 
 - (instancetype)init {
     self = [super init];
     [OSBackgroundTaskManager setTaskInvalid:SESSION_OUTCOMES_TASK];
     return self;
-}
-
-- (int)getMinSessionTime {
-    return UNATTRIBUTED_MIN_SESSION_TIME_SEC;
 }
 
 - (NSString*)unsentActiveTimeUserDefaultsKey {
@@ -65,10 +60,6 @@ static let DELAY_TIME = 30;
 
     [super saveUnsentActiveTime:totalTimeActive];
 
-    if (![super hasMinSyncTime:totalTimeActive]) {
-        return;
-    }
-
     [self sendOnFocusCallWithParams:params totalTimeActive:totalTimeActive];
 }
 
@@ -80,6 +71,11 @@ static let DELAY_TIME = 30;
 }
 
 - (void)sendOnFocusCallWithParams:(OSFocusCallParams *)params totalTimeActive:(NSTimeInterval)totalTimeActive {
+    if (totalTimeActive < 1) {
+        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"sendSessionEndOutcomes not sending active time %f", totalTimeActive]];
+        return;
+    }
+    
     [OSBackgroundTaskManager beginBackgroundTask:SESSION_OUTCOMES_TASK];
 
     if (params.onSessionEnded) {


### PR DESCRIPTION
# Description
## One Line Summary
Align iOS session duration reporting (both attributed and unattributed) with Android SDK behavior by deferring all sends behind a 30-second timer.

## Details

### Motivation
Previously, attributed and unattributed session processors behaved differently:
- **Attributed**: Sent session time to Update User on every background event with just the current interval, and deferred the `outcomes/measure` call behind a 30-second timer. This is so the outcome event only sends at the end of a session rather than on every background.
- **Unattributed**: Required 60 seconds of accumulated time before sending anything, then sent the session time to Update User (with the full total) and the `outcomes/measure` call immediately with no delay. This means outcomes can be sent multiple times for a single session. Analytics would be overcounted for unattributed session counts.

This caused inconsistency between attribution types and also it diverged from the Android SDK, which uses a single model: send both the user property update and the outcomes call together once after a 30-second timer confirms the user has left the app, with no minimum accumulation time required.

### Scope
**What changed:**

`OSUnattributedFocusTimeProcessor`:
- Added a 30-second `NSTimer` delay before sending to `outcomes/measure` (matching attributed)
- Sends immediately (no delay) when a session ends via influence change (`onSessionEnded`)
- Implemented `cancelDelayedJob` to invalidate the timer when the user returns to foreground within 30 seconds
- Moved `sendSessionTime` from `sendOnFocusCall:` to the final send method, so it fires once with the full accumulated total (not on every background)
- Removed the 60-second minimum accumulation threshold
- Unsent time is now only cleared on outcomes success (retried on next open if it fails)

`OSAttributedFocusTimeProcessor`:
- Moved `sendSessionTime` from `sendOnFocusCall:` to `sendBackgroundAttributedSessionTimeWithParams:`, so it fires once with the full accumulated total when the 30-second timer fires or the session ends

### Resulting behavior (same for both attributed and unattributed)
1. User backgrounds the app → time interval is accumulated and persisted, no network calls
2. If user returns within 30 seconds → timer is cancelled, accumulation continues on next background
3. If 30 seconds pass in background → both `sendSessionTime` (user property update) and `outcomes/measure` are sent together with the full accumulated session total
4. If session ends due to influence change → both calls are sent immediately with the full accumulated total

# Testing
## Unit testing

## Manual testing
Tested attributed and unattributed session flows by foregrounding/backgrounding the app and verifying:
- No network calls on background events within 30 seconds
- Both `sendSessionTime` and `outcomes/measure` fire together after 30 seconds with the correct accumulated total
- Timer is cancelled and no calls are made when returning within 30 seconds
- Immediate send when session ends due to influence change

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [x] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
