### PR TITLE
fix: [SDK-4766] stabilize parallel user tests

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalUserMocks/OneSignalUserMocks.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserMocks/OneSignalUserMocks.swift
@@ -37,6 +37,13 @@ public class OneSignalUserMocks: NSObject {
     // TODO: create mocked server responses to user requests
     @objc
     public static func reset() {
+        OSResilientStorage.setStrings([
+            OSResilientStorage.keyAppId: "",
+            OSResilientStorage.keySubscriptionId: "",
+            OSResilientStorage.keyReceiveReceiptsEnabled: "",
+            OSResilientStorage.keyHasPriorSession: ""
+        ])
+        _ = OSResilientStorage.snapshot()
         OSCoreMocks.resetOperationRepo()
         OneSignalUserManagerImpl.sharedInstance.reset()
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/UserExecutorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/Executors/UserExecutorTests.swift
@@ -107,10 +107,9 @@ final class UserExecutorTests: XCTestCase {
 
         /* When */
         let anonIdentityModel = OSIdentityModel(aliases: [OS_ONESIGNAL_ID: userA_OSID], changeNotifier: OSEventProducer())
-        let newIdentityModel = OSIdentityModel(aliases: [OS_EXTERNAL_ID: userA_EUID], changeNotifier: OSEventProducer())
-
-        // The current user needs to be the same, set it in the user manager
-        OneSignalUserManagerImpl.sharedInstance.identityModelStore.add(id: OS_IDENTITY_MODEL_KEY, model: newIdentityModel, hydrating: false)
+        let newIdentityModel = OneSignalUserMocks
+            .setUserManagerInternalUser(externalId: userA_EUID, onesignalId: nil)
+            .identityModel
         mocks.userExecutor.identifyUser(externalId: userA_EUID, identityModelToIdentify: anonIdentityModel, identityModelToUpdate: newIdentityModel)
 
         OneSignalCoreMocks.waitForBackgroundThreads(seconds: 0.5)

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserObjcTests.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserObjcTests.m
@@ -32,13 +32,11 @@
     /* Setup */
 
     MockOneSignalClient* client = [MockOneSignalClient new];
-
-    // 0. Purchases will be dropped if there is no user instance.
-    [OneSignalUserManagerImpl.sharedInstance start];
-
-    // 1. Set up mock responses for the anonymous user
     [MockUserRequests setDefaultCreateAnonUserResponsesWith:client onesignalId:nil subscriptionId:nil];
     [OneSignalCoreImpl setSharedClient:client];
+
+    // Purchases will be dropped if there is no user instance.
+    [OneSignalUserManagerImpl.sharedInstance start];
 
     /* When */
 

--- a/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalUserTests/OneSignalUserTests.swift
@@ -275,12 +275,13 @@ final class OneSignalUserTests: XCTestCase {
         let checkedUser = manager.currentUser(matching: userA.identityModel.modelId)
         // A concurrent login switches the current user before the response is applied
         let userB = OneSignalUserMocks.setUserManagerInternalUser(externalId: userB_EUID, onesignalId: userB_OSID)
+        let userBLanguage = userB.propertiesModel.language
         checkedUser?.propertiesModel.hydrate(["language": "language-for-user-a"])
 
         /* Then */
         // The response's data went to the user it was for, and the new current user is untouched
         XCTAssertEqual(userA.propertiesModel.language, "language-for-user-a")
-        XCTAssertNil(userB.propertiesModel.language)
+        XCTAssertEqual(userB.propertiesModel.language, userBLanguage)
         XCTAssertEqual(manager._user?.identityModel.externalId, userB_EUID)
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Reset resilient identifier storage and correct test setup so parallel SDK tests no longer inherit stale user state.

## Details
### Motivation
The reduced CI test plan intermittently reused file-backed identifiers between tests, causing IAM, Live Activities, and user tests to observe subscriptions or users created by earlier tests.

### Scope
This changes test mocks and test setup only. Production SDK behavior and public APIs are unchanged.

# Testing
## Unit testing
- Full `UnitTestApp_TestPlan_Reduced` test plan passes.
- Original failing test set passes for five iterations with four parallel workers.
- Focused user tests pass for ten iterations.
- Focused Live Activities test passes for ten iterations.

## Manual testing
Not applicable because this change only affects automated test isolation.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] No public API changes

## Testing
   - [x] I have included test coverage for these changes, or explained why it is not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] Manual device testing is not applicable and is explained above

## Final pass
   - [x] Code is as readable as possible
   - [x] I have reviewed this PR myself

Made with [Cursor](https://cursor.com)