### PR TITLE
chore: [SDK-5114] drop unused swiftVersion after KMP bump

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/Logging/OSLoggerPlatformProvider.swift
@@ -120,10 +120,6 @@ final class OSLoggerPlatformProvider: ILoggerPlatformProvider {
     /// `ossdk.kmp_version` instead.
     let kotlinVersion: String? = nil
 
-    /// Nil on iOS: there is no runtime API for the Swift language version, and anything
-    /// derivable would just re-encode `xcode_version` less precisely.
-    let swiftVersion: String? = nil
-
     let additionalVersionAttributes: [String: String] =
         OSLoggerPlatformProvider.hostBuildAttributes()
     var enabledFeatureFlags: [String] {


### PR DESCRIPTION
## Summary

Linear: [SDK-5114](https://linear.app/onesignal/issue/SDK-5114/remove-unused-swiftversion-from-the-logger-platform-contract)

Consume [OneSignal-KMP-SDK#22](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/22) and drop the always-nil `swiftVersion` stub from `OSLoggerPlatformProvider`. The shared contract no longer has that property; `ossdk.swift_version` stays reserved so extras cannot smuggle it back.

`kotlinVersion` is unchanged.

## Pin

Submodule `87e87fd` (v0.3.0) → `6c6bb90` (KMP `main`). That walk includes two already-merged KMP commits on the way to #22:

- [KMP#20](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/20) / SDK-5065 — shared crash-record retention policy
- [KMP#21](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/21) / SDK-5065 — bounded retry/backoff on log export (KMP-only; becomes active with this pin)
- [KMP#22](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/22) / SDK-5114 — drop `swiftVersion`

Native iOS crash-cache bounding stays on #1725. If this lands first, #1725 should fast-forward its gitlink to `6c6bb90` (or later) rather than rewind it.

## Test plan

- [x] `OneSignalOSCoreTests` 107 passing, 0 failures, against the new pin
- [x] `swiftlint` clean on the changed source file
- [x] KMP XCFramework rebuilt at `6c6bb90`


Made with [Cursor](https://cursor.com)