### PR TITLE
fix: prevent stale FetchUser from clobbering the current user's identity

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSUserExecutor.swift
@@ -448,6 +448,12 @@ extension OSUserExecutor {
         OneSignalCoreImpl.sharedClient().execute(request) { response in
             self.removeFromQueue(request)
 
+            // A fetch for a user that is no longer current is stale
+            guard OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel) else {
+                self.executePendingRequests()
+                return
+            }
+
             if let response = response {
                 // Clear local data in preparation for hydration
                 OneSignalUserManagerImpl.sharedInstance.clearUserData()
@@ -455,7 +461,6 @@ extension OSUserExecutor {
 
                 // If this is a on-new-session's fetch user call, check that the subscription still exists
                 if request.onNewSession,
-                   OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel),
                    let subId = OneSignalUserManagerImpl.sharedInstance.pushSubscriptionModel?.subscriptionId,
                    let subscriptionObjects = self.parseSubscriptionObjectResponse(response) {
                     var subscriptionExists = false

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/UserExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/UserExecutorTests.swift
@@ -187,4 +187,61 @@ final class UserExecutorTests: XCTestCase {
         XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestCreateUser.self))
         XCTAssertTrue(mocks.newRecordsState.records.isEmpty)
     }
+
+    /**
+     Regression test for a login race that landed identity (and subsequent user updates) data on the wrong user.
+
+     When an on-new-session Fetch User request for a *previous* user (e.g. a cached anonymous user) is still
+     pending and a `login()` switches the current user, the in-flight Fetch User must NOT clear the new current
+     user's data.
+     */
+    func testFetchUser_forNonCurrentUser_doesNotClearCurrentUserData() {
+        /* Setup */
+        let mocks = Mocks()
+
+        // The current user has just logged in with an external_id (userB).
+        let currentUser = OneSignalUserMocks.setUserManagerInternalUser(externalId: userB_EUID, onesignalId: userB_OSID)
+
+        // A stale on-new-session Fetch User is in flight for a different, no-longer-current user (userA),
+        // and its response only carries an onesignal_id (as an anonymous user's would).
+        let staleIdentityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: userA_OSID], changeNotifier: OSEventProducer())
+        mocks.client.setMockResponseForRequest(
+            request: "<OSRequestFetchUser with onesignal_id: \(userA_OSID)>",
+            response: MockUserRequests.testIdentityPayload(onesignalId: userA_OSID, externalId: nil)
+        )
+
+        /* When */
+        mocks.userExecutor.fetchUser(aliasLabel: OS_ONESIGNAL_ID, aliasId: userA_OSID, identityModel: staleIdentityModel, onNewSession: true)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestFetchUser.self))
+        // The current user's external_id must be intact — the stale fetch must not have cleared it.
+        XCTAssertEqual(currentUser.identityModel.externalId, userB_EUID)
+        XCTAssertEqual(OneSignalUserManagerImpl.sharedInstance._user?.identityModel.externalId, userB_EUID)
+    }
+
+    /**
+     The normal new-session Fetch User for the *current* user must still clear stale local data before hydrating
+     from the response, so the `isCurrentUser` guard added for the race above does not regress the common path.
+     */
+    func testFetchUser_forCurrentUser_stillClearsStaleData() {
+        /* Setup */
+        let mocks = Mocks()
+        let currentUser = OneSignalUserMocks.setUserManagerInternalUser(externalId: userA_EUID, onesignalId: userA_OSID)
+        // A stale local alias that is not present in the server response and should be cleared by the fetch.
+        currentUser.identityModel.addAliases(["stale_label": "stale_value"])
+
+        MockUserRequests.setDefaultFetchUserResponseForHydration(with: mocks.client, externalId: userA_EUID)
+
+        /* When */
+        mocks.userExecutor.fetchUser(aliasLabel: OS_ONESIGNAL_ID, aliasId: userA_OSID, identityModel: currentUser.identityModel, onNewSession: false)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* Then */
+        XCTAssertTrue(mocks.client.hasExecutedRequestOfType(OSRequestFetchUser.self))
+        // clearUserData() ran for the current user: the stale alias is gone and server aliases are hydrated.
+        XCTAssertNil(currentUser.identityModel.aliases["stale_label"])
+        XCTAssertEqual(currentUser.identityModel.externalId, userA_EUID)
+    }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Stop a stale Fetch User call from clearing the current user's data, which was dropping the `external_id` set by `login()` and orphaning subsequent properties updates on that user.

## Details

### Motivation
Reported by a customer who added the SDK in an app update, then called `login` + `addEmail`, and sometimes the emails landed on the wrong anonymous user and the login silently failed.

Root cause is an ordering race in `OSUserExecutor`: when an on-new-session `OSRequestFetchUser` for a previous user (a cached anonymous user) is still pending and `login()` switches the current user, the in-flight Fetch User's success handler called `clearUserData()` unconditionally, wiping the `external_id` that `login()` had just set on the new current user. The following user-2 (409) conflict recovery then built an `OSRequestCreateUser` with `external_id: nil`, minting a stray anonymous user and dropping the login.

#1669 (the prewarm fix) makes this reproduction now very hard to hit (by deferring user creation until after first unlock it restores the normal launch ordering where no on-new-session Fetch User races ahead of login) but it does address the root issue. The stale-fetch clobber still occurs any time a Fetch User is pending ahead of a login()-driven request (e.g. a programmatic login() right after initialize, or slow network), no prewarm required.

### Scope
- `executeFetchUserRequest` now early-returns when the fetched user is no longer the current user, which is safe, a stale response is discarded rather than clearing/hydrating the now-current user.
- `parseFetchUserResponse` is unchanged, as it is also used by the Create User path that remains unaffected.
- No public API changes.

# Testing
## Unit testing
Added two regression tests in `UserExecutorTests`:
- `testFetchUser_forNonCurrentUser_doesNotClearCurrentUserData` — a stale fetch must not clear the current user (fails before this fix, passes after).
- `testFetchUser_forCurrentUser_stillClearsStaleData` — the normal current-user fetch still clears + hydrates.

Full `UserExecutorTests` and `SwitchUserIntegrationTests` pass.

## Manual testing
The original bug was captured in repro logs (FetchUser running ahead of IdentifyUser → `CreateUser with external_id: nil`). The race is now reproduced deterministically by the unit test above; reproducing the prewarm-triggered timing reliably on-device is impractical.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
