### PR TITLE
fix(iam): enable inline media playback in WKWebView for in-app messages

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageView.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/UI/OSInAppMessageView.m
@@ -95,6 +95,8 @@
 
 - (void)setupWebviewWithMessageHandler:(id<WKScriptMessageHandler>)handler {
     let configuration = [WKWebViewConfiguration new];
+    configuration.allowsInlineMediaPlayback = YES;
+    configuration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
     [configuration.userContentController addScriptMessageHandler:handler name:@"iosListener"];
     
     CGFloat marginSpacing = [OneSignalCoreHelper sizeToScale:MESSAGE_MARGIN];


### PR DESCRIPTION
## Summary

HTML `<video>` elements inside in-app messages always open in fullscreen native player on iOS, even when `playsinline` attribute is set. This happens because `WKWebViewConfiguration.allowsInlineMediaPlayback` defaults to `NO` on iOS, and it is not being set during WebView initialization in `OSInAppMessageView`.

This PR adds two configuration lines to the `setupWebviewWithMessageHandler:` method:

```objc
configuration.allowsInlineMediaPlayback = YES;
configuration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
```

## Problem

When an in-app message contains a `<video playsinline>` tag:
1. User taps play
2. iOS opens the native fullscreen video player **on top** of the in-app message WebView
3. A black screen appears while audio plays behind it
4. The user cannot see the video content

This was confirmed to work correctly on Android (where `WebView` allows inline playback by default) but fails on all iOS devices regardless of HTML attributes used (`playsinline`, `webkit-playsinline`, `x-webkit-airplay="deny"`, etc.).

## Root Cause

In `OSInAppMessageView.m`, the `WKWebViewConfiguration` is created without setting `allowsInlineMediaPlayback`. Per [Apple's documentation](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1614793-allowsinlinemediaplayback), this property defaults to `NO` on iPhone. When it is `NO`, the HTML `playsinline` attribute is completely ignored by WKWebView.

## Changes

- Set `allowsInlineMediaPlayback = YES` so HTML5 videos can play inline within in-app messages
- Set `mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone` to allow media playback without requiring additional user interaction beyond the initial tap

## Testing

Tested with a OneSignal in-app message containing an HTML5 video player:
- **Before fix (iOS)**: Video opens fullscreen native player, black screen, audio plays behind
- **After fix (iOS)**: Video plays inline within the in-app message as expected
- **Android**: Already works correctly (no changes needed)