### PR TITLE
fix: [SDK-4757] recover startup when initialized before UIApplicationMain

### DIFF
--- a/examples/demo/App/App.swift
+++ b/examples/demo/App/App.swift
@@ -31,9 +31,22 @@ import OneSignalLiveActivities
 
 @main
 struct App: SwiftUI.App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var viewModel = OneSignalViewModel()
     @StateObject private var toastPresenter = ToastPresenter()
+
+    // REPRO SDK-4757: pure SwiftUI lifecycle (no AppDelegate), initialize in App.init()
+    // like the reporter's app. Revert to the @UIApplicationDelegateAdaptor version after.
+    init() {
+        let sharedApp = UIApplication
+            .perform(NSSelectorFromString("sharedApplication"))?
+            .takeUnretainedValue() as? UIApplication
+        if let app = sharedApp {
+            print("[SDK-4757 REPRO] App.init — sharedApplication exists, isProtectedDataAvailable=\(app.isProtectedDataAvailable)")
+        } else {
+            print("[SDK-4757 REPRO] App.init — UIApplication.sharedApplication is NIL (UIApplicationMain not called yet)")
+        }
+        OneSignalService.shared.initialize(launchOptions: nil)
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -41,48 +54,6 @@ struct App: SwiftUI.App {
                 .environmentObject(viewModel)
                 .environmentObject(toastPresenter)
         }
-    }
-}
-
-// MARK: - App Delegate
-
-class AppDelegate: NSObject, UIApplicationDelegate {
-
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-    ) -> Bool {
-        // Initialize OneSignal
-        OneSignalService.shared.initialize(launchOptions: launchOptions)
-
-        // Set up notification lifecycle listeners
-        setupNotificationListeners()
-
-        // Set up in-app message listeners
-        setupInAppMessageListeners()
-
-        // Set up Live Activities (iOS 16.1+)
-        if #available(iOS 16.1, *) {
-            LiveActivityController.setup()
-        }
-
-        return true
-    }
-
-    private func setupNotificationListeners() {
-        // Foreground notification display
-        OneSignal.Notifications.addForegroundLifecycleListener(NotificationLifecycleHandler.shared)
-
-        // Notification click handling
-        OneSignal.Notifications.addClickListener(NotificationClickHandler.shared)
-    }
-
-    private func setupInAppMessageListeners() {
-        // In-app message lifecycle
-        OneSignal.InAppMessages.addLifecycleListener(InAppMessageLifecycleHandler.shared)
-
-        // In-app message click handling
-        OneSignal.InAppMessages.addClickListener(InAppMessageClickHandler.shared)
     }
 }
 

--- a/examples/demo/App/App.swift
+++ b/examples/demo/App/App.swift
@@ -31,22 +31,9 @@ import OneSignalLiveActivities
 
 @main
 struct App: SwiftUI.App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var viewModel = OneSignalViewModel()
     @StateObject private var toastPresenter = ToastPresenter()
-
-    // REPRO SDK-4757: pure SwiftUI lifecycle (no AppDelegate), initialize in App.init()
-    // like the reporter's app. Revert to the @UIApplicationDelegateAdaptor version after.
-    init() {
-        let sharedApp = UIApplication
-            .perform(NSSelectorFromString("sharedApplication"))?
-            .takeUnretainedValue() as? UIApplication
-        if let app = sharedApp {
-            print("[SDK-4757 REPRO] App.init — sharedApplication exists, isProtectedDataAvailable=\(app.isProtectedDataAvailable)")
-        } else {
-            print("[SDK-4757 REPRO] App.init — UIApplication.sharedApplication is NIL (UIApplicationMain not called yet)")
-        }
-        OneSignalService.shared.initialize(launchOptions: nil)
-    }
 
     var body: some Scene {
         WindowGroup {
@@ -54,6 +41,48 @@ struct App: SwiftUI.App {
                 .environmentObject(viewModel)
                 .environmentObject(toastPresenter)
         }
+    }
+}
+
+// MARK: - App Delegate
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // Initialize OneSignal
+        OneSignalService.shared.initialize(launchOptions: launchOptions)
+
+        // Set up notification lifecycle listeners
+        setupNotificationListeners()
+
+        // Set up in-app message listeners
+        setupInAppMessageListeners()
+
+        // Set up Live Activities (iOS 16.1+)
+        if #available(iOS 16.1, *) {
+            LiveActivityController.setup()
+        }
+
+        return true
+    }
+
+    private func setupNotificationListeners() {
+        // Foreground notification display
+        OneSignal.Notifications.addForegroundLifecycleListener(NotificationLifecycleHandler.shared)
+
+        // Notification click handling
+        OneSignal.Notifications.addClickListener(NotificationClickHandler.shared)
+    }
+
+    private func setupInAppMessageListeners() {
+        // In-app message lifecycle
+        OneSignal.InAppMessages.addLifecycleListener(InAppMessageLifecycleHandler.shared)
+
+        // In-app message click handling
+        OneSignal.InAppMessages.addClickListener(InAppMessageClickHandler.shared)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -463,10 +463,24 @@ static BOOL ComputeInitialStorageReadable(void) {
     if (hasPriorSession) { // returning user during prewarm; defer
         return NO;
     }
-    if ([NSThread isMainThread]) {
-        return UIApplication.sharedApplication.isProtectedDataAvailable;
+    if (![NSThread isMainThread]) {
+        return YES; // off-main: can't safely read UIApplication
     }
-    return YES; // off-main: can't safely read UIApplication
+    UIApplication *sharedApp = UIApplication.sharedApplication;
+    if (sharedApp) {
+        return sharedApp.isProtectedDataAvailable;
+    }
+    // sharedApplication is nil: we are running before UIApplicationMain, e.g. a SwiftUI
+    // App.init() or an ObjC +load. (Messaging nil here would silently return NO and leave
+    // the SDK permanently gated, since the recovery notification below may never fire.)
+    // A user-initiated launch implies the device is unlocked, so storage is readable.
+    // Only a prewarm-created process can reach this point while storage may still be
+    // locked; iOS marks those processes with the ActivePrewarm environment variable,
+    // which is cleared after launch completes — but pre-UIApplicationMain is always
+    // before that, so the read is reliable here.
+    BOOL isPrewarm = [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqualToString:@"1"];
+    [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OneSignal initialized before UIApplicationMain (ActivePrewarm=%d); %@", isPrewarm, isPrewarm ? @"deferring storage reads until launch completes" : @"treating storage as readable"]];
+    return !isPrewarm;
 }
 
 /// One-time setup of the protected-data readiness check that matters during iOS app
@@ -478,12 +492,14 @@ static BOOL ComputeInitialStorageReadable(void) {
 ///   * Read via `OneSignalConfig.isProtectedDataAvailableProvider`
 ///
 /// Seed case table:
-///   1. pushModels populated                              → YES (UD is readable)
-///   2. `keyHasPriorSession` set, no UD    → NO  (returning user during prewarm; defer)
-///   3. neither + main thread                                → fall back to `UIApplication.isProtectedDataAvailable`
-///   4. neither + off-main thread                           → YES (can't safely read UIApplication)
+///   1. pushModels populated                  → YES (UD is readable)
+///   2. `keyHasPriorSession` set, no UD       → NO  (returning user during prewarm; defer)
+///   3. neither + off-main thread             → YES (can't safely read UIApplication)
+///   4. neither + sharedApplication exists    → `UIApplication.isProtectedDataAvailable`
+///   5. neither + sharedApplication nil       → NO only when `ActivePrewarm=1` (pre-UIApplicationMain:
+///      a user-initiated launch implies unlocked storage; only prewarm can mean locked storage)
 ///
-/// `keyHasPriorSession`  is the only reliable "SDK previously ran here" sentinel, and case 3's
+/// `keyHasPriorSession` is the only reliable "SDK previously ran here" sentinel, and case 4's
 /// `isProtectedDataAvailable` tiebreaker also protects SDK upgraders who never wrote `keyHasPriorSession`.
 ///
 /// `gObserverShouldRecover` is set when init defers (storage isn't yet readable) and cleared by the

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -488,7 +488,8 @@ static BOOL ComputeInitialStorageReadable(void) {
 ///
 /// The cached flag is a one-way latch (NO → YES, never reverses). It is:
 ///   * Seeded by `ComputeInitialStorageReadable` (case table below).
-///   * Flipped to YES on `UIApplicationProtectedDataDidBecomeAvailable`.
+///   * Flipped to YES on `UIApplicationProtectedDataDidBecomeAvailable`, or on
+///     `didFinishLaunching`/`didBecomeActive` when `isProtectedDataAvailable` verifies YES.
 ///   * Read via `OneSignalConfig.isProtectedDataAvailableProvider`
 ///
 /// Seed case table:
@@ -502,30 +503,60 @@ static BOOL ComputeInitialStorageReadable(void) {
 /// `keyHasPriorSession` is the only reliable "SDK previously ran here" sentinel, and case 4's
 /// `isProtectedDataAvailable` tiebreaker also protects SDK upgraders who never wrote `keyHasPriorSession`.
 ///
-/// `gObserverShouldRecover` is set when init defers (storage isn't yet readable) and cleared by the
-/// observer's first fire (tracked since `DidBecomeAvailable` posts on every device unlock).
+/// `gObserverShouldRecover` is set when init defers (storage isn't yet readable) and cleared when
+/// recovery runs once. Recovery triggers, whichever verifies first:
+///   * `UIApplicationProtectedDataDidBecomeAvailable` — posts on unlock, including the
+///     first unlock after boot (the locked-prewarm case). Does NOT post if storage was
+///     never locked, so it cannot be the only trigger.
+///   * `didFinishLaunching` / `didBecomeActive` with a live `isProtectedDataAvailable` == YES
+///     re-check — covers deferrals where storage was readable all along (e.g. a prewarm-created
+///     process the user later foregrounds, when the unlock notification never fires).
 + (void)setupProtectedDataObserverOnce {
     static _Atomic(BOOL) gProtectedDataAvailable = NO;
     static _Atomic(BOOL) gObserverShouldRecover = NO;
     static dispatch_once_t protectedDataOnce;
     dispatch_once(&protectedDataOnce, ^{
-        [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification * _Nonnull note) {
+        // Marks storage readable, then re-drives the SDK components that init skipped —
+        // at most once. If `gObserverShouldRecover == YES`, atomically swap to NO and
+        // proceed; otherwise bail (already consumed, or init never deferred).
+        void (^recoverIfDeferred)(void) = ^{
             atomic_store(&gProtectedDataAvailable, YES);
-            // Only run the recovery if init deferred. If `gObserverShouldRecover == YES`,
-            // atomically swap to NO and proceed; otherwise bail (already consumed, or never set).
             BOOL shouldRecover = YES;
             if (!atomic_compare_exchange_strong(&gObserverShouldRecover, &shouldRecover, NO)) {
                 return;
             }
+            [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"Device storage became readable; starting deferred OneSignal components"];
             [OneSignalUserManagerImpl.sharedInstance start];
             [OSNotificationsManager sendPushTokenToDelegate];
             [OneSignal startLiveActivitiesManager];
             [OneSignal startInAppMessages];
             [OneSignal startNewSession:YES];
+        };
+
+        // Authoritative signal: the OS says protected data just became available.
+        [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification * _Nonnull note) {
+            recoverIfDeferred();
         }];
+
+        // Lifecycle signals: if init deferred while storage was actually readable (seed
+        // case 5, or a conservative misjudgment), the unlock notification never posts.
+        // Once UIApplicationMain has run, `sharedApplication` exists and we can consult
+        // the real `isProtectedDataAvailable`. Skipped when it reports NO (e.g. a
+        // background launch before first unlock) — the unlock notification covers those.
+        for (NSNotificationName name in @[UIApplicationDidFinishLaunchingNotification,
+                                          UIApplicationDidBecomeActiveNotification]) {
+            [NSNotificationCenter.defaultCenter addObserverForName:name
+                                object:nil
+                                 queue:NSOperationQueue.mainQueue
+                            usingBlock:^(NSNotification * _Nonnull note) {
+                if (UIApplication.sharedApplication.isProtectedDataAvailable) {
+                    recoverIfDeferred();
+                }
+            }];
+        }
 
         OneSignalConfig.isProtectedDataAvailableProvider = ^BOOL {
             return atomic_load(&gProtectedDataAvailable);

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -471,12 +471,11 @@ static BOOL ComputeInitialStorageReadable(void) {
         return sharedApp.isProtectedDataAvailable;
     }
     // sharedApplication is nil: we are running before UIApplicationMain, e.g. a SwiftUI
-    // App.init() or an ObjC +load. (Messaging nil here would silently return NO and leave
-    // the SDK permanently gated, since the recovery notification below may never fire.)
+    // App.init().
     // A user-initiated launch implies the device is unlocked, so storage is readable.
     // Only a prewarm-created process can reach this point while storage may still be
     // locked; iOS marks those processes with the ActivePrewarm environment variable,
-    // which is cleared after launch completes — but pre-UIApplicationMain is always
+    // which is cleared after launch completes, but pre-UIApplicationMain is always
     // before that, so the read is reliable here.
     BOOL isPrewarm = [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqualToString:@"1"];
     [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:[NSString stringWithFormat:@"OneSignal initialized before UIApplicationMain (ActivePrewarm=%d); %@", isPrewarm, isPrewarm ? @"deferring storage reads until launch completes" : @"treating storage as readable"]];
@@ -505,19 +504,19 @@ static BOOL ComputeInitialStorageReadable(void) {
 ///
 /// `gObserverShouldRecover` is set when init defers (storage isn't yet readable) and cleared when
 /// recovery runs once. Recovery triggers, whichever verifies first:
-///   * `UIApplicationProtectedDataDidBecomeAvailable` — posts on unlock, including the
+///   * `UIApplicationProtectedDataDidBecomeAvailable` posts on unlock, including the
 ///     first unlock after boot (the locked-prewarm case). Does NOT post if storage was
 ///     never locked, so it cannot be the only trigger.
 ///   * `didFinishLaunching` / `didBecomeActive` with a live `isProtectedDataAvailable` == YES
-///     re-check — covers deferrals where storage was readable all along (e.g. a prewarm-created
+///     re-check covers deferrals where storage was readable all along (e.g. a prewarm-created
 ///     process the user later foregrounds, when the unlock notification never fires).
 + (void)setupProtectedDataObserverOnce {
     static _Atomic(BOOL) gProtectedDataAvailable = NO;
     static _Atomic(BOOL) gObserverShouldRecover = NO;
     static dispatch_once_t protectedDataOnce;
     dispatch_once(&protectedDataOnce, ^{
-        // Marks storage readable, then re-drives the SDK components that init skipped —
-        // at most once. If `gObserverShouldRecover == YES`, atomically swap to NO and
+        // Marks storage readable, then re-drives the SDK components that init skipped
+        // (at most once). If `gObserverShouldRecover == YES`, atomically swap to NO and
         // proceed; otherwise bail (already consumed, or init never deferred).
         void (^recoverIfDeferred)(void) = ^{
             atomic_store(&gProtectedDataAvailable, YES);
@@ -541,11 +540,9 @@ static BOOL ComputeInitialStorageReadable(void) {
             recoverIfDeferred();
         }];
 
-        // Lifecycle signals: if init deferred while storage was actually readable (seed
-        // case 5, or a conservative misjudgment), the unlock notification never posts.
-        // Once UIApplicationMain has run, `sharedApplication` exists and we can consult
-        // the real `isProtectedDataAvailable`. Skipped when it reports NO (e.g. a
-        // background launch before first unlock) — the unlock notification covers those.
+        // Lifecycle signals: if init deferred while storage was actually readable,
+        // the unlock notification never posts. Once UIApplicationMain has run,
+        // `sharedApplication` exists and we can consult the real `isProtectedDataAvailable`.
         for (NSNotificationName name in @[UIApplicationDidFinishLaunchingNotification,
                                           UIApplicationDidBecomeActiveNotification]) {
             [NSNotificationCenter.defaultCenter addObserverForName:name


### PR DESCRIPTION
# Description
## One Line Summary
Fix anonymous user creation when OneSignal initializes from SwiftUI `App.init()` before `UIApplicationMain` exists.

## Details

### Motivation
OneSignal iOS SDK 5.5.2 could permanently gate startup on clean installs when initialized from a pure SwiftUI `App.init()`. In that lifecycle, `UIApplication.sharedApplication` is nil before `UIApplicationMain`; the previous protected-data readiness check silently treated that as `false`, deferred the user manager/session startup, and could wait forever for a protected-data notification that never fires on an already-unlocked device. The result was no anonymous user or push subscription creation.

### Scope
This change is limited to SDK startup readiness around protected-data availability. It explicitly handles pre-`UIApplicationMain` initialization, distinguishes actual iOS prewarm using `ActivePrewarm`, and adds lifecycle-based recovery once `UIApplication` exists and reports protected data is available. It does not change public APIs.

### Other
The branch history intentionally includes a temporary demo repro commit followed by a restore commit, so reviewers can check out the repro state if needed. The net PR diff only changes `iOS_SDK/OneSignalSDK/Source/OneSignal.m`.

# Testing
## Unit testing
No new unit tests were added for the UIKit/SwiftUI launch-order path. 

## Manual testing
Manually verified on an iOS 26.5 iPhone 17 Pro simulator:
- Reproduced the issue by initializing the demo app from SwiftUI `App.init()`: before the fix, `UIApplication.sharedApplication` was nil, startup stayed gated, and `OSRequestCreateUser` did not fire.
- Verified the fixed SwiftUI-init repro: `ActivePrewarm=0` was treated as readable, `OSRequestCreateUser` returned 201, and an `onesignal_id` was hydrated.
- Verified the normal AppDelegate-based demo path still creates the user normally.
- Verified deferred recovery by preserving `onesignal_identity.json` while removing UserDefaults-backed state, then relaunching and observing the lifecycle recovery path start deferred OneSignal components and send `OSRequestCreateUser`.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)