### PR TITLE
fix: restore local tags cleared by a concurrent FetchUser

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSPropertyOperationExecutor.swift
@@ -246,8 +246,7 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
         }
 
         OneSignalCoreImpl.sharedClient().execute(request) { response in
-            // On success, remove request from cache, and we do need to hydrate
-            // TODO: We need to hydrate after all ? What why ?
+            // On success, remove request from cache
             self.dispatchQueue.async {
                 self.updateRequestQueue.removeAll(where: { $0 == request})
                 OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_PROPERTIES_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
@@ -255,6 +254,16 @@ class OSPropertyOperationExecutor: OSOperationExecutor {
                     OSBackgroundTaskManager.endBackgroundTask(backgroundTaskIdentifier)
                 }
             }
+
+            // Re-assert the tags the server just confirmed by merging them back into the local model,
+            // to remedy a concurrent FetchUser whose response is missing the just-written tags
+            if OneSignalUserManagerImpl.sharedInstance.isCurrentUser(request.identityModel),
+               let properties = response?["properties"] as? [String: Any],
+               let confirmedTags = properties["tags"] as? [String: String],
+               !confirmedTags.isEmpty {
+                OneSignalUserManagerImpl.sharedInstance._user?.propertiesModel.mergeConfirmedTags(confirmedTags)
+            }
+
             if let onesignalId = request.identityModel.onesignalId {
                 if let rywToken = response?["ryw_token"] as? String
                 {

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/OSPropertiesModel.swift
@@ -151,6 +151,25 @@ class OSPropertiesModel: OSModel {
         self.set(property: "tags", newValue: tagsToSend)
     }
 
+    /**
+     Merges server-confirmed tags into the local model, without enqueuing a new delta.
+     A value of `""` removes the tag.
+
+     Used to re-assert tags in order to remedy a concurrent FetchUser whose response
+     may be missing the just-written tags.
+     */
+    func mergeConfirmedTags(_ serverTags: [String: String]) {
+        tagsLock.withLock {
+            for (key, value) in serverTags {
+                if value.isEmpty {
+                    self.tags.removeValue(forKey: key)
+                } else {
+                    self.tags[key] = value
+                }
+            }
+        }
+    }
+
     public override func hydrateModel(_ response: [String: Any]) {
         for property in response {
             switch property.key {

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
@@ -189,4 +189,63 @@ final class OneSignalUserTests: XCTestCase {
             contains: expectedPayload)
         )
     }
+
+    /**
+     Unit test for the tag-merge primitive.
+
+     `mergeConfirmedTags` must overlay only the provided keys onto the local model: update existing
+     values, remove keys whose value is `""`, add new keys, and leave all other (e.g. backend-managed)
+     tags untouched. It must never wholesale-replace the tag dictionary.
+     */
+    func testMergeConfirmedTags_mergesAndRemovesWithoutTouchingOtherTags() throws {
+        /* Setup */
+        let model = OSPropertiesModel(changeNotifier: OSEventProducer())
+        model.hydrate(["tags": ["keep": "1", "update": "old", "remove": "2"]])
+
+        /* When */
+        // "update" changes, "remove" is deleted (""), "add" is new; "keep" must be left untouched
+        model.mergeConfirmedTags(["update": "new", "remove": "", "add": "3"])
+
+        /* Then */
+        XCTAssertEqual(model.tags, ["keep": "1", "update": "new", "add": "3"])
+    }
+
+    /**
+     Regression test: `getTags()` returns `{}` after a concurrent, stale `FetchUser` overwrites the
+     local tag model.
+
+     A concurrent `FetchUser` whose response is missing a recently written tag clears the local tag
+     cache (`clearUserData()`) and hydrates without it. The `OSRequestUpdateProperties` 202 response
+     echoes the tags the server just confirmed, so merging those back into the local model must restore
+     the tags that the stale fetch cleared.
+     */
+    func testUpdatePropertiesResponse_restoresTagsClearedByConcurrentFetch() throws {
+        /* Setup */
+        let client = MockOneSignalClient()
+        MockUserRequests.setDefaultCreateAnonUserResponses(with: client)
+        let tags = ["tag_a": "value_a", "tag_b": "value_b"]
+        MockUserRequests.setAddTagsResponse(with: client, tags: tags)
+        OneSignalCoreImpl.setSharedClient(client)
+
+        OneSignalUserManagerImpl.sharedInstance.start()
+
+        // Let the anonymous user be created so it has a OneSignal ID for the update request
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        /* When */
+        // Tags are applied optimistically to the local model and queued as an update request
+        OneSignalUserManagerImpl.sharedInstance.addTags(tags)
+
+        // Simulate a concurrent, stale FetchUser clearing the local tag cache before the
+        // UpdateProperties 202 response is processed
+        OneSignalUserManagerImpl.sharedInstance.user.propertiesModel.clearData()
+        XCTAssertTrue(OneSignalUserManagerImpl.sharedInstance.getTags().isEmpty)
+
+        // Let the queued UpdateProperties request flush and its 202 echo be processed
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 1)
+
+        /* Then */
+        // The confirmed tags from the 202 response are merged back into the local model
+        XCTAssertEqual(OneSignalUserManagerImpl.sharedInstance.getTags(), tags)
+    }
 }


### PR DESCRIPTION
# Description

## One Line Summary
Restore locally set tags that a concurrent `FetchUser` can wipe, by re-asserting server-confirmed tags when an `UpdateProperties` request succeeds.

## Details

### Motivation
`getTags()` could return `{}` or missing recently-added tags, even when the tags exist on the server. `addTags` writes tags optimistically to the local model and sends them via `OSRequestUpdateProperties`. If a `FetchUser` runs concurrently (e.g. a new session after backgrounding/foregrounding) and its response is missing the just-written tags, its `clearUserData()` + hydrate wipes the local tag cache and nothing restores it — so `getTags()` keeps returning only a subset of tags. The write itself succeeds; only the SDK's local mirror ends up wrong.

### Fix
On a successful `OSRequestUpdateProperties` (202) response, merge the tags the server just confirmed (echoed back in the response) into the local properties model. This is a **merge, never a replace**:
- only the keys present in the response are touched, so tags managed elsewhere (e.g. the app's backend via the REST API) are left intact;
- a `""` value is treated as a removal, matching how the server echoes removed tags.

### Scope
Affects only user tags, on `UpdateProperties` success. The `FetchUser` flow and other user properties are unchanged. No public API changes.

### Alternatives considered
- **Restore the full local tag snapshot during `FetchUser` hydration**: rejected — it would re-introduce stale local-only tags and drop tags the app's backend set via the REST API, clobbering backend state.
- **Preserve only the pending tag writes during `FetchUser` hydration**: viable and race-equivalent to the chosen approach, but needs more cross-executor plumbing (inspecting the operation repo + property executor queues). Merge-on-confirm is simpler, self-contained, and only ever re-asserts tags the server just confirmed.

### Trade-offs / concessions / limitations
- This is a best-effort, eventually-consistent, last-writer-wins system. Inherent staleness (e.g. an offline write that lands later and overwrites a newer backend change) is **out of scope** and not solvable client-side. This fix only addresses the SDK destroying its *own* successfully-written tags locally.
- The `UpdateProperties` response echoes only the tags that were sent (confirmed from logs), not the user's full tag set — so this is necessarily a merge, not a full resync.
- **Relies on the response echoing tags:** the merge reads `properties.tags` from the 202 response. If a response omits it, the merge simply no-ops for that round (no restoration); a later clean fetch reconciles.
- **Assumes removals are echoed as `key: ""`:** removed tags come back as a non-empty `tags` object with empty-string values, which the merge treats as deletions. If the backend ever collapsed an all-removals update to `tags: {}`, the `!confirmedTags.isEmpty` guard would skip the merge; a later clean fetch still reconciles.
- **Residual race (accepted):** a stale `FetchUser` applied *after* the write is already confirmed is not covered in that instant; it self-corrects on the next fetch user call.
- **Minor wart (accepted):** removing a tag whose earlier add is still in flight in a *separate* request can briefly re-add it until the removal confirms; self-corrects on next fetch user. This is an inherent problem outside the scope of this PR. If 2 concurrent requests updating the same tag key are sent to the server, the value persisted on server just depends on random chance.

# Testing
## Unit testing
- `testMergeConfirmedTags_mergesAndRemovesWithoutTouchingOtherTags` — merge semantics: updates, `""` removals, additions, and other tags left untouched (never a wholesale replace).
- `testUpdatePropertiesResponse_restoresTagsClearedByConcurrentFetch` — regression: add tags, simulate a concurrent fetch clearing the local cache, then assert the tags are restored once the update confirms.
- `OneSignalUserTests`, `UserExecutorTests`, `UserConcurrencyTests`, and `SwitchUserIntegrationTests` pass.

## Manual testing
Not performed on-device: the race is timing-dependent and not naturally reproducible, so it is covered by the regression test above, which simulates the clobber via the property model's `clearData()` — the same clearing a stale `FetchUser` performs.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs (no public API changes)

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible (race is timing-dependent and not naturally reproducible; covered by an automated regression test)

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
