### PR TITLE
feat: send a per-occurrence event_id on IAM engagement [NOTP-1520]

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Controller/OSMessagingController.m
@@ -647,7 +647,8 @@ static BOOL _isInAppMessagingPaused = false;
                                                        withPlayerId:OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId
                                                       withMessageId:message.messageId
                                                          withPageId:pageId
-                                                       forVariantId:message.variantId];
+                                                       forVariantId:message.variantId
+                                                        withEventId:[NSUUID UUID].UUIDString];
 
     [OneSignalCoreImpl.sharedClient executeRequest:metricsRequest
                                        onSuccess:^(NSDictionary *result) {
@@ -683,10 +684,14 @@ static BOOL _isInAppMessagingPaused = false;
     [self.impressionedInAppMessages addObject:message.messageId];
     
     // Create the request and attach a payload to it
+    // Per-occurrence event_id so turbine can dedup at-least-once retries. The
+    // request object is reused across client reattempts, so this id is stable
+    // across them (NOTP-1520).
     let metricsRequest = [OSRequestInAppMessageViewed withAppId:OneSignalIdentifiers.currentAppId
                                                    withPlayerId:OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId
                                                   withMessageId:message.messageId
-                                                   forVariantId:message.variantId];
+                                                   forVariantId:message.variantId
+                                                    withEventId:[NSUUID UUID].UUIDString];
     
     [OneSignalCoreImpl.sharedClient executeRequest:metricsRequest
                                        onSuccess:^(NSDictionary *result) {
@@ -1098,7 +1103,8 @@ static BOOL _isInAppMessagingPaused = false;
                                                     withPlayerId:OneSignalUserManagerImpl.sharedInstance.pushSubscriptionId
                                                    withMessageId:message.messageId
                                                     forVariantId:message.variantId
-                                                      withAction:action];
+                                                      withAction:action
+                                                     withEventId:[NSUUID UUID].UUIDString];
 
    [OneSignalCoreImpl.sharedClient executeRequest:metricsRequest
                                       onSuccess:^(NSDictionary *result) {

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Requests/OSInAppMessagingRequests.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Requests/OSInAppMessagingRequests.h
@@ -33,11 +33,11 @@
 @end
 
 @interface OSRequestInAppMessageViewed : OneSignalRequest
-+ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withPlayerId:(NSString * _Nonnull)playerId withMessageId:(NSString * _Nonnull)messageId forVariantId:(NSString * _Nonnull)variantId;
++ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withPlayerId:(NSString * _Nonnull)playerId withMessageId:(NSString * _Nonnull)messageId forVariantId:(NSString * _Nonnull)variantId withEventId:(NSString * _Nonnull)eventId;
 @end
 
 @interface OSRequestInAppMessagePageViewed : OneSignalRequest
-+ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withPlayerId:(NSString * _Nonnull)playerId withMessageId:(NSString * _Nonnull)messageId withPageId:(NSString * _Nonnull)pageId forVariantId:(NSString * _Nonnull)variantId;
++ (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId withPlayerId:(NSString * _Nonnull)playerId withMessageId:(NSString * _Nonnull)messageId withPageId:(NSString * _Nonnull)pageId forVariantId:(NSString * _Nonnull)variantId withEventId:(NSString * _Nonnull)eventId;
 @end
 
 @interface OSRequestLoadInAppMessageContent : OneSignalRequest
@@ -53,5 +53,6 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                       forVariantId:(NSString * _Nonnull)variantId
-                     withAction:(OSInAppMessageClickResult * _Nonnull)action;
+                     withAction:(OSInAppMessageClickResult * _Nonnull)action
+                       withEventId:(NSString * _Nonnull)eventId;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Requests/OSInAppMessagingRequests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessages/Requests/OSInAppMessagingRequests.m
@@ -65,7 +65,8 @@
 + (instancetype _Nonnull)withAppId:(NSString * _Nonnull)appId
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
-                      forVariantId:(NSString *)variantId {
+                      forVariantId:(NSString *)variantId
+                       withEventId:(NSString *)eventId {
     let request = [OSRequestInAppMessageViewed new];
 
     let params = [NSMutableDictionary new];
@@ -73,6 +74,7 @@
     params[@"player_id"] = playerId;
     params[@"app_id"] = appId;
     params[@"variant_id"] = variantId;
+    params[@"event_id"] = eventId;
 
     request.parameters = params;
     request.method = POST;
@@ -87,7 +89,8 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                         withPageId:(NSString * _Nonnull)pageId
-                      forVariantId:(NSString *)variantId {
+                      forVariantId:(NSString *)variantId
+                       withEventId:(NSString *)eventId {
     let request = [OSRequestInAppMessagePageViewed new];
 
     let params = [NSMutableDictionary new];
@@ -96,6 +99,7 @@
     params[@"app_id"] = appId;
     params[@"variant_id"] = variantId;
     params[@"page_id"] = pageId;
+    params[@"event_id"] = eventId;
 
     request.parameters = params;
     request.method = POST;
@@ -110,7 +114,8 @@
                       withPlayerId:(NSString * _Nonnull)playerId
                      withMessageId:(NSString * _Nonnull)messageId
                       forVariantId:(NSString * _Nonnull)variantId
-                     withAction:(OSInAppMessageClickResult * _Nonnull)action {
+                     withAction:(OSInAppMessageClickResult * _Nonnull)action
+                       withEventId:(NSString * _Nonnull)eventId {
     let request = [OSRequestInAppMessageClicked new];
 
     let params = [NSMutableDictionary new];
@@ -120,6 +125,7 @@
     params[@"click_id"] = action.clickId ?: @"";
     params[@"variant_id"] = variantId;
     params[@"first_click"] = @(action.firstClick);
+    params[@"event_id"] = eventId;
 
     request.parameters = params;
     request.method = POST;

--- a/iOS_SDK/OneSignalSDK/OneSignalInAppMessagesTests/IAMRequestTests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalInAppMessagesTests/IAMRequestTests.m
@@ -85,7 +85,8 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
                                 withAppId:testAppId
                                 withPlayerId:testSubscriptionId
                                 withMessageId:testMessageId
-                                forVariantId:testVariantId];
+                                forVariantId:testVariantId
+                                withEventId:@"test_event_id"];
     NSString *correctUrl = correctUrlWithPath([NSString stringWithFormat:@"in_app_messages/%@/impression", testMessageId]);
 
     XCTAssertEqualObjects(correctUrl, request.urlRequest.URL.absoluteString);
@@ -93,7 +94,8 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
        @"device_type": @0,
        @"player_id": testSubscriptionId,
        @"app_id": testAppId,
-       @"variant_id": testVariantId
+       @"variant_id": testVariantId,
+       @"event_id": @"test_event_id"
     }));
 }
 
@@ -102,11 +104,13 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
                                 withAppId:testAppId
                                 withPlayerId:nil
                                 withMessageId:testMessageId
-                                forVariantId:nil];
+                                forVariantId:nil
+                                withEventId:@"test_event_id"];
 
     XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{
        @"device_type": @0,
-       @"app_id": testAppId
+       @"app_id": testAppId,
+       @"event_id": @"test_event_id"
     }));
 }
 
@@ -116,7 +120,8 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
                     withPlayerId:testSubscriptionId
                     withMessageId:testMessageId
                     withPageId:testPageId
-                    forVariantId:testVariantId];
+                    forVariantId:testVariantId
+                    withEventId:@"test_event_id"];
     NSString *correctUrl = correctUrlWithPath([NSString stringWithFormat:@"in_app_messages/%@/pageImpression", testMessageId]);
 
     XCTAssertEqualObjects(correctUrl, request.urlRequest.URL.absoluteString);
@@ -125,7 +130,8 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
        @"player_id": testSubscriptionId,
        @"app_id": testAppId,
        @"variant_id": testVariantId,
-       @"page_id": testPageId
+       @"page_id": testPageId,
+       @"event_id": @"test_event_id"
     }));
 }
 
@@ -135,11 +141,13 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
                     withPlayerId:nil
                     withMessageId:testMessageId
                     withPageId:nil
-                    forVariantId:nil];
+                    forVariantId:nil
+                    withEventId:@"test_event_id"];
 
     XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{
        @"device_type": @0,
        @"app_id": testAppId,
+       @"event_id": @"test_event_id"
     }));
 }
 
@@ -149,7 +157,8 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
                    withPlayerId:testSubscriptionId
                    withMessageId:testMessageId
                    forVariantId:testVariantId
-                   withAction:testClickResult];
+                   withAction:testClickResult
+                   withEventId:@"test_event_id"];
     NSString *correctUrl = correctUrlWithPath([NSString stringWithFormat:@"in_app_messages/%@/click", testMessageId]);
 
     XCTAssertEqualObjects(correctUrl, request.urlRequest.URL.absoluteString);
@@ -159,7 +168,8 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
        @"player_id": testSubscriptionId,
        @"click_id": testClickResult.clickId ?: @"",
        @"variant_id": testVariantId,
-       @"first_click": @(testClickResult.firstClick)
+       @"first_click": @(testClickResult.firstClick),
+       @"event_id": @"test_event_id"
    }));
 }
 
@@ -169,13 +179,15 @@ BOOL checkHttpBody(NSData *bodyData, NSDictionary *correct) {
                    withPlayerId:nil
                    withMessageId:testMessageId
                    forVariantId:nil
-                   withAction:testClickResult];
+                   withAction:testClickResult
+                   withEventId:@"test_event_id"];
 
     XCTAssertTrue(checkHttpBody(request.urlRequest.HTTPBody, @{
        @"app_id": testAppId,
        @"device_type": @0,
        @"click_id": testClickResult.clickId ?: @"",
-       @"first_click": @(testClickResult.firstClick)
+       @"first_click": @(testClickResult.firstClick),
+       @"event_id": @"test_event_id"
    }));
 }
 


### PR DESCRIPTION
## Summary

Mint a per-occurrence `event_id` and send it on IAM engagement requests (click,
impression, pageImpression). Turbine deduplicates these on the SDK-supplied
`event_id` (see OneSignal/turbine#1768), so at-least-once deliveries collapse to
a single event downstream instead of becoming duplicate Kafka records /
double-counted engagement (NOTP-1520).

## What changed

- `OSInAppMessagingRequests`: new `withEventId:` param on the Viewed / PageViewed
  / Clicked requests, added to the body as `event_id`.
- `OSMessagingController`: mint `[NSUUID UUID]` at each engagement call site.
- `IAMRequestTests` updated to pass and assert `event_id` (the body check is an
  exact match).

## Why mint at request-construction

`OneSignalClient` reattempts a failed request (`statusCode >= 500 || == 0`, i.e.
5xx or a network error, up to `MAX_ATTEMPT_COUNT`) by re-executing the **same**
`OneSignalRequest` object, whose `parameters` are set once at construction. So
minting the id when the request is built keeps it stable across those retries,
which is exactly the response-lost duplicate turbine needs to fold. After the
reattempts are exhausted, the controller's `onFailure` clears its guard, so a
later send is a redisplay = a new occurrence = a new id.

This client retry makes iOS the primary retry-driven duplicate source for IAM
engagement.

## Validation

Code-only change (no local build in this environment); relies on CI. Body
assertions added to `IAMRequestTests` for all three requests.

## Task / Ticket

https://linear.app/onesignal/issue/NOTP-1520
