### PR TITLE
feat: [SDK-5193] let an app opt out of subscription ID copy in Info.plist

### DIFF
--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDeviceGestureDetector.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDeviceGestureDetector.swift
@@ -42,7 +42,9 @@ import UIKit
 /// at round trips of five seconds or faster.
 ///
 /// The `killSwitchKey` catalog flag turns the gesture off. Absent means enabled, so a device
-/// that has never fetched flags still has it.
+/// that has never fetched flags still has it. An app can also opt out for good with the
+/// Info.plist key `disableInfoPlistKey`; then the detector never starts, so nothing is counted
+/// or recorded.
 ///
 /// Every recognised gesture also records `OSObservabilityEvent.deviceGesture`, with its outcome
 /// and the copied ID, so the gesture's usage can be measured.
@@ -55,6 +57,7 @@ public final class OSDeviceGestureDetector: NSObject {
     static let minBackgroundDwellSeconds: TimeInterval = 0.25
 
     static let killSwitchKey = "sdk_device_gesture_disabled"
+    static let disableInfoPlistKey = "OneSignal_disable_subscription_id_copy"
 
     /// The copied ID expires after five minutes. Whatever it replaced is not restored.
     static let pasteboardExpirySeconds: TimeInterval = 300
@@ -80,6 +83,7 @@ public final class OSDeviceGestureDetector: NSObject {
     /// hours apart into one window.
     private let nowProvider: () -> TimeInterval
     private let isDisabledRemotelyProvider: () -> Bool
+    private let isDisabledByAppProvider: () -> Bool
     private let subscriptionIdProvider: () -> String?
     private let shouldAwaitProvider: () -> Bool
     private let pasteboardWriter: (String) -> Void
@@ -103,6 +107,9 @@ public final class OSDeviceGestureDetector: NSObject {
         isDisabledRemotelyProvider: @escaping () -> Bool = {
             OSFeatureManager.shared.isEnabled(featureKey: OSDeviceGestureDetector.killSwitchKey)
         },
+        isDisabledByAppProvider: @escaping () -> Bool = {
+            (Bundle.main.object(forInfoDictionaryKey: OSDeviceGestureDetector.disableInfoPlistKey) as? NSNumber)?.boolValue ?? false
+        },
         subscriptionIdProvider: @escaping () -> String? = { OneSignalIdentifiers.subscriptionId },
         shouldAwaitProvider: @escaping () -> Bool = {
             OneSignalConfig.shouldAwaitAppIdAndLogMissingPrivacyConsent(forMethod: nil)
@@ -114,6 +121,7 @@ public final class OSDeviceGestureDetector: NSObject {
         self.mainQueue = mainQueue
         self.nowProvider = nowProvider
         self.isDisabledRemotelyProvider = isDisabledRemotelyProvider
+        self.isDisabledByAppProvider = isDisabledByAppProvider
         self.subscriptionIdProvider = subscriptionIdProvider
         self.shouldAwaitProvider = shouldAwaitProvider
         self.pasteboardWriter = pasteboardWriter
@@ -137,6 +145,8 @@ public final class OSDeviceGestureDetector: NSObject {
     /// once the last scene backgrounds, exactly the whole-app signal a cycle counter needs.
     /// Per-scene events would over-count on multi-window iPad.
     func registerLifecycleObserversIfNeeded() {
+        // Read before the lock; it touches the app bundle, not the SDK.
+        let optedOut = isDisabledByAppProvider()
         let shouldSkip = stateLock.withLock { () -> Bool in
             if started || invalidated {
                 return true
@@ -145,6 +155,11 @@ public final class OSDeviceGestureDetector: NSObject {
             return false
         }
         guard !shouldSkip else {
+            return
+        }
+        // The app owner's opt-out. Logged so a developer can confirm the key took.
+        guard !optedOut else {
+            OneSignalLog.onesignalLog(.LL_INFO, message: "OSDeviceGestureDetector: disabled by \(Self.disableInfoPlistKey), not starting")
             return
         }
 

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDeviceGestureDetector.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCore/Source/OSDeviceGestureDetector.swift
@@ -41,7 +41,7 @@ import UIKit
 /// synthetic sub-millisecond pair. The window is the only rate rule; six cycles fit inside it
 /// at round trips of five seconds or faster.
 ///
-/// The `killSwitchKey` catalog flag turns the gesture off. Absent means enabled, so a device
+/// The `remoteKillSwitchKey` catalog flag turns the gesture off. Absent means enabled, so a device
 /// that has never fetched flags still has it. An app can also opt out for good with the
 /// Info.plist key `disableInfoPlistKey`; then the detector never starts, so nothing is counted
 /// or recorded.
@@ -56,7 +56,7 @@ public final class OSDeviceGestureDetector: NSObject {
     /// Shortest background phase a human can produce; anything faster is synthetic.
     static let minBackgroundDwellSeconds: TimeInterval = 0.25
 
-    static let killSwitchKey = "sdk_device_gesture_disabled"
+    static let remoteKillSwitchKey = "sdk_device_gesture_disabled"
     static let disableInfoPlistKey = "OneSignal_disable_subscription_id_copy"
 
     /// The copied ID expires after five minutes. Whatever it replaced is not restored.
@@ -105,10 +105,12 @@ public final class OSDeviceGestureDetector: NSObject {
             TimeInterval(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)) / TimeInterval(NSEC_PER_SEC)
         },
         isDisabledRemotelyProvider: @escaping () -> Bool = {
-            OSFeatureManager.shared.isEnabled(featureKey: OSDeviceGestureDetector.killSwitchKey)
+            OSFeatureManager.shared.isEnabled(featureKey: OSDeviceGestureDetector.remoteKillSwitchKey)
         },
         isDisabledByAppProvider: @escaping () -> Bool = {
-            (Bundle.main.object(forInfoDictionaryKey: OSDeviceGestureDetector.disableInfoPlistKey) as? NSNumber)?.boolValue ?? false
+            OSDeviceGestureDetector.isDisabledByApp(
+                infoPlistValue: Bundle.main.object(forInfoDictionaryKey: OSDeviceGestureDetector.disableInfoPlistKey)
+            )
         },
         subscriptionIdProvider: @escaping () -> String? = { OneSignalIdentifiers.subscriptionId },
         shouldAwaitProvider: @escaping () -> Bool = {
@@ -300,6 +302,12 @@ public final class OSDeviceGestureDetector: NSObject {
     /// anyone who copied it by accident.
     static func clipText(subscriptionId: String) -> String {
         clipPrefix + subscriptionId
+    }
+
+    /// Dynamic `boolValue`, as Objective-C sends to `id`. A Boolean, Number or String such as
+    /// `YES` opts out. Anything else, including a missing key, does not.
+    static func isDisabledByApp(infoPlistValue value: Any?) -> Bool {
+        (value as AnyObject?)?.boolValue ?? false
     }
 
     /// No `localOnly` option: Universal Clipboard carrying the ID to the Mac running the

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSDeviceGestureDetectorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSDeviceGestureDetectorTests.swift
@@ -250,7 +250,7 @@ final class OSDeviceGestureDetectorTests: XCTestCase {
     func testKillSwitchKeyMatchesTheCatalog() {
         // The feature manager only answers for catalog keys, so a drift here would silently
         // turn the switch into a no-op.
-        XCTAssertEqual(OSDeviceGestureDetector.killSwitchKey, FeatureFlag.sdkDeviceGestureDisabled.key)
+        XCTAssertEqual(OSDeviceGestureDetector.remoteKillSwitchKey, FeatureFlag.sdkDeviceGestureDisabled.key)
     }
 
     func testNotReadySdkSuppressesTheWrite() {
@@ -448,5 +448,61 @@ final class OSDeviceGestureDetectorTests: XCTestCase {
 
         XCTAssertEqual(harness.recorder.events, [.deviceGesture, .deviceGesture])
         XCTAssertEqual(harness.recorder.attributes.map { $0["gesture.result"] }, ["copied", "copied"])
+    }
+}
+
+/// Parsing of the Info.plist opt-out value. A separate class so the one above stays under
+/// SwiftLint's body length limit.
+final class OSDeviceGestureDetectorInfoPlistTests: XCTestCase {
+    func testReadsTheValueTypesTheOlderSwitchesAccept() throws {
+        // Each case is the literal Info.plist text. A String such as YES has to count too.
+        let optedOut = [
+            "<true/>",
+            "<integer>1</integer>",
+            "<real>1.0</real>",
+            "<string>YES</string>",
+            "<string>yes</string>",
+            "<string>true</string>",
+            "<string>1</string>"
+        ]
+        for xml in optedOut {
+            XCTAssertTrue(OSDeviceGestureDetector.isDisabledByApp(infoPlistValue: try plistValue(xml)), xml)
+        }
+
+        let stillOn = [
+            "<false/>",
+            "<integer>0</integer>",
+            "<string>NO</string>",
+            "<string>false</string>",
+            "<string>0</string>",
+            "<string></string>"
+        ]
+        for xml in stillOn {
+            XCTAssertFalse(OSDeviceGestureDetector.isDisabledByApp(infoPlistValue: try plistValue(xml)), xml)
+        }
+    }
+
+    func testIgnoresAMissingOrMistypedValue() throws {
+        // A missing or mistyped value leaves the gesture on and must not crash.
+        XCTAssertFalse(OSDeviceGestureDetector.isDisabledByApp(infoPlistValue: nil))
+        let mistyped = [
+            "<array><string>YES</string></array>",
+            "<dict><key>enabled</key><true/></dict>",
+            "<date>2026-09-11T00:00:00Z</date>",
+            "<data>WUVT</data>"
+        ]
+        for xml in mistyped {
+            XCTAssertFalse(OSDeviceGestureDetector.isDisabledByApp(infoPlistValue: try plistValue(xml)), xml)
+        }
+    }
+
+    /// The value of one Info.plist key written as `xml`, with the type `Bundle.main` would return.
+    private func plistValue(_ xml: String) throws -> Any {
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <plist version="1.0"><dict><key>k</key>\(xml)</dict></plist>
+        """
+        let dict = try XCTUnwrap(PropertyListSerialization.propertyList(from: Data(plist.utf8), format: nil) as? [String: Any])
+        return try XCTUnwrap(dict["k"], xml)
     }
 }

--- a/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSDeviceGestureDetectorTests.swift
+++ b/iOS_SDK/OneSignalSDK/OneSignalOSCoreTests/OSDeviceGestureDetectorTests.swift
@@ -106,13 +106,14 @@ private final class Harness {
     let recorder = EventRecorderSpy()
     private(set) var detector: OSDeviceGestureDetector!
 
-    init(center: NotificationCenter = NotificationCenter(), queue: OSDispatchQueue = InlineQueue()) {
+    init(center: NotificationCenter = NotificationCenter(), queue: OSDispatchQueue = InlineQueue(), disabledByApp: Bool = false) {
         self.center = center
         detector = OSDeviceGestureDetector(
             notificationCenter: center,
             mainQueue: queue,
             nowProvider: { [unowned self] in self.now },
             isDisabledRemotelyProvider: { [unowned self] in self.killSwitchOn },
+            isDisabledByAppProvider: { disabledByApp },
             subscriptionIdProvider: { [unowned self] in self.currentSubscriptionId },
             shouldAwaitProvider: { [unowned self] in self.shouldAwait },
             pasteboardWriter: { [unowned self] in self.writes.append($0) },
@@ -301,6 +302,23 @@ final class OSDeviceGestureDetectorTests: XCTestCase {
         XCTAssertEqual(center.liveObservers, 2)
 
         harness.detector.tearDown()
+        XCTAssertEqual(center.liveObservers, 0)
+    }
+
+    func testInfoPlistOptOutKeepsTheDetectorFromStarting() {
+        // The app owner said no: no observers are registered, so nothing is counted, written
+        // or recorded, and a second start does not register either because the latch holds.
+        let center = ObserverTrackingCenter()
+        let harness = Harness(center: center, disabledByApp: true)
+        XCTAssertEqual(center.liveObservers, 0)
+
+        for _ in 1...6 {
+            harness.cycle()
+        }
+        XCTAssertEqual(harness.writes, [])
+        XCTAssertEqual(harness.recorder.events, [])
+
+        harness.detector.registerLifecycleObserversIfNeeded()
         XCTAssertEqual(center.liveObservers, 0)
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Lets an app turn off subscription ID copy with an Info.plist key.

## Details

### Motivation
The gesture in #1730 is on by default, and the only switch is OneSignal's remote kill switch. An app that doesn't want a pasteboard write in production should be able to say so itself, in its own Info.plist, without a support ticket.

Ticket SDK-5193. Follows #1730, which merged as c23c6f99b; this PR targets main.

### Scope

`OneSignal_disable_subscription_id_copy` set to `YES` in Info.plist

- read like the SDK's older Info.plist switches (`OneSignal_disable_swizzling`, `OneSignal_suppress_launch_urls`, `OneSignal_disable_badge_clearing`): a Boolean or Number counts by value and a String through `NSString.boolValue`, so `<true/>` and `<string>YES</string>` both opt out. That matters because Xcode's plist editor stores a new row as a String unless its type is changed. A missing or mistyped value leaves the gesture on instead of crashing on `boolValue` the way the Objective-C reads would.
- checked before the observers register. With the key set the detector registers nothing, so nothing is counted, written or recorded.
- That is stricter than the remote kill switch, which still records `disabled` so we can count attempts; an app that opted out has said no.
- One INFO line at start says the key was honoured, so a developer can confirm it took. The started latch still flips, so the recovery path's second `start()` stays quiet.
- The key names the outcome, not the gesture, so the docs can call the feature one thing.
- No public API, so the wrapper SDKs expose it with no change.

### Other
The docs page and release notes need to say the feature is on by default and name the key.

# Testing
## Unit testing
`OSDeviceGestureDetectorTests` injects the opt-out and asserts, through the observer-counting center, that no observers register, that six cycles write nothing and record nothing, and that a second start registers nothing either. `OSDeviceGestureDetectorInfoPlistTests` deserialises each Info.plist value shape from its literal XML and checks the parse: `<true/>`, `<integer>1</integer>`, `<real>1.0</real>` and the strings `YES`, `yes`, `true` and `1` opt out; `<false/>`, `<integer>0</integer>` and the strings `NO`, `false`, `0` and empty do not; nil, array, dict, date and data values leave the gesture on. The parse tests fail against the previous `NSNumber`-only read. 187 OneSignalOSCore tests pass serially, SwiftLint clean apart from the pre-existing file length warning on the test file.

## Manual testing
Not run on a device. The read is the same `Bundle.main` lookup the other Info.plist switches use.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
