### PR TITLE
chore: [CI] Treat CocoaPods Trunk duplicate pushes as a no-op

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -91,7 +91,7 @@ jobs:
             OUTPUT=$(pod trunk push "$podspec" --allow-warnings 2>&1) && { echo "$OUTPUT"; return; }
             echo "$OUTPUT"
             echo "$OUTPUT" | grep -q "Unable to accept duplicate entry" || exit 1
-            echo "⏭️  SKIPPED: $podspec already on Trunk (duplicate) — treating as no-op"
+            echo "::warning::$podspec already on Trunk (duplicate) — skipped"
           }
 
           push_podspec OneSignal.podspec

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -83,15 +83,19 @@ jobs:
           echo "Validating OneSignalXCFramework.podspec..."
           pod spec lint OneSignalXCFramework.podspec --allow-warnings
 
-      - name: Publish OneSignal.podspec to CocoaPods Trunk
+      - name: Publish podspecs to CocoaPods Trunk
         run: |
-          echo "Publishing OneSignal.podspec to CocoaPods Trunk..."
-          pod trunk push OneSignal.podspec --allow-warnings
+          push_podspec() {
+            local podspec="$1"
+            echo "Publishing $podspec to CocoaPods Trunk..."
+            OUTPUT=$(pod trunk push "$podspec" --allow-warnings 2>&1) && { echo "$OUTPUT"; return; }
+            echo "$OUTPUT"
+            echo "$OUTPUT" | grep -q "Unable to accept duplicate entry" || exit 1
+            echo "⏭️  SKIPPED: $podspec already on Trunk (duplicate) — treating as no-op"
+          }
 
-      - name: Publish OneSignalXCFramework.podspec to CocoaPods Trunk
-        run: |
-          echo "Publishing OneSignalXCFramework.podspec to CocoaPods Trunk..."
-          pod trunk push OneSignalXCFramework.podspec --allow-warnings
+          push_podspec OneSignal.podspec
+          push_podspec OneSignalXCFramework.podspec
 
       - name: ✅ CocoaPods Published
         run: |


### PR DESCRIPTION
# Description
## One Line Summary
Treat already-published CocoaPods versions as a skipped no-op so the `publish-release` workflow can be re-run after a partial upload success.

## Details

### Motivation
Pushing to cocoapods with `pod trunk push` can return an internal server error after the version has already been accepted. Re-running the workflow then fails with `Unable to accept duplicate entry`, blocking the remaining steps of the workflow (XCFramework publish, SPM release, wrapper PRs). This change treats that duplicate as a no-op and emits a workflow warning so the skip is visible in Actions annotations.

### Scope
Only `.github/workflows/publish-release.yml` CocoaPods publish steps. No SDK runtime behavior changes.

# Testing
## Unit testing
Not applicable — CI workflow-only change.

## Manual testing
1. Release workflow for `5.3.0-beta-03` hit a cocoapods internal server error (but the version was already accepted) and returned early.
2. Re-running the workflow also returned early with failure due to duplicate version being uploaded
3. **After fix**: Re-ran `publish-release` for `5.3.0-beta-03`: OneSignal Pod was skipped as a duplicate, and workflow continued successfully.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

Made with [Cursor](https://cursor.com)