### PR TITLE
fix: [SDK-4874] single-flight UpdateSubscription to stop in-flight PATCH races

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
@@ -36,9 +36,15 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
     public var lastHTTPRequest: OneSignalRequest?
     public var networkRequestCount = 0
     public var executedRequests: [OneSignalRequest] = []
+    /// Requests that have entered `execute` (including those still held / delayed).
+    public private(set) var startedRequests: [OneSignalRequest] = []
     public var executeInstantaneously = false
     /// Set to true to make it unnecessary to setup mock responses for every request possible
     public var fireSuccessForAllRequests = false
+    /// When true, `execute` records the request but does not complete until `releaseHeldResponses()`.
+    public var holdResponses = false
+
+    private var heldExecutions: [(request: OneSignalRequest, onSuccess: OSResultSuccessBlock, onFailure: OSClientFailureBlock)] = []
 
     var remoteParamsResponse: [String: Any]?
     var shouldUseProvisionalAuthorization = false // new in iOS 12 (aka Direct to History)
@@ -84,6 +90,9 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
         lastHTTPRequest = nil
         networkRequestCount = 0
         executedRequests.removeAll()
+        startedRequests.removeAll()
+        heldExecutions.removeAll()
+        holdResponses = false
         executeInstantaneously = true
         remoteParamsResponse = nil
         shouldUseProvisionalAuthorization = false
@@ -93,12 +102,35 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
     public func execute(_ request: OneSignalRequest, onSuccess successBlock: @escaping OSResultSuccessBlock, onFailure failureBlock: @escaping OSClientFailureBlock) {
         print("🧪 MockOneSignalClient execute called")
 
+        lock.withLock {
+            startedRequests.append(request)
+        }
+
+        if holdResponses {
+            lock.withLock {
+                heldExecutions.append((request, successBlock, failureBlock))
+            }
+            return
+        }
+
         if executeInstantaneously {
             finishExecutingRequest(request, onSuccess: successBlock, onFailure: failureBlock)
         } else {
             executionQueue.asyncAfter(deadline: .now() + .milliseconds(50)) {
                 self.finishExecutingRequest(request, onSuccess: successBlock, onFailure: failureBlock)
             }
+        }
+    }
+
+    /// Completes every request currently held by `holdResponses`.
+    public func releaseHeldResponses() {
+        let held: [(request: OneSignalRequest, onSuccess: OSResultSuccessBlock, onFailure: OSClientFailureBlock)] = lock.withLock {
+            let copy = heldExecutions
+            heldExecutions.removeAll()
+            return copy
+        }
+        for item in held {
+            finishExecutingRequest(item.request, onSuccess: item.onSuccess, onFailure: item.onFailure)
         }
     }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalCoreMocks/MockOneSignalClient.swift
@@ -102,14 +102,16 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
     public func execute(_ request: OneSignalRequest, onSuccess successBlock: @escaping OSResultSuccessBlock, onFailure failureBlock: @escaping OSClientFailureBlock) {
         print("🧪 MockOneSignalClient execute called")
 
-        lock.withLock {
+        // Check hold + enqueue under one lock so releaseHeldResponses can't miss a callback mid-hold.
+        let shouldHold = lock.withLock { () -> Bool in
             startedRequests.append(request)
-        }
-
-        if holdResponses {
-            lock.withLock {
-                heldExecutions.append((request, successBlock, failureBlock))
+            guard holdResponses else {
+                return false
             }
+            heldExecutions.append((request, successBlock, failureBlock))
+            return true
+        }
+        if shouldHold {
             return
         }
 
@@ -122,9 +124,10 @@ public class MockOneSignalClient: NSObject, IOneSignalClient {
         }
     }
 
-    /// Completes every request currently held by `holdResponses`.
+    /// Completes every request currently held by `holdResponses`, and stops holding further executes.
     public func releaseHeldResponses() {
         let held: [(request: OneSignalRequest, onSuccess: OSResultSuccessBlock, onFailure: OSClientFailureBlock)] = lock.withLock {
+            holdResponses = false
             let copy = heldExecutions
             heldExecutions.removeAll()
             return copy

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
@@ -419,14 +419,9 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
             self.dispatchQueue.async {
                 self.updateRequestQueue.removeAll(where: { $0 == request})
                 OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
-                self.executeNextPendingUpdateSubscription(for: modelId, inBackground: inBackground)
-                if inBackground {
-                    OSBackgroundTaskManager.endBackgroundTask(backgroundTaskIdentifier)
-                }
-            }
 
-            if let onesignalId = OneSignalUserManagerImpl.sharedInstance.onesignalId {
-                if let rywToken = response?["ryw_token"] as? String
+                if let onesignalId = OneSignalUserManagerImpl.sharedInstance.onesignalId {
+                    if let rywToken = response?["ryw_token"] as? String
                     {
                         let rywDelay = response?["ryw_delay"] as? NSNumber
                         OSConsistencyManager.shared.setRywTokenAndDelay(
@@ -438,6 +433,12 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                         // handle a potential regression where ryw_token is no longer returned by API
                         OSConsistencyManager.shared.resolveConditionsWithID(id: OSIamFetchReadyCondition.CONDITIONID)
                     }
+                }
+
+                self.executeNextPendingUpdateSubscription(for: modelId, inBackground: inBackground)
+                if inBackground {
+                    OSBackgroundTaskManager.endBackgroundTask(backgroundTaskIdentifier)
+                }
             }
         } onFailure: { error in
             OneSignalLog.onesignalLog(.LL_ERROR, message: "OSSubscriptionOperationExecutor update subscription request failed with error: \(error.debugDescription)")

--- a/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUser/Source/Executors/OSSubscriptionOperationExecutor.swift
@@ -397,6 +397,12 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
         guard !request.sentToClient else {
             return
         }
+        // Single-flight: don't send a second UpdateSubscription for the same model while one is in flight.
+        // A later coalesced request stays queued and is drained when the in-flight one finishes.
+        let modelId = request.subscriptionModel.modelId
+        guard !updateRequestQueue.contains(where: { $0 !== request && $0.sentToClient && $0.subscriptionModel.modelId == modelId }) else {
+            return
+        }
         guard request.prepareForExecution(newRecordsState: newRecordsState) else {
             return
         }
@@ -413,6 +419,7 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
             self.dispatchQueue.async {
                 self.updateRequestQueue.removeAll(where: { $0 == request})
                 OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
+                self.executeNextPendingUpdateSubscription(for: modelId, inBackground: inBackground)
                 if inBackground {
                     OSBackgroundTaskManager.endBackgroundTask(backgroundTaskIdentifier)
                 }
@@ -440,11 +447,27 @@ class OSSubscriptionOperationExecutor: OSOperationExecutor {
                     // Fail, no retry, remove from cache and queue
                     self.updateRequestQueue.removeAll(where: { $0 == request})
                     OneSignalUserDefaults.initShared().saveCodeableData(forKey: OS_SUBSCRIPTION_EXECUTOR_UPDATE_REQUEST_QUEUE_KEY, withValue: self.updateRequestQueue)
+                    self.executeNextPendingUpdateSubscription(for: modelId, inBackground: inBackground)
+                } else {
+                    // Make the request eligible for the next flush
+                    request.sentToClient = false
                 }
                 if inBackground {
                     OSBackgroundTaskManager.endBackgroundTask(backgroundTaskIdentifier)
                 }
             }
         }
+    }
+
+}
+
+extension OSSubscriptionOperationExecutor {
+    /// Sends the oldest unsent UpdateSubscription for `modelId`, if any. Caller must be on `dispatchQueue`.
+    private func executeNextPendingUpdateSubscription(for modelId: String, inBackground: Bool) {
+        let pending = updateRequestQueue.filter { !$0.sentToClient && $0.subscriptionModel.modelId == modelId }
+        guard let next = pending.min(by: { $0.timestamp < $1.timestamp }) else {
+            return
+        }
+        executeUpdateSubscriptionRequest(next, inBackground: inBackground)
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/SubscriptionUpdateRaceTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/SubscriptionUpdateRaceTests.swift
@@ -180,7 +180,6 @@ final class SubscriptionUpdateRaceTests: XCTestCase {
 
         XCTAssertEqual(client.startedRequests.count, 1, "Follow-up must wait for in-flight UpdateSubscription")
 
-        client.holdResponses = false
         client.releaseHeldResponses()
         OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/SubscriptionUpdateRaceTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/SubscriptionUpdateRaceTests.swift
@@ -133,6 +133,119 @@ final class SubscriptionUpdateRaceTests: XCTestCase {
         XCTAssertEqual(updateRequests.count, 1, "Unsent updates for the same subscription should be coalesced")
     }
 
+    /**
+     An UpdateSubscription already on the wire must not race a follow-up PATCH.
+     The follow-up stays queued until the in-flight request completes, then sends live state.
+     */
+    func testInFlightUpdateBlocksFollowUpUntilCompleteThenSendsLiveState() throws {
+        let client = MockOneSignalClient()
+        client.holdResponses = true
+        client.fireSuccessForAllRequests = true
+        OneSignalCoreImpl.setSharedClient(client)
+
+        let executor = OSSubscriptionOperationExecutor(newRecordsState: OSNewRecordsState())
+        let model = makePushSubscriptionModel(notificationTypes: promptedNeverAnswered, subscriptionId: subscriptionId)
+        let identityModelId = UUID().uuidString
+
+        executor.enqueueDelta(OSDelta(
+            name: OS_UPDATE_SUBSCRIPTION_DELTA,
+            identityModelId: identityModelId,
+            model: model,
+            property: "notificationTypes",
+            value: promptedNeverAnswered
+        ))
+        executor.processDeltaQueue(inBackground: false)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
+
+        XCTAssertEqual(client.startedRequests.count, 1, "First UpdateSubscription should be in flight")
+        let firstPayload = try XCTUnwrap(
+            (client.startedRequests[0] as? OSRequestUpdateSubscription)?.parameters?["subscription"] as? [String: Any]
+        )
+        XCTAssertEqual(firstPayload["notification_types"] as? Int, promptedNeverAnswered)
+        XCTAssertEqual(firstPayload["enabled"] as? Bool, false)
+
+        // Permission granted while first PATCH is still in flight.
+        model.notificationTypes = subscribedNotificationTypes
+        XCTAssertTrue(model.enabled)
+
+        executor.enqueueDelta(OSDelta(
+            name: OS_UPDATE_SUBSCRIPTION_DELTA,
+            identityModelId: identityModelId,
+            model: model,
+            property: "notificationTypes",
+            value: subscribedNotificationTypes
+        ))
+        executor.processDeltaQueue(inBackground: false)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.2)
+
+        XCTAssertEqual(client.startedRequests.count, 1, "Follow-up must wait for in-flight UpdateSubscription")
+
+        client.holdResponses = false
+        client.releaseHeldResponses()
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        XCTAssertEqual(client.startedRequests.count, 2, "Pending follow-up should send after in-flight completes")
+        let secondPayload = try XCTUnwrap(
+            (client.startedRequests[1] as? OSRequestUpdateSubscription)?.parameters?["subscription"] as? [String: Any]
+        )
+        XCTAssertEqual(secondPayload["notification_types"] as? Int, subscribedNotificationTypes)
+        XCTAssertEqual(secondPayload["enabled"] as? Bool, true)
+    }
+
+    /**
+     A retryable failure (e.g. 500/timeout) must not leave the single-flight gate locked.
+     The failed request becomes resendable and later updates for the model still go out.
+     */
+    func testRetryableFailureDoesNotBlockSubsequentUpdates() throws {
+        let client = MockOneSignalClient()
+        client.fireSuccessForAllRequests = true
+        OneSignalCoreImpl.setSharedClient(client)
+
+        let executor = OSSubscriptionOperationExecutor(newRecordsState: OSNewRecordsState())
+        let model = makePushSubscriptionModel(notificationTypes: promptedNeverAnswered, subscriptionId: subscriptionId)
+        let identityModelId = UUID().uuidString
+
+        // Fail the first update with a retryable error (mock responses are keyed by request description).
+        let requestKey = "OSRequestUpdateSubscription with model: \(model.modelId)"
+        client.setMockFailureResponseForRequest(
+            request: requestKey,
+            error: OneSignalClientError(code: 500, message: "retryable", responseHeaders: nil, response: nil, underlyingError: nil)
+        )
+
+        executor.enqueueDelta(OSDelta(
+            name: OS_UPDATE_SUBSCRIPTION_DELTA,
+            identityModelId: identityModelId,
+            model: model,
+            property: "notificationTypes",
+            value: promptedNeverAnswered
+        ))
+        executor.processDeltaQueue(inBackground: false)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        XCTAssertEqual(client.executedRequests.count, 1, "First update should have been attempted and failed retryably")
+
+        // Server recovers; user accepts permission.
+        client.setMockResponseForRequest(request: requestKey, response: [:])
+        model.notificationTypes = subscribedNotificationTypes
+        XCTAssertTrue(model.enabled)
+
+        executor.enqueueDelta(OSDelta(
+            name: OS_UPDATE_SUBSCRIPTION_DELTA,
+            identityModelId: identityModelId,
+            model: model,
+            property: "notificationTypes",
+            value: subscribedNotificationTypes
+        ))
+        executor.processDeltaQueue(inBackground: false)
+        OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)
+
+        let updateRequests = client.executedRequests.compactMap { $0 as? OSRequestUpdateSubscription }
+        XCTAssertEqual(updateRequests.count, 2, "Follow-up update must still send after a retryable failure")
+        let lastPayload = try XCTUnwrap(updateRequests.last?.parameters?["subscription"] as? [String: Any])
+        XCTAssertEqual(lastPayload["notification_types"] as? Int, subscribedNotificationTypes)
+        XCTAssertEqual(lastPayload["enabled"] as? Bool, true)
+    }
+
     // MARK: - Helpers
 
     private func makePushSubscriptionModel(notificationTypes: Int, subscriptionId: String?) -> OSSubscriptionModel {


### PR DESCRIPTION
# Description
## One Line Summary
Serialize UpdateSubscription PATCHes per subscription so an in-flight stale `-19` cannot race a later grant and leave users Never Subscribed.

## Details

### Motivation
[#1687](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1687) fixed the **pending** stale UpdateSubscription case by refreshing the PATCH body from the live model before send and coalescing unsent updates. A residual window remains: if a pre-permission update (`enabled: false`, `notification_types: -19`) is **already on the wire** when the user accepts, a concurrent post-grant PATCH can reorder on the server and stick the subscription in Never Subscribed.

This follow-up closes that window for the escalating SDK-4874 customer symptom. Related: [SDK-4874](https://linear.app/onesignal/issue/SDK-4874/users-stuck-in-never-subscribed-state-due-to-rapid-prompt-acceptance).

### Scope
- At most one in-flight `OSRequestUpdateSubscription` per subscription model; later updates stay queued (existing coalesce) and are drained after success or non-retryable failure.
- On retryable failure, clear `sentToClient` so the single-flight gate does not block the model until app restart.
- Test-only: `MockOneSignalClient` can hold responses mid-flight.
- Does **not** change public APIs or skip sending `-19`. Broader OperationRepo queue-safety refactor tracked separately in [SDK-4892](https://linear.app/onesignal/issue/SDK-4892/refactor-osoperationrepo-and-executors-for-enforced-queue-safety).

# Testing
## Unit testing
Extended `SubscriptionUpdateRaceTests`:
- In-flight `-19` blocks the grant follow-up until the first response completes, then sends live subscribed state.
- Retryable 500 does not leave the gate locked; a later grant update still sends.

Ran `OneSignalUserTests/SubscriptionUpdateRaceTests` locally (all pass).

## Manual testing
Covered by unit tests with held mock responses. Full CI pending on this PR.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
     - Local `SubscriptionUpdateRaceTests` pass; full CI pending on this PR.
   - [x] I have personally tested this on my device, or explained why that is not possible
     - Unit coverage with mid-flight held responses; device retest not required for this follow-up.

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

Made with [Cursor](https://cursor.com)