### PR TITLE
fix: [SDK-4814] Live Activities Confirmed Receipts exceeding Delivered count

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
@@ -115,11 +115,11 @@ class StartRequestCache: RequestCache {
 }
 
 class ReceiveReceiptsRequestCache: RequestCache {
-    // Keep receive receipts requests for up to 30 days.
-    static let OneMonthInSeconds = TimeInterval(60 * 60 * 24 * 30)
+    // Only pending receipts live here; de-duplication is handled by the executor's confirmedReceiptIds.
+    static let OneWeekInSeconds = TimeInterval(60 * 60 * 24 * 7)
 
     init() {
-        super.init(cacheKey: OS_LIVE_ACTIVITIES_EXECUTOR_RECEIVE_RECEIPTS_KEY, ttl: ReceiveReceiptsRequestCache.OneMonthInSeconds)
+        super.init(cacheKey: OS_LIVE_ACTIVITIES_EXECUTOR_RECEIVE_RECEIPTS_KEY, ttl: ReceiveReceiptsRequestCache.OneWeekInSeconds)
     }
 }
 
@@ -138,6 +138,8 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
     let startTokens: StartRequestCache = StartRequestCache()
     let receiveReceipts: ReceiveReceiptsRequestCache = ReceiveReceiptsRequestCache()
     let clickEvents: ClickedRequestCache = ClickedRequestCache()
+    // Dedupes receipts per session so duplicate content-update listeners can't over-report.
+    var confirmedReceiptIds: Set<String> = []
 
     // The live activities request dispatch queue, serial.  This synchronizes access to `updateTokens` and `startTokens`.
     private var requestDispatch: OSDispatchQueue
@@ -172,6 +174,10 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
 
     func append(_ request: OSLiveActivityRequest) {
         self.requestDispatch.async {
+            if request is OSRequestLiveActivityReceiveReceipts, !self.claimReceipt(request.key) {
+                return
+            }
+
             let cache = self.getCache(request)
             let existingRequest = cache.items[request.key]
 
@@ -182,6 +188,16 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
                 OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.LiveActivities superseded request not saved/executed: \(request)")
             }
         }
+    }
+
+    // False if this notificationId was already claimed this session. Call on requestDispatch.
+    private func claimReceipt(_ notificationId: String) -> Bool {
+        if confirmedReceiptIds.contains(notificationId) {
+            OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.LiveActivities duplicate receive receipt not sent for notificationId: \(notificationId)")
+            return false
+        }
+        confirmedReceiptIds.insert(notificationId)
+        return true
     }
 
     private func pollPendingRequests() {

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
@@ -115,11 +115,11 @@ class StartRequestCache: RequestCache {
 }
 
 class ReceiveReceiptsRequestCache: RequestCache {
-    // Only pending receipts live here; de-duplication is handled by the executor's confirmedReceiptIds.
-    static let OneWeekInSeconds = TimeInterval(60 * 60 * 24 * 7)
+    // Sent receipts stay as dedup markers (not only pending retries), so re-emits after relaunch aren't re-sent.
+    static let ThreeDaysInSeconds = TimeInterval(60 * 60 * 24 * 3)
 
     init() {
-        super.init(cacheKey: OS_LIVE_ACTIVITIES_EXECUTOR_RECEIVE_RECEIPTS_KEY, ttl: ReceiveReceiptsRequestCache.OneWeekInSeconds)
+        super.init(cacheKey: OS_LIVE_ACTIVITIES_EXECUTOR_RECEIVE_RECEIPTS_KEY, ttl: ReceiveReceiptsRequestCache.ThreeDaysInSeconds)
     }
 }
 
@@ -138,8 +138,6 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
     let startTokens: StartRequestCache = StartRequestCache()
     let receiveReceipts: ReceiveReceiptsRequestCache = ReceiveReceiptsRequestCache()
     let clickEvents: ClickedRequestCache = ClickedRequestCache()
-    // Dedupes receipts per session so duplicate content-update listeners can't over-report.
-    var confirmedReceiptIds: Set<String> = []
 
     // The live activities request dispatch queue, serial.  This synchronizes access to `updateTokens` and `startTokens`.
     private var requestDispatch: OSDispatchQueue
@@ -174,10 +172,6 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
 
     func append(_ request: OSLiveActivityRequest) {
         self.requestDispatch.async {
-            if request is OSRequestLiveActivityReceiveReceipts, !self.claimReceipt(request.key) {
-                return
-            }
-
             let cache = self.getCache(request)
             let existingRequest = cache.items[request.key]
 
@@ -188,16 +182,6 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
                 OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.LiveActivities superseded request not saved/executed: \(request)")
             }
         }
-    }
-
-    // False if this notificationId was already claimed this session. Call on requestDispatch.
-    private func claimReceipt(_ notificationId: String) -> Bool {
-        if confirmedReceiptIds.contains(notificationId) {
-            OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.LiveActivities duplicate receive receipt not sent for notificationId: \(notificationId)")
-            return false
-        }
-        confirmedReceiptIds.insert(notificationId)
-        return true
     }
 
     private func pollPendingRequests() {

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
@@ -115,11 +115,12 @@ class StartRequestCache: RequestCache {
 }
 
 class ReceiveReceiptsRequestCache: RequestCache {
-    // Sent receipts stay as dedup markers (not only pending retries), so re-emits after relaunch aren't re-sent.
-    static let ThreeDaysInSeconds = TimeInterval(60 * 60 * 24 * 3)
+    // Sent receipts are kept as dedup markers, so bound retention: an active activity re-emits for at most
+    // ~12h on relaunch, and updates arrive over the network, so a day covers dedup and retries without piling up.
+    static let OneDayInSeconds = TimeInterval(60 * 60 * 24)
 
     init() {
-        super.init(cacheKey: OS_LIVE_ACTIVITIES_EXECUTOR_RECEIVE_RECEIPTS_KEY, ttl: ReceiveReceiptsRequestCache.ThreeDaysInSeconds)
+        super.init(cacheKey: OS_LIVE_ACTIVITIES_EXECUTOR_RECEIVE_RECEIPTS_KEY, ttl: ReceiveReceiptsRequestCache.OneDayInSeconds)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Executors/OSLiveActivitiesExecutor.swift
@@ -142,10 +142,11 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
 
     // The live activities request dispatch queue, serial.  This synchronizes access to `updateTokens` and `startTokens`.
     private var requestDispatch: OSDispatchQueue
-    private var pollIntervalSeconds = 30
+    private var pollIntervalSeconds: Int
 
-    init(requestDispatch: OSDispatchQueue) {
+    init(requestDispatch: OSDispatchQueue, pollIntervalSeconds: Int = 30) {
         self.requestDispatch = requestDispatch
+        self.pollIntervalSeconds = pollIntervalSeconds
     }
 
     func start() {
@@ -185,7 +186,7 @@ class OSLiveActivitiesExecutor: OSPushSubscriptionObserver {
         }
     }
 
-    private func pollPendingRequests() {
+    func pollPendingRequests() {
         OneSignalLog.onesignalLog(.LL_VERBOSE, message: "OneSignal.LiveActivities pollPendingRequests")
 
         self.requestDispatch.asyncAfterTime(deadline: .now() + .seconds(pollIntervalSeconds)) { [weak self] in

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/OneSignalLiveActivitiesManagerImpl.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/OneSignalLiveActivitiesManagerImpl.swift
@@ -334,7 +334,7 @@ public class OneSignalLiveActivitiesManagerImpl: NSObject, OSLiveActivities {
         Task {
             for await content in activity.contentUpdates {
                 // Don't track a live activity started / updated "in app" without a notification
-                if let notificationId = activity.content.state.onesignal?.notificationId {
+                if let notificationId = content.state.onesignal?.notificationId {
                     OneSignalLiveActivitiesManagerImpl.addReceiveReceipts(notificationId: notificationId, activityType: "\(activityType)", activityId: activity.attributes.onesignal.activityId)
                 }
             }

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestLiveActivityReceiveReceipts.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestLiveActivityReceiveReceipts.swift
@@ -36,6 +36,7 @@ class OSRequestLiveActivityReceiveReceipts: OneSignalRequest, OSLiveActivityRequ
     var activityType: String
     var activityId: String
     var requestSuccessful: Bool
+    // Forgotten once sent; duplicate suppression is handled by the executor's confirmedReceiptIds.
     var shouldForgetWhenSuccessful: Bool = true
 
     func prepareForExecution() -> Bool {

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestLiveActivityReceiveReceipts.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivities/Source/Requests/OSRequestLiveActivityReceiveReceipts.swift
@@ -36,8 +36,8 @@ class OSRequestLiveActivityReceiveReceipts: OneSignalRequest, OSLiveActivityRequ
     var activityType: String
     var activityId: String
     var requestSuccessful: Bool
-    // Forgotten once sent; duplicate suppression is handled by the executor's confirmedReceiptIds.
-    var shouldForgetWhenSuccessful: Bool = true
+    // Kept after success so the persisted cache suppresses re-sends across relaunches.
+    var shouldForgetWhenSuccessful: Bool = false
 
     func prepareForExecution() -> Bool {
         guard let appId = OneSignalIdentifiers.currentAppId else {

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
@@ -49,9 +49,8 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
 
     override func tearDownWithError() throws { }
 
-    func testAppendSetStartTokenWithSuccessfulRequest() throws {
-        /* Setup */
-        let mockDispatchQueue = MockDispatchQueue()
+    // Subscribes a user, then resets the client so tests assert only on the requests they make.
+    private func setUpSubscribedUser() -> MockOneSignalClient {
         let mockClient = MockOneSignalClient()
         OneSignalCoreImpl.setSharedClient(mockClient)
         OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
@@ -59,6 +58,13 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         // Wait for any user setup requests to complete
         OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
         mockClient.reset()
+        return mockClient
+    }
+
+    func testAppendSetStartTokenWithSuccessfulRequest() throws {
+        /* Setup */
+        let mockDispatchQueue = MockDispatchQueue()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestSetStartToken(key: "my-activity-type", token: "my-token")
         mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
@@ -79,13 +85,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testRemoveStartTokenWithSuccessfulRequest() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestRemoveStartToken(key: "my-activity-type")
         mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
@@ -104,13 +104,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetUpdateTokenWithSuccessfulRequest() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestSetUpdateToken(key: "my-activity-id", token: "my-token")
         mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
@@ -131,13 +125,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testRemoveUpdateTokenWithSuccessfulRequest() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestRemoveUpdateToken(key: "my-activity-id")
         mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
@@ -156,13 +144,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testReceiveReceiptsWithSuccessfulRequest() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestLiveActivityReceiveReceipts(key: "notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
         mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
@@ -183,13 +165,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testClickEventWithSuccessfulRequest() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestLiveActivityClicked(key: "unique-click-id", activityType: "my-activity-type", activityId: "my-activity-id", notificationId: "my-notif-id")
         mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
@@ -227,13 +203,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testRequestStaysInCacheForRetryableError() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestSetStartToken(key: "my-activity-type", token: "my-token")
         mockClient.setMockFailureResponseForRequest(request: String(describing: request), error: OneSignalClientError(code: 500, message: "not-important", responseHeaders: nil, response: nil, underlyingError: nil))
@@ -254,13 +224,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testRequestRemovedFromCacheForNonRetryableError() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request = OSRequestSetStartToken(key: "my-activity-type", token: "my-token")
         mockClient.setMockFailureResponseForRequest(request: String(describing: request), error: OneSignalClientError(code: 401, message: "not-important", responseHeaders: nil, response: nil, underlyingError: nil))
@@ -321,13 +285,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetStartRequestNotExecutedWithSameActivityTypeAndToken() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestSetStartToken(key: "my-activity-type", token: "my-token")
         let request2 = OSRequestSetStartToken(key: "my-activity-type", token: "my-token")
@@ -350,13 +308,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetStartRequestNotExecutedWithSameActivityTypeAndDiffToken() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestSetStartToken(key: "my-activity-type", token: "my-token-1")
         let request2 = OSRequestSetStartToken(key: "my-activity-type", token: "my-token-2")
@@ -380,13 +332,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetStartRequestFollowedByRemoveStartIsSuccessful() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestSetStartToken(key: "my-activity-type", token: "my-token-1")
         let request2 = OSRequestRemoveStartToken(key: "my-activity-type")
@@ -409,13 +355,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetUpdateRequestNotExecutedWithSameActivityIdAndToken() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestSetUpdateToken(key: "my-activity-id", token: "my-token")
         let request2 = OSRequestSetUpdateToken(key: "my-activity-id", token: "my-token")
@@ -438,13 +378,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetUpdateRequestNotExecutedWithSameActivityIdAndDiffToken() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestSetUpdateToken(key: "my-activity-id", token: "my-token-1")
         let request2 = OSRequestSetUpdateToken(key: "my-activity-id", token: "my-token-2")
@@ -468,13 +402,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testSetUpdateRequestFollowedByRemoveUpdateIsSuccessful() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestSetUpdateToken(key: "my-activity-id", token: "my-token-1")
         let request2 = OSRequestRemoveUpdateToken(key: "my-activity-id")
@@ -497,13 +425,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
     func testReceiveReceiptsRequestNotExecutedWithSameNotificationId() throws {
         /* Setup */
         let mockDispatchQueue = MockDispatchQueue()
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type-1", activityId: "my-activity-id-1")
         let request2 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type-2", activityId: "my-activity-id-2")
@@ -530,13 +452,7 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
      */
     func testReceiveReceiptsNotResentForSameNotificationIdAfterRelaunch() throws {
         /* Setup */
-        let mockClient = MockOneSignalClient()
-        OneSignalCoreImpl.setSharedClient(mockClient)
-        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
-        OneSignalUserManagerImpl.sharedInstance.start()
-        // Wait for any user setup requests to complete
-        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
-        mockClient.reset()
+        let mockClient = setUpSubscribedUser()
 
         let request1 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
         let request2 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
@@ -173,7 +173,9 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         mockDispatchQueue.waitForDispatches(2)
 
         /* Then */
+        // Forgotten from the cache, but its notificationId is remembered so it isn't reported again.
         XCTAssertEqual(executor.receiveReceipts.items.count, 0)
+        XCTAssertTrue(executor.confirmedReceiptIds.contains("notification-id"))
         XCTAssertEqual(mockClient.executedRequests.count, 1)
         XCTAssertTrue(mockClient.executedRequests[0] == request)
     }
@@ -515,8 +517,50 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         mockDispatchQueue.waitForDispatches(3)
 
         /* Then */
+        // request2 is suppressed as a duplicate of request1; the sent receipt is then forgotten.
         XCTAssertEqual(executor.receiveReceipts.items.count, 0)
         XCTAssertEqual(mockClient.executedRequests.count, 1)
+        XCTAssertTrue(mockClient.executedRequests[0] == request1)
+    }
+
+    /**
+     A receive-receipt for a notificationId must be sent at most once per device. This covers the
+     cross-cycle case: unlike `testReceiveReceiptsRequestNotExecutedWithSameNotificationId` (both receipts
+     appended in one cycle), here the first fully completes and is forgotten before the second arrives, so
+     the duplicate is caught by the remembered notificationIds rather than by the request cache.
+     */
+    func testReceiveReceiptsNotResentForSameNotificationIdAcrossDeliveryCycles() throws {
+        /* Setup */
+        let mockDispatchQueue = MockDispatchQueue()
+        let mockClient = MockOneSignalClient()
+        OneSignalCoreImpl.setSharedClient(mockClient)
+        OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
+        OneSignalUserManagerImpl.sharedInstance.start()
+        // Wait for any user setup requests to complete
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
+        mockClient.reset()
+
+        let request1 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
+        let request2 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
+        mockClient.setMockResponseForRequest(request: String(describing: request1), response: [String: Any]())
+        mockClient.setMockResponseForRequest(request: String(describing: request2), response: [String: Any]())
+
+        /* When */
+        let executor = OSLiveActivitiesExecutor(requestDispatch: mockDispatchQueue)
+
+        // First cycle: receipt is sent, succeeds, is forgotten, and its notificationId is remembered.
+        executor.append(request1)
+        mockDispatchQueue.waitForDispatches(2)
+        XCTAssertEqual(mockClient.executedRequests.count, 1)
+        XCTAssertEqual(executor.receiveReceipts.items.count, 0)
+        XCTAssertTrue(executor.confirmedReceiptIds.contains("my-notification-id"))
+
+        // Second cycle, same notificationId (e.g. another content update / relaunch): a duplicate.
+        executor.append(request2)
+        mockDispatchQueue.waitForDispatches(3)
+
+        /* Then */
+        XCTAssertEqual(mockClient.executedRequests.count, 1, "Duplicate receive-receipt must not be sent for the same notificationId across delivery cycles")
         XCTAssertTrue(mockClient.executedRequests[0] == request1)
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
@@ -173,9 +173,9 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         mockDispatchQueue.waitForDispatches(2)
 
         /* Then */
-        // Forgotten from the cache, but its notificationId is remembered so it isn't reported again.
-        XCTAssertEqual(executor.receiveReceipts.items.count, 0)
-        XCTAssertTrue(executor.confirmedReceiptIds.contains("notification-id"))
+        // The sent receipt is kept as a dedup marker so the same notificationId isn't reported again.
+        XCTAssertEqual(executor.receiveReceipts.items.count, 1)
+        XCTAssertTrue(executor.receiveReceipts.items["notification-id"]?.requestSuccessful ?? false)
         XCTAssertEqual(mockClient.executedRequests.count, 1)
         XCTAssertTrue(mockClient.executedRequests[0] == request)
     }
@@ -517,21 +517,19 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         mockDispatchQueue.waitForDispatches(3)
 
         /* Then */
-        // request2 is suppressed as a duplicate of request1; the sent receipt is then forgotten.
-        XCTAssertEqual(executor.receiveReceipts.items.count, 0)
+        // request2 is suppressed as a duplicate of request1, which is kept as a dedup marker.
+        XCTAssertEqual(executor.receiveReceipts.items.count, 1)
         XCTAssertEqual(mockClient.executedRequests.count, 1)
         XCTAssertTrue(mockClient.executedRequests[0] == request1)
     }
 
     /**
-     A receive-receipt for a notificationId must be sent at most once per device. This covers the
-     cross-cycle case: unlike `testReceiveReceiptsRequestNotExecutedWithSameNotificationId` (both receipts
-     appended in one cycle), here the first fully completes and is forgotten before the second arrives, so
-     the duplicate is caught by the remembered notificationIds rather than by the request cache.
+     A receive receipt must be sent at most once per device, even across app launches. The second executor
+     reloads the persisted cache with in-memory state gone, simulating a relaunch where ActivityKit re-emits
+     the active activity's current content and the same notificationId is reported again.
      */
-    func testReceiveReceiptsNotResentForSameNotificationIdAcrossDeliveryCycles() throws {
+    func testReceiveReceiptsNotResentForSameNotificationIdAfterRelaunch() throws {
         /* Setup */
-        let mockDispatchQueue = MockDispatchQueue()
         let mockClient = MockOneSignalClient()
         OneSignalCoreImpl.setSharedClient(mockClient)
         OneSignalUserDefaults.initShared().saveString(forKey: OSUD_LEGACY_PLAYER_ID, withValue: "my-subscription-id")
@@ -546,21 +544,21 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         mockClient.setMockResponseForRequest(request: String(describing: request2), response: [String: Any]())
 
         /* When */
-        let executor = OSLiveActivitiesExecutor(requestDispatch: mockDispatchQueue)
-
-        // First cycle: receipt is sent, succeeds, is forgotten, and its notificationId is remembered.
-        executor.append(request1)
-        mockDispatchQueue.waitForDispatches(2)
+        // First launch: the receipt is sent and succeeds.
+        let firstLaunch = MockDispatchQueue()
+        let executor1 = OSLiveActivitiesExecutor(requestDispatch: firstLaunch)
+        executor1.append(request1)
+        firstLaunch.waitForDispatches(2)
         XCTAssertEqual(mockClient.executedRequests.count, 1)
-        XCTAssertEqual(executor.receiveReceipts.items.count, 0)
-        XCTAssertTrue(executor.confirmedReceiptIds.contains("my-notification-id"))
 
-        // Second cycle, same notificationId (e.g. another content update / relaunch): a duplicate.
-        executor.append(request2)
-        mockDispatchQueue.waitForDispatches(3)
+        // Relaunch: a fresh executor reloads the persisted cache; ActivityKit re-emits the same content.
+        let secondLaunch = MockDispatchQueue()
+        let executor2 = OSLiveActivitiesExecutor(requestDispatch: secondLaunch)
+        executor2.append(request2)
+        secondLaunch.waitForDispatches(1)
 
         /* Then */
-        XCTAssertEqual(mockClient.executedRequests.count, 1, "Duplicate receive-receipt must not be sent for the same notificationId across delivery cycles")
+        XCTAssertEqual(mockClient.executedRequests.count, 1, "Receive receipt must not be re-sent for the same notificationId after relaunch")
         XCTAssertTrue(mockClient.executedRequests[0] == request1)
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalLiveActivitiesTests/OSLiveActivitiesExecutorTests.swift
@@ -478,3 +478,104 @@ final class OSLiveActivitiesExecutorTests: XCTestCase {
         XCTAssertTrue(mockClient.executedRequests[0] == request1)
     }
 }
+
+// Receive-receipt dedup robustness: retry poll, TTL expiry, and non-retryable failure.
+extension OSLiveActivitiesExecutorTests {
+    /**
+     After relaunch the persisted success marker is reloaded; the retry poll only re-executes unsent
+     requests, so an already-confirmed notificationId must not be sent again.
+     */
+    func testPollDoesNotResendReloadedSuccessfulReceipt() throws {
+        /* Setup */
+        let mockClient = setUpSubscribedUser()
+
+        let request = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
+        mockClient.setMockResponseForRequest(request: String(describing: request), response: [String: Any]())
+
+        // First launch: send the receipt so a success marker is persisted.
+        let firstLaunch = MockDispatchQueue()
+        let executor1 = OSLiveActivitiesExecutor(requestDispatch: firstLaunch)
+        executor1.append(request)
+        firstLaunch.waitForDispatches(2)
+        XCTAssertEqual(mockClient.executedRequests.count, 1)
+
+        /* When */
+        // Relaunch and drive the retry poll directly against the reloaded marker.
+        let secondLaunch = MockDispatchQueue()
+        let executor2 = OSLiveActivitiesExecutor(requestDispatch: secondLaunch, pollIntervalSeconds: 0)
+        XCTAssertTrue(executor2.receiveReceipts.items["my-notification-id"]?.requestSuccessful ?? false, "Success marker must survive reload")
+        executor2.pollPendingRequests()
+        secondLaunch.waitForDispatches(1)
+
+        /* Then */
+        XCTAssertEqual(mockClient.executedRequests.count, 1, "Poll must skip a receipt already marked successful")
+    }
+
+    /**
+     A success marker only suppresses re-sends until its TTL elapses. Once expired and pruned, the same
+     notificationId can be confirmed again on a later relaunch.
+     */
+    func testReceiveReceiptResentAfterMarkerExpires() throws {
+        /* Setup */
+        let mockClient = setUpSubscribedUser()
+
+        let expiredNotif = "expired-notification-id"
+        let request1 = OSRequestLiveActivityReceiveReceipts(key: expiredNotif, activityType: "my-activity-type", activityId: "my-activity-id")
+        let request2 = OSRequestLiveActivityReceiveReceipts(key: expiredNotif, activityType: "my-activity-type", activityId: "my-activity-id")
+        mockClient.setMockResponseForRequest(request: String(describing: request1), response: [String: Any]())
+        mockClient.setMockResponseForRequest(request: String(describing: request2), response: [String: Any]())
+
+        // First launch: send the receipt, then age its persisted marker past the TTL.
+        let firstLaunch = MockDispatchQueue()
+        let executor1 = OSLiveActivitiesExecutor(requestDispatch: firstLaunch)
+        executor1.append(request1)
+        firstLaunch.waitForDispatches(2)
+        executor1.receiveReceipts.items[expiredNotif]?.timestamp = Date(timeIntervalSinceNow: -(ReceiveReceiptsRequestCache.OneDayInSeconds + 60))
+
+        // Any later save prunes the expired marker; append an unrelated receipt to trigger one.
+        let other = OSRequestLiveActivityReceiveReceipts(key: "other-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
+        mockClient.setMockResponseForRequest(request: String(describing: other), response: [String: Any]())
+        executor1.append(other)
+        firstLaunch.waitForDispatches(4)
+        XCTAssertNil(executor1.receiveReceipts.items[expiredNotif], "Expired marker should be pruned on the next save")
+
+        /* When */
+        // Relaunch: the expired notificationId is re-emitted and must be sent again.
+        let secondLaunch = MockDispatchQueue()
+        let executor2 = OSLiveActivitiesExecutor(requestDispatch: secondLaunch)
+        executor2.append(request2)
+        secondLaunch.waitForDispatches(2)
+
+        /* Then */
+        XCTAssertTrue(mockClient.executedRequests.contains { $0 == request2 }, "Receipt should be re-sent after its marker expires")
+    }
+
+    /**
+     A non-retryable failure removes the receipt from the cache, leaving no marker, so a later re-emit of
+     the same notificationId is sent again rather than suppressed.
+     */
+    func testReceiveReceiptResentAfterNonRetryableFailure() throws {
+        /* Setup */
+        let mockClient = setUpSubscribedUser()
+
+        let request1 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
+        mockClient.setMockFailureResponseForRequest(request: String(describing: request1), error: OneSignalClientError(code: 401, message: "not-important", responseHeaders: nil, response: nil, underlyingError: nil))
+
+        /* When */
+        let mockDispatchQueue = MockDispatchQueue()
+        let executor = OSLiveActivitiesExecutor(requestDispatch: mockDispatchQueue)
+        executor.append(request1)
+        mockDispatchQueue.waitForDispatches(2)
+        XCTAssertEqual(executor.receiveReceipts.items.count, 0, "A non-retryable failure should leave no dedup marker")
+
+        // Re-emit the same notificationId; this time it succeeds and must be sent again.
+        let request2 = OSRequestLiveActivityReceiveReceipts(key: "my-notification-id", activityType: "my-activity-type", activityId: "my-activity-id")
+        mockClient.setMockResponseForRequest(request: String(describing: request2), response: [String: Any]())
+        executor.append(request2)
+        mockDispatchQueue.waitForDispatches(4)
+
+        /* Then */
+        XCTAssertEqual(mockClient.executedRequests.count, 2, "Receipt should be re-sent after a non-retryable failure")
+        XCTAssertTrue(executor.receiveReceipts.items["my-notification-id"]?.requestSuccessful ?? false)
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Stop Live Activities from reporting a receive receipt more than once per device, which inflated the dashboard's Confirmed Receipts count above Delivered.

## Details

Reproduced this manually by starting a live activity on the device, opening the app, swiping it away, reopening the app… It looks like ActivityKit re-emits content updates on app relaunches even when the content of the live activity does not change. The SDK had been treating each update as a separate message and was not deduplicating.

### Motivation
For Live Activities, the dashboard's Confirmed Receipts count could exceed Delivered (SDK-4814). A receive receipt for a given `notificationId` was reported to OneSignal more than once per device because:

- The receipt was attributed to the Activity's *current* content snapshot (`activity.content.state`) instead of the content actually delivered in that update, so a burst of content updates could mis-attribute the `notificationId`.
- On success the receipt request was forgotten with no record that it had already been sent, so a later content update — or ActivityKit re-emitting the active activity's content on app relaunch — re-sent it.

### Scope
- Receive receipts are attributed to the iterated `content.state` of each update rather than the live `activity.content` snapshot.
- The receive-receipts request cache is now the single source of truth for dedup: sent receipts are kept (`shouldForgetWhenSuccessful = false`) as markers, so both in-session re-emits and post-relaunch re-emits for the same `notificationId` are suppressed.
- The cache TTL is reduced from 30 to 3 days, bounding how long sent markers and unsent retries are retained.
- No change to Live Activity start/update token handling, notification display, or open behavior.

# Testing
## Unit testing
- Added `testReceiveReceiptsNotResentForSameNotificationIdAfterRelaunch`, a regression test that sends a receipt through one executor, then has a second executor (simulating an app relaunch sharing the same persisted cache) re-enqueue the same `notificationId` and verifies it is not re-sent.
- Updated `testReceiveReceiptsWithSuccessfulRequest` and `testReceiveReceiptsRequestNotExecutedWithSameNotificationId` to assert the sent receipt is retained in the cache as a dedup marker (`requestSuccessful == true`) rather than removed.

## Manual testing
On-device, with a Live Activity on the Lock Screen, swiped the app away to terminate it and reopened it — the path where ActivityKit re-emits the active activity's current content on launch. Before the fix this sent a duplicate Confirmed Receipt for the same `notificationId`; after the fix the duplicate no longer reproduces.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [x] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)
