### PR TITLE
feat: [SDK-5106] report host app build toolchain on iOS logs

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -51,6 +51,9 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         static let deviceManufacturer = "Apple"
         static let unknown = "unknown"
         static let osBuildName = "kern.osversion"
+        static let xcodeVersionInfoKey = "DTXcode"
+        static let xcodeVersionAttribute = "xcode_version"
+        static let macCatalystAttribute = "apple_platform"
         static let disabledLogLevel = "NONE"
         static let crashDirectoryComponents = ["onesignal", "logger", "crashes"]
 
@@ -107,15 +110,20 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     let osBuildId = OSLoggerPlatformProvider.systemValue(named: Constants.osBuildName)
     let sdkWrapper = OneSignalWrapper.sdkType
     let sdkWrapperVersion = OneSignalWrapper.sdkVersion
+    /// Nil on iOS: this describes the *host app's* Kotlin stack, and an iOS app is
+    /// not a Kotlin host. The shared module's own provenance rides on
+    /// `ossdk.kmp_version` instead.
     let kotlinVersion: String? = nil
-    let swiftVersion: String? = nil
-    let additionalVersionAttributes: [String: String] = {
-        #if targetEnvironment(macCatalyst)
-        return ["apple_platform": "mac_catalyst"]
-        #else
-        return [:]
-        #endif
-    }()
+
+    /// Approximated from the host app's Xcode version. Apple ships one Swift
+    /// toolchain per Xcode release and exposes no runtime API for the language
+    /// version, so this is the closest signal available. `xcode_version` is emitted
+    /// alongside and is exact, so a stale row in the lookup table stays recoverable.
+    let swiftVersion: String? = OSLoggerPlatformProvider.hostXcodeVersion()
+        .flatMap(OSLoggerPlatformProvider.approximateSwiftVersion(forXcodeVersion:))
+
+    let additionalVersionAttributes: [String: String] =
+        OSLoggerPlatformProvider.hostBuildAttributes()
     var enabledFeatureFlags: [String] {
         featureFlagsProvider()
     }
@@ -188,6 +196,89 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     }
 
     let apiBaseUrl = OS_API_SERVER_URL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+    /// Xcode stamps its own version, the compiler, and the SDK it built against
+    /// into the *host app's* `Info.plist`. Reading `Bundle.main` is deliberate:
+    /// this SDK ships as a prebuilt XCFramework, so a compile-time check here would
+    /// describe OneSignal's build machine and be identical for every customer.
+    ///
+    /// These are build-time facts. The OS actually running is reported separately
+    /// as `os.name` / `os.version` / `os.build_id`.
+    private static let buildMetadataKeys: [(infoKey: String, attribute: String)] = [
+        ("DTXcodeBuild", "xcode_build"),
+        ("DTCompiler", "build_compiler"),
+        ("DTPlatformName", "build_platform_name"),
+        ("DTPlatformVersion", "build_platform_version"),
+        ("DTPlatformBuild", "build_platform_build"),
+        ("DTSDKName", "build_sdk_name"),
+        ("DTSDKBuild", "build_sdk_build")
+    ]
+
+    /// Floor lookup, so an Xcode newer than every row resolves to the most recent
+    /// known Swift release rather than dropping the attribute. Add a row whenever
+    /// an Xcode release ships a new Swift version.
+    private static let swiftVersionByXcode: [(xcode: (major: Int, minor: Int), swift: String)] = [
+        ((14, 0), "5.7"),
+        ((14, 3), "5.8"),
+        ((15, 0), "5.9"),
+        ((15, 3), "5.10"),
+        ((16, 0), "6.0"),
+        ((16, 3), "6.1"),
+        ((26, 0), "6.2")
+    ]
+
+    static func hostBuildAttributes(
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> [String: String] {
+        var attributes: [String: String] = [:]
+        #if targetEnvironment(macCatalyst)
+        attributes[Constants.macCatalystAttribute] = "mac_catalyst"
+        #endif
+        if let xcodeVersion = hostXcodeVersion(infoDictionary: infoDictionary) {
+            attributes[Constants.xcodeVersionAttribute] = xcodeVersion
+        }
+        for (infoKey, attribute) in buildMetadataKeys {
+            guard let value = infoDictionary?[infoKey] as? String, !value.isEmpty else {
+                continue
+            }
+            attributes[attribute] = value
+        }
+        return attributes
+    }
+
+    static func hostXcodeVersion(
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> String? {
+        guard let raw = infoDictionary?[Constants.xcodeVersionInfoKey] as? String else {
+            return nil
+        }
+        return decodeXcodeVersion(raw)
+    }
+
+    /// `DTXcode` packs major/minor/patch into digits: `"2620"` is 26.2, `"0900"` is 9.0.
+    static func decodeXcodeVersion(_ raw: String) -> String? {
+        guard let packed = Int(raw.trimmingCharacters(in: .whitespaces)), packed > 0 else {
+            return nil
+        }
+        let major = packed / 100
+        let minor = (packed / 10) % 10
+        let patch = packed % 10
+        return patch == 0 ? "\(major).\(minor)" : "\(major).\(minor).\(patch)"
+    }
+
+    static func approximateSwiftVersion(forXcodeVersion version: String) -> String? {
+        let components = version.split(separator: ".").compactMap { Int($0) }
+        guard let major = components.first else {
+            return nil
+        }
+        let minor = components.count > 1 ? components[1] : 0
+        var resolved: String?
+        for entry in swiftVersionByXcode
+        where (entry.xcode.major, entry.xcode.minor) <= (major, minor) {
+            resolved = entry.swift
+        }
+        return resolved
+    }
 
     private static func systemValue(named name: String) -> String {
         var size = 0

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -55,10 +55,12 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         static let xcodeVersionAttribute = "xcode_version"
         static let xcodeBuildInfoKey = "DTXcodeBuild"
         static let xcodeBuildAttribute = "xcode_build"
-        /// Catalyst bundles declare their floor as `LSMinimumSystemVersion`; iOS uses
-        /// `MinimumOSVersion`. First match wins.
-        static let minimumOSVersionInfoKeys = ["MinimumOSVersion", "LSMinimumSystemVersion"]
+        /// iOS / tvOS / watchOS deployment target. Distinct from the macOS floor:
+        /// `LSMinimumSystemVersion` is a macOS version and must not share this key.
+        static let minimumOSVersionInfoKey = "MinimumOSVersion"
         static let minimumOSVersionAttribute = "minimum_os_version"
+        static let minimumMacOSVersionInfoKey = "LSMinimumSystemVersion"
+        static let minimumMacOSVersionAttribute = "minimum_macos_version"
         static let applePlatformAttribute = "apple_platform"
         static let disabledLogLevel = "NONE"
         static let crashDirectoryComponents = ["onesignal", "logger", "crashes"]
@@ -205,9 +207,11 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     /// prebuilt XCFramework — a compile-time check would describe OneSignal's build
     /// machine, identically for every customer.
     ///
-    /// `minimum_os_version` is what the host *commits to* supporting, which is the fact
-    /// that gates raising our own deployment target. The OS actually running is separate
-    /// (`os.name` / `os.version` / `os.build_id`) and routinely diverges from it.
+    /// `minimum_os_version` is the iOS deployment target the host *commits to*, which
+    /// is the fact that gates raising our own target. Catalyst's macOS floor is a
+    /// different namespace (`LSMinimumSystemVersion` → `minimum_macos_version`) and
+    /// is not mixed in. The OS actually running is separate (`os.name` / `os.version`
+    /// / `os.build_id`) and routinely diverges from both.
     static func hostBuildAttributes(
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary
     ) -> [String: String] {
@@ -221,11 +225,14 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         if let xcodeBuild = infoValue(Constants.xcodeBuildInfoKey, in: infoDictionary) {
             attributes[Constants.xcodeBuildAttribute] = xcodeBuild
         }
-        if let minimumOSVersion = Constants.minimumOSVersionInfoKeys
-            .lazy
-            .compactMap({ infoValue($0, in: infoDictionary) })
-            .first {
+        if let minimumOSVersion = infoValue(Constants.minimumOSVersionInfoKey, in: infoDictionary) {
             attributes[Constants.minimumOSVersionAttribute] = minimumOSVersion
+        }
+        if let minimumMacOSVersion = infoValue(
+            Constants.minimumMacOSVersionInfoKey,
+            in: infoDictionary
+        ) {
+            attributes[Constants.minimumMacOSVersionAttribute] = minimumMacOSVersion
         }
         return attributes
     }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -53,7 +53,13 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         static let osBuildName = "kern.osversion"
         static let xcodeVersionInfoKey = "DTXcode"
         static let xcodeVersionAttribute = "xcode_version"
-        static let macCatalystAttribute = "apple_platform"
+        static let xcodeBuildInfoKey = "DTXcodeBuild"
+        static let xcodeBuildAttribute = "xcode_build"
+        /// Catalyst bundles declare their floor as `LSMinimumSystemVersion`; iOS uses
+        /// `MinimumOSVersion`. First match wins.
+        static let minimumOSVersionInfoKeys = ["MinimumOSVersion", "LSMinimumSystemVersion"]
+        static let minimumOSVersionAttribute = "minimum_os_version"
+        static let applePlatformAttribute = "apple_platform"
         static let disabledLogLevel = "NONE"
         static let crashDirectoryComponents = ["onesignal", "logger", "crashes"]
 
@@ -115,12 +121,8 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     /// `ossdk.kmp_version` instead.
     let kotlinVersion: String? = nil
 
-    /// Nil on iOS. Apple exposes no runtime API for the Swift language version and
-    /// there is no `DTSwiftVersion` key, so the only derivable value would come from
-    /// the Xcode version — which maps to a Swift compiler 1:1 and is already emitted
-    /// exactly as `xcode_version`. The one thing a distinct value could carry is the
-    /// per-target language mode (`SWIFT_VERSION`, 5 vs 6), and that is not in the
-    /// host's `Info.plist` at all.
+    /// Nil on iOS: there is no runtime API for the Swift language version, and anything
+    /// derivable would just re-encode `xcode_version` less precisely.
     let swiftVersion: String? = nil
 
     let additionalVersionAttributes: [String: String] =
@@ -198,45 +200,41 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
 
     let apiBaseUrl = OS_API_SERVER_URL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
-    /// Xcode stamps its own version, the compiler, and the SDK it built against into
-    /// the *host app's* `Info.plist`, alongside the deployment target the app
-    /// declares. Reading `Bundle.main` is deliberate: this SDK ships as a prebuilt
-    /// XCFramework, so a compile-time check here would describe OneSignal's build
-    /// machine and be identical for every customer.
+    /// Toolchain and deployment target of the running executable, read from its
+    /// `Info.plist`. Read at runtime rather than with `#if swift(...)` because we ship a
+    /// prebuilt XCFramework — a compile-time check would describe OneSignal's build
+    /// machine, identically for every customer.
     ///
-    /// These are build-time facts and answer what the host *commits to* supporting.
-    /// The OS actually running is reported separately as `os.name` / `os.version` /
-    /// `os.build_id`, and the two diverge: an app can serve only iOS 18 users while
-    /// still declaring a much older `minimum_os_version`, which is what constrains
-    /// raising our own deployment target.
-    private static let buildMetadataKeys: [(infoKey: String, attribute: String)] = [
-        ("DTXcodeBuild", "xcode_build"),
-        ("DTCompiler", "build_compiler"),
-        ("DTPlatformName", "build_platform_name"),
-        ("DTPlatformVersion", "build_platform_version"),
-        ("DTPlatformBuild", "build_platform_build"),
-        ("DTSDKName", "build_sdk_name"),
-        ("DTSDKBuild", "build_sdk_build"),
-        ("MinimumOSVersion", "minimum_os_version")
-    ]
-
+    /// `minimum_os_version` is what the host *commits to* supporting, which is the fact
+    /// that gates raising our own deployment target. The OS actually running is separate
+    /// (`os.name` / `os.version` / `os.build_id`) and routinely diverges from it.
     static func hostBuildAttributes(
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary
     ) -> [String: String] {
         var attributes: [String: String] = [:]
         #if targetEnvironment(macCatalyst)
-        attributes[Constants.macCatalystAttribute] = "mac_catalyst"
+        attributes[Constants.applePlatformAttribute] = "mac_catalyst"
         #endif
         if let xcodeVersion = hostXcodeVersion(infoDictionary: infoDictionary) {
             attributes[Constants.xcodeVersionAttribute] = xcodeVersion
         }
-        for (infoKey, attribute) in buildMetadataKeys {
-            guard let value = infoDictionary?[infoKey] as? String, !value.isEmpty else {
-                continue
-            }
-            attributes[attribute] = value
+        if let xcodeBuild = infoValue(Constants.xcodeBuildInfoKey, in: infoDictionary) {
+            attributes[Constants.xcodeBuildAttribute] = xcodeBuild
+        }
+        if let minimumOSVersion = Constants.minimumOSVersionInfoKeys
+            .lazy
+            .compactMap({ infoValue($0, in: infoDictionary) })
+            .first {
+            attributes[Constants.minimumOSVersionAttribute] = minimumOSVersion
         }
         return attributes
+    }
+
+    private static func infoValue(_ key: String, in infoDictionary: [String: Any]?) -> String? {
+        guard let value = infoDictionary?[key] as? String, !value.isEmpty else {
+            return nil
+        }
+        return value
     }
 
     static func hostXcodeVersion(

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -51,17 +51,6 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         static let deviceManufacturer = "Apple"
         static let unknown = "unknown"
         static let osBuildName = "kern.osversion"
-        static let xcodeVersionInfoKey = "DTXcode"
-        static let xcodeVersionAttribute = "xcode_version"
-        static let xcodeBuildInfoKey = "DTXcodeBuild"
-        static let xcodeBuildAttribute = "xcode_build"
-        /// iOS / tvOS / watchOS deployment target. Distinct from the macOS floor:
-        /// `LSMinimumSystemVersion` is a macOS version and must not share this key.
-        static let minimumOSVersionInfoKey = "MinimumOSVersion"
-        static let minimumOSVersionAttribute = "minimum_os_version"
-        static let minimumMacOSVersionInfoKey = "LSMinimumSystemVersion"
-        static let minimumMacOSVersionAttribute = "minimum_macos_version"
-        static let applePlatformAttribute = "apple_platform"
         static let disabledLogLevel = "NONE"
         static let crashDirectoryComponents = ["onesignal", "logger", "crashes"]
 
@@ -217,22 +206,23 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     ) -> [String: String] {
         var attributes: [String: String] = [:]
         #if targetEnvironment(macCatalyst)
-        attributes[Constants.applePlatformAttribute] = "mac_catalyst"
+        attributes["apple_platform"] = "mac_catalyst"
         #endif
         if let xcodeVersion = hostXcodeVersion(infoDictionary: infoDictionary) {
-            attributes[Constants.xcodeVersionAttribute] = xcodeVersion
+            attributes["xcode_version"] = xcodeVersion
         }
-        if let xcodeBuild = infoValue(Constants.xcodeBuildInfoKey, in: infoDictionary) {
-            attributes[Constants.xcodeBuildAttribute] = xcodeBuild
+        if let xcodeBuild = infoValue("DTXcodeBuild", in: infoDictionary) {
+            attributes["xcode_build"] = xcodeBuild
         }
-        if let minimumOSVersion = infoValue(Constants.minimumOSVersionInfoKey, in: infoDictionary) {
-            attributes[Constants.minimumOSVersionAttribute] = minimumOSVersion
+        if let minimumOSVersion = infoValue("MinimumOSVersion", in: infoDictionary) {
+            attributes["minimum_os_version"] = minimumOSVersion
         }
+        // macOS version — do not fold into minimum_os_version
         if let minimumMacOSVersion = infoValue(
-            Constants.minimumMacOSVersionInfoKey,
+            "LSMinimumSystemVersion",
             in: infoDictionary
         ) {
-            attributes[Constants.minimumMacOSVersionAttribute] = minimumMacOSVersion
+            attributes["minimum_macos_version"] = minimumMacOSVersion
         }
         return attributes
     }
@@ -247,7 +237,7 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     static func hostXcodeVersion(
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary
     ) -> String? {
-        guard let raw = infoDictionary?[Constants.xcodeVersionInfoKey] as? String else {
+        guard let raw = infoDictionary?["DTXcode"] as? String else {
             return nil
         }
         return decodeXcodeVersion(raw)

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -115,12 +115,13 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     /// `ossdk.kmp_version` instead.
     let kotlinVersion: String? = nil
 
-    /// Approximated from the host app's Xcode version. Apple ships one Swift
-    /// toolchain per Xcode release and exposes no runtime API for the language
-    /// version, so this is the closest signal available. `xcode_version` is emitted
-    /// alongside and is exact, so a stale row in the lookup table stays recoverable.
-    let swiftVersion: String? = OSLoggerPlatformProvider.hostXcodeVersion()
-        .flatMap(OSLoggerPlatformProvider.approximateSwiftVersion(forXcodeVersion:))
+    /// Nil on iOS. Apple exposes no runtime API for the Swift language version and
+    /// there is no `DTSwiftVersion` key, so the only derivable value would come from
+    /// the Xcode version — which maps to a Swift compiler 1:1 and is already emitted
+    /// exactly as `xcode_version`. The one thing a distinct value could carry is the
+    /// per-target language mode (`SWIFT_VERSION`, 5 vs 6), and that is not in the
+    /// host's `Info.plist` at all.
+    let swiftVersion: String? = nil
 
     let additionalVersionAttributes: [String: String] =
         OSLoggerPlatformProvider.hostBuildAttributes()
@@ -197,13 +198,17 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
 
     let apiBaseUrl = OS_API_SERVER_URL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
-    /// Xcode stamps its own version, the compiler, and the SDK it built against
-    /// into the *host app's* `Info.plist`. Reading `Bundle.main` is deliberate:
-    /// this SDK ships as a prebuilt XCFramework, so a compile-time check here would
-    /// describe OneSignal's build machine and be identical for every customer.
+    /// Xcode stamps its own version, the compiler, and the SDK it built against into
+    /// the *host app's* `Info.plist`, alongside the deployment target the app
+    /// declares. Reading `Bundle.main` is deliberate: this SDK ships as a prebuilt
+    /// XCFramework, so a compile-time check here would describe OneSignal's build
+    /// machine and be identical for every customer.
     ///
-    /// These are build-time facts. The OS actually running is reported separately
-    /// as `os.name` / `os.version` / `os.build_id`.
+    /// These are build-time facts and answer what the host *commits to* supporting.
+    /// The OS actually running is reported separately as `os.name` / `os.version` /
+    /// `os.build_id`, and the two diverge: an app can serve only iOS 18 users while
+    /// still declaring a much older `minimum_os_version`, which is what constrains
+    /// raising our own deployment target.
     private static let buildMetadataKeys: [(infoKey: String, attribute: String)] = [
         ("DTXcodeBuild", "xcode_build"),
         ("DTCompiler", "build_compiler"),
@@ -211,20 +216,8 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         ("DTPlatformVersion", "build_platform_version"),
         ("DTPlatformBuild", "build_platform_build"),
         ("DTSDKName", "build_sdk_name"),
-        ("DTSDKBuild", "build_sdk_build")
-    ]
-
-    /// Floor lookup, so an Xcode newer than every row resolves to the most recent
-    /// known Swift release rather than dropping the attribute. Add a row whenever
-    /// an Xcode release ships a new Swift version.
-    private static let swiftVersionByXcode: [(xcode: (major: Int, minor: Int), swift: String)] = [
-        ((14, 0), "5.7"),
-        ((14, 3), "5.8"),
-        ((15, 0), "5.9"),
-        ((15, 3), "5.10"),
-        ((16, 0), "6.0"),
-        ((16, 3), "6.1"),
-        ((26, 0), "6.2")
+        ("DTSDKBuild", "build_sdk_build"),
+        ("MinimumOSVersion", "minimum_os_version")
     ]
 
     static func hostBuildAttributes(
@@ -264,20 +257,6 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         let minor = (packed / 10) % 10
         let patch = packed % 10
         return patch == 0 ? "\(major).\(minor)" : "\(major).\(minor).\(patch)"
-    }
-
-    static func approximateSwiftVersion(forXcodeVersion version: String) -> String? {
-        let components = version.split(separator: ".").compactMap { Int($0) }
-        guard let major = components.first else {
-            return nil
-        }
-        let minor = components.count > 1 ? components[1] : 0
-        var resolved: String?
-        for entry in swiftVersionByXcode
-        where (entry.xcode.major, entry.xcode.minor) <= (major, minor) {
-            resolved = entry.swift
-        }
-        return resolved
     }
 
     private static func systemValue(named name: String) -> String {

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -51,6 +51,14 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         static let deviceManufacturer = "Apple"
         static let unknown = "unknown"
         static let osBuildName = "kern.osversion"
+        static let xcodeVersionInfoKey = "DTXcode"
+        static let xcodeVersionAttribute = "xcode_version"
+        static let xcodeBuildInfoKey = "DTXcodeBuild"
+        static let xcodeBuildAttribute = "xcode_build"
+        static let minimumOSVersionInfoKey = "MinimumOSVersion"
+        static let minimumOSVersionAttribute = "minimum_os_version"
+        static let minimumMacOSVersionInfoKey = "LSMinimumSystemVersion"
+        static let minimumMacOSVersionAttribute = "minimum_macos_version"
         static let disabledLogLevel = "NONE"
         static let crashDirectoryComponents = ["onesignal", "logger", "crashes"]
 
@@ -209,20 +217,20 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
         attributes["apple_platform"] = "mac_catalyst"
         #endif
         if let xcodeVersion = hostXcodeVersion(infoDictionary: infoDictionary) {
-            attributes["xcode_version"] = xcodeVersion
+            attributes[Constants.xcodeVersionAttribute] = xcodeVersion
         }
-        if let xcodeBuild = infoValue("DTXcodeBuild", in: infoDictionary) {
-            attributes["xcode_build"] = xcodeBuild
+        if let xcodeBuild = infoValue(Constants.xcodeBuildInfoKey, in: infoDictionary) {
+            attributes[Constants.xcodeBuildAttribute] = xcodeBuild
         }
-        if let minimumOSVersion = infoValue("MinimumOSVersion", in: infoDictionary) {
-            attributes["minimum_os_version"] = minimumOSVersion
+        if let minimumOSVersion = infoValue(Constants.minimumOSVersionInfoKey, in: infoDictionary) {
+            attributes[Constants.minimumOSVersionAttribute] = minimumOSVersion
         }
         // macOS version — do not fold into minimum_os_version
         if let minimumMacOSVersion = infoValue(
-            "LSMinimumSystemVersion",
+            Constants.minimumMacOSVersionInfoKey,
             in: infoDictionary
         ) {
-            attributes["minimum_macos_version"] = minimumMacOSVersion
+            attributes[Constants.minimumMacOSVersionAttribute] = minimumMacOSVersion
         }
         return attributes
     }
@@ -237,7 +245,7 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     static func hostXcodeVersion(
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary
     ) -> String? {
-        guard let raw = infoDictionary?["DTXcode"] as? String else {
+        guard let raw = infoDictionary?[Constants.xcodeVersionInfoKey] as? String else {
             return nil
         }
         return decodeXcodeVersion(raw)

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
@@ -440,20 +440,6 @@ final class OSLoggerHostBuildAttributesTests: XCTestCase {
         XCTAssertNil(OSLoggerPlatformProvider.decodeXcodeVersion("not-a-number"))
     }
 
-    func testApproximateSwiftVersionFloorsToNearestKnownXcode() {
-        let approximate = OSLoggerPlatformProvider.approximateSwiftVersion(forXcodeVersion:)
-
-        XCTAssertEqual(approximate("16.0"), "6.0")
-        XCTAssertEqual(approximate("16.3"), "6.1")
-        // Unlisted release between known rows floors to the row below it.
-        XCTAssertEqual(approximate("16.4"), "6.1")
-        // Newer than every row keeps the last known value rather than dropping.
-        XCTAssertEqual(approximate("99.9"), "6.2")
-        // Older than every row has nothing sensible to report.
-        XCTAssertNil(approximate("13.4"))
-        XCTAssertNil(approximate(""))
-    }
-
     func testHostBuildAttributesMapsInfoPlistKeys() {
         let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
             "DTXcode": "2620",
@@ -462,6 +448,7 @@ final class OSLoggerHostBuildAttributesTests: XCTestCase {
             "DTPlatformName": "iphonesimulator",
             "DTPlatformVersion": "26.2",
             "DTSDKName": "iphonesimulator26.2",
+            "MinimumOSVersion": "12.0",
             "DTSDKBuild": ""
         ])
 
@@ -471,6 +458,8 @@ final class OSLoggerHostBuildAttributesTests: XCTestCase {
         XCTAssertEqual(attributes["build_platform_name"], "iphonesimulator")
         XCTAssertEqual(attributes["build_platform_version"], "26.2")
         XCTAssertEqual(attributes["build_sdk_name"], "iphonesimulator26.2")
+        // The host's declared deployment target, not the OS it happens to run on.
+        XCTAssertEqual(attributes["minimum_os_version"], "12.0")
         // Blank and absent values are omitted rather than emitted empty.
         XCTAssertNil(attributes["build_sdk_build"])
         XCTAssertNil(attributes["build_platform_build"])

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
@@ -444,32 +444,48 @@ final class OSLoggerHostBuildAttributesTests: XCTestCase {
         let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
             "DTXcode": "2620",
             "DTXcodeBuild": "17C52",
+            "MinimumOSVersion": "12.0",
+            // Present in every built Info.plist but deliberately not emitted: each is
+            // either constant across all apps or derivable from the fields above.
             "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
             "DTPlatformName": "iphonesimulator",
             "DTPlatformVersion": "26.2",
+            "DTPlatformBuild": "23C53",
             "DTSDKName": "iphonesimulator26.2",
-            "MinimumOSVersion": "12.0",
-            "DTSDKBuild": ""
+            "DTSDKBuild": "23C53"
         ])
 
         XCTAssertEqual(attributes["xcode_version"], "26.2")
         XCTAssertEqual(attributes["xcode_build"], "17C52")
-        XCTAssertEqual(attributes["build_compiler"], "com.apple.compilers.llvm.clang.1_0")
-        XCTAssertEqual(attributes["build_platform_name"], "iphonesimulator")
-        XCTAssertEqual(attributes["build_platform_version"], "26.2")
-        XCTAssertEqual(attributes["build_sdk_name"], "iphonesimulator26.2")
         // The host's declared deployment target, not the OS it happens to run on.
         XCTAssertEqual(attributes["minimum_os_version"], "12.0")
-        // Blank and absent values are omitted rather than emitted empty.
-        XCTAssertNil(attributes["build_sdk_build"])
-        XCTAssertNil(attributes["build_platform_build"])
+        XCTAssertEqual(attributes.count, 3)
     }
 
-    func testHostBuildAttributesOmitsXcodeVersionWhenKeyMissing() {
-        let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [:])
+    func testHostBuildAttributesFallsBackToCatalystMinimumSystemVersion() {
+        let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
+            "LSMinimumSystemVersion": "13.1"
+        ])
 
-        XCTAssertNil(attributes["xcode_version"])
-        XCTAssertNil(attributes["xcode_build"])
+        XCTAssertEqual(attributes["minimum_os_version"], "13.1")
+    }
+
+    func testHostBuildAttributesPrefersMinimumOSVersionOverCatalystKey() {
+        let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
+            "MinimumOSVersion": "12.0",
+            "LSMinimumSystemVersion": "13.1"
+        ])
+
+        XCTAssertEqual(attributes["minimum_os_version"], "12.0")
+    }
+
+    func testHostBuildAttributesOmitsBlankAndMissingValues() {
+        let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
+            "DTXcodeBuild": "",
+            "MinimumOSVersion": ""
+        ])
+
+        XCTAssertTrue(attributes.isEmpty)
     }
 }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
@@ -428,6 +428,62 @@ final class OSLoggerAdaptersTests: XCTestCase {
     }
 }
 
+/// Host build metadata read from the app's `Info.plist`, kept separate from the
+/// adapter tests above so neither class outgrows the lint limit.
+final class OSLoggerHostBuildAttributesTests: XCTestCase {
+    func testDecodeXcodeVersionUnpacksDTXcodeDigits() {
+        XCTAssertEqual(OSLoggerPlatformProvider.decodeXcodeVersion("2620"), "26.2")
+        XCTAssertEqual(OSLoggerPlatformProvider.decodeXcodeVersion("1600"), "16.0")
+        XCTAssertEqual(OSLoggerPlatformProvider.decodeXcodeVersion("0900"), "9.0")
+        XCTAssertEqual(OSLoggerPlatformProvider.decodeXcodeVersion("1632"), "16.3.2")
+        XCTAssertNil(OSLoggerPlatformProvider.decodeXcodeVersion(""))
+        XCTAssertNil(OSLoggerPlatformProvider.decodeXcodeVersion("not-a-number"))
+    }
+
+    func testApproximateSwiftVersionFloorsToNearestKnownXcode() {
+        let approximate = OSLoggerPlatformProvider.approximateSwiftVersion(forXcodeVersion:)
+
+        XCTAssertEqual(approximate("16.0"), "6.0")
+        XCTAssertEqual(approximate("16.3"), "6.1")
+        // Unlisted release between known rows floors to the row below it.
+        XCTAssertEqual(approximate("16.4"), "6.1")
+        // Newer than every row keeps the last known value rather than dropping.
+        XCTAssertEqual(approximate("99.9"), "6.2")
+        // Older than every row has nothing sensible to report.
+        XCTAssertNil(approximate("13.4"))
+        XCTAssertNil(approximate(""))
+    }
+
+    func testHostBuildAttributesMapsInfoPlistKeys() {
+        let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
+            "DTXcode": "2620",
+            "DTXcodeBuild": "17C52",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformName": "iphonesimulator",
+            "DTPlatformVersion": "26.2",
+            "DTSDKName": "iphonesimulator26.2",
+            "DTSDKBuild": ""
+        ])
+
+        XCTAssertEqual(attributes["xcode_version"], "26.2")
+        XCTAssertEqual(attributes["xcode_build"], "17C52")
+        XCTAssertEqual(attributes["build_compiler"], "com.apple.compilers.llvm.clang.1_0")
+        XCTAssertEqual(attributes["build_platform_name"], "iphonesimulator")
+        XCTAssertEqual(attributes["build_platform_version"], "26.2")
+        XCTAssertEqual(attributes["build_sdk_name"], "iphonesimulator26.2")
+        // Blank and absent values are omitted rather than emitted empty.
+        XCTAssertNil(attributes["build_sdk_build"])
+        XCTAssertNil(attributes["build_platform_build"])
+    }
+
+    func testHostBuildAttributesOmitsXcodeVersionWhenKeyMissing() {
+        let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [:])
+
+        XCTAssertNil(attributes["xcode_version"])
+        XCTAssertNil(attributes["xcode_build"])
+    }
+}
+
 private final class LoggerAdapterListener: NSObject, OSLogListener {
     var levels: [ONE_S_LOG_LEVEL] = []
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSLoggerAdaptersTests.swift
@@ -462,27 +462,30 @@ final class OSLoggerHostBuildAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.count, 3)
     }
 
-    func testHostBuildAttributesFallsBackToCatalystMinimumSystemVersion() {
+    func testHostBuildAttributesEmitsCatalystFloorAsMacOSVersion() {
         let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
             "LSMinimumSystemVersion": "13.1"
         ])
 
-        XCTAssertEqual(attributes["minimum_os_version"], "13.1")
+        XCTAssertEqual(attributes["minimum_macos_version"], "13.1")
+        XCTAssertNil(attributes["minimum_os_version"])
     }
 
-    func testHostBuildAttributesPrefersMinimumOSVersionOverCatalystKey() {
+    func testHostBuildAttributesEmitsIOSAndMacOSFloorsIndependently() {
         let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
             "MinimumOSVersion": "12.0",
             "LSMinimumSystemVersion": "13.1"
         ])
 
         XCTAssertEqual(attributes["minimum_os_version"], "12.0")
+        XCTAssertEqual(attributes["minimum_macos_version"], "13.1")
     }
 
     func testHostBuildAttributesOmitsBlankAndMissingValues() {
         let attributes = OSLoggerPlatformProvider.hostBuildAttributes(infoDictionary: [
             "DTXcodeBuild": "",
-            "MinimumOSVersion": ""
+            "MinimumOSVersion": "",
+            "LSMinimumSystemVersion": ""
         ])
 
         XCTAssertTrue(attributes.isEmpty)


### PR DESCRIPTION
## Summary

Linear: [SDK-5106](https://linear.app/onesignal/issue/SDK-5106/report-host-xcode-version-and-deployment-target-on-ios-remote-logs)

`OSLoggerPlatformProvider` shipped `swiftVersion`, `kotlinVersion`, and `additionalVersionAttributes` as placeholders (`nil` / Catalyst-only), so iOS logs carried nothing about the toolchain that built the host app. `LogFields` uses `putIfValueNotBlank`, so those attributes were silently absent from every record rather than failing loudly.

This reads Xcode's `DT*` keys and the declared deployment target from the **running executable's** `Info.plist` via `Bundle.main`.

**Why not a compile-time check.** `#if swift(>=6.0)` inside SDK source is evaluated when *we* build the SDK. Since we distribute a prebuilt XCFramework (podspecs vend `OneSignalCore.xcframework`, `Package.swift` uses binary targets), that value freezes at our build time and is identical for every customer — it would duplicate `ossdk.sdk_base_version` and tell you nothing about the app. Reading `Bundle.main` describes the customer's build and varies per app.

### Attributes added

Emitted as `ossdk.<key>` resource attributes (attached once per resource, not per record):

| Attribute | Source | Example |
| --- | --- | --- |
| `xcode_version` | `DTXcode`, decoded | `26.2` |
| `xcode_build` | `DTXcodeBuild` | `17C52` |
| `minimum_os_version` | `MinimumOSVersion` | `12.0` |
| `minimum_macos_version` | `LSMinimumSystemVersion` (Catalyst / macOS) | `13.1` |

`apple_platform` (`mac_catalyst`) is pre-existing and stays. `DTXcode` is packed (`"2620"` = 26.2) so it is decoded rather than shipped raw. Blank and missing keys are dropped rather than emitted empty.

`LSMinimumSystemVersion` is a macOS version, so it is not folded into `minimum_os_version` — a query for hosts below iOS 15 would otherwise include Catalyst apps pinned to macOS 13. Both keys can be present and are emitted independently.

Review trimmed `build_compiler`, `build_platform_*`, and `build_sdk_*` — they duplicated existing `device.*` / `os.*` fields or each other.

### Why `minimum_os_version` matters

These attributes exist to answer support questions, not for general telemetry, and this is the one that answers **"can we raise our deployment target?"**

It is deliberately distinct from `os.version`, which is already emitted. `os.version` is what a customer's users are *running*; `minimum_os_version` is what their build is *pinned to*. A customer can serve 100% iOS 18 traffic while still declaring min iOS 13 — and raising our deployment target breaks their build regardless of where their users are. #1724 just raised our minimum to iOS 12; this is the field that would show who that affects before the next bump.

## Why `swiftVersion` stays nil

An earlier revision of this PR approximated `swiftVersion` from the Xcode version via a lookup table. That has been dropped, and the field is left `nil`. Three reasons:

**1. It is redundant with `xcode_version`.** Xcode determines the Swift compiler 1:1 — there is no Xcode 16 shipping a Swift 5.9 compiler. Anything derived from the Xcode version is a lossy re-encoding of a field we already emit exactly, and can only ever be less accurate than the value sitting next to it.

**2. The one thing a distinct value could carry, this approach cannot capture.** A `swift_version` meaningfully different from the Xcode version would be the *language mode* — the per-target `SWIFT_VERSION` build setting, 5 vs 6. That would answer a real question ("if we adopt Swift 6 strict concurrency in our public API, do customers still building in Swift 5 mode break?"). But language mode is not in the host `Info.plist` at all, and an approximation derived from the compiler reports the wrong thing for exactly that case. A field that looks like it answers the question and does not is worse than an absent field.

**3. The iOS compatibility cliff is not shaped like Kotlin's.** On Android, `kotlin_version` gates a real hazard: Kotlin metadata is forward-incompatible, so a library compiled with Kotlin 2.x cannot be consumed by a 1.9 compiler, making the customer's Kotlin version a hard blocker on bumping ours. iOS has no equivalent, because we build every target with `BUILD_LIBRARY_FOR_DISTRIBUTION = YES` and therefore ship a module-stable `.swiftinterface`, which newer compilers consume fine. The practical gate is "customer's Xcode >= ours", and `xcode_version` answers that directly.

Worth noting *why* Android can do this and we cannot: `KotlinVersion.CURRENT` works because `kotlin-stdlib` is an ordinary dependency bundled into the APK, so the version travels with the app as readable data. Swift's runtime has been ABI-stable and OS-provided since Swift 5, so there is no app-bundled artifact carrying a language version — anything readable at runtime describes the OS's Swift runtime, which already tracks `os.version`.

`kotlinVersion` likewise stays `nil`: the protocol scopes it to a Kotlin *host app*, which iOS is not. The shared module's own provenance is already on `ossdk.kmp_version`.

## Test plan

- [x] `OneSignalOSCoreTests` green against `main` with KMP at the pinned `v0.3.0`
- [x] New `OSLoggerHostBuildAttributesTests` covering `DTXcode` digit unpacking, key mapping including `minimum_os_version` / `minimum_macos_version`, and omission of blank/missing keys
- [x] `swiftlint` clean on the changed source file
- [x] KMP XCFramework rebuilt at the pinned submodule commit
- [ ] Confirm the new `ossdk.*` attributes land in GCP Logs Explorer on a real device build

Verify on device with:

```
resource.type="k8s_container"
labels.log_source="sdk_log"
jsonPayload."ossdk.app_id"="<app id>"
```

Related: [SDK-5106](https://linear.app/onesignal/issue/SDK-5106/report-host-xcode-version-and-deployment-target-on-ios-remote-logs), [SDK-4999](https://linear.app/onesignal/issue/SDK-4999/add-kotlinswift-language-versions-to-remote-log-resource-attributes) (KMP contract), [SDK-5081](https://linear.app/onesignal/issue/SDK-5081/bug-bash-ios-remote-logging-turbine-feature-flags-kmp) (bug bash covering remote logging + feature flags).