### PR TITLE
chore: Log when OneSignalInAppMessages module is missing

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -400,6 +400,8 @@ static OneSignalReceiveReceiptsController* _receiveReceiptsController;
     let oneSignalInAppMessages = NSClassFromString(ONE_SIGNAL_IN_APP_MESSAGES_CLASS_NAME);
     if (oneSignalInAppMessages != nil && [oneSignalInAppMessages respondsToSelector:@selector(start)]) {
         [oneSignalInAppMessages performSelector:@selector(start)];
+    } else {
+        [OneSignalLog onesignalLog:ONE_S_LL_DEBUG message:@"OneSignalInAppMessages not found. In-App Messages will be unavailable. Add the OneSignalInAppMessages module if you intend to use them."];
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a DEBUG log in `startInAppMessages` when the optional IAM module is not linked, instead of failing silently.
- We already surface ERROR logs only when someone uses the `OneSignal.InAppMessages` API

## Manual test
- [x] App without `OneSignalInAppMessages`: confirm DEBUG log appears at init
- [x] App with `OneSignalInAppMessages`: confirm no log and IAM still starts normally


Made with [Cursor](https://cursor.com)