### PR TITLE
chore: [SDK-4975] consume KMP in iOS SDK

### DIFF
--- a/.github/workflows/bump-kmp-submodule.yml
+++ b/.github/workflows/bump-kmp-submodule.yml
@@ -1,0 +1,105 @@
+name: Bump KMP Submodule
+
+on:
+  workflow_call:
+    inputs:
+      kmp_version:
+        description: "OneSignal-KMP-SDK tag to pin the submodule to (e.g. v0.2.0)"
+        required: true
+        type: string
+      kmp_sha:
+        description: "Commit SHA the tag points at"
+        required: true
+        type: string
+    secrets:
+      GH_PUSH_TOKEN:
+        required: false
+        description: Cross-repo push token with contents and pull-request write access
+  workflow_dispatch:
+    inputs:
+      kmp_version:
+        description: "OneSignal-KMP-SDK tag to pin the submodule to (e.g. v0.2.0)"
+        required: true
+        type: string
+      kmp_sha:
+        description: "Commit SHA the tag points at"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      SUBMODULE_PATH: OneSignal-KMP-SDK
+      VERSION: ${{ inputs.kmp_version }}
+      NEW_SHA: ${{ inputs.kmp_sha }}
+    steps:
+      - name: "[Checkout] iOS SDK"
+        uses: actions/checkout@v4
+        with:
+          repository: OneSignal/OneSignal-iOS-SDK
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+
+      - name: "[Setup] Git user"
+        uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
+
+      - name: "[Bump] Re-point submodule gitlink"
+        id: bump
+        run: |
+          set -euo pipefail
+          branch="chore/bump-kmp-${VERSION}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+          git checkout -b "$branch"
+          git update-index --add --cacheinfo "160000,${NEW_SHA},${SUBMODULE_PATH}"
+
+          if git diff --cached --quiet; then
+            echo "Submodule already at ${NEW_SHA}; nothing to bump."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git commit -m "chore(logger): bump ${SUBMODULE_PATH} submodule to ${VERSION}"
+          git push origin "$branch" --force-with-lease
+
+      - name: "[PR] Open or update bump PR"
+        if: ${{ steps.bump.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          branch="${{ steps.bump.outputs.branch }}"
+          notes_url="https://github.com/OneSignal/OneSignal-KMP-SDK/releases/tag/${VERSION}"
+          notes="$(gh release view "$VERSION" --repo OneSignal/OneSignal-KMP-SDK --json body --jq .body 2>/dev/null || true)"
+
+          body_file="$RUNNER_TEMP/bump_pr_body.md"
+          {
+            printf 'Automated bump of the `%s` submodule to **%s** (`%s`).\n\n' "$SUBMODULE_PATH" "$VERSION" "$NEW_SHA"
+            printf '## Release notes — %s\n\n' "$VERSION"
+            if [ -n "$notes" ]; then
+              printf '%s\n\n' "$notes"
+              printf '_Source: [%s](%s)_\n\n' "$VERSION" "$notes_url"
+            else
+              printf 'See [%s](%s).\n\n' "$VERSION" "$notes_url"
+            fi
+            printf 'After merge, run `git submodule update --init --recursive` locally to sync.\n'
+          } > "$body_file"
+
+          if gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr edit "$branch" \
+              --title "chore(logger): bump shared KMP logger to ${VERSION}" \
+              --body-file "$body_file"
+          else
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "chore(logger): bump shared KMP logger to ${VERSION}" \
+              --body-file "$body_file"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,18 @@ jobs:
         run: |
           sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
       - name: Checkout OneSignal-iOS-SDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build OneSignalKMP XCFramework
+        run: iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
       - name: Set Default Scheme
         run: |
           default="UnitTestApp"

--- a/.github/workflows/create-release-prs.yml
+++ b/.github/workflows/create-release-prs.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           ref: ${{ needs.prep.outputs.release_branch }}
           fetch-depth: 0
+          submodules: recursive
 
       - name: Setup Git User
         uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
@@ -88,6 +89,18 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "15.2"
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build OneSignalKMP XCFramework
+        run: iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
 
       - name: Install the Apple distribution certificate (OneSignal)
         uses: apple-actions/import-codesign-certs@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "OneSignal-KMP-SDK"]
+	path = OneSignal-KMP-SDK
+	url = https://github.com/OneSignal/OneSignal-KMP-SDK.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,25 @@ If your proposed contribution is a small bug fix, please feel free to create you
 
 If your contribution would _break_ or _change_ the functionality of the SDK, please reach out to us on (contact) before you put in a lot of effort into a change we may not be able to use. We try our best to make sure that the SDK remains stable so that developers do not have to continually change their code, however some breaking changes _are_ desirable, so please get in touch to discuss your idea before you put in a lot of effort.
 
+#### Shared KMP dependency
+
+The iOS SDK pins `OneSignal-KMP-SDK` as a git submodule. Initialize it after cloning
+or switching branches:
+
+```bash
+git submodule update --init --recursive
+```
+
+Build the static KMP XCFramework before opening the Xcode project:
+
+```bash
+iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
+```
+
+`OneSignalCore` links the generated device and simulator slices internally. KMP
+releases are updated by advancing the submodule gitlink to a tagged commit; do not
+edit files inside the detached submodule checkout.
+
 #### Before Submitting A Bug Report
 Before creating bug reports, please check this list of steps to follow.
 

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -3525,8 +3525,6 @@
 				3C60BB9E2ECF860600C765F7 /* PBXTargetDependency */,
 			);
 			name = OneSignalInAppMessagesMocks;
-			packageProductDependencies = (
-			);
 			productName = OneSignalInAppMessagesMocks;
 			productReference = 3C70221C2ECF124B001768C6 /* OneSignalInAppMessagesMocks.framework */;
 			productType = "com.apple.product-type.framework";
@@ -7719,6 +7717,14 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_TESTABILITY = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -7739,6 +7745,16 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "";
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64/OneSignalKMP.framework/OneSignalKMP",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator/OneSignalKMP.framework/OneSignalKMP",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -8103,6 +8119,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OneSignalCoreFramework/Info.plist;
@@ -8120,6 +8144,16 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "";
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64/OneSignalKMP.framework/OneSignalKMP",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator/OneSignalKMP.framework/OneSignalKMP",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -8166,6 +8200,14 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_TESTABILITY = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -8189,6 +8231,16 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "";
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64/OneSignalKMP.framework/OneSignalKMP",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator/OneSignalKMP.framework/OneSignalKMP",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
+++ b/iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KMP_REPO="$SCRIPT_DIR/../../OneSignal-KMP-SDK"
+
+if [[ ! -f "$KMP_REPO/gradlew" ]]; then
+  echo "OneSignal-KMP-SDK is missing. Run: git submodule update --init --recursive" >&2
+  exit 1
+fi
+
+"$KMP_REPO/gradlew" \
+  -p "$KMP_REPO" \
+  :kmp:verifyOneSignalKMPXCFramework \
+  --console=plain


### PR DESCRIPTION
# Description
## One Line Summary
Pin the shared KMP repository and link its static XCFramework internally into `OneSignalCore`.

## Details
### Motivation
The iOS SDK needs the same shared logger implementation as Android while preserving the existing public SPM and CocoaPods dependency surface. KMP releases must also be able to advance both host SDKs in lockstep.

### Scope
- Add `OneSignal-KMP-SDK` as a pinned git submodule
- Build the XCFramework before iOS CI and release builds
- Force-load KMP into `OneSignalCore` for iOS device and simulator builds
- Keep Catalyst builds unchanged because the KMP artifact has no Catalyst slice
- Add a reusable workflow for automated KMP submodule bump PRs
- Document contributor setup

No Swift adapters or logger calls are included; those remain follow-up work.

### Dependencies
- [KMP packaging PR #9](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/9)
- [KMP release automation PR #10](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/10)

# Testing
## Unit testing
The shared KMP JVM, iOS simulator, and XCFramework verification tasks pass. The local reduced iOS test plan produced 138 passes and 9 existing state/timing-sensitive failures under Xcode 26.5; CI uses Xcode 16.4, which is unavailable locally.

## Manual testing
- Built `OneSignalCore` for generic iOS device and simulator destinations
- Built `OneSignalCore` for Mac Catalyst to confirm the conditional KMP link does not affect Catalyst
- Confirmed `OSKMPLoggerFactory` symbols are embedded in the simulator `OneSignalCore` binary
- Validated all changed workflows, the build script, and the KMP manifests

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] No public API changes

## Testing
   - [x] I have included test coverage for these changes, or explained why it is not needed
   - [x] All automated test results are documented above
   - [x] Device builds were tested without code signing; physical-device runtime behavior is out of scope because no adapter invokes KMP yet

## Final pass
   - [x] Code is as readable as possible
   - [x] I have reviewed this PR myself

Made with [Cursor](https://cursor.com)