### PR TITLE
fix: restore the deprecated 2-arg NSE selector

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.h
@@ -37,7 +37,6 @@
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 // Call from a UNNotificationServiceExtension on iOS 10 and later.
 // Processes media attachments and action buttons.
-// The 2-arg form is the sync path (nil handler). Prefer the contentHandler overload.
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent __deprecated_msg("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.");
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.h
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.h
@@ -37,6 +37,8 @@
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 // Call from a UNNotificationServiceExtension on iOS 10 and later.
 // Processes media attachments and action buttons.
+// The 2-arg form is the sync path (nil handler). Prefer the contentHandler overload.
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent __deprecated_msg("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.");
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;
 @end

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.m
@@ -30,6 +30,13 @@
 
 @implementation OneSignalExtension
 
+// Called from the app's Notification Service Extension. Sync path; forwards with a nil handler.
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
+    return [OneSignalNotificationServiceExtensionHandler
+            didReceiveNotificationExtensionRequest:request
+            withMutableNotificationContent:replacementContent];
+}
+
 // Called from the app's Notification Service Extension. Calls contentHandler() to display the notification
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request                              withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent
                 withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {

--- a/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.m
+++ b/iOS_SDK/OneSignalSDK/OneSignalExtension/OneSignalExtension.m
@@ -30,7 +30,7 @@
 
 @implementation OneSignalExtension
 
-// Called from the app's Notification Service Extension. Sync path; forwards with a nil handler.
+// Called from the app's Notification Service Extension
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
     return [OneSignalNotificationServiceExtensionHandler
             didReceiveNotificationExtensionRequest:request

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -835,7 +835,7 @@ static BOOL ComputeInitialStorageReadable(void) {
     
 }
 
-// Called from the app's Notification Service Extension. Sync path; forwards with a nil handler.
+// Called from the app's Notification Service Extension
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
     return [OneSignalNotificationServiceExtensionHandler
             didReceiveNotificationExtensionRequest:request

--- a/iOS_SDK/OneSignalSDK/Source/OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignal.m
@@ -835,6 +835,13 @@ static BOOL ComputeInitialStorageReadable(void) {
     
 }
 
+// Called from the app's Notification Service Extension. Sync path; forwards with a nil handler.
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent {
+    return [OneSignalNotificationServiceExtensionHandler
+            didReceiveNotificationExtensionRequest:request
+            withMutableNotificationContent:replacementContent];
+}
+
 // Called from the app's Notification Service Extension. Calls contentHandler() to display the notification
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest*)request                              withMutableNotificationContent:(UNMutableNotificationContent*)replacementContent
                 withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -106,7 +106,6 @@ NS_SWIFT_NAME(login(externalId:token:));
 #pragma mark Extension
 // Call from a UNNotificationServiceExtension on iOS 10 and later.
 // Processes media attachments and action buttons.
-// The 2-arg form is the sync path (nil handler). Prefer the contentHandler overload.
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent __deprecated_msg("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.");
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;

--- a/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
+++ b/iOS_SDK/OneSignalSDK/Source/OneSignalFramework.h
@@ -106,6 +106,8 @@ NS_SWIFT_NAME(login(externalId:token:));
 #pragma mark Extension
 // Call from a UNNotificationServiceExtension on iOS 10 and later.
 // Processes media attachments and action buttons.
+// The 2-arg form is the sync path (nil handler). Prefer the contentHandler overload.
++ (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent __deprecated_msg("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.");
 + (UNMutableNotificationContent*)didReceiveNotificationExtensionRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
 + (UNMutableNotificationContent*)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest* _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent* _Nullable)replacementContent;
 @end


### PR DESCRIPTION
# Description
## One Line Summary
Put `didReceiveNotificationExtensionRequest:withMutableNotificationContent:` back on `OneSignal` and `OneSignalExtension` as a deprecated public wrapper.

## Details

### Motivation
5.6.0 removed this selector in [#1726](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1726) as unsupported iOS 10 code. The "iOS 10 only" comment meant NSE's floor is iOS 10, not that the method died on 11+. Wrappers and old `NotificationService` files still call the 2-arg form, so 5.6.0 is a compile break in a minor.

It was deprecated in 3.5.0 ([#934](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/934)) because confirmed-delivery spreading needs `contentHandler` to keep the NSE alive after the banner shows. The 2-arg path is still the sync contract (`nil` handler, no receipt delay). Deprecation is not the same as removal. Drop it in 6.0, not 5.6.x.

### Scope
- Public headers and `.m` wrappers on `OneSignal` and `OneSignalExtension` only
- Still deprecated, same message as before
- Forwards to the existing handler 2-arg method, which already calls the 3-arg path with `nil`
- No change to attachments, action buttons, or the contentHandler path
- XCFramework binaries are rebuilt at release

# Testing
## Unit testing
None added. The internal handler never lost the 2-arg method, and that is what these wrappers call. Existing NSE handler tests cover that path.

## Manual testing
Not device-tested. This restores a public selector so NSE files that still call it compile against 5.6.x. The 3-arg path is unchanged.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [x] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)