### PR TITLE
feat: [SDK-4998] enable KMP logger on Mac Catalyst

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,23 +30,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build OneSignalKMP XCFramework
         run: iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
-      - name: Verify OneSignalKMP Catalyst slice
-        run: |
-          binary="OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst/OneSignalKMP.framework/OneSignalKMP"
-          architectures=" $(lipo -archs "$binary") "
-          [[ "$architectures" == *" arm64 "* ]]
-          [[ "$architectures" == *" x86_64 "* ]]
-          verification_dir="$(mktemp -d)"
-          trap 'rm -rf "$verification_dir"' EXIT
-          for architecture in arm64 x86_64; do
-            mkdir "$verification_dir/$architecture"
-            lipo "$binary" -thin "$architecture" -output "$verification_dir/$architecture/OneSignalKMP.a"
-            (
-              cd "$verification_dir/$architecture"
-              ar -x OneSignalKMP.a OneSignalKMP.framework.o
-              vtool -show-build OneSignalKMP.framework.o | grep -q 'platform MACCATALYST'
-            )
-          done
       - name: Archive OneSignalOSCore for Catalyst
         run: |
           xcodebuild archive \
@@ -64,7 +47,7 @@ jobs:
           frameworks="$RUNNER_TEMP/OneSignalOSCore-Catalyst.xcarchive/Products/Library/Frameworks"
           host="$RUNNER_TEMP/CatalystLoggerHost"
           xcrun --sdk macosx swiftc \
-            -target arm64-apple-ios14.0-macabi \
+            -target "$(uname -m)-apple-ios14.0-macabi" \
             -F "$frameworks" \
             -framework OneSignalOSCore \
             -framework OneSignalCore \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           xcodebuild archive \
             -scheme OneSignalFramework \
+            -configuration Release \
             -project iOS_SDK/OneSignalSDK/OneSignal.xcodeproj \
             -destination 'generic/platform=macOS,variant=Mac Catalyst' \
             -archivePath "$RUNNER_TEMP/OneSignalFramework-Catalyst.xcarchive" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,49 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build OneSignalKMP XCFramework
         run: iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
+      - name: Verify OneSignalKMP Catalyst slice
+        run: |
+          binary="OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst/OneSignalKMP.framework/OneSignalKMP"
+          architectures=" $(lipo -archs "$binary") "
+          [[ "$architectures" == *" arm64 "* ]]
+          [[ "$architectures" == *" x86_64 "* ]]
+          verification_dir="$(mktemp -d)"
+          trap 'rm -rf "$verification_dir"' EXIT
+          for architecture in arm64 x86_64; do
+            mkdir "$verification_dir/$architecture"
+            lipo "$binary" -thin "$architecture" -output "$verification_dir/$architecture/OneSignalKMP.a"
+            (
+              cd "$verification_dir/$architecture"
+              ar -x OneSignalKMP.a OneSignalKMP.framework.o
+              vtool -show-build OneSignalKMP.framework.o | grep -q 'platform MACCATALYST'
+            )
+          done
+      - name: Archive OneSignalOSCore for Catalyst
+        run: |
+          xcodebuild archive \
+            -scheme OneSignalOSCore \
+            -project iOS_SDK/OneSignalSDK/OneSignal.xcodeproj \
+            -destination 'generic/platform=macOS,variant=Mac Catalyst' \
+            -archivePath "$RUNNER_TEMP/OneSignalOSCore-Catalyst.xcarchive" \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Run KMP logger Catalyst host
+        run: |
+          frameworks="$RUNNER_TEMP/OneSignalOSCore-Catalyst.xcarchive/Products/Library/Frameworks"
+          host="$RUNNER_TEMP/CatalystLoggerHost"
+          xcrun --sdk macosx swiftc \
+            -target arm64-apple-ios14.0-macabi \
+            -F "$frameworks" \
+            -framework OneSignalOSCore \
+            -framework OneSignalCore \
+            -Xlinker -rpath \
+            -Xlinker "$frameworks" \
+            iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift \
+            -o "$host"
+          DYLD_FRAMEWORK_PATH="$frameworks" "$host"
       - name: Set Default Scheme
         run: |
           default="UnitTestApp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build OneSignalKMP XCFramework
         run: iOS_SDK/OneSignalSDK/build_kmp_xcframework.sh
-      - name: Archive OneSignalOSCore for Catalyst
+      - name: Archive OneSignalFramework for Catalyst
         run: |
           xcodebuild archive \
-            -scheme OneSignalOSCore \
+            -scheme OneSignalFramework \
             -project iOS_SDK/OneSignalSDK/OneSignal.xcodeproj \
             -destination 'generic/platform=macOS,variant=Mac Catalyst' \
-            -archivePath "$RUNNER_TEMP/OneSignalOSCore-Catalyst.xcarchive" \
+            -archivePath "$RUNNER_TEMP/OneSignalFramework-Catalyst.xcarchive" \
             SKIP_INSTALL=NO \
             BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
             CODE_SIGN_IDENTITY= \
@@ -44,7 +44,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
       - name: Run KMP logger Catalyst host
         run: |
-          frameworks="$RUNNER_TEMP/OneSignalOSCore-Catalyst.xcarchive/Products/Library/Frameworks"
+          frameworks="$RUNNER_TEMP/OneSignalFramework-Catalyst.xcarchive/Products/Library/Frameworks"
           host="$RUNNER_TEMP/CatalystLoggerHost"
           xcrun --sdk macosx swiftc \
             -target "$(uname -m)-apple-ios14.0-macabi" \

--- a/OneSignal.podspec
+++ b/OneSignal.podspec
@@ -8,6 +8,9 @@ Pod::Spec.new do |s|
   
   s.source           = { :git => "https://github.com/OneSignal/OneSignal-iOS-SDK.git", :tag => s.version.to_s }
   s.platform         = :ios, "11.0"
+  s.pod_target_xcconfig = {
+    'IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]' => '14.0'
+  }
   s.requires_arc     = true
   s.default_subspec = "OneSignalComplete"
     

--- a/OneSignalXCFramework.podspec
+++ b/OneSignalXCFramework.podspec
@@ -8,6 +8,9 @@ Pod::Spec.new do |s|
     
     s.source           = { :git => "https://github.com/OneSignal/OneSignal-iOS-SDK.git", :tag => s.version.to_s }
     s.platform         = :ios, '11.0'
+    s.pod_target_xcconfig = {
+      'IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]' => '14.0'
+    }
     s.requires_arc     = true
     s.default_subspec = "OneSignalComplete"
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,14 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "OneSignalFramework", // Package name MUST be on line 7 for release automation
+    platforms: [
+        .iOS(.v11),
+        .macCatalyst(.v14),
+    ],
     products: [
         .library(
             name: "OneSignalFramework",

--- a/iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift
+++ b/iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift
@@ -1,6 +1,46 @@
 import Foundation
-import OneSignalOSCore
+@_spi(OneSignalInternal) import OneSignalOSCore
 
+final class CapturingRequestSender {
+    let captured = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private(set) var requests: [URLRequest] = []
+
+    func send(
+        request: URLRequest,
+        completion: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) {
+        lock.lock()
+        requests.append(request)
+        lock.unlock()
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 202,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        DispatchQueue.global().async {
+            completion(nil, response, nil)
+            self.captured.signal()
+        }
+    }
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests.count
+    }
+
+    var firstRequest: URLRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests.first
+    }
+}
+
+let requestSender = CapturingRequestSender()
 let logger = OSRemoteLogger(
     installIdProvider: { "catalyst-host" },
     onesignalIdProvider: { nil },
@@ -8,7 +48,8 @@ let logger = OSRemoteLogger(
     appStateProvider: { "foreground" },
     featureFlagsProvider: { [] },
     remoteLogLevelProvider: { "INFO" },
-    exporterLoggingEnabledProvider: { false }
+    exporterLoggingEnabledProvider: { false },
+    requestSender: requestSender.send
 )
 
 precondition(!logger.kmpVersion.isEmpty)
@@ -22,4 +63,16 @@ logger.forceFlush {
     flushed.signal()
 }
 precondition(flushed.wait(timeout: .now() + 5) == .success)
+precondition(requestSender.captured.wait(timeout: .now() + 5) == .success)
+
+let request = requestSender.firstRequest
+precondition(request?.httpMethod == "POST")
+precondition(request?.url?.path == "/sdk/log")
+precondition(request?.httpBody?.isEmpty == false)
+
 logger.shutdown()
+
+let requestCountAfterShutdown = requestSender.requestCount
+logger.log(level: "INFO", message: "Must not be exported after shutdown")
+precondition(requestSender.captured.wait(timeout: .now() + 1) == .timedOut)
+precondition(requestSender.requestCount == requestCountAfterShutdown)

--- a/iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift
+++ b/iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift
@@ -1,0 +1,24 @@
+import Foundation
+import OneSignalOSCore
+
+let logger = OSRemoteLogger(
+    installIdProvider: { "catalyst-host" },
+    onesignalIdProvider: { nil },
+    pushSubscriptionIdProvider: { nil },
+    appStateProvider: { "foreground" },
+    featureFlagsProvider: { [] },
+    remoteLogLevelProvider: { "INFO" },
+    exporterLoggingEnabledProvider: { false }
+)
+
+precondition(logger.kmpVersion != "unavailable")
+precondition(logger.crashStoragePath != "unavailable")
+
+logger.log(level: "INFO", message: "Catalyst logger round trip")
+
+let flushed = DispatchSemaphore(value: 0)
+logger.forceFlush {
+    flushed.signal()
+}
+precondition(flushed.wait(timeout: .now() + 5) == .success)
+logger.shutdown()

--- a/iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift
+++ b/iOS_SDK/OneSignalSDK/CatalystLoggerHost/main.swift
@@ -11,9 +11,10 @@ let logger = OSRemoteLogger(
     exporterLoggingEnabledProvider: { false }
 )
 
-precondition(logger.kmpVersion != "unavailable")
-precondition(logger.crashStoragePath != "unavailable")
+precondition(!logger.kmpVersion.isEmpty)
+precondition(!logger.crashStoragePath.isEmpty)
 
+logger.start()
 logger.log(level: "INFO", message: "Catalyst logger round trip")
 
 let flushed = DispatchSemaphore(value: 0)

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -6844,6 +6844,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6917,6 +6918,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6986,6 +6988,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7293,6 +7296,7 @@
 				INFOPLIST_FILE = OneSignalFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7498,6 +7502,7 @@
 				INFOPLIST_FILE = OneSignalFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7704,6 +7709,7 @@
 				INFOPLIST_FILE = OneSignalFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7998,6 +8004,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8062,6 +8069,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8124,6 +8132,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8185,6 +8194,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8251,6 +8261,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8492,6 +8503,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8559,6 +8571,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8619,6 +8632,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8685,6 +8699,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8890,6 +8905,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8957,6 +8973,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9020,6 +9037,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9080,6 +9098,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9147,6 +9166,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9210,6 +9230,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9450,6 +9471,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9516,6 +9538,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9577,6 +9600,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -7198,6 +7198,10 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7402,6 +7406,10 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7608,6 +7616,10 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7928,6 +7940,11 @@
 					"$(inherited)",
 					"-force_load",
 					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator/OneSignalKMP.framework/OneSignalKMP",
+				);
+				"OTHER_LDFLAGS[sdk=macosx*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst/OneSignalKMP.framework/OneSignalKMP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -8328,6 +8345,11 @@
 					"-force_load",
 					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator/OneSignalKMP.framework/OneSignalKMP",
 				);
+				"OTHER_LDFLAGS[sdk=macosx*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst/OneSignalKMP.framework/OneSignalKMP",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -8414,6 +8436,11 @@
 					"$(inherited)",
 					"-force_load",
 					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-simulator/OneSignalKMP.framework/OneSignalKMP",
+				);
+				"OTHER_LDFLAGS[sdk=macosx*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst/OneSignalKMP.framework/OneSignalKMP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.OneSignalCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/project.pbxproj
@@ -5440,6 +5440,10 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
+				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64",
@@ -5481,6 +5485,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5508,6 +5513,10 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
+				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64",
@@ -5556,6 +5565,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7198,10 +7208,6 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
-					"$(inherited)",
-					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
-				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7406,10 +7412,6 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
-					"$(inherited)",
-					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
-				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7616,10 +7618,6 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
-					"$(inherited)",
-					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
-				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7920,6 +7918,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8324,6 +8323,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8416,6 +8416,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Hiptic. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9262,6 +9263,10 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64_x86_64-maccatalyst",
+				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../../OneSignal-KMP-SDK/kmp/build/XCFrameworks/release/OneSignalKMP.xcframework/ios-arm64",
@@ -9283,6 +9288,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OneSignalOSCoreFramework/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/xcshareddata/xcschemes/OneSignalOSCore.xcscheme
+++ b/iOS_SDK/OneSignalSDK/OneSignal.xcodeproj/xcshareddata/xcschemes/OneSignalOSCore.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C115160289A259500565C41"
+               BuildableName = "OneSignalOSCore.framework"
+               BlueprintName = "OneSignalOSCore"
+               ReferencedContainer = "container:OneSignal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Test"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3C115160289A259500565C41"
+            BuildableName = "OneSignalOSCore.framework"
+            BlueprintName = "OneSignalOSCore"
+            ReferencedContainer = "container:OneSignal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/FileLogStore.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/FileLogStore.swift
@@ -25,9 +25,6 @@
  THE SOFTWARE.
  */
 
-// Kotlin/Native does not produce a Mac Catalyst framework slice.
-#if !targetEnvironment(macCatalyst)
-
 import Darwin
 import Foundation
 import OneSignalCore
@@ -236,5 +233,3 @@ final class FileLogStore: ILogFileStore {
         }
     }
 }
-
-#endif

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/IOSLogger.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/IOSLogger.swift
@@ -25,9 +25,6 @@
  THE SOFTWARE.
  */
 
-// Kotlin/Native does not produce a Mac Catalyst framework slice.
-#if !targetEnvironment(macCatalyst)
-
 import Foundation
 import OneSignalCore
 @_implementationOnly import OneSignalKMP
@@ -51,5 +48,3 @@ final class IOSLogger: ILogger {
         OneSignalLog.onesignalLog(.LL_DEBUG, message: message)
     }
 }
-
-#endif

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/KotlinByteArray+Data.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/KotlinByteArray+Data.swift
@@ -25,9 +25,6 @@
  THE SOFTWARE.
  */
 
-// Kotlin/Native does not produce a Mac Catalyst framework slice.
-#if !targetEnvironment(macCatalyst)
-
 import Foundation
 @_implementationOnly import OneSignalKMP
 
@@ -36,11 +33,8 @@ extension KotlinByteArray {
         AppleByteArrayInterop.shared.toNSData(bytes: self)
     }
 }
-
 extension Data {
     var kotlinByteArray: KotlinByteArray {
         AppleByteArrayInterop.shared.toByteArray(data: self)
     }
 }
-
-#endif

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLogCrashHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLogCrashHandler.swift
@@ -48,7 +48,7 @@ final class OSCrashLogger: ILogger {
     private let write: (String) -> Void
 
     init(
-        consoleLogLevel: @escaping () -> ONE_S_LOG_LEVEL = { OneSignalLog.getLogLevel() },
+        consoleLogLevel: @escaping () -> ONE_S_LOG_LEVEL = { OneSignalLog.getLevel() },
         write: @escaping (String) -> Void = { NSLog("%@", $0) }
     ) {
         self.consoleLogLevel = consoleLogLevel

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLogCrashHandler.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLogCrashHandler.swift
@@ -25,9 +25,6 @@
  THE SOFTWARE.
  */
 
-// Kotlin/Native does not produce a Mac Catalyst framework slice.
-#if !targetEnvironment(macCatalyst)
-
 import Darwin
 import Foundation
 import OneSignalCore
@@ -306,5 +303,3 @@ final class OSLogCrashHandler: ILogCrashHandler {
         return String(symbol[moduleNameStart..<moduleNameEnd])
     }
 }
-
-#endif

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -109,7 +109,13 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     let sdkWrapperVersion = OneSignalWrapper.sdkVersion
     let kotlinVersion: String? = nil
     let swiftVersion: String? = nil
-    let additionalVersionAttributes: [String: String] = [:]
+    let additionalVersionAttributes: [String: String] = {
+        #if targetEnvironment(macCatalyst)
+        return ["apple_platform": "mac_catalyst"]
+        #else
+        return [:]
+        #endif
+    }()
     var enabledFeatureFlags: [String] {
         featureFlagsProvider()
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -25,9 +25,6 @@
  THE SOFTWARE.
  */
 
-// Kotlin/Native does not produce a Mac Catalyst framework slice.
-#if !targetEnvironment(macCatalyst)
-
 import Darwin
 import Foundation
 import OneSignalCore
@@ -110,6 +107,9 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     let osBuildId = OSLoggerPlatformProvider.systemValue(named: Constants.osBuildName)
     let sdkWrapper = OneSignalWrapper.sdkType
     let sdkWrapperVersion = OneSignalWrapper.sdkVersion
+    let kotlinVersion: String? = nil
+    let swiftVersion: String? = nil
+    let additionalVersionAttributes: [String: String] = [:]
     var enabledFeatureFlags: [String] {
         featureFlagsProvider()
     }
@@ -241,5 +241,3 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     }
 
 }
-
-#endif

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSRemoteLogger.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSRemoteLogger.swift
@@ -155,6 +155,12 @@ final class OSCrashUploaderCoordinator {
 /// Owns the KMP-specific logger composition while exposing a platform-neutral
 /// lifecycle API to the umbrella framework.
 public final class OSRemoteLogger: OSRemoteLoggerProtocol {
+    @_spi(OneSignalInternal)
+    public typealias RequestSender = (
+        URLRequest,
+        @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> Void
+
     private let telemetry: ILogTelemetryRemote
     private let platformProvider: OSLoggerPlatformProvider
     private let crashHandler: ILogCrashHandler
@@ -164,7 +170,7 @@ public final class OSRemoteLogger: OSRemoteLoggerProtocol {
     private let lifecycleOperationLock = NSLock()
     private let uploaderOwner = UUID()
 
-    public init(
+    public convenience init(
         installIdProvider: @escaping () -> String,
         onesignalIdProvider: @escaping () -> String?,
         pushSubscriptionIdProvider: @escaping () -> String?,
@@ -172,6 +178,51 @@ public final class OSRemoteLogger: OSRemoteLoggerProtocol {
         featureFlagsProvider: @escaping () -> [String],
         remoteLogLevelProvider: @escaping () -> String?,
         exporterLoggingEnabledProvider: @escaping () -> Bool
+    ) {
+        self.init(
+            installIdProvider: installIdProvider,
+            onesignalIdProvider: onesignalIdProvider,
+            pushSubscriptionIdProvider: pushSubscriptionIdProvider,
+            appStateProvider: appStateProvider,
+            featureFlagsProvider: featureFlagsProvider,
+            remoteLogLevelProvider: remoteLogLevelProvider,
+            exporterLoggingEnabledProvider: exporterLoggingEnabledProvider,
+            requestSenderOverride: nil
+        )
+    }
+
+    @_spi(OneSignalInternal)
+    public convenience init(
+        installIdProvider: @escaping () -> String,
+        onesignalIdProvider: @escaping () -> String?,
+        pushSubscriptionIdProvider: @escaping () -> String?,
+        appStateProvider: @escaping () -> String,
+        featureFlagsProvider: @escaping () -> [String],
+        remoteLogLevelProvider: @escaping () -> String?,
+        exporterLoggingEnabledProvider: @escaping () -> Bool,
+        requestSender: @escaping RequestSender
+    ) {
+        self.init(
+            installIdProvider: installIdProvider,
+            onesignalIdProvider: onesignalIdProvider,
+            pushSubscriptionIdProvider: pushSubscriptionIdProvider,
+            appStateProvider: appStateProvider,
+            featureFlagsProvider: featureFlagsProvider,
+            remoteLogLevelProvider: remoteLogLevelProvider,
+            exporterLoggingEnabledProvider: exporterLoggingEnabledProvider,
+            requestSenderOverride: requestSender
+        )
+    }
+
+    private init(
+        installIdProvider: @escaping () -> String,
+        onesignalIdProvider: @escaping () -> String?,
+        pushSubscriptionIdProvider: @escaping () -> String?,
+        appStateProvider: @escaping () -> String,
+        featureFlagsProvider: @escaping () -> [String],
+        remoteLogLevelProvider: @escaping () -> String?,
+        exporterLoggingEnabledProvider: @escaping () -> Bool,
+        requestSenderOverride: RequestSender?
     ) {
         let provider = OSLoggerPlatformProvider(
             installIdProvider: installIdProvider,
@@ -186,15 +237,15 @@ public final class OSRemoteLogger: OSRemoteLoggerProtocol {
         let crashLogger = OSCrashLogger()
         let lifecycle = OSRemoteLoggerLifecycle()
         let fileStore = FileLogStore(rootPath: provider.crashStoragePath)
+        let httpSender = Self.makeHttpSender(
+            requestSender: requestSenderOverride,
+            logger: logger,
+            isDiagnosticsEnabled: exporterLoggingEnabledProvider,
+            lifecycle: lifecycle
+        )
         let remoteTelemetry = LoggerFactory.shared.createRemoteTelemetry(
             platformProvider: provider,
-            httpSender: OneSignalLogHttpSender(
-                logger: logger,
-                isDiagnosticsEnabled: exporterLoggingEnabledProvider,
-                executeIfEnabled: { work in
-                    lifecycle.performIfTransportActive(work)
-                }
-            )
+            httpSender: httpSender
         )
         let crashTelemetry = LoggerFactory.shared.createCrashLocalTelemetry(
             platformProvider: provider,
@@ -218,6 +269,30 @@ public final class OSRemoteLogger: OSRemoteLoggerProtocol {
         self.crashUploader = crashUploader
         self.logger = logger
         self.lifecycle = lifecycle
+    }
+
+    private static func makeHttpSender(
+        requestSender: RequestSender?,
+        logger: ILogger,
+        isDiagnosticsEnabled: @escaping () -> Bool,
+        lifecycle: OSRemoteLoggerLifecycle
+    ) -> OneSignalLogHttpSender {
+        let executeIfEnabled: (@escaping () -> Void) -> Bool = { work in
+            lifecycle.performIfTransportActive(work)
+        }
+        if let requestSender {
+            return OneSignalLogHttpSender(
+                requestSender: requestSender,
+                logger: logger,
+                isDiagnosticsEnabled: isDiagnosticsEnabled,
+                executeIfEnabled: executeIfEnabled
+            )
+        }
+        return OneSignalLogHttpSender(
+            logger: logger,
+            isDiagnosticsEnabled: isDiagnosticsEnabled,
+            executeIfEnabled: executeIfEnabled
+        )
     }
 
     public func start() {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSRemoteLogger.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSRemoteLogger.swift
@@ -52,8 +52,6 @@ public extension OSRemoteLoggerProtocol {
     func start() {}
 }
 
-#if !targetEnvironment(macCatalyst)
-
 @_implementationOnly import OneSignalKMP
 
 private final class OSRemoteLoggerLifecycle {
@@ -305,39 +303,3 @@ public final class OSRemoteLogger: OSRemoteLoggerProtocol {
 
 @_spi(OneSignalInternal)
 extension OSRemoteLogger: OSStructuredRemoteLoggerProtocol {}
-
-#else
-
-public final class OSRemoteLogger: OSRemoteLoggerProtocol {
-    public init(
-        installIdProvider: @escaping () -> String,
-        onesignalIdProvider: @escaping () -> String?,
-        pushSubscriptionIdProvider: @escaping () -> String?,
-        appStateProvider: @escaping () -> String,
-        featureFlagsProvider: @escaping () -> [String],
-        remoteLogLevelProvider: @escaping () -> String?,
-        exporterLoggingEnabledProvider: @escaping () -> Bool
-    ) {}
-
-    public let kmpVersion = "unavailable"
-    public let crashStoragePath = "unavailable"
-
-    public func start() {}
-    public func log(level: String, message: String) {}
-    public func log(
-        level: String,
-        message: String,
-        exceptionType: String?,
-        exceptionMessage: String?,
-        exceptionStacktrace: String?
-    ) {}
-    public func forceFlush(completion: @escaping () -> Void) {
-        completion()
-    }
-    public func shutdown() {}
-}
-
-@_spi(OneSignalInternal)
-extension OSRemoteLogger: OSStructuredRemoteLoggerProtocol {}
-
-#endif

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OneSignalLogHttpSender.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OneSignalLogHttpSender.swift
@@ -25,9 +25,6 @@
  THE SOFTWARE.
  */
 
-// Kotlin/Native does not produce a Mac Catalyst framework slice.
-#if !targetEnvironment(macCatalyst)
-
 import Foundation
 @_implementationOnly import OneSignalKMP
 
@@ -207,5 +204,3 @@ final class OneSignalLogHttpSender: ILogHttpSender {
         String(body.prefix(maximumDiagnosticBodyLength))
     }
 }
-
-#endif


### PR DESCRIPTION
# Description
## One Line Summary
Enables the shared KMP logger when the iOS SDK is built for Mac Catalyst.

## Details
### Motivation
Mac Catalyst builds previously used a no-op remote logger because the KMP XCFramework did not expose a Catalyst slice. With the Catalyst slice added in [OneSignal-KMP-SDK#18](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/18), the iOS SDK can compile, link, and run the shared logging pipeline on Catalyst.

### Scope
- Removes the Catalyst exclusions from the Swift KMP logger adapters.
- Pins and links the KMP XCFramework containing the Mac Catalyst slice.
- Sets Mac Catalyst 14.0 as the minimum across shipped framework targets, SwiftPM, and CocoaPods while retaining iOS 11.0 for device builds.
- Adds an internal SPI transport seam so the Catalyst host captures and validates an exported request without contacting production.
- Archives the umbrella `OneSignalFramework` consumer for Catalyst and runs a host that verifies start, log, flush, shutdown, and post-shutdown transport blocking.
- Keeps Catalyst slice architecture and Mach-O metadata validation in the KMP build task.

### API impact
The existing public `OSRemoteLogger` initializer is unchanged. The new request-sender initializer is exposed only through `@_spi(OneSignalInternal)` for integration verification. SwiftPM now requires tools version 5.5 to declare Mac Catalyst 14.0 support.

# Testing
## Automated testing
- Built and verified the KMP XCFramework with arm64 and x86_64 Mac Catalyst slices.
- Confirmed all eight shipped consumer schemes resolve Mac Catalyst deployment target 14.0.
- Archived `OneSignalFramework` for `generic/platform=macOS,variant=Mac Catalyst` using the Release configuration.
- Compiled and ran the Catalyst logger host; it captured a non-empty `POST /sdk/log`, opened no network sockets, and rejected export after shutdown.
- Ran 13 focused `OSLoggerAdaptersTests` successfully on an iOS simulator.
- Validated SwiftPM and both CocoaPods specifications.
- SwiftLint reported no violations in the changed Swift files.

## Manual testing
The Catalyst host provides the runtime verification; no physical Catalyst device is required.

# Affected code checklist
 - [ ] Notifications
 - [ ] Display
 - [ ] Open
 - [ ] Push Processing
 - [ ] Confirm Deliveries
 - [ ] Outcomes
 - [ ] Sessions
 - [ ] In-App Messaging
 - [ ] REST API requests
 - [ ] Public API changes

# Checklist
## Overview
 - [x] I have filled out all **REQUIRED** sections above
 - [x] PR does one thing
 - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
 - [x] I have included test coverage for these changes, or explained why they are not needed
 - [x] All automated tests pass, or I explained why that is not possible
 - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
 - [x] Code is as readable as possible.
 - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)
