### PR TITLE
fix: pin CI Xcode selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ on:
 jobs:
   build:
     name: Build and Test using any available iPhone simulator
-    runs-on: macos-latest-large
+    runs-on: macos-15-large
 
     steps:
       - name: Select Xcode Version
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.4.0.app
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
       - name: Checkout OneSignal-iOS-SDK
         uses: actions/checkout@v3
       - name: Set Default Scheme


### PR DESCRIPTION
## Summary
- Pin the CI runner to `macos-15-large` so the image does not drift under `macos-latest-large`.
- Select Xcode 16.4 via `/Applications/Xcode_16.4.app/Contents/Developer` instead of the brittle `Xcode_16.4.0.app` path.

## Test plan
- Added this commit to a failing PR and the error was resolved

<img width="1030" height="194" alt="error_screenshot" src="https://github.com/user-attachments/assets/0a46d4a5-55f2-4e58-8bd8-4c711d6d02a1" />




Made with [Cursor](https://cursor.com)