### PR TITLE
fix: replace deprecated NSKeyedArchiver/NSKeyedUnarchiver APIs

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalUserDefaults.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalCore/Source/OneSignalUserDefaults.m
@@ -152,14 +152,21 @@
 }
 
 - (id _Nullable)getSavedCodeableDataForKey:(NSString * _Nonnull)key defaultValue:(id _Nullable)value {
-    if ([self keyExists:key])
-        return [NSKeyedUnarchiver unarchiveObjectWithData:[self.userDefaults objectForKey:key]];
-    
+    if ([self keyExists:key]) {
+        NSData *data = [self.userDefaults objectForKey:key];
+        NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nil];
+        unarchiver.requiresSecureCoding = NO;
+        id result = [unarchiver decodeTopLevelObjectAndReturnError:nil];
+        [unarchiver finishDecoding];
+        return result;
+    }
+
     return value;
 }
 
 - (void)saveCodeableDataForKey:(NSString * _Nonnull)key withValue:(id _Nullable)value {
-    [self.userDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:value] forKey:key];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:value requiringSecureCoding:NO error:nil];
+    [self.userDefaults setObject:data forKey:key];
     [self.userDefaults synchronize];
 }
 


### PR DESCRIPTION
## Summary

- Replaces deprecated `+[NSKeyedUnarchiver unarchiveObjectWithData:]` with instance-based `NSKeyedUnarchiver` using `initForReadingFromData:error:` and `decodeTopLevelObjectAndReturnError:`
- Replaces deprecated `+[NSKeyedArchiver archivedDataWithRootObject:]` with `archivedDataWithRootObject:requiringSecureCoding:NO error:`
- Both modern APIs are available since iOS 11.0, which matches the SDK's minimum deployment target

The deprecated methods are flagged as unsafe by security scanners (CWE-676). Setting `requiresSecureCoding = NO` maintains backward compatibility with existing model classes that implement `NSCoding`.

Resolves #919

## Test plan

- [ ] Verify existing unit tests pass (archiving/unarchiving behavior is unchanged)
- [ ] Verify migration flows (IAM redisplay cache, class name migrations) work correctly
- [ ] Confirm no deprecation warnings from `NSKeyedArchiver`/`NSKeyedUnarchiver` in build output