### PR TITLE
fix: [SDK-5065] report unbuildable log requests as a permanent failure

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OneSignalLogHttpSender.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OneSignalLogHttpSender.swift
@@ -31,8 +31,15 @@ import Foundation
 /// Sends the KMP logger's encoded OTLP requests using the native URL loading system.
 final class OneSignalLogHttpSender: ILogHttpSender {
     private static let requestTimeout: TimeInterval = 10
+    /// The request was sent and got no usable response — DNS, timeout, socket reset. The
+    /// shared retry policy treats this as transient and will try again.
     private static let transportFailureStatusCode: Int32 = -1
     private static let disabledStatusCode: Int32 = -2
+    /// The request could never be built, so retrying cannot help. Kept distinct from
+    /// `transportFailureStatusCode` because the shared policy classifies anything it does not
+    /// recognise as permanent — reusing -1 here would burn the whole retry budget, on every
+    /// batch, against a misconfiguration that will not fix itself.
+    private static let invalidRequestStatusCode: Int32 = -3
     private static let maximumDiagnosticBodyLength = 500
     private static let defaultSession: URLSession = {
         let configuration = URLSessionConfiguration.default
@@ -91,7 +98,7 @@ final class OneSignalLogHttpSender: ILogHttpSender {
             completionHandler(
                 LogHttpResponse(
                     success: false,
-                    statusCode: Self.transportFailureStatusCode,
+                    statusCode: Self.invalidRequestStatusCode,
                     message: "Invalid log request URL"
                 ),
                 nil


### PR DESCRIPTION
fix: [SDK-5065] report unbuildable log requests as a permanent failure

The -1 transport sentinel was returned both when a request got no usable
response and when the URL could not be constructed at all. The shared retry
policy in the KMP logger classifies -1 as transient, so a malformed base URL or
app id would burn the full retry budget and its backoff on every batch,
indefinitely, against a misconfiguration that cannot resolve itself.

Reports -3 for the unbuildable case instead. The shared policy already treats
anything it does not recognise as permanent, so this needs no coordinated
change; the KMP side documents the distinction and pins it with a test.

No behavioural change until the export-retry work lands — before it, every
failure was single-shot regardless of code.

Companion to [OneSignal-KMP-SDK#21](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/21), which adds the retry policy that makes this distinction matter. Independent of [#1725](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1725) — it touches only the HTTP sender and needs no submodule bump.

## Testing
`OneSignalOSCore` builds clean for iphonesimulator against the current submodule pin.

Made with [Cursor](https://cursor.com)